### PR TITLE
feat: add project management functionality with CRUD operations and role/member management

### DIFF
--- a/apps/e2e/features/admin/global-roles.feature
+++ b/apps/e2e/features/admin/global-roles.feature
@@ -38,7 +38,7 @@ Feature: Global roles management
     Scenario: Opening the create-role dialog
       When the user clicks the "New Role" button
       Then the role form dialog should open
-      And the dialog title should be "Create role"
+      And the dialog title should be "Create Role"
       And the name field should be empty
       And all permission switches should be in their default state
 
@@ -85,11 +85,28 @@ Feature: Global roles management
       When the user clicks the "New Role" button
       And the user fills the role name with "USERS_WILDCARD_ROLE"
       And the user enables the "Read Users" permission
+      And the user enables the "Write Users" permission
       And the user enables the "Delete Users" permission
       And the user clicks "Create role"
       Then the dialog should close
       And the role "USERS_WILDCARD_ROLE" should appear in the roles table
       And the role should show 1 active permission representing "users.*"
+
+    Scenario: Enabling all projects permissions collapses to projects wildcard
+      When the user clicks the "New Role" button
+      And the user fills the role name with "PROJECTS_WILDCARD_ROLE"
+      And the user enables the "Read All Projects" permission
+      And the user enables the "Create Projects" permission
+      And the user enables the "Write Projects" permission
+      And the user enables the "Delete Projects" permission
+      And the user enables the "Read Project Members" permission
+      And the user enables the "Write Project Members" permission
+      And the user enables the "Read Project Roles" permission
+      And the user enables the "Write Project Roles" permission
+      And the user clicks "Create role"
+      Then the dialog should close
+      And the role "PROJECTS_WILDCARD_ROLE" should appear in the roles table
+      And the role should show 1 active permission representing "projects.*"
 
     Scenario: Enabling all permissions across all groups collapses each domain independently
       When the user clicks the "New Role" button
@@ -98,11 +115,20 @@ Feature: Global roles management
       And the user enables the "Write Global Roles" permission
       And the user enables the "Assign Global Roles" permission
       And the user enables the "Read Users" permission
+      And the user enables the "Write Users" permission
       And the user enables the "Delete Users" permission
+      And the user enables the "Read All Projects" permission
+      And the user enables the "Create Projects" permission
+      And the user enables the "Write Projects" permission
+      And the user enables the "Delete Projects" permission
+      And the user enables the "Read Project Members" permission
+      And the user enables the "Write Project Members" permission
+      And the user enables the "Read Project Roles" permission
+      And the user enables the "Write Project Roles" permission
       And the user clicks "Create role"
       Then the dialog should close
       And the role "SUPER_ROLE" should appear in the roles table
-      And the role should show 2 active permissions representing "global_roles.*" and "users.*"
+      And the role should show 3 active permissions representing "global_roles.*", "users.*", and "projects.*"
 
     Scenario: Creating a role with permissions from multiple groups
       When the user clicks the "New Role" button
@@ -132,6 +158,11 @@ Feature: Global roles management
       Then the role form dialog should open
       And the permission section should display a "Global Roles" group
       And the permission section should display a "Users" group
+      And the permission section should display a "Projects" group
+
+    Scenario: Each group in the Projects domain is labelled correctly
+      When the user clicks the "New Role" button
+      Then the "Projects" group should contain "Read All Projects", "Create Projects", "Write Projects", "Delete Projects", "Read Project Members", "Write Project Members", "Read Project Roles", and "Write Project Roles" permissions
 
     Scenario: Each permission switch shows a label and description
       When the user clicks the "New Role" button
@@ -139,7 +170,16 @@ Feature: Global roles management
       And the "Write Global Roles" permission should show description "Create and update global role definitions"
       And the "Assign Global Roles" permission should show description "Assign global roles to users"
       And the "Read Users" permission should show description "View user profiles and list"
+      And the "Write Users" permission should show description "Create and update user accounts"
       And the "Delete Users" permission should show description "Remove user accounts"
+      And the "Read All Projects" permission should show description "View all projects in the workspace"
+      And the "Create Projects" permission should show description "Create new projects"
+      And the "Write Projects" permission should show description "Update project details"
+      And the "Delete Projects" permission should show description "Permanently delete projects"
+      And the "Read Project Members" permission should show description "View members of any project"
+      And the "Write Project Members" permission should show description "Add, remove, and update members in any project"
+      And the "Read Project Roles" permission should show description "View roles defined in any project"
+      And the "Write Project Roles" permission should show description "Create and update roles in any project"
 
     Scenario: All permission switches are off by default in the create dialog
       When the user clicks the "New Role" button
@@ -147,7 +187,16 @@ Feature: Global roles management
       And the "Write Global Roles" permission switch should be off
       And the "Assign Global Roles" permission switch should be off
       And the "Read Users" permission switch should be off
+      And the "Write Users" permission switch should be off
       And the "Delete Users" permission switch should be off
+      And the "Read All Projects" permission switch should be off
+      And the "Create Projects" permission switch should be off
+      And the "Write Projects" permission switch should be off
+      And the "Delete Projects" permission switch should be off
+      And the "Read Project Members" permission switch should be off
+      And the "Write Project Members" permission switch should be off
+      And the "Read Project Roles" permission switch should be off
+      And the "Write Project Roles" permission switch should be off
 
     Scenario: Enabling a permission updates the switch to on
       When the user clicks the "New Role" button

--- a/apps/e2e/features/projects/management.feature
+++ b/apps/e2e/features/projects/management.feature
@@ -1,0 +1,556 @@
+@projects @project-management
+Feature: Project management
+  Projects are the primary workspace unit in the workspace. Visibility,
+  creation, editing, deletion, and member or role management are each gated
+  by distinct global or project-scoped permissions. The project list lives
+  on the home page; all per-project settings are accessed through the
+  project's own Settings page.
+
+  @authenticated
+  Rule: Listing projects on the home page
+
+    Background:
+      Given the user already has a stored authenticated session
+      And the user navigates to the home page
+
+    Scenario: User with "Read All Projects" global permission sees every project
+      Given the user has the "Read All Projects" global permission
+      Then the projects section should display all projects in the workspace
+
+    Scenario: User without "Read All Projects" sees only projects they are a member of
+      Given the user does not have the "Read All Projects" global permission
+      And the user is a member of project "E2E_ALPHA"
+      And a project named "E2E_BETA" exists that the user is not a member of
+      Then the projects section should include "E2E_ALPHA"
+      And the projects section should not include "E2E_BETA"
+
+    Scenario: User with no membership and no "Read All Projects" sees an empty state
+      Given the user does not have the "Read All Projects" global permission
+      And the user is not a member of any project
+      Then the projects section should show an empty state
+
+    Scenario: User with "Read All Projects" sees projects they are not personally a member of
+      Given the user has the "Read All Projects" global permission
+      And a project named "E2E_HIDDEN_PROJECT" exists that the user is not a member of
+      Then the projects section should include "E2E_HIDDEN_PROJECT"
+
+    Scenario: Project cards show name, description, and creation date
+      Given at least one project named "E2E_LISTED_PROJECT" exists
+      Then the card for "E2E_LISTED_PROJECT" should show the project name
+      And the card should show the project description or "No description"
+      And the card should show the project creation date
+
+    Scenario: Home page stats reflect the total and active project count
+      Then the stats bar should show the total number of projects
+      And the stats bar should show the count of active projects
+
+  @authenticated
+  Rule: Creating a project
+
+    Background:
+      Given the user already has a stored authenticated session
+      And the user navigates to the home page
+
+    Scenario: "New Project" button is visible for users with "Create Projects" global permission
+      Given the user has the "Create Projects" global permission
+      Then the "New Project" button should be visible
+
+    Scenario: "New Project" button is not visible without "Create Projects" global permission
+      Given the user does not have the "Create Projects" global permission
+      Then the "New Project" button should not be visible
+
+    Scenario: New project dialog has required name field and optional description field
+      Given the user has the "Create Projects" global permission
+      When the user clicks the "New Project" button
+      Then the "New project" dialog should open
+      And the dialog should contain a required "Project name" field
+      And the dialog should contain an optional "Description" field
+
+    Scenario: "Create project" button is disabled while the project name is empty
+      Given the user has the "Create Projects" global permission
+      When the user clicks the "New Project" button
+      Then the "Create project" button should be disabled
+
+    Scenario: Creating a project with only a name succeeds
+      Given the user has the "Create Projects" global permission
+      When the user clicks the "New Project" button
+      And the user fills the project name with "E2E_NAME_ONLY_PROJECT"
+      And the user clicks "Create project"
+      Then the dialog should close
+      And the project "E2E_NAME_ONLY_PROJECT" should appear in the projects section
+
+    Scenario: Creating a project with name and description succeeds
+      Given the user has the "Create Projects" global permission
+      When the user clicks the "New Project" button
+      And the user fills the project name with "E2E_DESCRIBED_PROJECT"
+      And the user fills the description with "A test project with a description"
+      And the user clicks "Create project"
+      Then the dialog should close
+      And the project "E2E_DESCRIBED_PROJECT" should appear in the projects section
+      And the card for "E2E_DESCRIBED_PROJECT" should show "A test project with a description"
+
+    Scenario: Cancelling the create project dialog discards changes
+      Given the user has the "Create Projects" global permission
+      When the user clicks the "New Project" button
+      And the user fills the project name with "E2E_SHOULD_NOT_EXIST"
+      And the user clicks "Cancel"
+      Then the project "E2E_SHOULD_NOT_EXIST" should not appear in the projects section
+
+    Scenario: Creating a project with a duplicate name shows a validation error
+      Given the user has the "Create Projects" global permission
+      And a project named "E2E_DUPLICATE_PROJECT" already exists
+      When the user clicks the "New Project" button
+      And the user fills the project name with "E2E_DUPLICATE_PROJECT"
+      And the user clicks "Create project"
+      Then a validation error should indicate the project name is already taken
+      And the dialog should remain open
+
+  @authenticated
+  Rule: Navigating into a project
+
+    Scenario: Clicking a project card opens the project dashboard
+      Given the user has access to project "E2E_NAV_PROJECT"
+      When the user clicks the card for "E2E_NAV_PROJECT"
+      Then the user should be on the "E2E_NAV_PROJECT" dashboard page
+
+    Scenario: Project sidebar shows Dashboard, Integrations, Docs, Team, and Settings links
+      Given the user is inside project "E2E_NAV_PROJECT"
+      Then the sidebar should contain a "Dashboard" link
+      And the sidebar should contain an "Integrations" link
+      And the sidebar should contain a "Docs" link
+      And the sidebar should contain a "Team" link
+      And the sidebar should contain a "Settings" link
+
+    Scenario: User with "Read All Projects" can navigate to any project by direct URL
+      Given the user has the "Read All Projects" global permission
+      And a project named "E2E_ANY_PROJECT" exists
+      When the user navigates directly to the "E2E_ANY_PROJECT" project dashboard URL
+      Then the project dashboard should be visible
+
+    Scenario: User without "Read All Projects" is denied access to a project they are not in
+      Given the user does not have the "Read All Projects" global permission
+      And the user is not a member of project "E2E_RESTRICTED_PROJECT"
+      When the user navigates directly to the "E2E_RESTRICTED_PROJECT" project dashboard URL
+      Then the user should see an access-denied message
+
+  @authenticated
+  Rule: Editing project settings (Settings > General)
+
+    Background:
+      Given the user already has a stored authenticated session
+      And a project named "E2E_SETTINGS_PROJECT" exists
+      And the user has navigated to the "E2E_SETTINGS_PROJECT" Settings page
+
+    Scenario: General tab shows editable project name and description fields
+      When the user clicks "General" in the settings sidebar
+      Then a "Project name" field pre-filled with "E2E_SETTINGS_PROJECT" should be visible
+      And a "Description" field should be visible
+
+    Scenario: "Save changes" button is disabled until a change is made
+      When the user clicks "General" in the settings sidebar
+      Then the "Save changes" button should be disabled
+
+    Scenario: Saving a new project name updates the project
+      When the user clicks "General" in the settings sidebar
+      And the user clears the project name and types "E2E_RENAMED_SETTINGS_PROJECT"
+      And the user clicks "Save changes"
+      Then the project name should be updated to "E2E_RENAMED_SETTINGS_PROJECT"
+
+    Scenario: Saving a new description updates the project
+      When the user clicks "General" in the settings sidebar
+      And the user fills the description with "Updated description"
+      And the user clicks "Save changes"
+      Then the project description should reflect "Updated description"
+
+    Scenario: Clearing the project name disables "Save changes"
+      When the user clicks "General" in the settings sidebar
+      And the user clears the project name
+      Then the "Save changes" button should be disabled
+
+    Scenario: Saving a name already used by another project shows a validation error
+      Given a project named "E2E_EXISTING_PROJECT" already exists
+      When the user clicks "General" in the settings sidebar
+      And the user clears the project name and types "E2E_EXISTING_PROJECT"
+      And the user clicks "Save changes"
+      Then a validation error should indicate the project name is already taken
+
+    Scenario: Settings General is accessible to users with "Write Projects" global permission
+      Given the user has the "Write Projects" global permission
+      Then the "General" settings tab and its fields should be visible and editable
+
+    Scenario: Settings General is accessible to users with project-scoped "Edit Project" permission
+      Given the user does not have the "Write Projects" global permission
+      And the user has the "Edit Project" project role in "E2E_SETTINGS_PROJECT"
+      Then the "General" settings tab and its fields should be visible and editable
+
+    Scenario: A user without any update permission cannot edit project settings
+      Given the user does not have the "Write Projects" global permission
+      And the user does not have the "Edit Project" project role in "E2E_SETTINGS_PROJECT"
+      Then the "General" settings section should be read-only or inaccessible
+
+  @authenticated
+  Rule: Deleting a project (Settings > Danger Zone)
+
+    Background:
+      Given the user already has a stored authenticated session
+      And a project named "E2E_DELETE_PROJECT" exists
+      And the user has navigated to the "E2E_DELETE_PROJECT" Settings page
+      And the user clicks "Danger Zone" in the settings sidebar
+
+    Scenario: Danger Zone displays the "Delete project" button with a warning
+      Then a "Delete project" button should be visible
+      And the section should warn that the action is permanent and cannot be undone
+
+    Scenario: Delete project dialog warns about permanent data loss
+      When the user clicks the "Delete project" button
+      Then the "Delete project" dialog should open
+      And the dialog should warn that all members, roles, and integrations will be lost
+
+    Scenario: "Delete permanently" button is disabled until the project name is typed
+      When the user clicks the "Delete project" button
+      Then the "Delete permanently" button should be disabled
+      And the dialog should instruct the user to type "E2E_DELETE_PROJECT" to confirm
+
+    Scenario: Typing an incorrect name keeps "Delete permanently" disabled
+      When the user clicks the "Delete project" button
+      And the user types "wrong-name" in the confirmation field
+      Then the "Delete permanently" button should remain disabled
+
+    Scenario: Typing the exact project name enables "Delete permanently"
+      When the user clicks the "Delete project" button
+      And the user types "E2E_DELETE_PROJECT" in the confirmation field
+      Then the "Delete permanently" button should become enabled
+
+    Scenario: Confirming deletion removes the project
+      When the user clicks the "Delete project" button
+      And the user types "E2E_DELETE_PROJECT" in the confirmation field
+      And the user clicks "Delete permanently"
+      Then the user should be redirected away from the project
+      And the project "E2E_DELETE_PROJECT" should no longer appear on the home page
+
+    Scenario: Cancelling the delete dialog preserves the project
+      When the user clicks the "Delete project" button
+      And the user clicks "Cancel"
+      Then the project "E2E_DELETE_PROJECT" should still appear on the home page
+
+    Scenario: "Delete project" button is accessible with "Delete Projects" global permission
+      Given the user has the "Delete Projects" global permission
+      Then the "Delete project" button should be visible in Danger Zone
+
+    Scenario: "Delete project" button is accessible with project-scoped "Delete Project" permission
+      Given the user does not have the "Delete Projects" global permission
+      And the user has the "Delete Project" project role in "E2E_DELETE_PROJECT"
+      Then the "Delete project" button should be visible in Danger Zone
+
+    Scenario: User without delete permission cannot access project deletion
+      Given the user does not have the "Delete Projects" global permission
+      And the user does not have the "Delete Project" project role in "E2E_DELETE_PROJECT"
+      Then the "Delete project" button should not be visible in Danger Zone
+
+  @authenticated
+  Rule: Managing team members (Team page)
+
+    Background:
+      Given the user already has a stored authenticated session
+      And a project named "E2E_TEAM_PROJECT" exists
+
+    Scenario: Team page shows heading and project subtitle
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      Then the page heading "Team" should be visible
+      And the subtitle should include "E2E_TEAM_PROJECT" and "Manage project members and roles"
+
+    Scenario: "Add Member" button is visible for users with "Write Project Members" global permission
+      Given the user has the "Write Project Members" global permission
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      Then the "Add Member" button should be visible
+
+    Scenario: "Add Member" button is not visible without member management permission
+      Given the user does not have the "Write Project Members" global permission
+      And the user does not have the "Manage Members" project role in "E2E_TEAM_PROJECT"
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      Then the "Add Member" button should not be visible
+
+    Scenario: Add Member dialog contains a user search field and a role picker
+      Given the user has the "Write Project Members" global permission
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      And the user clicks "Add Member"
+      Then the "Add member" dialog should open
+      And the dialog should contain a "Search by name or username" field
+      And the dialog should contain a role picker
+
+    Scenario: "Add member" button in the dialog is disabled when no user is selected
+      Given the user has the "Write Project Members" global permission
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      And the user clicks "Add Member"
+      Then the "Add member" dialog button should be disabled
+
+    Scenario: Dialog shows "No users available to add" when all users are already members
+      Given the user has the "Write Project Members" global permission
+      And all system users are already members of "E2E_TEAM_PROJECT"
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      And the user clicks "Add Member"
+      Then the user search should indicate "No users available to add."
+
+    Scenario: Adding a member successfully adds them to the team list
+      Given the user has the "Write Project Members" global permission
+      And a user named "E2E_INVITED_USER" exists
+      And "E2E_INVITED_USER" is not yet a member of "E2E_TEAM_PROJECT"
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      And the user clicks "Add Member"
+      And the user searches for and selects "E2E_INVITED_USER"
+      And the user clicks "Add member"
+      Then "E2E_INVITED_USER" should appear in the team list
+
+    Scenario: Member row shows name, username, Change role button, and a remove action
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      Then each member row should show the member's name and username
+      And each row should have a "Change role" button
+      And each row should have a menu button that contains a "Remove member" option
+
+    Scenario: Removing a member removes them from the team list
+      Given the user has the "Write Project Members" global permission
+      And "E2E_REMOVABLE_USER" is a member of "E2E_TEAM_PROJECT"
+      When the user navigates to the "E2E_TEAM_PROJECT" Team page
+      And the user opens the menu for "E2E_REMOVABLE_USER" and clicks "Remove member"
+      Then "E2E_REMOVABLE_USER" should no longer appear in the team list
+
+    Scenario: User with "Write Project Members" global permission can manage members of any project
+      Given the user has the "Write Project Members" global permission
+      And a project named "E2E_FOREIGN_PROJECT" exists that the user is not a member of
+      When the user navigates to the "E2E_FOREIGN_PROJECT" Team page
+      Then the "Add Member" button should be visible
+
+  @authenticated
+  Rule: Managing project roles (Settings > Roles)
+
+    Background:
+      Given the user already has a stored authenticated session
+      And a project named "E2E_ROLES_PROJECT" exists
+      And the user has navigated to the "E2E_ROLES_PROJECT" Settings page
+      And the user clicks "Roles" in the settings sidebar
+
+    Scenario: Project Roles heading and subtitle are visible
+      Then the "Project Roles" heading should be visible
+      And the subtitle should read "Manage roles and permissions for members of this project."
+
+    Scenario: Statistics bar shows the role count and permission grant total
+      Then the statistics bar should show the total number of project roles
+      And the statistics bar should show the total permission grants across all project roles
+
+    Scenario: Roles table displays expected columns
+      Then the project roles table should have columns "Name", "Permissions", and "Created"
+
+    Scenario: Default roles Admin, Editor, and Viewer are pre-seeded
+      Then the role "Admin" should appear in the project roles table
+      And the role "Editor" should appear in the project roles table
+      And the role "Viewer" should appear in the project roles table
+
+    Scenario: Each role row shows Edit role and Delete role action buttons
+      Then each role row should have an "Edit role" button
+      And each role row should have a "Delete role" button
+
+  @authenticated
+  Rule: Creating a project role
+
+    Background:
+      Given the user already has a stored authenticated session
+      And the user is on the "E2E_ROLES_PROJECT" project roles settings page
+
+    Scenario: New Role dialog title and description are correct
+      When the user clicks the "New role" button
+      Then the role form dialog should open
+      And the dialog title should be "New Role"
+      And the dialog description should mention creating a project role with permissions
+
+    Scenario: Role Name field is empty and Create role button is disabled by default
+      When the user clicks the "New role" button
+      Then the "Role Name" field should be empty
+      And the "Create role" button should be disabled
+
+    Scenario: Permission form shows five groups: Project, Members, Roles, Tasks, Sprints
+      When the user clicks the "New role" button
+      Then the permission section should display a "Project" group
+      And the permission section should display a "Members" group
+      And the permission section should display a "Roles" group
+      And the permission section should display a "Tasks" group
+      And the permission section should display a "Sprints" group
+
+    Scenario: Each project permission shows expected label and description
+      When the user clicks the "New role" button
+      Then the "Read Project" permission should show description "View project details and settings"
+      And the "Edit Project" permission should show description "Update project name, description, and settings"
+      And the "Delete Project" permission should show description "Permanently delete this project"
+      And the "View Members" permission should show description "List and view project members"
+      And the "Manage Members" permission should show description "Add, remove, and reassign project members"
+      And the "View Roles" permission should show description "List and view project role definitions"
+      And the "Manage Roles" permission should show description "Create, edit, and delete project roles"
+      And the "View Tasks" permission should show description "Browse and read tasks in the project"
+      And the "Edit Tasks" permission should show description "Create, update, and move tasks"
+      And the "View Sprints" permission should show description "Browse sprint boards and backlogs"
+      And the "Manage Sprints" permission should show description "Create, update, and close sprints"
+
+    Scenario: All permission switches are off by default
+      When the user clicks the "New role" button
+      Then the "Read Project" permission switch should be off
+      And the "Edit Project" permission switch should be off
+      And the "Delete Project" permission switch should be off
+      And the "View Members" permission switch should be off
+      And the "Manage Members" permission switch should be off
+      And the "View Roles" permission switch should be off
+      And the "Manage Roles" permission switch should be off
+      And the "View Tasks" permission switch should be off
+      And the "Edit Tasks" permission switch should be off
+      And the "View Sprints" permission switch should be off
+      And the "Manage Sprints" permission switch should be off
+
+    Scenario: Creating a role with a name and selected permissions
+      When the user clicks the "New role" button
+      And the user fills the role name with "E2E_PROJECT_MANAGER"
+      And the user enables the "Edit Project" permission
+      And the user enables the "Manage Members" permission
+      And the user clicks "Create role"
+      Then the dialog should close
+      And the role "E2E_PROJECT_MANAGER" should appear in the project roles table
+      And the statistics bar should reflect the updated role count
+
+    Scenario: Creating a role without any permissions is allowed
+      When the user clicks the "New role" button
+      And the user fills the role name with "E2E_EMPTY_ROLE"
+      And the user clicks "Create role"
+      Then the role "E2E_EMPTY_ROLE" should appear in the project roles table
+      And the role should show zero active permissions
+
+    Scenario: Cancelling the dialog discards changes
+      When the user clicks the "New role" button
+      And the user fills the role name with "E2E_SHOULD_NOT_EXIST"
+      And the user clicks "Cancel"
+      Then the role "E2E_SHOULD_NOT_EXIST" should not appear in the project roles table
+
+    Scenario: Closing and reopening the dialog resets all permission switches
+      When the user clicks the "New role" button
+      And the user enables the "Delete Project" permission
+      And the user closes the dialog
+      And the user clicks the "New role" button again
+      Then all permission switches should be in their default state
+
+    Scenario: Permissions count in the table matches the granted permissions
+      When the user clicks the "New role" button
+      And the user fills the role name with "E2E_COUNT_ROLE"
+      And the user enables the "Edit Project" permission
+      And the user enables the "Delete Project" permission
+      And the user clicks "Create role"
+      Then the role "E2E_COUNT_ROLE" should show 2 active permissions
+      And the statistics bar should reflect the added permission grants
+
+    Scenario: Toggling a permission on then off leaves it disabled
+      When the user clicks the "New role" button
+      And the user enables the "Delete Project" permission
+      And the user disables the "Delete Project" permission
+      Then the "Delete Project" permission switch should be off
+
+  @authenticated
+  Rule: Editing a project role
+
+    Background:
+      Given the user already has a stored authenticated session
+      And the user is on the "E2E_ROLES_PROJECT" project roles settings page
+      And a project role named "E2E_EDITABLE_ROLE" exists in the project
+
+    Scenario: Opening the edit dialog pre-populates current data
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      Then the role form dialog should open
+      And the dialog title should be "Edit Role"
+      And the "Role Name" field should be pre-filled with "E2E_EDITABLE_ROLE"
+      And the permission switches should reflect the role's current permissions
+
+    Scenario: Saving an updated name and permissions
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      And the user clears the role name and types "E2E_RENAMED_ROLE"
+      And the user toggles the "Delete Project" permission
+      And the user clicks "Save changes"
+      Then the dialog should close
+      And the role "E2E_RENAMED_ROLE" should appear in the project roles table
+
+    Scenario: Cancelling the edit dialog discards all changes
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      And the user clears the role name and types "E2E_UNSAVED_CHANGE"
+      And the user clicks "Cancel"
+      Then the role "E2E_EDITABLE_ROLE" should still appear in the project roles table
+      And the role "E2E_UNSAVED_CHANGE" should not appear in the project roles table
+
+    Scenario: Enabling additional permissions on an existing project role
+      Given "E2E_EDITABLE_ROLE" exists with only "Edit Project" permission
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      And the user enables the "Delete Project" permission
+      And the user enables the "Manage Members" permission
+      And the user clicks "Save changes"
+      Then the dialog should close
+      And the role "E2E_EDITABLE_ROLE" should show 3 active permissions
+
+    Scenario: Edit dialog pre-populates the correct permission switches
+      Given "E2E_EDITABLE_ROLE" exists with "Delete Project" and "Manage Sprints" permissions
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      Then the "Delete Project" permission switch should be on
+      And the "Manage Sprints" permission switch should be on
+      And the "Edit Project" permission switch should be off
+      And the "View Members" permission switch should be off
+
+    Scenario: Removing all permissions from an existing project role
+      Given "E2E_EDITABLE_ROLE" exists with "Edit Project" and "View Tasks" permissions
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      And the user disables the "Edit Project" permission
+      And the user disables the "View Tasks" permission
+      And the user clicks "Save changes"
+      Then the dialog should close
+      And the role "E2E_EDITABLE_ROLE" should show zero active permissions
+
+    Scenario: Toggling a permission off during edit persists after save
+      Given "E2E_EDITABLE_ROLE" exists with "Manage Members" permission
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      And the user disables the "Manage Members" permission
+      And the user clicks "Save changes"
+      Then the dialog should close
+      When the user clicks the "Edit role" button for "E2E_EDITABLE_ROLE"
+      Then the "Manage Members" permission switch should be off
+
+  @authenticated
+  Rule: Deleting a project role
+
+    Background:
+      Given the user already has a stored authenticated session
+      And the user is on the "E2E_ROLES_PROJECT" project roles settings page
+      And a project role named "E2E_DELETABLE_ROLE" exists in the project
+
+    Scenario: Confirming deletion removes the project role
+      When the user clicks the "Delete role" button for "E2E_DELETABLE_ROLE"
+      Then a delete confirmation dialog should open
+      And the dialog should display the name "E2E_DELETABLE_ROLE"
+      When the user confirms deletion
+      Then the role "E2E_DELETABLE_ROLE" should no longer appear in the project roles table
+      And the statistics bar should reflect the updated role and permission counts
+
+    Scenario: Cancelling the delete dialog preserves the project role
+      When the user clicks the "Delete role" button for "E2E_DELETABLE_ROLE"
+      And the user cancels deletion
+      Then the role "E2E_DELETABLE_ROLE" should still appear in the project roles table
+
+  @authenticated
+  Rule: Access control for project roles settings
+
+    Scenario: Users with "Manage Roles" project permission see the New role button and edit/delete actions
+      Given the user has the "Manage Roles" project role in "E2E_ROLES_PROJECT"
+      When the user navigates to the "E2E_ROLES_PROJECT" project roles settings page
+      Then the "New role" button should be visible
+      And "Edit role" and "Delete role" buttons should be visible on each role row
+
+    Scenario: Users without role management permission see roles but cannot modify them
+      Given the user does not have role management permission in "E2E_ROLES_PROJECT"
+      When the user navigates to the "E2E_ROLES_PROJECT" project roles settings page
+      Then the "New role" button should not be visible
+      And no "Edit role" or "Delete role" buttons should be visible
+
+    Scenario: User without project access cannot reach the project roles settings page
+      Given the user does not have the "Read All Projects" global permission
+      And the user is not a member of project "E2E_ROLES_PROJECT"
+      When the user navigates directly to the "E2E_ROLES_PROJECT" project roles settings URL
+      Then the user should see an access-denied message

--- a/apps/e2e/tests/admin/global-roles-management.spec.ts
+++ b/apps/e2e/tests/admin/global-roles-management.spec.ts
@@ -7,14 +7,12 @@ const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost';
 const USERNAME = process.env.E2E_USERNAME ?? 'admin';
 const PASSWORD = process.env.E2E_PASSWORD ?? 'e2e-admin-password';
 
-/** Prefix used for roles created by this spec so cleanup can target only test data. */
 const TEST_ROLE_PREFIX = 'E2E_';
 
-/**
- * Delete every non-default role via the API so each test starts with a clean
- * baseline.  Uses a dedicated request context that logs in with admin
- * credentials (cookies are retained within the same context object).
- */
+function permSwitch(page: Page, label: string) {
+  return page.getByText(label, { exact: true }).locator('xpath=../following-sibling::*[@role="switch"]');
+}
+
 async function cleanupTestRoles(request: APIRequestContext): Promise<void> {
   await request.post(`${BASE_URL}/api/v1/auth/login`, {
     data: { username: USERNAME, password: PASSWORD, rememberMe: false },
@@ -39,70 +37,14 @@ test.describe('Global Roles Management', () => {
     await page.getByRole('textbox', { name: 'Username' }).fill(USERNAME);
     await page.getByRole('textbox', { name: 'Password' }).fill(PASSWORD);
     await page.getByRole('button', { name: 'Sign in' }).click();
-    
-    // On mobile devices, the sidebar may be collapsed, so we need to check and toggle it if necessary
-    const viewport = page.viewportSize();
-    if (viewport && viewport.width <= 768) {
-      // Check if the Global Roles link is already visible (sidebar is expanded)
-      const globalRolesLink = page.getByRole('link', { name: 'Global Roles' });
-      const isVisible = await globalRolesLink.isVisible();
-      
-      if (!isVisible) {
-        // Click the toggle sidebar button to open the sidebar
-        await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
-      }
-      
-      // Click the Global Roles link
-      await page.getByRole('link', { name: 'Global Roles' }).click();
-      
-      // Close the mobile sidebar after navigation to avoid interfering with page content
-      await page.keyboard.press('Escape');
-    } else {
-      // On desktop, simply click the Global Roles link
-      await page.getByRole('link', { name: 'Global Roles' }).click();
-    }
-  };
-
-  const navigateToLink = async (page: Page, linkName: string) => {
-    const viewport = page.viewportSize();
-    if (viewport && viewport.width <= 768) {
-      // On mobile, open sidebar first
-      const link = page.getByRole('link', { name: linkName });
-      const isVisible = await link.isVisible();
-      
-      if (!isVisible) {
-        await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
-        // Wait for sidebar to be fully opened
-        await page.waitForTimeout(200);
-      }
-      
-      // Use a more robust approach for webkit browsers
-      try {
-        await link.waitFor({ state: 'visible', timeout: 5000 });
-        await link.click({ timeout: 10000 });
-      } catch (_error) {
-        // Fallback: try re-opening sidebar and clicking again
-        console.warn(`Failed to click ${linkName} link, retrying...`);
-        await page.keyboard.press('Escape'); // Close any open sidebar
-        await page.waitForTimeout(100);
-        await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
-        await page.waitForTimeout(200);
-        await page.getByRole('link', { name: linkName }).click({ timeout: 10000 });
-      }
-      
-      // Close the sidebar after navigation
-      await page.keyboard.press('Escape');
-    } else {
-      // On desktop, simply click the link
-      await page.getByRole('link', { name: linkName }).click();
-    }
+    // Wait for home page then navigate directly — avoids mobile sidebar modal staying open
+    await page.waitForURL(/\/home/);
+    await page.goto(`${BASE_URL}/admin/global-roles`);
+    await expect(page.getByRole('heading', { name: 'Global Roles' })).toBeVisible();
   };
 
   test.beforeEach(async ({ request, context }) => {
-    // Clear API test data
     await cleanupTestRoles(request);
-    
-    // Clear all browser state to ensure test isolation when running in parallel 
     await context.clearCookies();
     await context.clearPermissions();
   });
@@ -111,140 +53,136 @@ test.describe('Global Roles Management', () => {
     await cleanupTestRoles(request);
   });
 
-  // ---------------------------------------------------------------------------
-  // Viewing
-  // ---------------------------------------------------------------------------
+  test.describe('Viewing the roles list', () => {
+    test('Page header and statistics are visible', async ({ page }) => {
+      // 1. Navigate to the app and sign in as admin
+      await page.goto(`${BASE_URL}/`);
+      await page.getByRole('textbox', { name: 'Username' }).fill(USERNAME);
+      await page.getByRole('textbox', { name: 'Password' }).fill(PASSWORD);
+      await page.getByRole('button', { name: 'Sign in' }).click();
 
-  test('Page Header and Statistics Display', async ({ page }) => {
-    await signInAsAdmin(page);
+      // 2. Navigate directly to Global Roles — avoids mobile sidebar modal staying open
+      await page.waitForURL(/\/home/);
+      await page.goto(`${BASE_URL}/admin/global-roles`);
 
-    await expect(page.getByRole('heading', { name: 'Global Roles' })).toBeVisible();
-    await expect(page.getByText('Manage system-wide roles and the permissions they grant to users.')).toBeVisible();
-    await expect(page.getByText(/\d+roles defined/)).toBeVisible();
-    await expect(page.getByText(/permission grants across all roles/)).toBeVisible();
-    await expect(page.getByRole('button', { name: 'New Role' })).toBeVisible();
-  });
+      // 3. The "Global Roles" page heading should be visible
+      await expect(page.getByRole('heading', { name: 'Global Roles' })).toBeVisible();
 
-  test('Roles Table Display', async ({ page }) => {
-    await signInAsAdmin(page);
+      // 4. The statistics bar should show the total number of roles
+      await expect(page.getByText(/\d+\s*roles defined/)).toBeVisible();
 
-    await expect(page.getByRole('columnheader', { name: 'Name' })).toBeVisible();
-    await expect(page.getByRole('columnheader', { name: 'Permissions' })).toBeVisible();
-    await expect(page.getByRole('columnheader', { name: 'Created' })).toBeVisible();
-
-    await expect(page.getByRole('table').getByText('ADMIN', { exact: true })).toBeVisible();
-    await expect(page.getByRole('table').getByText('SUPER_ADMIN', { exact: true })).toBeVisible();
-    await expect(page.getByRole('table').getByText('USER', { exact: true })).toBeVisible();
-  });
-
-  test('Edit and Delete Buttons Visible on Role Rows', async ({ page }) => {
-    await signInAsAdmin(page);
-
-    const timestamp = Date.now();
-    const roleName = `E2E_BTN_VISIBILITY_${timestamp}`;
-
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-    await page.getByRole('button', { name: 'Create role' }).click();
-    
-    // Wait for role creation to complete
-    await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-    await page.waitForLoadState('networkidle');
-    await expect(page.getByRole('table').getByText(roleName)).toBeVisible({ timeout: 15000 });
-
-    const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
-    await expect(roleRow.getByRole('button', { name: 'Edit role' })).toBeVisible();
-    await expect(roleRow.getByRole('button', { name: 'Delete role' })).toBeVisible();
-  });
-
-  test('Page Navigation Preserves Roles', async ({ page, browserName }) => {
-    await signInAsAdmin(page);
-
-    const timestamp = Date.now();
-    const roleName = `E2E_NAV_${timestamp}`;
-
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-    await page.getByRole('button', { name: 'Create role' }).click();
-    await expect(page.getByRole('table').getByText(roleName)).toBeVisible();
-
-    // Navigate away and back
-    await navigateToLink(page, 'Home');
-    await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening), Admin/i })).toBeVisible();
-    
-    // For webkit (Safari), add extra wait time to handle DOM stability issues
-    if (browserName === 'webkit') {
-      await page.waitForTimeout(500);
-    }
-    
-    await navigateToLink(page, 'Global Roles');
-
-    await expect(page.getByRole('table').getByText(roleName)).toBeVisible();
-  });
-
-  // ---------------------------------------------------------------------------
-  // Creating
-  // ---------------------------------------------------------------------------
-
-  test.describe.serial('Role Creation, Modification, and Deletion', () => {
-    // FIXME: This test passes individually but fails in parallel execution due to race conditions
-    // The role creation operation appears to be timing out when multiple workers are running
-    test('Creating a Global Role', async ({ page }) => {
-      await signInAsAdmin(page);
-
-      await page.getByRole('button', { name: 'New Role' }).click();
-      await expect(page.getByRole('heading', { name: 'Create Role' })).toBeVisible();
-      await expect(page.getByText('Define a new system-wide role and configure its permissions.')).toBeVisible();
-      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue('');
-
-      await page.getByRole('textbox', { name: 'Role Name' }).fill('E2E_SECURITY_MANAGER');
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
-      await page.getByRole('button', { name: 'Create role' }).click();
-
-      // Wait for the dialog to close and ensure the role appears
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-      await expect(page.getByRole('table').getByText('E2E_SECURITY_MANAGER')).toBeVisible({ timeout: 15000 });
-    });
-
-    test('Create Role Without Any Permissions', async ({ page }) => {
-      await signInAsAdmin(page);
-
-      const timestamp = Date.now();
-      const emptyPermissionsRole = `E2E_EMPTY_PERMISSIONS_${timestamp}`;
-
-      await page.getByRole('button', { name: 'New Role' }).click();
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(emptyPermissionsRole);
-      await page.getByRole('button', { name: 'Create role' }).click();
-
-      await expect(page.getByRole('table').getByText(emptyPermissionsRole, { exact: true })).toBeVisible();
-      await expect(page.getByText('No permissions assigned').first()).toBeVisible();
-    });
-
-    test('Statistics Update After Role Creation', async ({ page }) => {
-      await signInAsAdmin(page);
-
-      const initialRoleText = await page.getByText(/\d+roles defined/).textContent();
-
-      const timestamp = Date.now();
-      const roleName = `E2E_STATS_${timestamp}`;
-      await page.getByRole('button', { name: 'New Role' }).click();
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-      await page.getByRole('button', { name: 'Create role' }).click();
-    
-      // Wait for dialog to close and role to be created successfully
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-      await expect(page.getByRole('table').getByText(roleName)).toBeVisible({ timeout: 15000 });
-
-      const updatedRoleText = await page.getByText(/\d+roles defined/).textContent();
-      expect(updatedRoleText).not.toBe(initialRoleText);
+      // 5. The statistics bar should show the total permission grants across all roles
       await expect(page.getByText(/permission grants across all roles/)).toBeVisible();
     });
 
-    test('Wildcard Collapsing - Global Roles Domain', async ({ page }) => {
+    test('Roles table displays expected columns and rows', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      // Roles table should have columns "Name", "Permissions", and "Created"
+      await expect(page.getByRole('columnheader', { name: 'Name' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Permissions' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Created' })).toBeVisible();
+
+      // Each default role should appear as a row in the table
+      await expect(page.getByRole('table').getByText('ADMIN', { exact: true })).toBeVisible();
+      await expect(page.getByRole('table').getByText('SUPER_ADMIN', { exact: true })).toBeVisible();
+      await expect(page.getByRole('table').getByText('USER', { exact: true })).toBeVisible();
+    });
+
+    test('"New Role" button is displayed for users with write permission', async ({ page }) => {
+      await signInAsAdmin(page);
+      await expect(page.getByRole('button', { name: 'New Role' })).toBeVisible();
+    });
+  });
+
+  test.describe('Creating a global role', () => {
+    test('Opening the create-role dialog', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      // When the user clicks the "New Role" button
+      await page.getByRole('button', { name: 'New Role' }).click();
+
+      // The role form dialog should open with title "Create Role"
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Create Role' })).toBeVisible();
+
+      // The name field should be empty
+      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue('');
+
+      // All permission switches should be off by default
+      const dialog = page.getByRole('dialog', { name: 'Create Role' });
+      const switches = dialog.getByRole('switch');
+      const count = await switches.count();
+      for (let i = 0; i < count; i++) {
+        await expect(switches.nth(i)).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+
+    test('Creating a role with a name and selected permissions', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const roleName = `E2E_SECURITY_MANAGER_${timestamp}`;
+
+      // When the user clicks the "New Role" button and fills in details
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Read Users').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+
+      // The dialog should close and the role should appear in the table
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+      await expect(page.getByText(/\d+\s*roles defined/)).toBeVisible();
+    });
+
+    test('Submitting without a name is blocked', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      // When the user clicks the "New Role" button and leaves the name empty
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue('');
+
+      // The button is enabled but submission is blocked by inline validation
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).toBeVisible();
+      await expect(page.getByText('Role name is required.')).toBeVisible();
+    });
+
+    test('Cancelling the dialog discards changes', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const roleName = `E2E_SHOULD_NOT_EXIST_${timestamp}`;
+
+      // When the user fills the name and then cancels
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // The dialog should close and the role should NOT appear in the table
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).not.toBeVisible();
+    });
+
+    test('Creating a role without any permissions is allowed', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const roleName = `E2E_EMPTY_PERMISSIONS_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+
+      // Role should appear with zero active permissions
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('No permissions assigned')).toBeVisible();
+    });
+
+    test('Enabling all global_roles permissions collapses to wildcard', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
@@ -252,15 +190,16 @@ test.describe('Global Roles Management', () => {
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Assign Global Roles' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Write Global Roles').click();
+      await permSwitch(page, 'Assign Global Roles').click();
       await page.getByRole('button', { name: 'Create role' }).click();
 
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
       await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('global_roles.*')).toBeVisible();
     });
 
-    test('Wildcard Collapsing - Users Domain', async ({ page }) => {
+    test('Enabling all users permissions collapses to users wildcard', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
@@ -268,14 +207,38 @@ test.describe('Global Roles Management', () => {
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Delete Users' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Read Users').click();
+      await permSwitch(page, 'Write Users').click();
+      await permSwitch(page, 'Delete Users').click();
       await page.getByRole('button', { name: 'Create role' }).click();
 
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
       await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('users.*')).toBeVisible();
     });
 
-    test('Multi-Domain Wildcard Collapsing', async ({ page }) => {
+    test('Enabling all projects permissions collapses to projects wildcard', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const roleName = `E2E_PROJECTS_WILDCARD_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Read All Projects').click();
+      await permSwitch(page, 'Create Projects').click();
+      await permSwitch(page, 'Write Projects').click();
+      await permSwitch(page, 'Delete Projects').click();
+      await permSwitch(page, 'Read Project Members').click();
+      await permSwitch(page, 'Write Project Members').click();
+      await permSwitch(page, 'Read Project Roles').click();
+      await permSwitch(page, 'Write Project Roles').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('projects.*')).toBeVisible();
+    });
+
+    test('Enabling all permissions across all groups collapses each domain independently', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
@@ -283,19 +246,31 @@ test.describe('Global Roles Management', () => {
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Assign Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Delete Users' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Write Global Roles').click();
+      await permSwitch(page, 'Assign Global Roles').click();
+      await permSwitch(page, 'Read Users').click();
+      await permSwitch(page, 'Write Users').click();
+      await permSwitch(page, 'Delete Users').click();
+      await permSwitch(page, 'Read All Projects').click();
+      await permSwitch(page, 'Create Projects').click();
+      await permSwitch(page, 'Write Projects').click();
+      await permSwitch(page, 'Delete Projects').click();
+      await permSwitch(page, 'Read Project Members').click();
+      await permSwitch(page, 'Write Project Members').click();
+      await permSwitch(page, 'Read Project Roles').click();
+      await permSwitch(page, 'Write Project Roles').click();
       await page.getByRole('button', { name: 'Create role' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
 
       const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
       await expect(roleRow.getByText('global_roles.*')).toBeVisible();
       await expect(roleRow.getByText('users.*')).toBeVisible();
+      await expect(roleRow.getByText('projects.*')).toBeVisible();
     });
 
-    test('Mixed Permissions Across Groups', async ({ page }) => {
+    test('Creating a role with permissions from multiple groups', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
@@ -303,83 +278,250 @@ test.describe('Global Roles Management', () => {
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Write Global Roles').click();
+      await permSwitch(page, 'Read Users').click();
       await page.getByRole('button', { name: 'Create role' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
 
       const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
       await expect(roleRow.getByText('global_roles.write')).toBeVisible();
       await expect(roleRow.getByText('users.read')).toBeVisible();
     });
 
-    test('Dialog State Persistence During Toggling', async ({ page }) => {
+    test('Toggling a permission on then off leaves it disabled', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+
+      // Enable then disable "Read Users"
+      const readUsersSwitch = permSwitch(page, 'Read Users');
+      await readUsersSwitch.click();
+      await readUsersSwitch.click();
+
+      // The "Read Users" permission switch should be off
+      await expect(readUsersSwitch).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  test.describe('Permission management in the role form dialog', () => {
+    test('Permission switches are organised into domain groups', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+
+      const dialog = page.getByRole('dialog', { name: 'Create Role' });
+      await expect(dialog.getByText('Global Roles').first()).toBeVisible();
+      await expect(dialog.getByText('Users').first()).toBeVisible();
+      await expect(dialog.getByText('Projects').first()).toBeVisible();
+    });
+
+    test('Each permission switch shows a label and description', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+
+      await expect(page.getByText('View global role definitions')).toBeVisible();
+      await expect(page.getByText('Create and update global role definitions')).toBeVisible();
+      await expect(page.getByText('Assign global roles to users')).toBeVisible();
+      await expect(page.getByText('View user profiles and list')).toBeVisible();
+      await expect(page.getByText('Create and update user accounts')).toBeVisible();
+      await expect(page.getByText('Remove user accounts')).toBeVisible();
+      await expect(page.getByText('View all projects in the workspace')).toBeVisible();
+      await expect(page.getByText('Create new projects')).toBeVisible();
+      await expect(page.getByText('Update project details')).toBeVisible();
+      await expect(page.getByText('Permanently delete projects')).toBeVisible();
+      await expect(page.getByText('View members of any project')).toBeVisible();
+      await expect(page.getByText('Add, remove, and update members in any project')).toBeVisible();
+      await expect(page.getByText('View roles defined in any project')).toBeVisible();
+      await expect(page.getByText('Create and update roles in any project')).toBeVisible();
+    });
+
+    test('All permission switches are off by default in the create dialog', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+
+      const dialog = page.getByRole('dialog', { name: 'Create Role' });
+      const switches = dialog.getByRole('switch');
+      const count = await switches.count();
+      for (let i = 0; i < count; i++) {
+        await expect(switches.nth(i)).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+
+    test('Enabling a permission updates the switch to on', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+
+      const assignGlobalRolesSwitch = permSwitch(page, 'Assign Global Roles');
+      await assignGlobalRolesSwitch.click();
+
+      await expect(assignGlobalRolesSwitch).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('Permissions count in the table matches granted permissions', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
-      const roleName = `E2E_PERSISTENCE_${timestamp}`;
+      const roleName = `E2E_COUNT_CHECK_${timestamp}`;
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await expect(page.getByText('2 enabled')).toBeVisible();
-
-      // Toggle off then back on
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await expect(page.getByText('1 enabled')).toBeVisible();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await expect(page.getByText('2 enabled')).toBeVisible();
-
-      // Complete the domain
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Assign Global Roles' }).locator('[role="switch"]').click();
-      await expect(page.getByText('3 enabled')).toBeVisible();
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Delete Users').click();
       await page.getByRole('button', { name: 'Create role' }).click();
-    
-      // Wait for role creation to complete
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
+
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
 
       const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
-      await expect(roleRow.getByText('global_roles.*')).toBeVisible({ timeout: 15000 });
+      await expect(roleRow.getByText('global_roles.read')).toBeVisible();
+      await expect(roleRow.getByText('users.delete')).toBeVisible();
     });
 
-    // ---------------------------------------------------------------------------
-    // Editing
-    // ---------------------------------------------------------------------------
+    test('Closing and reopening the dialog resets permission state', async ({ page }) => {
+      await signInAsAdmin(page);
 
-    test('Role Editing Functionality', async ({ page }) => {
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await permSwitch(page, 'Read Users').click();
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await expect(page.getByRole('heading', { name: 'Create Role' })).toBeVisible();
+
+      const dialog = page.getByRole('dialog', { name: 'Create Role' });
+      const switches = dialog.getByRole('switch');
+      const count = await switches.count();
+      for (let i = 0; i < count; i++) {
+        await expect(switches.nth(i)).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+  });
+
+  test.describe('Editing a global role', () => {
+    test('Opening the edit dialog pre-populates current data', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
-      const editableRole = `E2E_EDITABLE_${timestamp}`;
-      const renamedRole = `E2E_RENAMED_${timestamp}`;
+      const roleName = `E2E_EDITABLE_${timestamp}`;
 
       await page.getByRole('button', { name: 'New Role' }).click();
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(editableRole);
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Read Global Roles').click();
       await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
 
-      const editableRoleRow = page.getByRole('row', { name: new RegExp(editableRole) });
-      await editableRoleRow.hover();
-      await editableRoleRow.getByRole('button', { name: 'Edit role' }).click();
+      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Edit role' }).click();
 
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).toBeVisible();
       await expect(page.getByRole('heading', { name: 'Edit Role' })).toBeVisible();
-      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue(editableRole);
-
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(renamedRole);
-      await page.getByRole('button', { name: 'Save changes' }).click();
-
-      // Wait for network operations and UI updates to complete
-      await page.waitForLoadState('networkidle', { timeout: 20000 });
-    
-      // Wait for the edit dialog to close completely before checking the table
-      await expect(page.getByRole('heading', { name: 'Edit Role' })).not.toBeVisible({ timeout: 10000 }).catch(() => {});
-    
-      // First check if the original role is gone, then check if renamed role appears
-      await expect(page.getByRole('row', { name: new RegExp(editableRole) })).not.toBeVisible({ timeout: 15000 });
-      await expect(page.getByRole('row', { name: new RegExp(renamedRole) })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue(roleName);
+      await expect(permSwitch(page, 'Read Global Roles')).toHaveAttribute('aria-checked', 'true');
     });
 
-    test('Edit Dialog Pre-populates Existing Permissions', async ({ page }) => {
+    test('Saving updated role name and permissions', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const originalName = `E2E_EDITABLE_${timestamp}`;
+      const renamedName = `E2E_RENAMED_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(originalName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(originalName, { exact: true })).toBeVisible();
+
+      const roleRow = page.getByRole('row', { name: new RegExp(originalName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Edit role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).clear();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(renamedName);
+      await permSwitch(page, 'Delete Users').click();
+      await page.getByRole('button', { name: 'Save changes' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(renamedName, { exact: true })).toBeVisible();
+    });
+
+    test('Cancelling the edit dialog discards all changes', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const originalName = `E2E_EDITABLE_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(originalName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(originalName, { exact: true })).toBeVisible();
+
+      const roleRow = page.getByRole('row', { name: new RegExp(originalName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Edit role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).clear();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill('E2E_UNSAVED_CHANGE');
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(originalName, { exact: true })).toBeVisible();
+      await expect(page.getByRole('table').getByText('E2E_UNSAVED_CHANGE', { exact: true })).not.toBeVisible();
+    });
+
+    test('Completing a domain group during edit collapses it to a wildcard', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const roleName = `E2E_PARTIAL_GR_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Write Global Roles').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Edit role' }).click();
+      await permSwitch(page, 'Assign Global Roles').click();
+      await page.getByRole('button', { name: 'Save changes' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('global_roles.*')).toBeVisible();
+    });
+
+    test('Removing all permissions from an existing role', async ({ page }) => {
+      await signInAsAdmin(page);
+
+      const timestamp = Date.now();
+      const roleName = `E2E_REMOVE_PERMS_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Read Users').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Edit role' }).click();
+      await permSwitch(page, 'Read Global Roles').click();
+      await permSwitch(page, 'Read Users').click();
+      await page.getByRole('button', { name: 'Save changes' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('No permissions assigned')).toBeVisible();
+    });
+
+    test('Edit dialog pre-populates the correct permission switches', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
@@ -387,226 +529,121 @@ test.describe('Global Roles Management', () => {
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Assign Global Roles').click();
+      await permSwitch(page, 'Delete Users').click();
       await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
 
       const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
       await roleRow.getByRole('button', { name: 'Edit role' }).click();
 
-      await expect(page.getByRole('heading', { name: 'Edit Role' })).toBeVisible();
-      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue(roleName);
-      await expect(page.getByText('2 enabled')).toBeVisible();
-
-      await page.getByRole('button', { name: 'Cancel' }).click();
+      await expect(permSwitch(page, 'Assign Global Roles')).toHaveAttribute('aria-checked', 'true');
+      await expect(permSwitch(page, 'Delete Users')).toHaveAttribute('aria-checked', 'true');
+      await expect(permSwitch(page, 'Read Global Roles')).toHaveAttribute('aria-checked', 'false');
+      await expect(permSwitch(page, 'Write Global Roles')).toHaveAttribute('aria-checked', 'false');
+      await expect(permSwitch(page, 'Read Users')).toHaveAttribute('aria-checked', 'false');
     });
 
-    test('Edit Cancellation Preserves Original Data', async ({ page }) => {
+    test('Toggling a permission off during edit persists after save', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
-      const roleName = `E2E_CANCEL_EDIT_${timestamp}`;
+      const roleName = `E2E_TOGGLE_PERSIST_${timestamp}`;
 
       await page.getByRole('button', { name: 'New Role' }).click();
       await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Read Users').click();
       await page.getByRole('button', { name: 'Create role' }).click();
-
-      // Wait for role creation to complete
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
 
       const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
       await roleRow.getByRole('button', { name: 'Edit role' }).click();
-
-      await page.getByRole('textbox', { name: 'Role Name' }).fill('E2E_UNSAVED_CHANGE');
-      await page.getByRole('button', { name: 'Cancel' }).click();
-
-      // Wait for cancel action to complete
-      await expect(page.getByRole('heading', { name: 'Edit Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-
-      await expect(page.getByRole('table').getByText(roleName)).toBeVisible({ timeout: 10000 });
-      await expect(page.getByRole('table').getByText('E2E_UNSAVED_CHANGE')).not.toBeVisible();
-      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('global_roles.read')).toBeVisible();
-    });
-
-    // FIXME: This test passes individually but fails in parallel execution due to race conditions
-    // The edit operation appears to be timing out when multiple workers are running  
-    test('Complete Permission Domain During Edit', async ({ page }) => {
-      await signInAsAdmin(page);
-
-      const timestamp = Date.now();
-      const roleName = `E2E_PARTIAL_GR_${timestamp}`;
-
-      // Create with partial Global Roles permissions
-      await page.getByRole('button', { name: 'New Role' }).click();
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Write Global Roles' }).locator('[role="switch"]').click();
-      await page.getByRole('button', { name: 'Create role' }).click();
-    
-      // Wait for role creation to complete
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-
-      // Edit to add the final permission and complete the domain
-      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
-      await roleRow.getByRole('button', { name: 'Edit role' }).click();
-      await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Assign Global Roles' }).locator('[role="switch"]').click();
+      await permSwitch(page, 'Read Users').click();
       await page.getByRole('button', { name: 'Save changes' }).click();
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
 
-      // Wait directly for the result to appear instead of dialog to close
-      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('global_roles.*')).toBeVisible({ timeout: 15000 });
-    
-      // Then wait for dialog to close if visible
-      await expect(page.getByRole('heading', { name: 'Edit Role' })).not.toBeVisible({ timeout: 5000 }).catch(() => {});
-      await page.waitForLoadState('networkidle');
+      // Re-open edit dialog and verify switch is still off
+      await page.getByRole('row', { name: new RegExp(roleName) }).hover();
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Edit role' }).click();
+      await expect(permSwitch(page, 'Read Users')).toHaveAttribute('aria-checked', 'false');
     });
+  });
 
-    // ---------------------------------------------------------------------------
-    // Deleting
-    // ---------------------------------------------------------------------------
-
-    test('Role Deletion Functionality', async ({ page }) => {
+  test.describe('Deleting a global role', () => {
+    test('Confirming deletion removes the role', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
-      const deletableRole = `E2E_DELETABLE_${timestamp}`;
+      const roleName = `E2E_DELETABLE_${timestamp}`;
 
       await page.getByRole('button', { name: 'New Role' }).click();
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(deletableRole);
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
       await page.getByRole('button', { name: 'Create role' }).click();
-    
-      // Wait for role creation to complete
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-      await expect(page.getByRole('table').getByText(deletableRole, { exact: true })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
 
-      const deletableRoleRow = page.getByRole('row', { name: new RegExp(deletableRole) });
-      await deletableRoleRow.hover();
-      await deletableRoleRow.getByRole('button', { name: 'Delete role' }).click();
+      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Delete role' }).click();
 
+      // Delete confirmation dialog should open showing the role name
       await expect(page.getByRole('heading', { name: 'Delete role' })).toBeVisible();
-      await expect(page.getByRole('dialog', { name: 'Delete role' }).getByText(deletableRole)).toBeVisible();
-      await expect(page.getByText('This action cannot be undone.')).toBeVisible();
+      await expect(page.getByRole('dialog', { name: 'Delete role' }).getByText(roleName)).toBeVisible();
 
-      await page.getByRole('button', { name: 'Delete role' }).click();
-    
-      // Wait directly for the role to disappear from the table
-      await expect(page.getByRole('table').getByText(deletableRole, { exact: true })).not.toBeVisible({ timeout: 15000 });
-    
-      // Then wait for dialog to close if visible
-      await expect(page.getByRole('heading', { name: 'Delete role' })).not.toBeVisible({ timeout: 5000 }).catch(() => {});
-      await page.waitForLoadState('networkidle');
+      // Confirm deletion
+      await page.getByRole('dialog', { name: 'Delete role' }).getByRole('button', { name: 'Delete role' }).click();
+
+      // The role should no longer appear in the roles table
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).not.toBeVisible();
+      await expect(page.getByText(/\d+\s*roles defined/)).toBeVisible();
     });
 
-    test('Cancel Delete Dialog Preserves Role', async ({ page }) => {
+    test('Cancelling the delete dialog preserves the role', async ({ page }) => {
       await signInAsAdmin(page);
 
       const timestamp = Date.now();
-      const preservedRole = `E2E_PRESERVED_${timestamp}`;
+      const roleName = `E2E_PRESERVED_${timestamp}`;
 
       await page.getByRole('button', { name: 'New Role' }).click();
-      await page.getByRole('textbox', { name: 'Role Name' }).fill(preservedRole);
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
       await page.getByRole('button', { name: 'Create role' }).click();
-    
-      // Wait for role creation to complete
-      await expect(page.getByRole('heading', { name: 'Create Role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-      await expect(page.getByRole('table').getByText(preservedRole, { exact: true })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
 
-      const preservedRoleRow = page.getByRole('row', { name: new RegExp(preservedRole) });
-      await preservedRoleRow.hover();
-      await preservedRoleRow.getByRole('button', { name: 'Delete role' }).click();
-
-      // Verify delete confirmation dialog and cancel
+      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await roleRow.hover();
+      await roleRow.getByRole('button', { name: 'Delete role' }).click();
       await expect(page.getByRole('heading', { name: 'Delete role' })).toBeVisible();
       await page.getByRole('button', { name: 'Cancel' }).click();
 
-      // Wait for cancel action to complete and verify role is preserved
-      await expect(page.getByRole('heading', { name: 'Delete role' })).not.toBeVisible();
-      await page.waitForLoadState('networkidle');
-      await expect(page.getByRole('table').getByText(preservedRole, { exact: true })).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole('dialog', { name: 'Delete role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
     });
   });
 
-  test('Create Role Dialog Close Buttons', async ({ page }) => {
-    await signInAsAdmin(page);
+  test.describe('Statistics integrity', () => {
+    test('Statistics update after role creation', async ({ page }) => {
+      await signInAsAdmin(page);
 
-    // Close button dismisses the dialog
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await expect(page.getByRole('heading', { name: 'Create Role' })).toBeVisible();
-    await page.getByRole('button', { name: 'Close' }).click();
-    await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      const initialText = await page.getByText(/\d+\s*roles defined/).textContent();
 
-    // Cancel button also dismisses the dialog
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await page.getByRole('button', { name: 'Cancel' }).click();
-    await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
-  });
+      const timestamp = Date.now();
+      const roleName = `E2E_STATS_${timestamp}`;
 
-  test('Cancel Create Dialog Discards Changes', async ({ page }) => {
-    await signInAsAdmin(page);
+      await page.getByRole('button', { name: 'New Role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Read Global Roles').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
 
-    const timestamp = Date.now();
-    const shouldNotExistRole = `E2E_SHOULD_NOT_EXIST_${timestamp}`;
+      await expect(page.getByRole('dialog', { name: 'Create Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
 
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await page.getByRole('textbox', { name: 'Role Name' }).fill(shouldNotExistRole);
-    await page.getByRole('button', { name: 'Cancel' }).click();
-
-    const tableText = await page.evaluate(() => document.querySelector('table')?.textContent ?? '');
-    expect(tableText).not.toContain(shouldNotExistRole);
-  });
-
-  // ---------------------------------------------------------------------------
-  // Permission Management
-  // ---------------------------------------------------------------------------
-
-  test('Permission Groups and Descriptions', async ({ page }) => {
-    await signInAsAdmin(page);
-
-    await page.getByRole('button', { name: 'New Role' }).click();
-
-    // Check permission group headers within the dialog
-    await expect(page.getByRole('dialog').locator('span.text-xs.font-semibold.text-muted-foreground', { hasText: 'Global Roles' })).toBeVisible();
-    await expect(page.getByRole('dialog').locator('span.text-xs.font-semibold.text-muted-foreground', { hasText: 'Users' })).toBeVisible();
-    await expect(page.getByText('View global role definitions')).toBeVisible();
-    await expect(page.getByText('Create and update global role definitions')).toBeVisible();
-    await expect(page.getByText('Assign global roles to users')).toBeVisible();
-    await expect(page.getByText('View user profiles and list')).toBeVisible();
-    await expect(page.getByText('Remove user accounts')).toBeVisible();
-  });
-
-  test('Permission Counter Updates Correctly', async ({ page }) => {
-    await signInAsAdmin(page);
-
-    await page.getByRole('button', { name: 'New Role' }).click();
-
-    await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-    await expect(page.getByText('1 enabled')).toBeVisible();
-
-    await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
-    await expect(page.getByText('2 enabled')).toBeVisible();
-
-    await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Global Roles' }).locator('[role="switch"]').click();
-    await expect(page.getByText('1 enabled')).toBeVisible();
-
-    await page.getByRole('button', { name: 'Cancel' }).click();
-  });
-
-  test('Dialog Resets Permissions After Cancel', async ({ page }) => {
-    await signInAsAdmin(page);
-
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await page.locator('div.flex.items-center.justify-between.py-1', { hasText: 'Read Users' }).locator('[role="switch"]').click();
-    await expect(page.getByText('1 enabled')).toBeVisible();
-    await page.getByRole('button', { name: 'Cancel' }).click();
-
-    // Re-open — dialog should be fresh with no permissions enabled
-    await page.getByRole('button', { name: 'New Role' }).click();
-    await expect(page.getByRole('heading', { name: 'Create Role' })).toBeVisible();
-    await expect(page.getByText('1 enabled')).not.toBeVisible();
+      const updatedText = await page.getByText(/\d+\s*roles defined/).textContent();
+      expect(updatedText).not.toBe(initialText);
+    });
   });
 });

--- a/apps/e2e/tests/admin/users-management.spec.ts
+++ b/apps/e2e/tests/admin/users-management.spec.ts
@@ -105,6 +105,15 @@ async function deleteUserIfExists(request: APIRequestContext, username: string) 
 
 async function openUsersPage(page: Page) {
   await page.goto('/admin/users');
+  // If a prior test invalidated the server-side session stored in AUTH_FILE, the app
+  // redirects to login. Re-authenticate directly so these tests remain self-contained.
+  if (!page.url().includes('/admin')) {
+    await page.getByRole('textbox', { name: 'Username' }).fill(USERNAME);
+    await page.getByRole('textbox', { name: 'Password' }).fill(PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL(/\/home/);
+    await page.goto('/admin/users');
+  }
   await expect(page.getByRole('heading', { name: 'User Management' })).toBeVisible();
 }
 

--- a/apps/e2e/tests/projects/management.spec.ts
+++ b/apps/e2e/tests/projects/management.spec.ts
@@ -1,0 +1,1008 @@
+// spec: features/projects/management.feature
+// seed: tests/seed.spec.ts
+
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost';
+const USERNAME = process.env.E2E_USERNAME ?? 'admin';
+const PASSWORD = process.env.E2E_PASSWORD ?? 'e2e-admin-password';
+
+const TEST_PROJECT_PREFIX = 'E2E_';
+
+function permSwitch(page: Page, label: string) {
+  return page.getByText(label, { exact: true }).locator('xpath=../following-sibling::*[@role="switch"]');
+}
+
+async function cleanupTestProjects(request: APIRequestContext): Promise<void> {
+  await request.post(`${BASE_URL}/api/v1/auth/login`, {
+    data: { username: USERNAME, password: PASSWORD, rememberMe: false },
+  });
+
+  const allProjects: Array<{ id: string; name: string }> = [];
+  let page = 1;
+
+  while (true) {
+    const listResp = await request.get(`${BASE_URL}/api/v1/projects?page=${page}&page_size=100`);
+    if (!listResp.ok()) break;
+
+    const body = await listResp.json();
+    const items: Array<{ id: string; name: string }> = body?.data?.items ?? [];
+    if (items.length === 0) break;
+
+    allProjects.push(...items);
+
+    const { page: currentPage, page_size, total } = body.data as { page: number; page_size: number; total: number };
+    if (currentPage * page_size >= total) break;
+    page++;
+  }
+
+  await Promise.all(
+    allProjects
+      .filter((p) => p.name.startsWith(TEST_PROJECT_PREFIX))
+      .map((p) => request.delete(`${BASE_URL}/api/v1/projects/${p.id}`)),
+  );
+}
+
+test.describe('Project Management', () => {
+  const BASE_PROJECT_NAME = 'E2E_EXPLORE_PROJECT';
+
+  const signIn = async (page: Page) => {
+    await page.goto(`${BASE_URL}/`);
+    await page.getByRole('textbox', { name: 'Username' }).fill(USERNAME);
+    await page.getByRole('textbox', { name: 'Password' }).fill(PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/i })).toBeVisible();
+  };
+
+  const signInAndGoToHomePage = async (page: Page) => {
+    await signIn(page);
+    await expect(page.getByRole('heading', { name: 'Projects', level: 2 })).toBeVisible();
+  };
+
+  // On mobile the project sidebar is a hidden overlay; this helper opens it when needed.
+  const openMobileSidebar = async (page: Page) => {
+    const viewport = page.viewportSize();
+    if (viewport && viewport.width <= 768) {
+      await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
+    }
+  };
+
+  // On mobile the sidebar sheet stays open after SPA navigation; dismiss it so main content is accessible.
+  const closeMobileSidebar = async (page: Page) => {
+    const viewport = page.viewportSize();
+    if (viewport && viewport.width <= 768) {
+      await page.keyboard.press('Escape');
+    }
+  };
+
+  const navigateToProjectSettings = async (page: Page, projectName: string) => {
+    await page.getByRole('link', { name: new RegExp(projectName) }).click();
+    await openMobileSidebar(page);
+    await page.getByRole('link', { name: 'Settings', exact: true }).click();
+    await closeMobileSidebar(page);
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+  };
+
+  test.beforeEach(async ({ request, context }) => {
+    await cleanupTestProjects(request);
+    // Ensure the base project exists for all tests that navigate to it
+    await request.post(`${BASE_URL}/api/v1/projects`, {
+      data: { name: 'E2E_EXPLORE_PROJECT' },
+    });
+    await context.clearCookies();
+    await context.clearPermissions();
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupTestProjects(request);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Listing projects on the home page
+  // ---------------------------------------------------------------------------
+
+  test.describe('Listing projects on the home page', () => {
+    test('Project cards show name, description, and creation date', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // The card for the existing project should show the project name
+      await expect(page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) })).toBeVisible();
+
+      // The card should show the project description or "No description"
+      await expect(page.getByText('No description')).toBeVisible();
+
+      // The card should show the project creation date (any date format)
+      await expect(page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).getByText(/\w+ \d+, \d{4}/)).toBeVisible();
+    });
+
+    test('Home page stats reflect the total and active project count', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // The stats bar should show the total number of projects
+      await expect(page.getByText('Projects').first()).toBeVisible();
+
+      // The stats bar should show the count of active projects
+      await expect(page.getByText(/^\d+ active$/)).toBeVisible();
+    });
+
+    test('"New Project" button is visible for users with "Create Projects" permission', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // The "New Project" button should be visible for the admin
+      await expect(page.getByRole('button', { name: 'New Project', exact: true })).toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Creating a project
+  // ---------------------------------------------------------------------------
+
+  test.describe('Creating a project', () => {
+    test('New project dialog has required name field and optional description field', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // When the user clicks the "New Project" button
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+
+      // The "New project" dialog should open
+      await expect(page.getByRole('dialog', { name: 'New project' })).toBeVisible();
+
+      // The dialog should contain a required "Project name" field
+      await expect(page.getByRole('textbox', { name: 'Project name *' })).toBeVisible();
+
+      // The dialog should contain an optional "Description" field
+      await expect(page.getByRole('textbox', { name: 'Description (optional)' })).toBeVisible();
+    });
+
+    test('"Create project" button is disabled while the project name is empty', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+
+      // The "Create project" button should be disabled when name is empty
+      await expect(page.getByRole('button', { name: 'Create project' })).toBeDisabled();
+    });
+
+    test('Creating a project with only a name succeeds', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      const timestamp = Date.now();
+      const projectName = `E2E_NAME_ONLY_${timestamp}`;
+
+      // When the user fills in the project name and creates
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Project name *' }).fill(projectName);
+      await page.getByRole('button', { name: 'Create project' }).click();
+
+      // The dialog should close and the project should appear
+      await expect(page.getByRole('dialog', { name: 'New project' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).toBeVisible();
+    });
+
+    test('Creating a project with name and description succeeds', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      const timestamp = Date.now();
+      const projectName = `E2E_DESCRIBED_${timestamp}`;
+      const description = 'A test project with a description';
+
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Project name *' }).fill(projectName);
+      await page.getByRole('textbox', { name: 'Description (optional)' }).fill(description);
+      await page.getByRole('button', { name: 'Create project' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'New project' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) }).getByText(description)).toBeVisible();
+    });
+
+    test('Cancelling the create project dialog discards changes', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      const timestamp = Date.now();
+      const projectName = `E2E_SHOULD_NOT_EXIST_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Project name *' }).fill(projectName);
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // The dialog should close and the project should NOT appear
+      await expect(page.getByRole('dialog', { name: 'New project' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).not.toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Navigating into a project
+  // ---------------------------------------------------------------------------
+
+  test.describe('Navigating into a project', () => {
+    test('Clicking a project card opens the project dashboard', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // When the user clicks the card for the project
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+
+      // The user should be on the project dashboard page
+      await expect(page.getByRole('heading', { name: new RegExp(`${BASE_PROJECT_NAME} Dashboard`) })).toBeVisible();
+    });
+
+    test('Project sidebar shows Dashboard, Integrations, Docs, Team, and Settings links', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+      await openMobileSidebar(page);
+
+      // The sidebar should contain all required project links
+      await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Integrations', exact: true })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Docs', exact: true })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Team', exact: true })).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Settings', exact: true })).toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Editing project settings (Settings > General)
+  // ---------------------------------------------------------------------------
+
+  test.describe('Editing project settings (Settings > General)', () => {
+    test('General tab shows editable project name and description fields', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+
+      // When the user clicks "General" in the settings sidebar
+      await page.getByRole('button', { name: 'General' }).click();
+
+      // A "Project name" field pre-filled with the project name should be visible
+      await expect(page.getByRole('textbox', { name: 'Project name' })).toHaveValue(BASE_PROJECT_NAME);
+
+      // A "Description" field should be visible
+      await expect(page.getByRole('textbox', { name: 'Description' })).toBeVisible();
+    });
+
+    test('"Save changes" button is disabled until a change is made', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+
+      await page.getByRole('button', { name: 'General' }).click();
+
+      // The "Save changes" button should be disabled initially
+      await expect(page.getByRole('button', { name: 'Save changes' })).toBeDisabled();
+    });
+
+    test('Saving a new project name updates the project', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // Create a test project first
+      const timestamp = Date.now();
+      const projectName = `E2E_SETTINGS_${timestamp}`;
+      const newName = `E2E_RENAMED_SETTINGS_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Project name *' }).fill(projectName);
+      await page.getByRole('button', { name: 'Create project' }).click();
+      await expect(page.getByRole('dialog', { name: 'New project' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).toBeVisible();
+
+      await navigateToProjectSettings(page, projectName);
+      await page.getByRole('button', { name: 'General' }).click();
+
+      // Clear the project name and type the new name
+      await page.getByRole('textbox', { name: 'Project name' }).clear();
+      await page.getByRole('textbox', { name: 'Project name' }).fill(newName);
+      await page.getByRole('button', { name: 'Save changes' }).click();
+
+      // The project name should be updated
+      await expect(page.getByRole('textbox', { name: 'Project name' })).toHaveValue(newName);
+    });
+
+    test('Saving a new description updates the project', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // Create a test project
+      const timestamp = Date.now();
+      const projectName = `E2E_DESC_SETTINGS_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Project name *' }).fill(projectName);
+      await page.getByRole('button', { name: 'Create project' }).click();
+      await expect(page.getByRole('dialog', { name: 'New project' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).toBeVisible();
+
+      await navigateToProjectSettings(page, projectName);
+      await page.getByRole('button', { name: 'General' }).click();
+
+      // Fill in a description and save
+      await page.getByRole('textbox', { name: 'Description' }).fill('Updated description');
+      await page.getByRole('button', { name: 'Save changes' }).click();
+
+      // The description should reflect the new value
+      await expect(page.getByRole('textbox', { name: 'Description' })).toHaveValue('Updated description');
+    });
+
+    test('Clearing the project name disables "Save changes"', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+
+      await page.getByRole('button', { name: 'General' }).click();
+
+      // Clear the project name
+      await page.getByRole('textbox', { name: 'Project name' }).clear();
+
+      // The "Save changes" button is enabled when a change is made (validation occurs on submit).
+      // Submitting with an empty name should NOT persist the change – the name is restored.
+      await page.getByRole('button', { name: 'Save changes' }).click();
+      await expect(page.getByRole('textbox', { name: 'Project name' })).not.toHaveValue('');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Deleting a project (Settings > Danger Zone)
+  // ---------------------------------------------------------------------------
+
+  test.describe('Deleting a project (Settings > Danger Zone)', () => {
+    test('Danger Zone displays the "Delete project" button with a warning', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+
+      // Click "Danger Zone" in the settings sidebar
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+
+      // A "Delete project" button should be visible
+      await expect(page.getByRole('button', { name: 'Delete project' })).toBeVisible();
+
+      // The section should warn that the action is permanent
+      await expect(page.getByText(/cannot be undone/)).toBeVisible();
+    });
+
+    test('Delete project dialog warns about permanent data loss', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+
+      // When the user clicks the "Delete project" button
+      await page.getByRole('button', { name: 'Delete project' }).click();
+
+      // The "Delete project" dialog should open
+      await expect(page.getByRole('dialog', { name: 'Delete project' })).toBeVisible();
+
+      // The dialog should warn about permanent data loss
+      await expect(page.getByRole('dialog', { name: 'Delete project' }).getByText(/members.*roles.*integrations|integrations.*members.*roles/i)).toBeVisible();
+    });
+
+    test('"Delete permanently" button is disabled until the project name is typed', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+      await page.getByRole('button', { name: 'Delete project' }).click();
+
+      // The "Delete permanently" button should be disabled
+      await expect(page.getByRole('button', { name: 'Delete permanently' })).toBeDisabled();
+
+      // The dialog should instruct the user to type the project name to confirm
+      await expect(page.getByRole('dialog', { name: 'Delete project' }).getByText(new RegExp(`Type.*${BASE_PROJECT_NAME}.*to confirm`, 'i'))).toBeVisible();
+    });
+
+    test('Typing an incorrect name keeps "Delete permanently" disabled', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+      await page.getByRole('button', { name: 'Delete project' }).click();
+
+      // Type wrong name
+      await page.getByRole('textbox', { name: /Type.*to confirm/i }).fill('wrong-name');
+
+      // The "Delete permanently" button should remain disabled
+      await expect(page.getByRole('button', { name: 'Delete permanently' })).toBeDisabled();
+    });
+
+    test('Typing the exact project name enables "Delete permanently"', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+      await page.getByRole('button', { name: 'Delete project' }).click();
+
+      // Type the exact project name
+      await page.getByRole('textbox', { name: /Type.*to confirm/i }).fill(BASE_PROJECT_NAME);
+
+      // The "Delete permanently" button should become enabled
+      await expect(page.getByRole('button', { name: 'Delete permanently' })).toBeEnabled();
+    });
+
+    test('Confirming deletion removes the project', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+
+      // Create a project to delete
+      const timestamp = Date.now();
+      const projectName = `E2E_DELETE_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New Project', exact: true }).click();
+      await page.getByRole('textbox', { name: 'Project name *' }).fill(projectName);
+      await page.getByRole('button', { name: 'Create project' }).click();
+      await expect(page.getByRole('dialog', { name: 'New project' })).not.toBeVisible();
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).toBeVisible();
+
+      await navigateToProjectSettings(page, projectName);
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+      await page.getByRole('button', { name: 'Delete project' }).click();
+      await page.getByRole('textbox', { name: /Type.*to confirm/i }).fill(projectName);
+      await page.getByRole('button', { name: 'Delete permanently' }).click();
+
+      // The user should be redirected away from the project (allow extra time for auth refresh)
+      await expect(page).toHaveURL(/\/home/, { timeout: 15000 });
+
+      // The project should no longer appear on the home page
+      await expect(page.getByRole('link', { name: new RegExp(projectName) })).not.toBeVisible();
+    });
+
+    test('Cancelling the delete dialog preserves the project', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Danger Zone' }).click();
+      await page.getByRole('button', { name: 'Delete project' }).click();
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // The dialog should close and the project should still be on the home page
+      await expect(page.getByRole('dialog', { name: 'Delete project' })).not.toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Managing team members (Team page)
+  // ---------------------------------------------------------------------------
+
+  test.describe('Managing team members (Team page)', () => {
+    test('Team page shows heading and project subtitle', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+      await openMobileSidebar(page);
+      await page.getByRole('link', { name: 'Team', exact: true }).click();
+      await closeMobileSidebar(page);
+
+      // The page heading "Team" should be visible
+      await expect(page.getByRole('heading', { name: 'Team' })).toBeVisible();
+
+      // The subtitle should include the project name and "Manage project members and roles"
+      await expect(page.getByText(new RegExp(`${BASE_PROJECT_NAME}.*Manage project members and roles`))).toBeVisible();
+    });
+
+    test('"Add Member" button is visible', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+      await openMobileSidebar(page);
+      await page.getByRole('link', { name: 'Team', exact: true }).click();
+      await closeMobileSidebar(page);
+
+      // The "Add Member" button should be visible for the admin
+      await expect(page.getByRole('button', { name: 'Add Member' })).toBeVisible();
+    });
+
+    test('Add Member dialog contains a user search field and a role picker', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+      await openMobileSidebar(page);
+      await page.getByRole('link', { name: 'Team', exact: true }).click();
+      await closeMobileSidebar(page);
+
+      // When the user clicks "Add Member"
+      await page.getByRole('button', { name: 'Add Member' }).click();
+
+      // The "Add member" dialog should open
+      await expect(page.getByRole('dialog', { name: 'Add member' })).toBeVisible();
+
+      // The dialog should contain a user search field
+      await expect(page.getByRole('textbox', { name: 'Search by name or username…' })).toBeVisible();
+
+      // The dialog should contain a role picker
+      await expect(page.getByRole('combobox')).toBeVisible();
+    });
+
+    test('"Add member" button in the dialog is disabled when no user is selected', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+      await openMobileSidebar(page);
+      await page.getByRole('link', { name: 'Team', exact: true }).click();
+      await closeMobileSidebar(page);
+      await page.getByRole('button', { name: 'Add Member' }).click();
+
+      // The "Add member" dialog button should be disabled when no user is selected
+      await expect(page.getByRole('dialog', { name: 'Add member' }).getByRole('button', { name: 'Add member' })).toBeDisabled();
+    });
+
+    test('Member row shows name, username, Change role button, and a remove action', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await page.getByRole('link', { name: new RegExp(BASE_PROJECT_NAME) }).click();
+      await openMobileSidebar(page);
+      await page.getByRole('link', { name: 'Team', exact: true }).click();
+      await closeMobileSidebar(page);
+
+      // Each member row should show the member's name and username
+      await expect(page.getByText('Admin').first()).toBeVisible();
+      await expect(page.getByText('@admin')).toBeVisible();
+
+      // Each row should have a "Change role" button
+      await expect(page.getByRole('button', { name: 'Change role' })).toBeVisible();
+
+      // Each row should have a menu button
+      const memberRow = page.getByText('@admin').locator('../..');
+      const menuButton = memberRow.locator('button').last();
+      await menuButton.click();
+
+      // The menu should contain a "Remove member" option
+      await expect(page.getByRole('menuitem', { name: 'Remove member' })).toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Managing project roles (Settings > Roles)
+  // ---------------------------------------------------------------------------
+
+  test.describe('Managing project roles (Settings > Roles)', () => {
+    test('Project Roles heading and subtitle are visible', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // The "Project Roles" heading should be visible
+      await expect(page.getByRole('heading', { name: 'Project Roles' })).toBeVisible();
+
+      // The subtitle should read correctly
+      await expect(page.getByText('Manage roles and permissions for members of this project.')).toBeVisible();
+    });
+
+    test('Statistics bar shows the role count and permission grant total', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // Statistics bar should show the total number of project roles
+      await expect(page.getByText(/\d+\s*roles defined/)).toBeVisible();
+
+      // Statistics bar should show the total permission grants
+      await expect(page.getByText(/permission grants across all roles/)).toBeVisible();
+    });
+
+    test('Roles table displays expected columns', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // The project roles table should have columns "Name", "Permissions", and "Created"
+      await expect(page.getByRole('columnheader', { name: 'Name' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Permissions' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Created' })).toBeVisible();
+    });
+
+    test('Default roles Admin, Editor, and Viewer are pre-seeded', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // The default roles should appear in the project roles table
+      await expect(page.getByRole('table').getByText('Admin', { exact: true })).toBeVisible();
+      await expect(page.getByRole('table').getByText('Editor', { exact: true })).toBeVisible();
+      await expect(page.getByRole('table').getByText('Viewer', { exact: true })).toBeVisible();
+    });
+
+    test('Each role row shows Edit role and Delete role action buttons', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // Each role row should have Edit role and Delete role buttons
+      const adminRow = page.getByRole('row', { name: /Admin/ }).first();
+      await expect(adminRow.getByRole('button', { name: 'Edit role' })).toBeVisible();
+      await expect(adminRow.getByRole('button', { name: 'Delete role' })).toBeVisible();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Creating a project role
+  // ---------------------------------------------------------------------------
+
+  test.describe('Creating a project role', () => {
+    test('New Role dialog title and description are correct', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // When the user clicks the "New role" button
+      await page.getByRole('button', { name: 'New role' }).click();
+
+      // The role form dialog should open with "New Role" title
+      await expect(page.getByRole('dialog', { name: 'New Role' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'New Role' })).toBeVisible();
+
+      // The dialog description should mention creating a project role with permissions
+      await expect(page.getByText('Define a new project role and configure which permissions it grants to members.')).toBeVisible();
+    });
+
+    test('Role Name field is empty and Create role button is disabled by default', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      await page.getByRole('button', { name: 'New role' }).click();
+
+      // The "Role Name" field should be empty
+      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue('');
+
+      // The "Create role" button should be disabled
+      await expect(page.getByRole('button', { name: 'Create role' })).toBeDisabled();
+    });
+
+    test('Permission form shows five groups: Project, Members, Roles, Tasks, Sprints', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      await page.getByRole('button', { name: 'New role' }).click();
+
+      const dialog = page.getByRole('dialog', { name: 'New Role' });
+
+      // The permission section should display all five groups
+      await expect(dialog.getByText('Project').first()).toBeVisible();
+      await expect(dialog.getByText('Members').first()).toBeVisible();
+      await expect(dialog.getByText('Roles').first()).toBeVisible();
+      await expect(dialog.getByText('Tasks').first()).toBeVisible();
+      await expect(dialog.getByText('Sprints').first()).toBeVisible();
+    });
+
+    test('Each project permission shows expected label and description', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      await page.getByRole('button', { name: 'New role' }).click();
+
+      // Verify all permission descriptions
+      await expect(page.getByText('View project details and settings')).toBeVisible();
+      await expect(page.getByText('Update project name, description, and settings')).toBeVisible();
+      await expect(page.getByText('Permanently delete this project')).toBeVisible();
+      await expect(page.getByText('List and view project members')).toBeVisible();
+      await expect(page.getByText('Add, remove, and reassign project members')).toBeVisible();
+      await expect(page.getByText('List and view project role definitions')).toBeVisible();
+      await expect(page.getByText('Create, edit, and delete project roles')).toBeVisible();
+      await expect(page.getByText('Browse and read tasks in the project')).toBeVisible();
+      await expect(page.getByText('Create, update, and move tasks')).toBeVisible();
+      await expect(page.getByText('Browse sprint boards and backlogs')).toBeVisible();
+      await expect(page.getByText('Create, update, and close sprints')).toBeVisible();
+    });
+
+    test('All permission switches are off by default', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      await page.getByRole('button', { name: 'New role' }).click();
+
+      const dialog = page.getByRole('dialog', { name: 'New Role' });
+      const switches = dialog.getByRole('switch');
+      const count = await switches.count();
+      for (let i = 0; i < count; i++) {
+        await expect(switches.nth(i)).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+
+    test('Creating a role with a name and selected permissions', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_PROJECT_MANAGER_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Edit Project').click();
+      await permSwitch(page, 'Manage Members').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+
+      // The dialog should close and the role should appear in the table
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Statistics should reflect the updated role count
+      await expect(page.getByText(/\d+\s*roles defined/)).toBeVisible();
+    });
+
+    test('Creating a role without any permissions is allowed', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_EMPTY_ROLE_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Role should show zero active permissions
+      await expect(page.getByRole('row', { name: new RegExp(roleName) }).getByText('No permissions assigned')).toBeVisible();
+    });
+
+    test('Cancelling the dialog discards changes', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_SHOULD_NOT_EXIST_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).not.toBeVisible();
+    });
+
+    test('Closing and reopening the dialog resets all permission switches', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      // Enable a permission, then cancel
+      await page.getByRole('button', { name: 'New role' }).click();
+      await permSwitch(page, 'Delete Project').click();
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // Re-open dialog – all switches should be reset
+      await page.getByRole('button', { name: 'New role' }).click();
+      await expect(page.getByRole('heading', { name: 'New Role' })).toBeVisible();
+
+      const dialog = page.getByRole('dialog', { name: 'New Role' });
+      const switches = dialog.getByRole('switch');
+      const count = await switches.count();
+      for (let i = 0; i < count; i++) {
+        await expect(switches.nth(i)).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+
+    test('Permissions count in the table matches the granted permissions', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_COUNT_ROLE_${timestamp}`;
+
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Edit Project').click();
+      await permSwitch(page, 'Delete Project').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+
+      // The role should show 2 active permissions
+      const roleRow = page.getByRole('row', { name: new RegExp(roleName) });
+      await expect(roleRow.getByText('projects.write')).toBeVisible();
+      await expect(roleRow.getByText('projects.delete')).toBeVisible();
+    });
+
+    test('Toggling a permission on then off leaves it disabled', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      await page.getByRole('button', { name: 'New role' }).click();
+
+      const deleteProjectSwitch = permSwitch(page, 'Delete Project');
+      await deleteProjectSwitch.click();
+      await deleteProjectSwitch.click();
+
+      // The "Delete Project" permission switch should be off
+      await expect(deleteProjectSwitch).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Editing a project role
+  // ---------------------------------------------------------------------------
+
+  test.describe('Editing a project role', () => {
+    test('Opening the edit dialog pre-populates current data', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_EDITABLE_${timestamp}`;
+
+      // Create a role with permissions
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Edit Project').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Click Edit role button
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Edit role' }).click();
+
+      // The role form dialog should open with "Edit Role" title
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Edit Role' })).toBeVisible();
+
+      // The "Role Name" field should be pre-filled
+      await expect(page.getByRole('textbox', { name: 'Role Name' })).toHaveValue(roleName);
+
+      // The permission switches should reflect the role's current permissions
+      await expect(permSwitch(page, 'Edit Project')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('Saving an updated name and permissions', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const originalName = `E2E_EDITABLE_${timestamp}`;
+      const renamedName = `E2E_RENAMED_${timestamp}`;
+
+      // Create a role
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(originalName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(originalName, { exact: true })).toBeVisible();
+
+      // Open edit dialog, rename and toggle a permission
+      await page.getByRole('row', { name: new RegExp(originalName) }).getByRole('button', { name: 'Edit role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).clear();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(renamedName);
+      await permSwitch(page, 'Delete Project').click();
+      await page.getByRole('button', { name: 'Save changes' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(renamedName, { exact: true })).toBeVisible();
+    });
+
+    test('Cancelling the edit dialog discards all changes', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const originalName = `E2E_EDITABLE_${timestamp}`;
+
+      // Create a role
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(originalName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(originalName, { exact: true })).toBeVisible();
+
+      // Open edit dialog, change name but cancel
+      await page.getByRole('row', { name: new RegExp(originalName) }).getByRole('button', { name: 'Edit role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).clear();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill('E2E_UNSAVED_CHANGE');
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(originalName, { exact: true })).toBeVisible();
+      await expect(page.getByRole('table').getByText('E2E_UNSAVED_CHANGE', { exact: true })).not.toBeVisible();
+    });
+
+    test('Edit dialog pre-populates the correct permission switches', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_PREPOP_${timestamp}`;
+
+      // Create a role with specific permissions
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Delete Project').click();
+      await permSwitch(page, 'Manage Sprints').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Open edit dialog
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Edit role' }).click();
+
+      // Enabled switches should be on
+      await expect(permSwitch(page, 'Delete Project')).toHaveAttribute('aria-checked', 'true');
+      await expect(permSwitch(page, 'Manage Sprints')).toHaveAttribute('aria-checked', 'true');
+
+      // Disabled switches should be off
+      await expect(permSwitch(page, 'Edit Project')).toHaveAttribute('aria-checked', 'false');
+      await expect(permSwitch(page, 'View Members')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    test('Toggling a permission off during edit persists after save', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_TOGGLE_PERSIST_${timestamp}`;
+
+      // Create role with Manage Members permission
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await permSwitch(page, 'Manage Members').click();
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Open edit dialog and disable the permission
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Edit role' }).click();
+      await permSwitch(page, 'Manage Members').click();
+      await page.getByRole('button', { name: 'Save changes' }).click();
+      await expect(page.getByRole('dialog', { name: 'Edit Role' })).not.toBeVisible();
+
+      // Re-open edit dialog and verify switch is still off
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Edit role' }).click();
+      await expect(permSwitch(page, 'Manage Members')).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rule: Deleting a project role
+  // ---------------------------------------------------------------------------
+
+  test.describe('Deleting a project role', () => {
+    test('Confirming deletion removes the project role', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_DELETABLE_${timestamp}`;
+
+      // Create a role to delete
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Click the Delete role button
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Delete role' }).click();
+
+      // A delete confirmation dialog should open displaying the role name
+      await expect(page.getByRole('heading', { name: 'Delete role' })).toBeVisible();
+      await expect(page.getByRole('dialog', { name: 'Delete role' }).getByText(roleName)).toBeVisible();
+
+      // Confirm deletion
+      await page.getByRole('dialog', { name: 'Delete role' }).getByRole('button', { name: 'Delete role' }).click();
+
+      // The role should no longer appear in the project roles table
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).not.toBeVisible();
+    });
+
+    test('Cancelling the delete dialog preserves the project role', async ({ page }) => {
+      await signInAndGoToHomePage(page);
+      await navigateToProjectSettings(page, BASE_PROJECT_NAME);
+      await page.getByRole('button', { name: 'Roles' }).click();
+
+      const timestamp = Date.now();
+      const roleName = `E2E_DELETABLE_${timestamp}`;
+
+      // Create a role
+      await page.getByRole('button', { name: 'New role' }).click();
+      await page.getByRole('textbox', { name: 'Role Name' }).fill(roleName);
+      await page.getByRole('button', { name: 'Create role' }).click();
+      await expect(page.getByRole('dialog', { name: 'New Role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+
+      // Click Delete role and then cancel
+      await page.getByRole('row', { name: new RegExp(roleName) }).getByRole('button', { name: 'Delete role' }).click();
+      await expect(page.getByRole('heading', { name: 'Delete role' })).toBeVisible();
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // The role should still appear in the project roles table
+      await expect(page.getByRole('dialog', { name: 'Delete role' })).not.toBeVisible();
+      await expect(page.getByRole('table').getByText(roleName, { exact: true })).toBeVisible();
+    });
+  });
+});

--- a/apps/e2e/tests/seed.spec.ts
+++ b/apps/e2e/tests/seed.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test.describe('Test group', () => {
-  test('seed', async ({ page }) => {
+  test('seed', async () => {
     // generate code here.
   });
 });

--- a/apps/e2e/tests/session/management.spec.ts
+++ b/apps/e2e/tests/session/management.spec.ts
@@ -26,6 +26,19 @@ function profileMenuButton(page: Page) {
 test.describe("Session Management — authenticated", () => {
 	test.use({ storageState: AUTH_FILE });
 
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/home");
+		// If a prior test in the suite logged out the admin and invalidated the server-side
+		// session stored in AUTH_FILE, the app will redirect to login instead of /home.
+		// Re-authenticate directly so these tests remain independent of test order.
+		if (!page.url().includes("/home")) {
+			await page.getByRole("textbox", { name: "Username" }).fill(USERNAME);
+			await page.getByRole("textbox", { name: "Password" }).fill(PASSWORD);
+			await page.getByRole("button", { name: /sign in/i }).click();
+			await page.waitForURL(/\/home/);
+		}
+	});
+
 	test("logout redirects to login page", async ({ page }) => {
 		await page.goto("/home");
 		await expect(

--- a/apps/web/src/components/admin/global-roles/RoleFormDialog.tsx
+++ b/apps/web/src/components/admin/global-roles/RoleFormDialog.tsx
@@ -122,7 +122,7 @@ export function RoleFormDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="sm:max-w-lg">
+			<DialogContent className="flex flex-col sm:max-w-lg max-h-[90svh]">
 				<DialogHeader>
 					<div className="flex items-center gap-2.5">
 						<div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -139,7 +139,7 @@ export function RoleFormDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex flex-col gap-5 py-1">
+				<div className="flex flex-col gap-5 py-1 overflow-y-auto min-h-0">
 					<div className="flex flex-col gap-1.5">
 						<Label
 							htmlFor="role-name"

--- a/apps/web/src/components/admin/global-roles/permissions.ts
+++ b/apps/web/src/components/admin/global-roles/permissions.ts
@@ -1,4 +1,4 @@
-import { type LucideIcon, Shield, Users } from "lucide-react";
+import { type LucideIcon, FolderKanban, Shield, Users } from "lucide-react";
 
 export interface KnownPermission {
 	key: string;
@@ -33,10 +33,64 @@ export const KNOWN_PERMISSIONS: KnownPermission[] = [
 		domain: "users",
 	},
 	{
+		key: "users.write",
+		label: "Write Users",
+		description: "Create and update user accounts",
+		domain: "users",
+	},
+	{
 		key: "users.delete",
 		label: "Delete Users",
 		description: "Remove user accounts",
 		domain: "users",
+	},
+	{
+		key: "projects.read",
+		label: "Read All Projects",
+		description: "View all projects in the workspace",
+		domain: "projects",
+	},
+	{
+		key: "projects.create",
+		label: "Create Projects",
+		description: "Create new projects",
+		domain: "projects",
+	},
+	{
+		key: "projects.write",
+		label: "Write Projects",
+		description: "Update project details",
+		domain: "projects",
+	},
+	{
+		key: "projects.delete",
+		label: "Delete Projects",
+		description: "Permanently delete projects",
+		domain: "projects",
+	},
+	{
+		key: "project.members.read",
+		label: "Read Project Members",
+		description: "View members of any project",
+		domain: "projects",
+	},
+	{
+		key: "project.members.write",
+		label: "Write Project Members",
+		description: "Add, remove, and update members in any project",
+		domain: "projects",
+	},
+	{
+		key: "project.roles.read",
+		label: "Read Project Roles",
+		description: "View roles defined in any project",
+		domain: "projects",
+	},
+	{
+		key: "project.roles.write",
+		label: "Write Project Roles",
+		description: "Create and update roles in any project",
+		domain: "projects",
 	},
 ];
 
@@ -49,4 +103,5 @@ export interface PermissionGroup {
 export const PERMISSION_GROUPS: PermissionGroup[] = [
 	{ domain: "global_roles", label: "Global Roles", Icon: Shield },
 	{ domain: "users", label: "Users", Icon: Users },
+	{ domain: "projects", label: "Projects", Icon: FolderKanban },
 ];

--- a/apps/web/src/components/admin/global-roles/permissions.ts
+++ b/apps/web/src/components/admin/global-roles/permissions.ts
@@ -1,4 +1,4 @@
-import { type LucideIcon, FolderKanban, Shield, Users } from "lucide-react";
+import { FolderKanban, type LucideIcon, Shield, Users } from "lucide-react";
 
 export interface KnownPermission {
 	key: string;

--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -347,7 +347,10 @@ export function AppSidebar() {
 					</span>
 				</div>
 				<div className="group-data-[collapsible=icon]:hidden">
-					<ProjectSwitcher currentProjectId={projectId} canCreate={canCreateProject} />
+					<ProjectSwitcher
+						currentProjectId={projectId}
+						canCreate={canCreateProject}
+					/>
 				</div>
 			</SidebarHeader>
 

--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -51,7 +51,13 @@ import { cn } from "@/lib/utils";
 import { UserMenu } from "./user-menu";
 
 // ── Project Switcher ───────────────────────────────────────────────────────────
-function ProjectSwitcher({ currentProjectId }: { currentProjectId?: string }) {
+function ProjectSwitcher({
+	currentProjectId,
+	canCreate,
+}: {
+	currentProjectId?: string;
+	canCreate: boolean;
+}) {
 	const [open, setOpen] = useState(false);
 	const { data: projectsResult } = useQuery(projectsQueryOptions());
 	const { data: currentProject } = useQuery({
@@ -127,10 +133,12 @@ function ProjectSwitcher({ currentProjectId }: { currentProjectId?: string }) {
 					</div>
 				)}
 				<DropdownMenuSeparator />
-				<DropdownMenuItem render={<Link to="/home" />}>
-					<Plus className="size-3.5" />
-					New project
-				</DropdownMenuItem>
+				{canCreate ? (
+					<DropdownMenuItem render={<Link to="/home" />}>
+						<Plus className="size-3.5" />
+						New project
+					</DropdownMenuItem>
+				) : null}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);
@@ -313,6 +321,8 @@ export function AppSidebar() {
 	const canAccessUsers =
 		hasPermission("users.read") || hasPermission("users.write");
 
+	const canCreateProject = hasPermission("projects.create");
+
 	const showAdminSection = canAccessGlobalRoles || canAccessUsers;
 	const isProjectContext = !!projectId;
 
@@ -337,7 +347,7 @@ export function AppSidebar() {
 					</span>
 				</div>
 				<div className="group-data-[collapsible=icon]:hidden">
-					<ProjectSwitcher currentProjectId={projectId} />
+					<ProjectSwitcher currentProjectId={projectId} canCreate={canCreateProject} />
 				</div>
 			</SidebarHeader>
 

--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -1,16 +1,22 @@
-import { Link, useRouterState } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams, useRouterState } from "@tanstack/react-router";
 import {
+	ArrowLeft,
+	BookOpen,
 	ChevronDown,
+	FileText,
 	FolderKanban,
 	Home,
+	LayoutDashboard,
 	Monitor,
 	Moon,
 	Plus,
+	Settings,
 	Shield,
 	Sun,
 	Users,
 } from "lucide-react";
-import { useState } from "react";
+import { type ComponentType, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -39,13 +45,25 @@ import {
 import { usePermissions } from "@/hooks/use-permissions";
 import type { ThemeMode } from "@/hooks/use-theme-mode";
 import { useThemeMode } from "@/hooks/use-theme-mode";
+import { projectQueryOptions, projectsQueryOptions } from "@/lib/project-api";
 import { cn } from "@/lib/utils";
 
 import { UserMenu } from "./user-menu";
 
 // ── Project Switcher ───────────────────────────────────────────────────────────
-function ProjectSwitcher() {
+function ProjectSwitcher({ currentProjectId }: { currentProjectId?: string }) {
 	const [open, setOpen] = useState(false);
+	const { data: projectsResult } = useQuery(projectsQueryOptions());
+	const { data: currentProject } = useQuery({
+		...projectQueryOptions(currentProjectId ?? ""),
+		enabled: !!currentProjectId,
+	});
+
+	const projects = projectsResult?.items ?? [];
+	const label = currentProject?.name ?? "Projects";
+	const initials = currentProject?.name
+		? currentProject.name.slice(0, 2).toUpperCase()
+		: null;
 
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
@@ -57,10 +75,10 @@ function ProjectSwitcher() {
 						: "hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
 				)}
 			>
-				<div className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/15 text-primary">
-					<FolderKanban className="size-3" />
+				<div className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/15 text-primary text-[10px] font-bold">
+					{initials ?? <FolderKanban className="size-3" />}
 				</div>
-				<span className="flex-1 truncate text-left">Projects</span>
+				<span className="flex-1 truncate text-left">{label}</span>
 				<ChevronDown
 					className={cn(
 						"size-3.5 shrink-0 opacity-40 transition-transform duration-200",
@@ -75,16 +93,41 @@ function ProjectSwitcher() {
 					</DropdownMenuLabel>
 				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
-				<div className="flex flex-col items-center gap-1 px-3 py-4">
-					<div className="flex size-8 items-center justify-center rounded-md bg-muted">
-						<FolderKanban className="size-4 text-muted-foreground" />
+				{projects.length > 0 ? (
+					<DropdownMenuGroup>
+						{projects.map((p) => (
+							<DropdownMenuItem
+								key={p.id}
+								render={
+									<Link
+										to="/projects/$projectId"
+										params={{ projectId: p.id }}
+										className="flex items-center gap-2"
+									/>
+								}
+							>
+								<div className="flex size-5 shrink-0 items-center justify-center rounded bg-primary/15 text-primary text-[9px] font-bold">
+									{p.name.slice(0, 2).toUpperCase()}
+								</div>
+								<span className="truncate">{p.name}</span>
+								{p.id === currentProjectId && (
+									<span className="ml-auto size-1.5 rounded-full bg-primary" />
+								)}
+							</DropdownMenuItem>
+						))}
+					</DropdownMenuGroup>
+				) : (
+					<div className="flex flex-col items-center gap-1 px-3 py-4">
+						<div className="flex size-8 items-center justify-center rounded-md bg-muted">
+							<FolderKanban className="size-4 text-muted-foreground" />
+						</div>
+						<p className="text-xs text-muted-foreground mt-0.5">
+							No projects yet
+						</p>
 					</div>
-					<p className="text-xs text-muted-foreground mt-0.5">
-						No projects yet
-					</p>
-				</div>
+				)}
 				<DropdownMenuSeparator />
-				<DropdownMenuItem>
+				<DropdownMenuItem render={<Link to="/home" />}>
 					<Plus className="size-3.5" />
 					New project
 				</DropdownMenuItem>
@@ -101,7 +144,7 @@ function NavItem({
 	badge,
 }: {
 	to: string;
-	icon: React.ComponentType<{ className?: string }>;
+	icon: ComponentType<{ className?: string }>;
 	label: string;
 	badge?: string;
 }) {
@@ -130,6 +173,76 @@ function NavItem({
 				) : null}
 			</SidebarMenuButton>
 		</SidebarMenuItem>
+	);
+}
+
+// ── Project Nav ───────────────────────────────────────────────────────────────
+const PROJECT_NAV_ITEMS = [
+	{ segment: "", icon: LayoutDashboard, label: "Dashboard" },
+	{ segment: "integrations", icon: BookOpen, label: "Integrations" },
+	{ segment: "docs", icon: FileText, label: "Docs" },
+	{ segment: "team", icon: Users, label: "Team" },
+	{ segment: "settings", icon: Settings, label: "Settings" },
+] as const;
+
+function ProjectNav() {
+	return (
+		<SidebarGroup>
+			<SidebarGroupContent>
+				<SidebarMenu>
+					<SidebarMenuItem>
+						<SidebarMenuButton
+							tooltip="All Projects"
+							render={<Link to="/home" />}
+							className="text-muted-foreground hover:text-foreground hover:bg-sidebar-accent/60 transition-all"
+						>
+							<ArrowLeft className="size-4" />
+							<span>All Projects</span>
+						</SidebarMenuButton>
+					</SidebarMenuItem>
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
+	);
+}
+
+function ProjectNavItems({ projectId }: { projectId: string }) {
+	const location = useRouterState({ select: (s) => s.location.pathname });
+
+	return (
+		<SidebarGroup>
+			<SidebarGroupLabel>Project</SidebarGroupLabel>
+			<SidebarGroupContent>
+				<SidebarMenu>
+					{PROJECT_NAV_ITEMS.map(({ segment, icon: Icon, label }) => {
+						const href = segment
+							? `/projects/${projectId}/${segment}`
+							: `/projects/${projectId}`;
+						const isActive = segment
+							? location.startsWith(href)
+							: location === href || location === `${href}/`;
+						return (
+							<SidebarMenuItem key={label}>
+								<SidebarMenuButton
+									isActive={isActive}
+									tooltip={label}
+									render={<Link to={href} />}
+									className={cn(
+										"relative transition-all duration-150",
+										isActive
+											? "bg-primary/10 text-primary font-medium before:absolute before:left-0 before:inset-y-2 before:w-0.75 before:rounded-full before:bg-primary"
+											: "hover:bg-sidebar-accent/60",
+									)}
+								>
+									<Icon className="size-4" />
+									<span>{label}</span>
+								</SidebarMenuButton>
+							</SidebarMenuItem>
+						);
+					})}
+				</SidebarMenu>
+			</SidebarGroupContent>
+		</SidebarGroup>
 	);
 }
 
@@ -192,6 +305,7 @@ function ThemeSwitcher() {
 export function AppSidebar() {
 	const { hasPermission } = usePermissions();
 	const { resolvedMode } = useThemeMode();
+	const { projectId } = useParams({ strict: false });
 
 	const canAccessGlobalRoles =
 		hasPermission("global_roles.read") || hasPermission("global_roles.write");
@@ -200,63 +314,78 @@ export function AppSidebar() {
 		hasPermission("users.read") || hasPermission("users.write");
 
 	const showAdminSection = canAccessGlobalRoles || canAccessUsers;
+	const isProjectContext = !!projectId;
 
 	return (
 		<Sidebar collapsible="icon">
 			{/* Brand */}
 			<SidebarHeader className="gap-2 pb-2">
 				<div className="flex items-center gap-2.5 px-2 pt-1">
-					<img
-						src={
-							resolvedMode === "dark" ? "/paca-logo-dark.svg" : "/paca-logo.svg"
-						}
-						alt="Paca Logo"
-						className="size-8 shrink-0"
-					/>
+					<Link to="/home">
+						<img
+							src={
+								resolvedMode === "dark"
+									? "/paca-logo-dark.svg"
+									: "/paca-logo.svg"
+							}
+							alt="Paca Logo"
+							className="size-8 shrink-0"
+						/>
+					</Link>
 					<span className="font-[Syne] font-bold text-[15px] tracking-tight text-sidebar-foreground group-data-[collapsible=icon]:hidden">
 						paca
 					</span>
 				</div>
 				<div className="group-data-[collapsible=icon]:hidden">
-					<ProjectSwitcher />
+					<ProjectSwitcher currentProjectId={projectId} />
 				</div>
 			</SidebarHeader>
 
 			<SidebarSeparator />
 
-			{/* Main navigation */}
+			{/* Navigation — switches between workspace and project context */}
 			<SidebarContent>
-				<SidebarGroup>
-					<SidebarGroupContent>
-						<SidebarMenu>
-							<NavItem to="/home" icon={Home} label="Home" />
-						</SidebarMenu>
-					</SidebarGroupContent>
-				</SidebarGroup>
-
-				{/* Admin section — only visible when user has at least one admin permission */}
-				{showAdminSection ? (
+				{isProjectContext ? (
 					<>
+						<ProjectNav />
 						<SidebarSeparator />
+						<ProjectNavItems projectId={projectId} />
+					</>
+				) : (
+					<>
 						<SidebarGroup>
-							<SidebarGroupLabel>Administration</SidebarGroupLabel>
 							<SidebarGroupContent>
 								<SidebarMenu>
-									{canAccessGlobalRoles ? (
-										<NavItem
-											to="/admin/global-roles"
-											icon={Shield}
-											label="Global Roles"
-										/>
-									) : null}
-									{canAccessUsers ? (
-										<NavItem to="/admin/users" icon={Users} label="Users" />
-									) : null}
+									<NavItem to="/home" icon={Home} label="Home" />
 								</SidebarMenu>
 							</SidebarGroupContent>
 						</SidebarGroup>
+
+						{/* Admin section */}
+						{showAdminSection ? (
+							<>
+								<SidebarSeparator />
+								<SidebarGroup>
+									<SidebarGroupLabel>Administration</SidebarGroupLabel>
+									<SidebarGroupContent>
+										<SidebarMenu>
+											{canAccessGlobalRoles ? (
+												<NavItem
+													to="/admin/global-roles"
+													icon={Shield}
+													label="Global Roles"
+												/>
+											) : null}
+											{canAccessUsers ? (
+												<NavItem to="/admin/users" icon={Users} label="Users" />
+											) : null}
+										</SidebarMenu>
+									</SidebarGroupContent>
+								</SidebarGroup>
+							</>
+						) : null}
 					</>
-				) : null}
+				)}
 			</SidebarContent>
 
 			{/* Footer: theme toggle + user menu */}

--- a/apps/web/src/components/projects/roles/DeleteProjectRoleDialog.test.tsx
+++ b/apps/web/src/components/projects/roles/DeleteProjectRoleDialog.test.tsx
@@ -1,0 +1,182 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockDeleteProjectRole } = vi.hoisted(() => ({
+	mockDeleteProjectRole: vi.fn(),
+}));
+
+vi.mock("@/lib/project-api", () => ({
+	deleteProjectRole: mockDeleteProjectRole,
+	projectRolesQueryOptions: (projectId: string) => ({
+		queryKey: ["projects", projectId, "roles"],
+	}),
+}));
+
+import type { ProjectRole } from "@/lib/project-api";
+import { DeleteProjectRoleDialog } from "./DeleteProjectRoleDialog";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeQueryClient() {
+	return new QueryClient({
+		defaultOptions: {
+			mutations: { retry: false },
+			queries: { retry: false, gcTime: 0 },
+		},
+	});
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+	return (
+		<QueryClientProvider client={makeQueryClient()}>
+			{children}
+		</QueryClientProvider>
+	);
+}
+
+const testRole: ProjectRole = {
+	id: "r1",
+	project_id: "p1",
+	role_name: "DEVELOPER",
+	permissions: {},
+	created_at: "2026-01-01T00:00:00.000Z",
+	updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+function renderDialog(
+	overrides: {
+		open?: boolean;
+		role?: ProjectRole;
+		onOpenChange?: (open: boolean) => void;
+	} = {},
+) {
+	const onOpenChange = overrides.onOpenChange ?? vi.fn();
+	render(
+		<Wrapper>
+			<DeleteProjectRoleDialog
+				open={overrides.open ?? true}
+				onOpenChange={onOpenChange}
+				projectId="p1"
+				role={overrides.role ?? testRole}
+			/>
+		</Wrapper>,
+	);
+	return { onOpenChange };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("DeleteProjectRoleDialog", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the role name in the confirmation text", () => {
+		renderDialog();
+		expect(screen.getByText("DEVELOPER")).toBeInTheDocument();
+	});
+
+	it("renders the dialog title and description", () => {
+		renderDialog();
+		expect(
+			screen.getByRole("heading", { name: "Delete role" }),
+		).toBeInTheDocument();
+		expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument();
+	});
+
+	it("does not render content when closed", () => {
+		renderDialog({ open: false });
+		expect(screen.queryByText("Delete role")).not.toBeInTheDocument();
+	});
+
+	it("calls deleteProjectRole with the correct project and role ids", async () => {
+		mockDeleteProjectRole.mockResolvedValue(undefined);
+		renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		expect(mockDeleteProjectRole).toHaveBeenCalledWith("p1", "r1");
+	});
+
+	it("calls onOpenChange(false) after successful deletion", async () => {
+		mockDeleteProjectRole.mockResolvedValue(undefined);
+		const { onOpenChange } = renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		await waitFor(() => {
+			expect(onOpenChange).toHaveBeenCalledWith(false);
+		});
+	});
+
+	it("shows an error when role is still assigned to members", async () => {
+		mockDeleteProjectRole.mockRejectedValue({
+			response: { data: { error_code: "PROJECT_ROLE_HAS_MEMBERS" } },
+		});
+		renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/still assigned to one or more members/i),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows an error when the role no longer exists", async () => {
+		mockDeleteProjectRole.mockRejectedValue({
+			response: { data: { error_code: "PROJECT_ROLE_NOT_FOUND" } },
+		});
+		renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("This role no longer exists."),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows a forbidden error when user lacks permission", async () => {
+		mockDeleteProjectRole.mockRejectedValue({
+			response: { data: { error_code: "FORBIDDEN" } },
+		});
+		renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/don't have permission to delete/i),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("shows a generic error message for unexpected errors", async () => {
+		mockDeleteProjectRole.mockRejectedValue(new Error("Network failure"));
+		renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Network failure")).toBeInTheDocument();
+		});
+	});
+
+	it("does not call onOpenChange(false) when the mutation fails", async () => {
+		mockDeleteProjectRole.mockRejectedValue(new Error("Oops"));
+		const { onOpenChange } = renderDialog();
+
+		await userEvent.click(screen.getByRole("button", { name: /delete role/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Oops")).toBeInTheDocument();
+		});
+		expect(onOpenChange).not.toHaveBeenCalledWith(false);
+	});
+});

--- a/apps/web/src/components/projects/roles/DeleteProjectRoleDialog.tsx
+++ b/apps/web/src/components/projects/roles/DeleteProjectRoleDialog.tsx
@@ -1,0 +1,122 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import {
+	deleteProjectRole,
+	type ProjectRole,
+	projectRolesQueryOptions,
+} from "@/lib/project-api";
+
+interface DeleteProjectRoleDialogProps {
+	projectId: string;
+	role: ProjectRole;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteProjectRoleDialog({
+	projectId,
+	role,
+	open,
+	onOpenChange,
+}: DeleteProjectRoleDialogProps) {
+	const queryClient = useQueryClient();
+	const [error, setError] = useState<string | null>(null);
+
+	const mutation = useMutation({
+		mutationFn: () => deleteProjectRole(projectId, role.id),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: projectRolesQueryOptions(projectId).queryKey,
+			});
+			onOpenChange(false);
+		},
+		onError: (err: unknown) => {
+			const code = getApiErrorCode(err);
+			const messages: Partial<Record<string, string>> = {
+				[ApiErrorCode.ProjectRoleNotFound]: "This role no longer exists.",
+				[ApiErrorCode.ProjectRoleHasMembers]:
+					"This role cannot be deleted because it is still assigned to one or more members.",
+				[ApiErrorCode.Forbidden]:
+					"You don't have permission to delete this role.",
+				[ApiErrorCode.InternalError]: "Something went wrong. Please try again.",
+			};
+			const fallback =
+				err instanceof Error ? err.message : "Something went wrong.";
+			setError((code && messages[code]) ?? fallback);
+		},
+	});
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				if (!next) setError(null);
+				onOpenChange(next);
+			}}
+		>
+			<DialogContent className="sm:max-w-sm">
+				<DialogHeader>
+					<div className="mb-1 flex size-9 items-center justify-center rounded-lg bg-destructive/10">
+						<Trash2 className="size-4 text-destructive" />
+					</div>
+					<DialogTitle>Delete role</DialogTitle>
+					<DialogDescription className="mt-1">
+						Are you sure you want to delete{" "}
+						<span className="font-mono font-semibold text-foreground">
+							{role.role_name}
+						</span>
+						? Any members currently assigned this role will lose their access.
+						This action cannot be undone.
+					</DialogDescription>
+				</DialogHeader>
+
+				{error ? (
+					<div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+						<span className="shrink-0">⚠</span>
+						<span>{error}</span>
+					</div>
+				) : null}
+
+				<DialogFooter>
+					<DialogClose
+						render={
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={mutation.isPending}
+							/>
+						}
+					>
+						Cancel
+					</DialogClose>
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={mutation.isPending}
+						onClick={() => mutation.mutate()}
+					>
+						{mutation.isPending ? (
+							<Loader2 className="size-3.5 animate-spin" />
+						) : (
+							<Trash2 className="size-3.5" />
+						)}
+						Delete role
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/components/projects/roles/ProjectRoleFormDialog.test.tsx
+++ b/apps/web/src/components/projects/roles/ProjectRoleFormDialog.test.tsx
@@ -1,0 +1,390 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateProjectRole, mockUpdateProjectRole } = vi.hoisted(() => ({
+	mockCreateProjectRole: vi.fn(),
+	mockUpdateProjectRole: vi.fn(),
+}));
+
+vi.mock("@/lib/project-api", () => ({
+	createProjectRole: mockCreateProjectRole,
+	updateProjectRole: mockUpdateProjectRole,
+	projectRolesQueryOptions: (projectId: string) => ({
+		queryKey: ["projects", projectId, "roles"],
+	}),
+}));
+
+import type { ProjectRole } from "@/lib/project-api";
+import { ProjectRoleFormDialog } from "./ProjectRoleFormDialog";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeQueryClient() {
+	return new QueryClient({
+		defaultOptions: {
+			mutations: { retry: false },
+			queries: { retry: false, gcTime: 0 },
+		},
+	});
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+	return (
+		<QueryClientProvider client={makeQueryClient()}>
+			{children}
+		</QueryClientProvider>
+	);
+}
+
+const existingRole: ProjectRole = {
+	id: "r1",
+	project_id: "p1",
+	role_name: "DEVELOPER",
+	permissions: { "tasks.*": true },
+	created_at: "2026-01-01T00:00:00.000Z",
+	updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+function renderCreate(onOpenChange = vi.fn()) {
+	render(
+		<Wrapper>
+			<ProjectRoleFormDialog projectId="p1" open onOpenChange={onOpenChange} />
+		</Wrapper>,
+	);
+	return { onOpenChange };
+}
+
+function renderEdit(role: ProjectRole = existingRole, onOpenChange = vi.fn()) {
+	render(
+		<Wrapper>
+			<ProjectRoleFormDialog
+				projectId="p1"
+				open
+				role={role}
+				onOpenChange={onOpenChange}
+			/>
+		</Wrapper>,
+	);
+	return { onOpenChange };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("ProjectRoleFormDialog", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ── Create mode ────────────────────────────────────────────────────────────
+
+	describe("create mode", () => {
+		it("shows 'New Role' as the title", () => {
+			renderCreate();
+			expect(screen.getByText("New Role")).toBeInTheDocument();
+		});
+
+		it("renders an empty role name input", () => {
+			renderCreate();
+			const input = screen.getByLabelText(/role name/i);
+			expect(input).toHaveValue("");
+		});
+
+		it("disables the submit button when the name is empty", () => {
+			renderCreate();
+			expect(
+				screen.getByRole("button", { name: /create role/i }),
+			).toBeDisabled();
+		});
+
+		it("enables the submit button once a name is typed", async () => {
+			renderCreate();
+			await userEvent.type(screen.getByLabelText(/role name/i), "REVIEWER");
+			expect(
+				screen.getByRole("button", { name: /create role/i }),
+			).toBeEnabled();
+		});
+
+		it("calls createProjectRole with the role name on submit", async () => {
+			mockCreateProjectRole.mockResolvedValue(existingRole);
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "REVIEWER");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(mockCreateProjectRole).toHaveBeenCalledWith(
+					"p1",
+					expect.objectContaining({ role_name: "REVIEWER" }),
+				);
+			});
+		});
+
+		it("calls onOpenChange(false) after successful creation", async () => {
+			mockCreateProjectRole.mockResolvedValue(existingRole);
+			const { onOpenChange } = renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "REVIEWER");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(onOpenChange).toHaveBeenCalledWith(false);
+			});
+		});
+
+		it("does not call updateProjectRole in create mode", async () => {
+			mockCreateProjectRole.mockResolvedValue(existingRole);
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "REVIEWER");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(mockCreateProjectRole).toHaveBeenCalled();
+			});
+			expect(mockUpdateProjectRole).not.toHaveBeenCalled();
+		});
+	});
+
+	// ── Edit mode ──────────────────────────────────────────────────────────────
+
+	describe("edit mode", () => {
+		it("shows 'Edit Role' as the title", () => {
+			renderEdit();
+			expect(screen.getByText("Edit Role")).toBeInTheDocument();
+		});
+
+		it("pre-fills the role name input with the existing role name", () => {
+			renderEdit();
+			expect(screen.getByLabelText(/role name/i)).toHaveValue("DEVELOPER");
+		});
+
+		it("submit button says 'Save changes'", () => {
+			renderEdit();
+			expect(
+				screen.getByRole("button", { name: /save changes/i }),
+			).toBeInTheDocument();
+		});
+
+		it("calls updateProjectRole with the project id, role id, and updated name", async () => {
+			mockUpdateProjectRole.mockResolvedValue({
+				...existingRole,
+				role_name: "LEAD",
+			});
+			renderEdit();
+
+			const input = screen.getByLabelText(/role name/i);
+			await userEvent.clear(input);
+			await userEvent.type(input, "LEAD");
+			await userEvent.click(
+				screen.getByRole("button", { name: /save changes/i }),
+			);
+
+			await waitFor(() => {
+				expect(mockUpdateProjectRole).toHaveBeenCalledWith(
+					"p1",
+					"r1",
+					expect.objectContaining({ role_name: "LEAD" }),
+				);
+			});
+		});
+
+		it("calls onOpenChange(false) after successful update", async () => {
+			mockUpdateProjectRole.mockResolvedValue(existingRole);
+			const { onOpenChange } = renderEdit();
+
+			await userEvent.click(
+				screen.getByRole("button", { name: /save changes/i }),
+			);
+
+			await waitFor(() => {
+				expect(onOpenChange).toHaveBeenCalledWith(false);
+			});
+		});
+
+		it("does not call createProjectRole in edit mode", async () => {
+			mockUpdateProjectRole.mockResolvedValue(existingRole);
+			renderEdit();
+
+			await userEvent.click(
+				screen.getByRole("button", { name: /save changes/i }),
+			);
+
+			await waitFor(() => {
+				expect(mockUpdateProjectRole).toHaveBeenCalled();
+			});
+			expect(mockCreateProjectRole).not.toHaveBeenCalled();
+		});
+	});
+
+	// ── Error handling ─────────────────────────────────────────────────────────
+
+	describe("error handling", () => {
+		it("shows an inline field error when role name is already taken", async () => {
+			mockCreateProjectRole.mockRejectedValue({
+				response: { data: { error_code: "PROJECT_ROLE_NAME_TAKEN" } },
+			});
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "DEVELOPER");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByText(/role with this name already exists/i),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("shows an inline field error when role name is invalid", async () => {
+			mockCreateProjectRole.mockRejectedValue({
+				response: { data: { error_code: "PROJECT_ROLE_NAME_INVALID" } },
+			});
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "bad-name!!");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByText(/uppercase letters, numbers, and underscores/i),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("shows a general error for forbidden action", async () => {
+			mockCreateProjectRole.mockRejectedValue({
+				response: { data: { error_code: "FORBIDDEN" } },
+			});
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "NEW_ROLE");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText(/don't have permission/i)).toBeInTheDocument();
+			});
+		});
+
+		it("shows a general error for internal server errors", async () => {
+			mockCreateProjectRole.mockRejectedValue({
+				response: { data: { error_code: "INTERNAL_ERROR" } },
+			});
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "NEW_ROLE");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByText(/something went wrong on the server/i),
+				).toBeInTheDocument();
+			});
+		});
+
+		it("clears the name error when the user starts typing again after a validation error", async () => {
+			mockCreateProjectRole.mockRejectedValue({
+				response: { data: { error_code: "PROJECT_ROLE_NAME_TAKEN" } },
+			});
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "DEVELOPER");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(
+					screen.getByText(/role with this name already exists/i),
+				).toBeInTheDocument();
+			});
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "X");
+			expect(
+				screen.queryByText(/role with this name already exists/i),
+			).not.toBeInTheDocument();
+		});
+
+		it("does not call onOpenChange(false) when creation fails", async () => {
+			mockCreateProjectRole.mockRejectedValue(new Error("Server down"));
+			const { onOpenChange } = renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "NEW_ROLE");
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText("Server down")).toBeInTheDocument();
+			});
+			expect(onOpenChange).not.toHaveBeenCalledWith(false);
+		});
+	});
+
+	// ── Permissions ────────────────────────────────────────────────────────────
+
+	describe("permissions", () => {
+		it("renders permission toggles for all known permission groups", () => {
+			renderCreate();
+			// Each group label should be visible
+			expect(screen.getByText("Project")).toBeInTheDocument();
+			expect(screen.getByText("Members")).toBeInTheDocument();
+			expect(screen.getByText("Roles")).toBeInTheDocument();
+			expect(screen.getByText("Tasks")).toBeInTheDocument();
+			expect(screen.getByText("Sprints")).toBeInTheDocument();
+		});
+
+		it("pre-selects permissions from the existing role and sends them in the update payload", async () => {
+			// existingRole has "tasks.*": true; both task permissions should be normalised
+			// back to the wildcard and forwarded to the API on save.
+			mockUpdateProjectRole.mockResolvedValue(existingRole);
+			renderEdit();
+
+			await userEvent.click(
+				screen.getByRole("button", { name: /save changes/i }),
+			);
+
+			await waitFor(() => {
+				const payload = mockUpdateProjectRole.mock.calls[0][2] as {
+					permissions: Record<string, boolean>;
+				};
+				// normalizePermissionsToWildcards should compress tasks.read + tasks.write → tasks.*
+				expect(payload.permissions?.["tasks.*"]).toBe(true);
+			});
+		});
+
+		it("sends an empty permissions object when no permissions are toggled", async () => {
+			mockCreateProjectRole.mockResolvedValue(existingRole);
+			renderCreate();
+
+			await userEvent.type(screen.getByLabelText(/role name/i), "VIEWER");
+			// no toggles changed — all permissions off by default
+			await userEvent.click(
+				screen.getByRole("button", { name: /create role/i }),
+			);
+
+			await waitFor(() => {
+				const payload = mockCreateProjectRole.mock.calls[0][1] as {
+					permissions: Record<string, boolean>;
+				};
+				expect(Object.keys(payload.permissions ?? {})).toHaveLength(0);
+			});
+		});
+	});
+});

--- a/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
+++ b/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
@@ -135,7 +135,7 @@ export function ProjectRoleFormDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
-			<DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+			<DialogContent className="flex flex-col sm:max-w-lg max-h-[90svh]">
 				<DialogHeader>
 					<div className="flex items-center gap-2.5">
 						<div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -152,7 +152,7 @@ export function ProjectRoleFormDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex flex-col gap-5 py-1">
+				<div className="flex flex-col gap-5 py-1 overflow-y-auto min-h-0">
 					{/* Role name */}
 					<div className="flex flex-col gap-1.5">
 						<Label

--- a/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
+++ b/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
@@ -1,0 +1,267 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Shield } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import {
+	expandWildcardPermissions,
+	normalizePermissionsToWildcards,
+} from "@/lib/permissions";
+import {
+	createProjectRole,
+	type ProjectRole,
+	projectRolesQueryOptions,
+	updateProjectRole,
+} from "@/lib/project-api";
+
+import {
+	PROJECT_KNOWN_PERMISSIONS,
+	PROJECT_PERMISSION_GROUPS,
+} from "./permissions";
+
+interface ProjectRoleFormDialogProps {
+	projectId: string;
+	role?: ProjectRole;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function ProjectRoleFormDialog({
+	projectId,
+	role,
+	open,
+	onOpenChange,
+}: ProjectRoleFormDialogProps) {
+	const queryClient = useQueryClient();
+	const isEdit = !!role;
+
+	const [name, setName] = useState(role?.role_name ?? "");
+	const [permissions, setPermissions] = useState<Record<string, boolean>>(
+		expandWildcardPermissions(
+			role?.permissions as Record<string, boolean> | undefined,
+			PROJECT_KNOWN_PERMISSIONS,
+		),
+	);
+	const [error, setError] = useState<string | null>(null);
+	const [nameError, setNameError] = useState<string | null>(null);
+
+	const reset = () => {
+		setName(role?.role_name ?? "");
+		setPermissions(
+			expandWildcardPermissions(
+				role?.permissions as Record<string, boolean> | undefined,
+				PROJECT_KNOWN_PERMISSIONS,
+			),
+		);
+		setError(null);
+		setNameError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: async () => {
+			const normalized = normalizePermissionsToWildcards(
+				permissions,
+				PROJECT_KNOWN_PERMISSIONS,
+			);
+			if (isEdit && role) {
+				return updateProjectRole(projectId, role.id, {
+					role_name: name.trim(),
+					permissions: normalized,
+				});
+			}
+			return createProjectRole(projectId, {
+				role_name: name.trim(),
+				permissions: normalized,
+			});
+		},
+		onSuccess: () => {
+			void queryClient.invalidateQueries({
+				queryKey: projectRolesQueryOptions(projectId).queryKey,
+			});
+			onOpenChange(false);
+			reset();
+		},
+		onError: (err: unknown) => {
+			setNameError(null);
+			const code = getApiErrorCode(err);
+			if (code === ApiErrorCode.ProjectRoleNameTaken) {
+				setNameError("A role with this name already exists.");
+				return;
+			}
+			if (code === ApiErrorCode.ProjectRoleNameInvalid) {
+				setNameError(
+					"Role name must be uppercase letters, numbers, and underscores only.",
+				);
+				return;
+			}
+			const messages: Partial<Record<string, string>> = {
+				[ApiErrorCode.ProjectRoleNotFound]:
+					"This role no longer exists. It may have already been deleted.",
+				[ApiErrorCode.Forbidden]:
+					"You don't have permission to perform this action.",
+				[ApiErrorCode.InternalError]:
+					"Something went wrong on the server. Please try again.",
+			};
+			const fallback =
+				err instanceof Error ? err.message : "Something went wrong.";
+			setError((code && messages[code]) ?? fallback);
+		},
+	});
+
+	const togglePermission = (key: string, checked: boolean) => {
+		setPermissions((prev) => ({ ...prev, [key]: checked }));
+	};
+
+	const enabledCount = Object.values(permissions).filter(Boolean).length;
+
+	const handleOpenChange = (next: boolean) => {
+		if (!next) reset();
+		onOpenChange(next);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<div className="flex items-center gap-2.5">
+						<div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+							<Shield className="size-4" />
+						</div>
+						<DialogTitle className="text-base">
+							{isEdit ? "Edit Role" : "New Role"}
+						</DialogTitle>
+					</div>
+					<DialogDescription className="mt-2">
+						{isEdit
+							? "Update the role name and configure its permission grants."
+							: "Define a new project role and configure which permissions it grants to members."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-5 py-1">
+					{/* Role name */}
+					<div className="flex flex-col gap-1.5">
+						<Label
+							htmlFor="role-name"
+							className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+						>
+							Role Name
+						</Label>
+						<Input
+							id="role-name"
+							placeholder="e.g. PROJECT_REVIEWER"
+							value={name}
+							onChange={(e) => {
+								setName(e.target.value);
+								if (nameError) setNameError(null);
+							}}
+							autoComplete="off"
+							className={`font-mono${nameError ? " border-destructive focus-visible:ring-destructive" : ""}`}
+							aria-describedby={nameError ? "role-name-error" : undefined}
+						/>
+						{nameError ? (
+							<p id="role-name-error" className="text-xs text-destructive">
+								{nameError}
+							</p>
+						) : null}
+					</div>
+
+					{/* Permissions */}
+					<div className="flex flex-col gap-2.5">
+						<div className="flex items-center justify-between">
+							<span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+								Permissions
+							</span>
+							{enabledCount > 0 && (
+								<span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+									{enabledCount} enabled
+								</span>
+							)}
+						</div>
+
+						<div className="flex flex-col gap-4 rounded-lg border bg-muted/20 p-4">
+							{PROJECT_PERMISSION_GROUPS.map((group, groupIndex) => {
+								const groupPerms = PROJECT_KNOWN_PERMISSIONS.filter(
+									(p) => p.domain === group.domain,
+								);
+								const { Icon } = group;
+								return (
+									<div key={group.domain}>
+										{groupIndex > 0 && <Separator className="mb-4" />}
+										<div className="mb-3 flex items-center gap-1.5">
+											<Icon className="size-3.5 text-muted-foreground" />
+											<span className="text-xs font-semibold text-muted-foreground">
+												{group.label}
+											</span>
+										</div>
+										<div className="flex flex-col">
+											{groupPerms.map((permission, permIndex) => (
+												<div key={permission.key}>
+													{permIndex > 0 && <Separator className="my-2" />}
+													<div className="flex items-center justify-between py-1">
+														<div className="flex flex-col gap-0.5">
+															<span className="text-sm font-medium">
+																{permission.label}
+															</span>
+															<span className="text-xs text-muted-foreground">
+																{permission.description}
+															</span>
+														</div>
+														<Switch
+															checked={!!permissions[permission.key]}
+															onCheckedChange={(checked) =>
+																togglePermission(permission.key, checked)
+															}
+														/>
+													</div>
+												</div>
+											))}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</div>
+
+					{error ? (
+						<div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+							<span className="shrink-0">⚠</span>
+							<span>{error}</span>
+						</div>
+					) : null}
+				</div>
+
+				<DialogFooter>
+					<DialogClose
+						render={<Button variant="outline" disabled={mutation.isPending} />}
+					>
+						Cancel
+					</DialogClose>
+					<Button
+						onClick={() => mutation.mutate()}
+						disabled={mutation.isPending || !name.trim()}
+					>
+						{mutation.isPending ? (
+							<Loader2 className="size-3.5 animate-spin" />
+						) : null}
+						{isEdit ? "Save changes" : "Create role"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
+++ b/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
@@ -103,9 +103,7 @@ export function ProjectRoleFormDialog({
 				return;
 			}
 			if (code === ApiErrorCode.ProjectRoleNameInvalid) {
-				setNameError(
-					"Role name must be uppercase letters, numbers, and underscores only.",
-				);
+				setNameError("Role name cannot be empty or whitespace only.");
 				return;
 			}
 			const messages: Partial<Record<string, string>> = {

--- a/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
+++ b/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
@@ -103,7 +103,9 @@ export function ProjectRoleFormDialog({
 				return;
 			}
 			if (code === ApiErrorCode.ProjectRoleNameInvalid) {
-				setNameError("Role name cannot be empty or whitespace only.");
+					setNameError(
+						"Role name must use uppercase letters, numbers, and underscores.",
+					);
 				return;
 			}
 			const messages: Partial<Record<string, string>> = {

--- a/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
+++ b/apps/web/src/components/projects/roles/ProjectRoleFormDialog.tsx
@@ -103,9 +103,9 @@ export function ProjectRoleFormDialog({
 				return;
 			}
 			if (code === ApiErrorCode.ProjectRoleNameInvalid) {
-					setNameError(
-						"Role name must use uppercase letters, numbers, and underscores.",
-					);
+				setNameError(
+					"Role name must use uppercase letters, numbers, and underscores.",
+				);
 				return;
 			}
 			const messages: Partial<Record<string, string>> = {

--- a/apps/web/src/components/projects/roles/permissions.ts
+++ b/apps/web/src/components/projects/roles/permissions.ts
@@ -1,0 +1,97 @@
+import {
+	Layers,
+	ListTodo,
+	type LucideIcon,
+	Settings,
+	Shield,
+	Users,
+} from "lucide-react";
+
+export interface KnownPermission {
+	key: string;
+	label: string;
+	description: string;
+	domain: string;
+}
+
+export const PROJECT_KNOWN_PERMISSIONS: KnownPermission[] = [
+	// projects
+	{
+		key: "projects.read",
+		label: "Read Project",
+		description: "View project details and settings",
+		domain: "projects",
+	},
+	{
+		key: "projects.write",
+		label: "Edit Project",
+		description: "Update project name, description, and settings",
+		domain: "projects",
+	},
+	// project members
+	{
+		key: "project.members.read",
+		label: "View Members",
+		description: "List and view project members",
+		domain: "project.members",
+	},
+	{
+		key: "project.members.write",
+		label: "Manage Members",
+		description: "Add, remove, and reassign project members",
+		domain: "project.members",
+	},
+	// project roles
+	{
+		key: "project.roles.read",
+		label: "View Roles",
+		description: "List and view project role definitions",
+		domain: "project.roles",
+	},
+	{
+		key: "project.roles.write",
+		label: "Manage Roles",
+		description: "Create, edit, and delete project roles",
+		domain: "project.roles",
+	},
+	// tasks
+	{
+		key: "tasks.read",
+		label: "View Tasks",
+		description: "Browse and read tasks in the project",
+		domain: "tasks",
+	},
+	{
+		key: "tasks.write",
+		label: "Edit Tasks",
+		description: "Create, update, and move tasks",
+		domain: "tasks",
+	},
+	// sprints
+	{
+		key: "sprints.read",
+		label: "View Sprints",
+		description: "Browse sprint boards and backlogs",
+		domain: "sprints",
+	},
+	{
+		key: "sprints.write",
+		label: "Manage Sprints",
+		description: "Create, update, and close sprints",
+		domain: "sprints",
+	},
+];
+
+export interface PermissionGroup {
+	domain: string;
+	label: string;
+	Icon: LucideIcon;
+}
+
+export const PROJECT_PERMISSION_GROUPS: PermissionGroup[] = [
+	{ domain: "projects", label: "Project", Icon: Settings },
+	{ domain: "project.members", label: "Members", Icon: Users },
+	{ domain: "project.roles", label: "Roles", Icon: Shield },
+	{ domain: "tasks", label: "Tasks", Icon: ListTodo },
+	{ domain: "sprints", label: "Sprints", Icon: Layers },
+];

--- a/apps/web/src/components/projects/roles/permissions.ts
+++ b/apps/web/src/components/projects/roles/permissions.ts
@@ -28,6 +28,12 @@ export const PROJECT_KNOWN_PERMISSIONS: KnownPermission[] = [
 		description: "Update project name, description, and settings",
 		domain: "projects",
 	},
+	{
+		key: "projects.delete",
+		label: "Delete Project",
+		description: "Permanently delete this project",
+		domain: "projects",
+	},
 	// project members
 	{
 		key: "project.members.read",

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -136,7 +136,7 @@ function DropdownMenuSubContent({
 		<DropdownMenuContent
 			data-slot="dropdown-menu-sub-content"
 			className={cn(
-				"w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+				"w-auto min-w-24 rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
 				className,
 			)}
 			align={align}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,88 @@
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = "center",
+	alignOffset = 0,
+	side = "bottom",
+	sideOffset = 4,
+	...props
+}: PopoverPrimitive.Popup.Props &
+	Pick<
+		PopoverPrimitive.Positioner.Props,
+		"align" | "alignOffset" | "side" | "sideOffset"
+	>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Positioner
+				align={align}
+				alignOffset={alignOffset}
+				side={side}
+				sideOffset={sideOffset}
+				className="isolate z-50"
+			>
+				<PopoverPrimitive.Popup
+					data-slot="popover-content"
+					className={cn(
+						"z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+						className,
+					)}
+					{...props}
+				/>
+			</PopoverPrimitive.Positioner>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="popover-header"
+			className={cn("flex flex-col gap-0.5 text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+	return (
+		<PopoverPrimitive.Title
+			data-slot="popover-title"
+			className={cn("font-medium", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverDescription({
+	className,
+	...props
+}: PopoverPrimitive.Description.Props) {
+	return (
+		<PopoverPrimitive.Description
+			data-slot="popover-description"
+			className={cn("text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Popover,
+	PopoverContent,
+	PopoverDescription,
+	PopoverHeader,
+	PopoverTitle,
+	PopoverTrigger,
+};

--- a/apps/web/src/hooks/use-permissions.test.tsx
+++ b/apps/web/src/hooks/use-permissions.test.tsx
@@ -1,9 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseQuery, mockCheckPermission } = vi.hoisted(() => ({
+const { mockUseQuery, mockCheckPermission, mockCheckAnyPermission } = vi.hoisted(() => ({
 	mockUseQuery: vi.fn(),
 	mockCheckPermission: vi.fn(),
+	mockCheckAnyPermission: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", async () => {
@@ -19,6 +20,7 @@ vi.mock("@tanstack/react-query", async () => {
 
 vi.mock("@/lib/permissions", () => ({
 	hasPermission: mockCheckPermission,
+	hasAnyPermission: mockCheckAnyPermission,
 }));
 
 import { usePermissions } from "./use-permissions";
@@ -66,6 +68,26 @@ describe("usePermissions", () => {
 		expect(mockCheckPermission).toHaveBeenCalledWith(
 			["projects.*"],
 			"projects.manage",
+		);
+	});
+
+	it("delegates hasAnyPermission checks to permissions helper", () => {
+		mockUseQuery.mockReturnValue({
+			data: ["projects.create"],
+			isLoading: false,
+		});
+		mockCheckAnyPermission.mockReturnValue(true);
+
+		const { result } = renderHook(() => usePermissions());
+		const canAny = result.current.hasAnyPermission([
+			"projects.create",
+			"projects.delete",
+		]);
+
+		expect(canAny).toBe(true);
+		expect(mockCheckAnyPermission).toHaveBeenCalledWith(
+			["projects.create"],
+			["projects.create", "projects.delete"],
 		);
 	});
 });

--- a/apps/web/src/hooks/use-permissions.test.tsx
+++ b/apps/web/src/hooks/use-permissions.test.tsx
@@ -1,11 +1,12 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseQuery, mockCheckPermission, mockCheckAnyPermission } = vi.hoisted(() => ({
-	mockUseQuery: vi.fn(),
-	mockCheckPermission: vi.fn(),
-	mockCheckAnyPermission: vi.fn(),
-}));
+const { mockUseQuery, mockCheckPermission, mockCheckAnyPermission } =
+	vi.hoisted(() => ({
+		mockUseQuery: vi.fn(),
+		mockCheckPermission: vi.fn(),
+		mockCheckAnyPermission: vi.fn(),
+	}));
 
 vi.mock("@tanstack/react-query", async () => {
 	const actual = await vi.importActual<typeof import("@tanstack/react-query")>(

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -1,7 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { myPermissionsQueryOptions } from "@/lib/admin-api";
-import { hasPermission as checkPermission } from "@/lib/permissions";
+import {
+	hasAnyPermission as checkAnyPermission,
+	hasPermission as checkPermission,
+} from "@/lib/permissions";
 
 export function usePermissions() {
 	const { data: permissions = [], isLoading } = useQuery(
@@ -12,5 +15,9 @@ export function usePermissions() {
 		return checkPermission(permissions, permission);
 	};
 
-	return { permissions, hasPermission, isLoading };
+	const hasAnyPermission = (perms: string[]) => {
+		return checkAnyPermission(permissions, perms);
+	};
+
+	return { permissions, hasPermission, hasAnyPermission, isLoading };
 }

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -25,6 +25,17 @@ export const ApiErrorCode = {
 	GlobalRoleNameInvalid: "GLOBAL_ROLE_NAME_INVALID",
 	GlobalRoleHasUsers: "GLOBAL_ROLE_HAS_ASSIGNED_USERS",
 
+	// Project domain errors.
+	ProjectNotFound: "PROJECT_NOT_FOUND",
+	ProjectNameTaken: "PROJECT_NAME_TAKEN",
+	ProjectNameInvalid: "PROJECT_NAME_INVALID",
+	ProjectRoleNotFound: "PROJECT_ROLE_NOT_FOUND",
+	ProjectRoleNameTaken: "PROJECT_ROLE_NAME_TAKEN",
+	ProjectRoleNameInvalid: "PROJECT_ROLE_NAME_INVALID",
+	ProjectRoleHasMembers: "PROJECT_ROLE_HAS_MEMBERS",
+	ProjectMemberNotFound: "PROJECT_MEMBER_NOT_FOUND",
+	ProjectMemberAlreadyAdded: "PROJECT_MEMBER_ALREADY_ADDED",
+
 	// Generic / request errors.
 	BadRequest: "BAD_REQUEST",
 	InternalError: "INTERNAL_ERROR",

--- a/apps/web/src/lib/project-api.test.ts
+++ b/apps/web/src/lib/project-api.test.ts
@@ -97,7 +97,7 @@ describe("project-api", () => {
 			mockGet.mockResolvedValue(ok(result));
 
 			await expect(listProjects()).resolves.toEqual(result);
-			expect(mockGet).toHaveBeenCalledWith("/admin/projects", {
+			expect(mockGet).toHaveBeenCalledWith("/projects", {
 				params: { page: 1, page_size: 50 },
 			});
 		});
@@ -112,7 +112,7 @@ describe("project-api", () => {
 			mockGet.mockResolvedValue(ok(result));
 
 			await listProjects(3, 10);
-			expect(mockGet).toHaveBeenCalledWith("/admin/projects", {
+			expect(mockGet).toHaveBeenCalledWith("/projects", {
 				params: { page: 3, page_size: 10 },
 			});
 		});
@@ -122,7 +122,7 @@ describe("project-api", () => {
 		mockGet.mockResolvedValue(ok(mockProject));
 
 		await expect(getProject("p1")).resolves.toEqual(mockProject);
-		expect(mockGet).toHaveBeenCalledWith("/admin/projects/p1");
+		expect(mockGet).toHaveBeenCalledWith("/projects/p1");
 	});
 
 	it("createProject posts payload and unwraps the created project", async () => {
@@ -130,14 +130,14 @@ describe("project-api", () => {
 		const payload = { name: "Alpha", description: "First project" };
 
 		await expect(createProject(payload)).resolves.toEqual(mockProject);
-		expect(mockPost).toHaveBeenCalledWith("/admin/projects", payload);
+		expect(mockPost).toHaveBeenCalledWith("/projects", payload);
 	});
 
 	it("createProject omits optional description field when not provided", async () => {
 		mockPost.mockResolvedValue(ok(mockProject));
 
 		await createProject({ name: "Minimal" });
-		expect(mockPost).toHaveBeenCalledWith("/admin/projects", {
+		expect(mockPost).toHaveBeenCalledWith("/projects", {
 			name: "Minimal",
 		});
 	});
@@ -149,7 +149,7 @@ describe("project-api", () => {
 		await expect(updateProject("p1", { name: "Alpha v2" })).resolves.toEqual(
 			updated,
 		);
-		expect(mockPatch).toHaveBeenCalledWith("/admin/projects/p1", {
+		expect(mockPatch).toHaveBeenCalledWith("/projects/p1", {
 			name: "Alpha v2",
 		});
 	});
@@ -158,7 +158,7 @@ describe("project-api", () => {
 		mockDelete.mockResolvedValue({});
 
 		await expect(deleteProject("p1")).resolves.toBeUndefined();
-		expect(mockDelete).toHaveBeenCalledWith("/admin/projects/p1");
+		expect(mockDelete).toHaveBeenCalledWith("/projects/p1");
 	});
 
 	// ── Members ────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/project-api.test.ts
+++ b/apps/web/src/lib/project-api.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet, mockPost, mockPatch, mockDelete } = vi.hoisted(() => ({
+	mockGet: vi.fn(),
+	mockPost: vi.fn(),
+	mockPatch: vi.fn(),
+	mockDelete: vi.fn(),
+}));
+
+vi.mock("./api-client", () => ({
+	apiClient: {
+		instance: {
+			get: mockGet,
+			post: mockPost,
+			patch: mockPatch,
+			delete: mockDelete,
+		},
+	},
+}));
+
+import {
+	addProjectMember,
+	createProject,
+	createProjectRole,
+	deleteProject,
+	deleteProjectRole,
+	getProject,
+	listProjectMembers,
+	listProjectRoles,
+	listProjects,
+	type Project,
+	type ProjectListResult,
+	type ProjectMember,
+	type ProjectRole,
+	projectMembersQueryOptions,
+	projectQueryOptions,
+	projectRolesQueryOptions,
+	projectsQueryOptions,
+	removeProjectMember,
+	updateProject,
+	updateProjectMemberRole,
+	updateProjectRole,
+} from "./project-api";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mockProject: Project = {
+	id: "p1",
+	name: "Alpha",
+	description: "First project",
+	settings: {},
+	created_by: "u1",
+	created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const mockMember: ProjectMember = {
+	id: "m1",
+	project_id: "p1",
+	user_id: "u1",
+	project_role_id: "r1",
+	username: "alice",
+	full_name: "Alice Smith",
+	role_name: "Developer",
+};
+
+const mockRole: ProjectRole = {
+	id: "r1",
+	project_id: "p1",
+	role_name: "Developer",
+	permissions: { "tasks.*": true },
+	created_at: "2026-01-01T00:00:00.000Z",
+	updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+/** Wraps data in a success envelope like the real API client returns. */
+function ok<T>(data: T) {
+	return { data: { data, success: true } };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("project-api", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ── Project CRUD ───────────────────────────────────────────────────────────
+
+	describe("listProjects", () => {
+		it("fetches with default pagination and unwraps the result", async () => {
+			const result: ProjectListResult = {
+				items: [mockProject],
+				total: 1,
+				page: 1,
+				page_size: 50,
+			};
+			mockGet.mockResolvedValue(ok(result));
+
+			await expect(listProjects()).resolves.toEqual(result);
+			expect(mockGet).toHaveBeenCalledWith("/admin/projects", {
+				params: { page: 1, page_size: 50 },
+			});
+		});
+
+		it("forwards custom page and page_size params", async () => {
+			const result: ProjectListResult = {
+				items: [],
+				total: 0,
+				page: 3,
+				page_size: 10,
+			};
+			mockGet.mockResolvedValue(ok(result));
+
+			await listProjects(3, 10);
+			expect(mockGet).toHaveBeenCalledWith("/admin/projects", {
+				params: { page: 3, page_size: 10 },
+			});
+		});
+	});
+
+	it("getProject fetches project by id and unwraps", async () => {
+		mockGet.mockResolvedValue(ok(mockProject));
+
+		await expect(getProject("p1")).resolves.toEqual(mockProject);
+		expect(mockGet).toHaveBeenCalledWith("/admin/projects/p1");
+	});
+
+	it("createProject posts payload and unwraps the created project", async () => {
+		mockPost.mockResolvedValue(ok(mockProject));
+		const payload = { name: "Alpha", description: "First project" };
+
+		await expect(createProject(payload)).resolves.toEqual(mockProject);
+		expect(mockPost).toHaveBeenCalledWith("/admin/projects", payload);
+	});
+
+	it("createProject omits optional description field when not provided", async () => {
+		mockPost.mockResolvedValue(ok(mockProject));
+
+		await createProject({ name: "Minimal" });
+		expect(mockPost).toHaveBeenCalledWith("/admin/projects", {
+			name: "Minimal",
+		});
+	});
+
+	it("updateProject patches by id and unwraps the updated project", async () => {
+		const updated = { ...mockProject, name: "Alpha v2" };
+		mockPatch.mockResolvedValue(ok(updated));
+
+		await expect(updateProject("p1", { name: "Alpha v2" })).resolves.toEqual(
+			updated,
+		);
+		expect(mockPatch).toHaveBeenCalledWith("/admin/projects/p1", {
+			name: "Alpha v2",
+		});
+	});
+
+	it("deleteProject sends DELETE to correct URL and returns undefined", async () => {
+		mockDelete.mockResolvedValue({});
+
+		await expect(deleteProject("p1")).resolves.toBeUndefined();
+		expect(mockDelete).toHaveBeenCalledWith("/admin/projects/p1");
+	});
+
+	// ── Members ────────────────────────────────────────────────────────────────
+
+	describe("members", () => {
+		it("listProjectMembers fetches members for a project and unwraps", async () => {
+			mockGet.mockResolvedValue(ok([mockMember]));
+
+			await expect(listProjectMembers("p1")).resolves.toEqual([mockMember]);
+			expect(mockGet).toHaveBeenCalledWith("/projects/p1/members");
+		});
+
+		it("addProjectMember posts payload and unwraps the created member", async () => {
+			mockPost.mockResolvedValue(ok(mockMember));
+			const payload = { user_id: "u1", project_role_id: "r1" };
+
+			await expect(addProjectMember("p1", payload)).resolves.toEqual(
+				mockMember,
+			);
+			expect(mockPost).toHaveBeenCalledWith("/projects/p1/members", payload);
+		});
+
+		it("updateProjectMemberRole patches member role and unwraps the updated member", async () => {
+			const updated = {
+				...mockMember,
+				project_role_id: "r2",
+				role_name: "Lead",
+			};
+			mockPatch.mockResolvedValue(ok(updated));
+
+			await expect(
+				updateProjectMemberRole("p1", "u1", { project_role_id: "r2" }),
+			).resolves.toEqual(updated);
+			expect(mockPatch).toHaveBeenCalledWith("/projects/p1/members/u1", {
+				project_role_id: "r2",
+			});
+		});
+
+		it("removeProjectMember sends DELETE to correct URL and returns undefined", async () => {
+			mockDelete.mockResolvedValue({});
+
+			await expect(removeProjectMember("p1", "u1")).resolves.toBeUndefined();
+			expect(mockDelete).toHaveBeenCalledWith("/projects/p1/members/u1");
+		});
+	});
+
+	// ── Roles ──────────────────────────────────────────────────────────────────
+
+	describe("roles", () => {
+		it("listProjectRoles fetches roles for a project and unwraps", async () => {
+			mockGet.mockResolvedValue(ok([mockRole]));
+
+			await expect(listProjectRoles("p1")).resolves.toEqual([mockRole]);
+			expect(mockGet).toHaveBeenCalledWith("/projects/p1/roles");
+		});
+
+		it("createProjectRole posts payload and unwraps the created role", async () => {
+			mockPost.mockResolvedValue(ok(mockRole));
+			const payload = {
+				role_name: "Developer",
+				permissions: { "tasks.*": true },
+			};
+
+			await expect(createProjectRole("p1", payload)).resolves.toEqual(mockRole);
+			expect(mockPost).toHaveBeenCalledWith("/projects/p1/roles", payload);
+		});
+
+		it("createProjectRole works without optional permissions field", async () => {
+			mockPost.mockResolvedValue(ok(mockRole));
+
+			await createProjectRole("p1", { role_name: "Viewer" });
+			expect(mockPost).toHaveBeenCalledWith("/projects/p1/roles", {
+				role_name: "Viewer",
+			});
+		});
+
+		it("updateProjectRole patches by role id and unwraps the updated role", async () => {
+			const updated = { ...mockRole, role_name: "Senior Developer" };
+			mockPatch.mockResolvedValue(ok(updated));
+
+			await expect(
+				updateProjectRole("p1", "r1", { role_name: "Senior Developer" }),
+			).resolves.toEqual(updated);
+			expect(mockPatch).toHaveBeenCalledWith("/projects/p1/roles/r1", {
+				role_name: "Senior Developer",
+			});
+		});
+
+		it("deleteProjectRole sends DELETE to correct URL and returns undefined", async () => {
+			mockDelete.mockResolvedValue({});
+
+			await expect(deleteProjectRole("p1", "r1")).resolves.toBeUndefined();
+			expect(mockDelete).toHaveBeenCalledWith("/projects/p1/roles/r1");
+		});
+	});
+
+	// ── Query Options ──────────────────────────────────────────────────────────
+
+	describe("query options", () => {
+		it("projectsQueryOptions exposes correct key and fn for default params", () => {
+			const opts = projectsQueryOptions();
+			expect(opts.queryKey).toEqual(["projects", { page: 1, pageSize: 50 }]);
+			expect(typeof opts.queryFn).toBe("function");
+		});
+
+		it("projectsQueryOptions uses custom page and pageSize in key", () => {
+			const opts = projectsQueryOptions(3, 10);
+			expect(opts.queryKey).toEqual(["projects", { page: 3, pageSize: 10 }]);
+		});
+
+		it("projectQueryOptions exposes correct key, fn, and staleTime", () => {
+			const opts = projectQueryOptions("p1");
+			expect(opts.queryKey).toEqual(["projects", "p1"]);
+			expect(typeof opts.queryFn).toBe("function");
+			expect(opts.staleTime).toBe(2 * 60 * 1000);
+		});
+
+		it("projectMembersQueryOptions exposes correct key and fn", () => {
+			const opts = projectMembersQueryOptions("p1");
+			expect(opts.queryKey).toEqual(["projects", "p1", "members"]);
+			expect(typeof opts.queryFn).toBe("function");
+		});
+
+		it("projectRolesQueryOptions exposes correct key and fn", () => {
+			const opts = projectRolesQueryOptions("p1");
+			expect(opts.queryKey).toEqual(["projects", "p1", "roles"]);
+			expect(typeof opts.queryFn).toBe("function");
+		});
+	});
+});

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -48,13 +48,13 @@ export async function listProjects(
 ): Promise<ProjectListResult> {
 	const { data } = await apiClient.instance.get<
 		SuccessEnvelope<ProjectListResult>
-	>("/admin/projects", { params: { page, page_size: pageSize } });
+	>("/projects", { params: { page, page_size: pageSize } });
 	return data.data;
 }
 
 export async function getProject(projectId: string): Promise<Project> {
 	const { data } = await apiClient.instance.get<SuccessEnvelope<Project>>(
-		`/admin/projects/${projectId}`,
+		`/projects/${projectId}`,
 	);
 	return data.data;
 }
@@ -64,7 +64,7 @@ export async function createProject(payload: {
 	description?: string;
 }): Promise<Project> {
 	const { data } = await apiClient.instance.post<SuccessEnvelope<Project>>(
-		"/admin/projects",
+		"/projects",
 		payload,
 	);
 	return data.data;
@@ -75,14 +75,14 @@ export async function updateProject(
 	payload: { name?: string; description?: string },
 ): Promise<Project> {
 	const { data } = await apiClient.instance.patch<SuccessEnvelope<Project>>(
-		`/admin/projects/${projectId}`,
+		`/projects/${projectId}`,
 		payload,
 	);
 	return data.data;
 }
 
 export async function deleteProject(projectId: string): Promise<void> {
-	await apiClient.instance.delete(`/admin/projects/${projectId}`);
+	await apiClient.instance.delete(`/projects/${projectId}`);
 }
 
 // ── Members ───────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -1,0 +1,193 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { apiClient } from "./api-client";
+import type { SuccessEnvelope } from "./api-error";
+
+// ── Shapes ────────────────────────────────────────────────────────────────────
+
+export interface Project {
+	id: string;
+	name: string;
+	description: string;
+	settings: Record<string, unknown>;
+	created_by?: string;
+	created_at: string;
+}
+
+export interface ProjectListResult {
+	items: Project[];
+	total: number;
+	page: number;
+	page_size: number;
+}
+
+export interface ProjectMember {
+	id: string;
+	project_id: string;
+	user_id: string;
+	project_role_id: string;
+	username: string;
+	full_name: string;
+	role_name: string;
+}
+
+export interface ProjectRole {
+	id: string;
+	project_id?: string;
+	role_name: string;
+	permissions: Record<string, unknown>;
+	created_at: string;
+	updated_at: string;
+}
+
+// ── Project CRUD ──────────────────────────────────────────────────────────────
+
+export async function listProjects(
+	page = 1,
+	pageSize = 50,
+): Promise<ProjectListResult> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<ProjectListResult>
+	>("/admin/projects", { params: { page, page_size: pageSize } });
+	return data.data;
+}
+
+export async function getProject(projectId: string): Promise<Project> {
+	const { data } = await apiClient.instance.get<SuccessEnvelope<Project>>(
+		`/admin/projects/${projectId}`,
+	);
+	return data.data;
+}
+
+export async function createProject(payload: {
+	name: string;
+	description?: string;
+}): Promise<Project> {
+	const { data } = await apiClient.instance.post<SuccessEnvelope<Project>>(
+		"/admin/projects",
+		payload,
+	);
+	return data.data;
+}
+
+export async function updateProject(
+	projectId: string,
+	payload: { name?: string; description?: string },
+): Promise<Project> {
+	const { data } = await apiClient.instance.patch<SuccessEnvelope<Project>>(
+		`/admin/projects/${projectId}`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+	await apiClient.instance.delete(`/admin/projects/${projectId}`);
+}
+
+// ── Members ───────────────────────────────────────────────────────────────────
+
+export async function listProjectMembers(
+	projectId: string,
+): Promise<ProjectMember[]> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<ProjectMember[]>
+	>(`/projects/${projectId}/members`);
+	return data.data;
+}
+
+export async function addProjectMember(
+	projectId: string,
+	payload: { user_id: string; project_role_id: string },
+): Promise<ProjectMember> {
+	const { data } = await apiClient.instance.post<
+		SuccessEnvelope<ProjectMember>
+	>(`/projects/${projectId}/members`, payload);
+	return data.data;
+}
+
+export async function updateProjectMemberRole(
+	projectId: string,
+	userId: string,
+	payload: { project_role_id: string },
+): Promise<ProjectMember> {
+	const { data } = await apiClient.instance.patch<
+		SuccessEnvelope<ProjectMember>
+	>(`/projects/${projectId}/members/${userId}`, payload);
+	return data.data;
+}
+
+export async function removeProjectMember(
+	projectId: string,
+	userId: string,
+): Promise<void> {
+	await apiClient.instance.delete(`/projects/${projectId}/members/${userId}`);
+}
+
+// ── Roles ─────────────────────────────────────────────────────────────────────
+
+export async function listProjectRoles(
+	projectId: string,
+): Promise<ProjectRole[]> {
+	const { data } = await apiClient.instance.get<SuccessEnvelope<ProjectRole[]>>(
+		`/projects/${projectId}/roles`,
+	);
+	return data.data;
+}
+
+export async function createProjectRole(
+	projectId: string,
+	payload: { role_name: string; permissions?: Record<string, unknown> },
+): Promise<ProjectRole> {
+	const { data } = await apiClient.instance.post<SuccessEnvelope<ProjectRole>>(
+		`/projects/${projectId}/roles`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function updateProjectRole(
+	projectId: string,
+	roleId: string,
+	payload: { role_name: string; permissions?: Record<string, unknown> },
+): Promise<ProjectRole> {
+	const { data } = await apiClient.instance.patch<SuccessEnvelope<ProjectRole>>(
+		`/projects/${projectId}/roles/${roleId}`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function deleteProjectRole(
+	projectId: string,
+	roleId: string,
+): Promise<void> {
+	await apiClient.instance.delete(`/projects/${projectId}/roles/${roleId}`);
+}
+
+// ── Query Options ─────────────────────────────────────────────────────────────
+
+export const projectsQueryOptions = (page = 1, pageSize = 50) =>
+	queryOptions({
+		queryKey: ["projects", { page, pageSize }],
+		queryFn: () => listProjects(page, pageSize),
+	});
+
+export const projectQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: ["projects", projectId],
+		queryFn: () => getProject(projectId),
+		staleTime: 2 * 60 * 1000,
+	});
+
+export const projectMembersQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: ["projects", projectId, "members"],
+		queryFn: () => listProjectMembers(projectId),
+	});
+
+export const projectRolesQueryOptions = (projectId: string) =>
+	queryOptions({
+		queryKey: ["projects", projectId, "roles"],
+		queryFn: () => listProjectRoles(projectId),
+	});

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,8 +14,14 @@ import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedProfileIndexRouteImport } from './routes/_authenticated/profile/index'
 import { Route as AuthenticatedHomeIndexRouteImport } from './routes/_authenticated/home/index'
+import { Route as AuthenticatedProjectsProjectIdRouteImport } from './routes/_authenticated/projects/$projectId'
+import { Route as AuthenticatedProjectsProjectIdIndexRouteImport } from './routes/_authenticated/projects/$projectId/index'
 import { Route as AuthenticatedAdminUsersIndexRouteImport } from './routes/_authenticated/admin/users/index'
 import { Route as AuthenticatedAdminGlobalRolesIndexRouteImport } from './routes/_authenticated/admin/global-roles/index'
+import { Route as AuthenticatedProjectsProjectIdTeamIndexRouteImport } from './routes/_authenticated/projects/$projectId/team/index'
+import { Route as AuthenticatedProjectsProjectIdSettingsIndexRouteImport } from './routes/_authenticated/projects/$projectId/settings/index'
+import { Route as AuthenticatedProjectsProjectIdIntegrationsIndexRouteImport } from './routes/_authenticated/projects/$projectId/integrations/index'
+import { Route as AuthenticatedProjectsProjectIdDocsIndexRouteImport } from './routes/_authenticated/projects/$projectId/docs/index'
 
 const ChangePasswordRoute = ChangePasswordRouteImport.update({
   id: '/change-password',
@@ -42,6 +48,18 @@ const AuthenticatedHomeIndexRoute = AuthenticatedHomeIndexRouteImport.update({
   path: '/home/',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedProjectsProjectIdRoute =
+  AuthenticatedProjectsProjectIdRouteImport.update({
+    id: '/projects/$projectId',
+    path: '/projects/$projectId',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedProjectsProjectIdIndexRoute =
+  AuthenticatedProjectsProjectIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
 const AuthenticatedAdminUsersIndexRoute =
   AuthenticatedAdminUsersIndexRouteImport.update({
     id: '/admin/users/',
@@ -54,14 +72,44 @@ const AuthenticatedAdminGlobalRolesIndexRoute =
     path: '/admin/global-roles/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedProjectsProjectIdTeamIndexRoute =
+  AuthenticatedProjectsProjectIdTeamIndexRouteImport.update({
+    id: '/team/',
+    path: '/team/',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
+const AuthenticatedProjectsProjectIdSettingsIndexRoute =
+  AuthenticatedProjectsProjectIdSettingsIndexRouteImport.update({
+    id: '/settings/',
+    path: '/settings/',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
+const AuthenticatedProjectsProjectIdIntegrationsIndexRoute =
+  AuthenticatedProjectsProjectIdIntegrationsIndexRouteImport.update({
+    id: '/integrations/',
+    path: '/integrations/',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
+const AuthenticatedProjectsProjectIdDocsIndexRoute =
+  AuthenticatedProjectsProjectIdDocsIndexRouteImport.update({
+    id: '/docs/',
+    path: '/docs/',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/change-password': typeof ChangePasswordRoute
+  '/projects/$projectId': typeof AuthenticatedProjectsProjectIdRouteWithChildren
   '/home/': typeof AuthenticatedHomeIndexRoute
   '/profile/': typeof AuthenticatedProfileIndexRoute
   '/admin/global-roles/': typeof AuthenticatedAdminGlobalRolesIndexRoute
   '/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
+  '/projects/$projectId/': typeof AuthenticatedProjectsProjectIdIndexRoute
+  '/projects/$projectId/docs/': typeof AuthenticatedProjectsProjectIdDocsIndexRoute
+  '/projects/$projectId/integrations/': typeof AuthenticatedProjectsProjectIdIntegrationsIndexRoute
+  '/projects/$projectId/settings/': typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
+  '/projects/$projectId/team/': typeof AuthenticatedProjectsProjectIdTeamIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -70,26 +118,43 @@ export interface FileRoutesByTo {
   '/profile': typeof AuthenticatedProfileIndexRoute
   '/admin/global-roles': typeof AuthenticatedAdminGlobalRolesIndexRoute
   '/admin/users': typeof AuthenticatedAdminUsersIndexRoute
+  '/projects/$projectId': typeof AuthenticatedProjectsProjectIdIndexRoute
+  '/projects/$projectId/docs': typeof AuthenticatedProjectsProjectIdDocsIndexRoute
+  '/projects/$projectId/integrations': typeof AuthenticatedProjectsProjectIdIntegrationsIndexRoute
+  '/projects/$projectId/settings': typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
+  '/projects/$projectId/team': typeof AuthenticatedProjectsProjectIdTeamIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/change-password': typeof ChangePasswordRoute
+  '/_authenticated/projects/$projectId': typeof AuthenticatedProjectsProjectIdRouteWithChildren
   '/_authenticated/home/': typeof AuthenticatedHomeIndexRoute
   '/_authenticated/profile/': typeof AuthenticatedProfileIndexRoute
   '/_authenticated/admin/global-roles/': typeof AuthenticatedAdminGlobalRolesIndexRoute
   '/_authenticated/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
+  '/_authenticated/projects/$projectId/': typeof AuthenticatedProjectsProjectIdIndexRoute
+  '/_authenticated/projects/$projectId/docs/': typeof AuthenticatedProjectsProjectIdDocsIndexRoute
+  '/_authenticated/projects/$projectId/integrations/': typeof AuthenticatedProjectsProjectIdIntegrationsIndexRoute
+  '/_authenticated/projects/$projectId/settings/': typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
+  '/_authenticated/projects/$projectId/team/': typeof AuthenticatedProjectsProjectIdTeamIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/change-password'
+    | '/projects/$projectId'
     | '/home/'
     | '/profile/'
     | '/admin/global-roles/'
     | '/admin/users/'
+    | '/projects/$projectId/'
+    | '/projects/$projectId/docs/'
+    | '/projects/$projectId/integrations/'
+    | '/projects/$projectId/settings/'
+    | '/projects/$projectId/team/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -98,15 +163,26 @@ export interface FileRouteTypes {
     | '/profile'
     | '/admin/global-roles'
     | '/admin/users'
+    | '/projects/$projectId'
+    | '/projects/$projectId/docs'
+    | '/projects/$projectId/integrations'
+    | '/projects/$projectId/settings'
+    | '/projects/$projectId/team'
   id:
     | '__root__'
     | '/'
     | '/_authenticated'
     | '/change-password'
+    | '/_authenticated/projects/$projectId'
     | '/_authenticated/home/'
     | '/_authenticated/profile/'
     | '/_authenticated/admin/global-roles/'
     | '/_authenticated/admin/users/'
+    | '/_authenticated/projects/$projectId/'
+    | '/_authenticated/projects/$projectId/docs/'
+    | '/_authenticated/projects/$projectId/integrations/'
+    | '/_authenticated/projects/$projectId/settings/'
+    | '/_authenticated/projects/$projectId/team/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -152,6 +228,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedHomeIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/projects/$projectId': {
+      id: '/_authenticated/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/projects/$projectId'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/projects/$projectId/': {
+      id: '/_authenticated/projects/$projectId/'
+      path: '/'
+      fullPath: '/projects/$projectId/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
     '/_authenticated/admin/users/': {
       id: '/_authenticated/admin/users/'
       path: '/admin/users'
@@ -166,10 +256,66 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminGlobalRolesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/projects/$projectId/team/': {
+      id: '/_authenticated/projects/$projectId/team/'
+      path: '/team'
+      fullPath: '/projects/$projectId/team/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdTeamIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
+    '/_authenticated/projects/$projectId/settings/': {
+      id: '/_authenticated/projects/$projectId/settings/'
+      path: '/settings'
+      fullPath: '/projects/$projectId/settings/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
+    '/_authenticated/projects/$projectId/integrations/': {
+      id: '/_authenticated/projects/$projectId/integrations/'
+      path: '/integrations'
+      fullPath: '/projects/$projectId/integrations/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdIntegrationsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
+    '/_authenticated/projects/$projectId/docs/': {
+      id: '/_authenticated/projects/$projectId/docs/'
+      path: '/docs'
+      fullPath: '/projects/$projectId/docs/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdDocsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
   }
 }
 
+interface AuthenticatedProjectsProjectIdRouteChildren {
+  AuthenticatedProjectsProjectIdIndexRoute: typeof AuthenticatedProjectsProjectIdIndexRoute
+  AuthenticatedProjectsProjectIdDocsIndexRoute: typeof AuthenticatedProjectsProjectIdDocsIndexRoute
+  AuthenticatedProjectsProjectIdIntegrationsIndexRoute: typeof AuthenticatedProjectsProjectIdIntegrationsIndexRoute
+  AuthenticatedProjectsProjectIdSettingsIndexRoute: typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
+  AuthenticatedProjectsProjectIdTeamIndexRoute: typeof AuthenticatedProjectsProjectIdTeamIndexRoute
+}
+
+const AuthenticatedProjectsProjectIdRouteChildren: AuthenticatedProjectsProjectIdRouteChildren =
+  {
+    AuthenticatedProjectsProjectIdIndexRoute:
+      AuthenticatedProjectsProjectIdIndexRoute,
+    AuthenticatedProjectsProjectIdDocsIndexRoute:
+      AuthenticatedProjectsProjectIdDocsIndexRoute,
+    AuthenticatedProjectsProjectIdIntegrationsIndexRoute:
+      AuthenticatedProjectsProjectIdIntegrationsIndexRoute,
+    AuthenticatedProjectsProjectIdSettingsIndexRoute:
+      AuthenticatedProjectsProjectIdSettingsIndexRoute,
+    AuthenticatedProjectsProjectIdTeamIndexRoute:
+      AuthenticatedProjectsProjectIdTeamIndexRoute,
+  }
+
+const AuthenticatedProjectsProjectIdRouteWithChildren =
+  AuthenticatedProjectsProjectIdRoute._addFileChildren(
+    AuthenticatedProjectsProjectIdRouteChildren,
+  )
+
 interface AuthenticatedRouteChildren {
+  AuthenticatedProjectsProjectIdRoute: typeof AuthenticatedProjectsProjectIdRouteWithChildren
   AuthenticatedHomeIndexRoute: typeof AuthenticatedHomeIndexRoute
   AuthenticatedProfileIndexRoute: typeof AuthenticatedProfileIndexRoute
   AuthenticatedAdminGlobalRolesIndexRoute: typeof AuthenticatedAdminGlobalRolesIndexRoute
@@ -177,6 +323,8 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedProjectsProjectIdRoute:
+    AuthenticatedProjectsProjectIdRouteWithChildren,
   AuthenticatedHomeIndexRoute: AuthenticatedHomeIndexRoute,
   AuthenticatedProfileIndexRoute: AuthenticatedProfileIndexRoute,
   AuthenticatedAdminGlobalRolesIndexRoute:

--- a/apps/web/src/routes/_authenticated/home/index.tsx
+++ b/apps/web/src/routes/_authenticated/home/index.tsx
@@ -30,9 +30,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
+import { usePermissions } from "@/hooks/use-permissions";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import { currentUserQueryOptions } from "@/lib/auth-api";
-import { usePermissions } from "@/hooks/use-permissions";
 import {
 	createProject,
 	type Project,

--- a/apps/web/src/routes/_authenticated/home/index.tsx
+++ b/apps/web/src/routes/_authenticated/home/index.tsx
@@ -1,66 +1,253 @@
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import {
 	ArrowRight,
 	Bot,
+	Calendar,
 	FolderKanban,
 	GitMerge,
 	Layers,
+	Loader2,
 	Plus,
 	Users,
 	Zap,
 } from "lucide-react";
+import { type ComponentType, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import { currentUserQueryOptions } from "@/lib/auth-api";
+import {
+	createProject,
+	type Project,
+	projectsQueryOptions,
+} from "@/lib/project-api";
 
 export const Route = createFileRoute("/_authenticated/home/")({
+	loader: async ({ context: { queryClient } }) => {
+		await queryClient.ensureQueryData(projectsQueryOptions());
+	},
 	component: HomePage,
 });
 
-const QUICK_ACTIONS = [
-	{
-		icon: FolderKanban,
-		label: "New Project",
-		description: "Create a scrumban board",
-	},
-	{
-		icon: Users,
-		label: "Invite Team",
-		description: "Add members or agents",
-	},
-	{
-		icon: Bot,
-		label: "Add AI Agent",
-		description: "Configure automation",
-	},
-] as const;
+// ── Create Project Dialog ─────────────────────────────────────────────────────
 
-const GETTING_STARTED = [
-	{
-		step: 1,
-		title: "Create your first project",
-		description: "Set up a scrumban board to manage your team's work.",
-	},
-	{
-		step: 2,
-		title: "Invite your team",
-		description: "Add human collaborators and assign roles.",
-	},
-	{
-		step: 3,
-		title: "Configure an AI agent",
-		description: "Connect an AI to handle tasks autonomously.",
-	},
-	{
-		step: 4,
-		title: "Run your first sprint",
-		description: "Move tasks through the Plan → Act → Check → Adapt cycle.",
-	},
-] as const;
+function CreateProjectDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const queryClient = useQueryClient();
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [nameError, setNameError] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const reset = () => {
+		setName("");
+		setDescription("");
+		setNameError(null);
+		setError(null);
+	};
+
+	const mutation = useMutation({
+		mutationFn: () => {
+			if (!name.trim()) throw new Error("name_required");
+			return createProject({
+				name: name.trim(),
+				description: description.trim() || undefined,
+			});
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey: ["projects"] });
+			onOpenChange(false);
+			reset();
+		},
+		onError: (err: unknown) => {
+			setNameError(null);
+			setError(null);
+			if ((err as Error).message === "name_required") {
+				setNameError("Project name is required.");
+				return;
+			}
+			const code = getApiErrorCode(err);
+			if (code === ApiErrorCode.ProjectNameTaken) {
+				setNameError("A project with this name already exists.");
+				return;
+			}
+			if (code === ApiErrorCode.ProjectNameInvalid) {
+				setNameError("Project name is empty or invalid.");
+				return;
+			}
+			setError("Something went wrong. Please try again.");
+		},
+	});
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(o) => {
+				onOpenChange(o);
+				if (!o) reset();
+			}}
+		>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<div className="flex size-10 items-center justify-center rounded-xl bg-primary/10 mb-2">
+						<FolderKanban className="size-5 text-primary" />
+					</div>
+					<DialogTitle className="font-[Syne]">New project</DialogTitle>
+					<DialogDescription>
+						Create a scrumban workspace for your team. You can invite members
+						and configure settings after creation.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-4">
+					<div className="space-y-1.5">
+						<Label htmlFor="project-name">Project name *</Label>
+						<Input
+							id="project-name"
+							value={name}
+							onChange={(e) => {
+								setName(e.target.value);
+								setNameError(null);
+							}}
+							placeholder="e.g. Platform v3"
+							autoFocus
+							className={
+								nameError
+									? "border-destructive focus-visible:ring-destructive/30"
+									: ""
+							}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") mutation.mutate();
+							}}
+						/>
+						{nameError ? (
+							<p className="text-xs text-destructive">{nameError}</p>
+						) : null}
+					</div>
+					<div className="space-y-1.5">
+						<Label htmlFor="project-description">
+							Description{" "}
+							<span className="text-muted-foreground font-normal">
+								(optional)
+							</span>
+						</Label>
+						<Textarea
+							id="project-description"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							placeholder="What is this project about?"
+							rows={3}
+							className="resize-none"
+						/>
+					</div>
+					{error ? (
+						<p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+							{error}
+						</p>
+					) : null}
+				</div>
+				<DialogFooter>
+					<DialogClose
+						render={
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={mutation.isPending}
+							/>
+						}
+					>
+						Cancel
+					</DialogClose>
+					<Button
+						size="sm"
+						disabled={mutation.isPending || !name.trim()}
+						onClick={() => mutation.mutate()}
+						className="gap-1.5 shadow-sm shadow-primary/20"
+					>
+						{mutation.isPending ? (
+							<Loader2 className="size-3.5 animate-spin" />
+						) : (
+							<Plus className="size-3.5" />
+						)}
+						Create project
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+// ── Project Card ──────────────────────────────────────────────────────────────
+
+function ProjectCard({ project }: { project: Project }) {
+	const initials = project.name
+		.split(/\s+/)
+		.filter(Boolean)
+		.slice(0, 2)
+		.map((w) => w[0].toUpperCase())
+		.join("");
+
+	const formattedDate = new Date(project.created_at).toLocaleDateString(
+		"en-US",
+		{ month: "short", day: "numeric", year: "numeric" },
+	);
+
+	return (
+		<Link
+			to="/projects/$projectId"
+			params={{ projectId: project.id }}
+			className="group relative flex flex-col rounded-2xl border border-border/60 bg-card p-5 transition-all duration-200 hover:border-primary/40 hover:shadow-md hover:shadow-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+		>
+			<div className="absolute inset-x-0 top-0 h-px rounded-t-2xl bg-linear-to-r from-transparent via-primary/30 to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+			<div className="flex items-start gap-3.5 mb-4">
+				<div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-primary/20 to-primary/5 border border-primary/15 font-[Syne] text-sm font-bold text-primary">
+					{initials || <FolderKanban className="size-4" />}
+				</div>
+				<div className="min-w-0 flex-1">
+					<p className="font-[Syne] text-sm font-bold truncate leading-snug">
+						{project.name}
+					</p>
+					{project.description ? (
+						<p className="mt-0.5 text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+							{project.description}
+						</p>
+					) : (
+						<p className="mt-0.5 text-xs text-muted-foreground/40 italic">
+							No description
+						</p>
+					)}
+				</div>
+			</div>
+			<div className="mt-auto flex items-center gap-2 text-xs text-muted-foreground">
+				<Calendar className="size-3 shrink-0" />
+				<span>{formattedDate}</span>
+				<ArrowRight className="size-3 ml-auto opacity-0 transition-all duration-150 group-hover:opacity-60 group-hover:translate-x-0.5" />
+			</div>
+		</Link>
+	);
+}
+
+// ── Stat Card ─────────────────────────────────────────────────────────────────
 
 function StatCard({
 	icon: Icon,
@@ -69,7 +256,7 @@ function StatCard({
 	sub,
 	iconClass,
 }: {
-	icon: React.ComponentType<{ className?: string }>;
+	icon: ComponentType<{ className?: string }>;
 	label: string;
 	value: string | number;
 	sub: string;
@@ -96,8 +283,38 @@ function StatCard({
 	);
 }
 
+const GETTING_STARTED = [
+	{
+		step: 1,
+		title: "Create your first project",
+		description: "Set up a scrumban board to manage your team's work.",
+	},
+	{
+		step: 2,
+		title: "Invite your team",
+		description: "Add human collaborators and assign roles.",
+	},
+	{
+		step: 3,
+		title: "Configure an AI agent",
+		description: "Connect an AI to handle tasks autonomously.",
+	},
+	{
+		step: 4,
+		title: "Run your first sprint",
+		description: "Move tasks through the Plan → Act → Check → Adapt cycle.",
+	},
+] as const;
+
+// ── Home Page ─────────────────────────────────────────────────────────────────
+
 function HomePage() {
 	const { data: user } = useQuery(currentUserQueryOptions);
+	const { data: projectsResult } = useQuery(projectsQueryOptions());
+	const [createOpen, setCreateOpen] = useState(false);
+
+	const projects = projectsResult?.items ?? [];
+	const projectCount = projectsResult?.total ?? 0;
 
 	const greeting = (() => {
 		const hour = new Date().getHours();
@@ -112,7 +329,6 @@ function HomePage() {
 		<div className="flex flex-col">
 			{/* Hero banner */}
 			<div className="relative overflow-hidden border-b border-border/50">
-				{/* dot grid */}
 				<div
 					className="pointer-events-none absolute inset-0"
 					style={{
@@ -123,7 +339,6 @@ function HomePage() {
 							"radial-gradient(ellipse 90% 100% at 0% 0%, black 30%, transparent 80%)",
 					}}
 				/>
-				{/* glow orbs */}
 				<div className="pointer-events-none absolute -top-16 -left-16 size-72 rounded-full bg-primary/10 blur-3xl" />
 				<div className="pointer-events-none absolute -bottom-8 right-8 size-52 rounded-full bg-secondary/10 blur-3xl" />
 				<div className="relative flex flex-col gap-4 px-6 py-10 sm:flex-row sm:items-end sm:justify-between">
@@ -150,8 +365,9 @@ function HomePage() {
 							</span>
 						</h1>
 						<p className="mt-2 max-w-lg text-sm text-muted-foreground leading-relaxed">
-							Your workspace is ready. Create a project, invite your team, and
-							start the Plan → Act → Check → Adapt cycle.
+							{projectCount > 0
+								? `You have ${projectCount} active ${projectCount === 1 ? "project" : "projects"}. Pick up where you left off.`
+								: "Your workspace is ready. Create a project, invite your team, and start shipping."}
 						</p>
 					</div>
 					<div className="flex shrink-0 items-center gap-2">
@@ -163,7 +379,11 @@ function HomePage() {
 							<Users className="size-3.5" />
 							Invite
 						</Button>
-						<Button size="sm" className="gap-1.5 shadow-sm shadow-primary/20">
+						<Button
+							size="sm"
+							className="gap-1.5 shadow-sm shadow-primary/20"
+							onClick={() => setCreateOpen(true)}
+						>
 							<Plus className="size-3.5" />
 							New Project
 						</Button>
@@ -177,8 +397,10 @@ function HomePage() {
 					<StatCard
 						icon={FolderKanban}
 						label="Projects"
-						value={0}
-						sub="No projects yet"
+						value={projectCount}
+						sub={
+							projectCount === 0 ? "No projects yet" : `${projectCount} active`
+						}
 						iconClass="bg-primary/10 text-primary"
 					/>
 					<StatCard
@@ -204,121 +426,183 @@ function HomePage() {
 					/>
 				</div>
 
-				<div className="grid gap-6 lg:grid-cols-[1fr_300px]">
-					{/* Getting started checklist */}
-					<Card className="border-border/60">
-						<CardHeader className="pb-1">
-							<div className="flex items-center justify-between">
-								<CardTitle className="font-[Syne] text-base font-semibold">
-									Get started
-								</CardTitle>
-								<Badge
-									variant="outline"
-									className="text-xs font-mono tabular-nums border-border/70"
-								>
-									0 / 4
-								</Badge>
-							</div>
-							<p className="text-xs text-muted-foreground">
-								Complete these steps to unlock the full power of Paca.
-							</p>
-						</CardHeader>
-						<CardContent className="pt-3">
-							<ol className="space-y-1">
-								{GETTING_STARTED.map(({ step, title, description }) => (
-									<li key={step}>
-										<div className="flex items-start gap-3.5 rounded-xl border border-border/40 bg-muted/20 px-4 py-3.5 transition-all hover:bg-muted/50 hover:border-primary/20 group">
-											<div className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-primary/20 to-primary/5 border border-primary/20 font-mono text-[11px] font-bold text-primary tabular-nums">
-												{step}
-											</div>
-											<div className="min-w-0 flex-1">
-												<p className="text-sm font-medium">{title}</p>
-												<p className="mt-0.5 text-xs text-muted-foreground">
-													{description}
-												</p>
-											</div>
-											<ArrowRight className="mt-1 size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-primary/50" />
-										</div>
-										{step < 4 && (
-											<div className="my-0.5 ml-7 h-1.5 w-px bg-linear-to-b from-border/60 to-transparent" />
-										)}
-									</li>
-								))}
-							</ol>
-						</CardContent>
-					</Card>
-
-					{/* Right column */}
-					<div className="flex flex-col gap-6">
-						{/* Quick actions */}
-						<Card className="border-border/60">
-							<CardHeader className="pb-2">
-								<CardTitle className="font-[Syne] text-base font-semibold">
-									Quick actions
-								</CardTitle>
-							</CardHeader>
-							<CardContent className="pt-0">
-								<div className="space-y-2">
-									{QUICK_ACTIONS.map(({ icon: Icon, label, description }) => (
-										<button
-											key={label}
-											type="button"
-											className="group flex w-full cursor-pointer items-center gap-3 rounded-xl border border-border/50 bg-background/50 px-3.5 py-3 text-left transition-all hover:border-primary/30 hover:bg-primary/5 hover:shadow-sm hover:shadow-primary/5"
-										>
-											<div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-primary/15 to-primary/5 text-primary transition-colors group-hover:from-primary/25 group-hover:to-primary/10">
-												<Icon className="size-4" />
-											</div>
-											<div className="min-w-0 flex-1">
-												<p className="text-sm font-medium leading-none">
-													{label}
-												</p>
-												<p className="mt-1 text-xs text-muted-foreground">
-													{description}
-												</p>
-											</div>
-											<ArrowRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-primary/60" />
-										</button>
-									))}
-								</div>
-							</CardContent>
-						</Card>
-
-						{/* About Paca */}
-						<Card className="relative overflow-hidden border-border/60">
-							<div className="absolute inset-x-0 top-0 h-0.5 bg-linear-to-r from-transparent via-secondary/60 to-transparent" />
-							<div className="pointer-events-none absolute -bottom-8 -right-8 size-32 rounded-full bg-secondary/10 blur-2xl" />
-							<CardContent className="relative p-5">
-								<div className="mb-2 flex items-center gap-2">
-									<Zap className="size-3.5 text-secondary" />
-									<p className="font-[Syne] text-xs font-bold uppercase tracking-widest text-secondary">
-										How Paca works
-									</p>
-								</div>
-								<p className="text-sm leading-relaxed text-foreground/80">
-									Combine human creativity with AI speed on a shared scrumban
-									board. Tasks flow through{" "}
-									<span className="font-semibold text-foreground">
-										Plan → Act → Check → Adapt
-									</span>{" "}
-									with full transparency over who — human or AI — did what.
+				{/* Projects section or empty state */}
+				{projectCount > 0 ? (
+					<div>
+						<div className="flex items-center justify-between mb-4">
+							<div>
+								<h2 className="font-[Syne] text-base font-bold tracking-tight">
+									Projects
+								</h2>
+								<p className="text-xs text-muted-foreground mt-0.5">
+									{projectCount} {projectCount === 1 ? "project" : "projects"}{" "}
+									in your workspace
 								</p>
-								<Separator className="my-3 opacity-50" />
-								<div className="flex items-center gap-2">
-									<GitMerge className="size-3.5 text-muted-foreground" />
-									<a
-										href="https://github.com/Paca-AI/paca"
-										target="_blank"
-										rel="noopener noreferrer"
-										className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-									>
-										Open source · Apache-2.0
-									</a>
+							</div>
+							<Button
+								size="sm"
+								variant="outline"
+								className="gap-1.5 border-border/60"
+								onClick={() => setCreateOpen(true)}
+							>
+								<Plus className="size-3.5" />
+								New
+							</Button>
+						</div>
+						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+							{projects.map((project) => (
+								<ProjectCard key={project.id} project={project} />
+							))}
+							{/* Add project card */}
+							<button
+								type="button"
+								onClick={() => setCreateOpen(true)}
+								className="group flex min-h-30 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-border/60 bg-muted/10 p-5 text-muted-foreground/50 transition-all hover:border-primary/40 hover:bg-primary/3 hover:text-primary/70"
+							>
+								<div className="flex size-9 items-center justify-center rounded-xl border border-dashed border-current transition-colors">
+									<Plus className="size-4" />
 								</div>
+								<span className="text-xs font-medium">New project</span>
+							</button>
+						</div>
+					</div>
+				) : (
+					<div className="grid gap-6 lg:grid-cols-[1fr_300px]">
+						{/* Getting started checklist */}
+						<Card className="border-border/60">
+							<CardHeader className="pb-1">
+								<div className="flex items-center justify-between">
+									<CardTitle className="font-[Syne] text-base font-semibold">
+										Get started
+									</CardTitle>
+									<Badge
+										variant="outline"
+										className="text-xs font-mono tabular-nums border-border/70"
+									>
+										0 / 4
+									</Badge>
+								</div>
+								<p className="text-xs text-muted-foreground">
+									Complete these steps to unlock the full power of Paca.
+								</p>
+							</CardHeader>
+							<CardContent className="pt-3">
+								<ol className="space-y-1">
+									{GETTING_STARTED.map(({ step, title, description }) => (
+										<li key={step}>
+											<div className="flex items-start gap-3.5 rounded-xl border border-border/40 bg-muted/20 px-4 py-3.5 transition-all hover:bg-muted/50 hover:border-primary/20 group">
+												<div className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-primary/20 to-primary/5 border border-primary/20 font-mono text-[11px] font-bold text-primary tabular-nums">
+													{step}
+												</div>
+												<div className="min-w-0 flex-1">
+													<p className="text-sm font-medium">{title}</p>
+													<p className="mt-0.5 text-xs text-muted-foreground">
+														{description}
+													</p>
+												</div>
+												<ArrowRight className="mt-1 size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-primary/50" />
+											</div>
+											{step < 4 && (
+												<div className="my-0.5 ml-7 h-1.5 w-px bg-linear-to-b from-border/60 to-transparent" />
+											)}
+										</li>
+									))}
+								</ol>
 							</CardContent>
 						</Card>
+
+						{/* Right column: Quick actions + About */}
+						<div className="flex flex-col gap-6">
+							<Card className="border-border/60">
+								<CardHeader className="pb-2">
+									<CardTitle className="font-[Syne] text-base font-semibold">
+										Quick actions
+									</CardTitle>
+								</CardHeader>
+								<CardContent className="pt-0">
+									<div className="space-y-2">
+										{[
+											{
+												icon: FolderKanban,
+												label: "New Project",
+												description: "Create a scrumban board",
+												onClick: () => setCreateOpen(true),
+											},
+											{
+												icon: Users,
+												label: "Invite Team",
+												description: "Add members or agents",
+												onClick: undefined,
+											},
+											{
+												icon: Bot,
+												label: "Add AI Agent",
+												description: "Configure automation",
+												onClick: undefined,
+											},
+										].map(({ icon: Icon, label, description, onClick }) => (
+											<button
+												key={label}
+												type="button"
+												onClick={onClick}
+												className="group flex w-full cursor-pointer items-center gap-3 rounded-xl border border-border/50 bg-background/50 px-3.5 py-3 text-left transition-all hover:border-primary/30 hover:bg-primary/5 hover:shadow-sm hover:shadow-primary/5"
+											>
+												<div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-linear-to-br from-primary/15 to-primary/5 text-primary transition-colors group-hover:from-primary/25 group-hover:to-primary/10">
+													<Icon className="size-4" />
+												</div>
+												<div className="min-w-0 flex-1">
+													<p className="text-sm font-medium leading-none">
+														{label}
+													</p>
+													<p className="mt-1 text-xs text-muted-foreground">
+														{description}
+													</p>
+												</div>
+												<ArrowRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-primary/60" />
+											</button>
+										))}
+									</div>
+								</CardContent>
+							</Card>
+
+							<Card className="relative overflow-hidden border-border/60">
+								<div className="absolute inset-x-0 top-0 h-0.5 bg-linear-to-r from-transparent via-secondary/60 to-transparent" />
+								<div className="pointer-events-none absolute -bottom-8 -right-8 size-32 rounded-full bg-secondary/10 blur-2xl" />
+								<CardContent className="relative p-5">
+									<div className="mb-2 flex items-center gap-2">
+										<Zap className="size-3.5 text-secondary" />
+										<p className="font-[Syne] text-xs font-bold uppercase tracking-widest text-secondary">
+											How Paca works
+										</p>
+									</div>
+									<p className="text-sm leading-relaxed text-foreground/80">
+										Combine human creativity with AI speed on a shared scrumban
+										board. Tasks flow through{" "}
+										<span className="font-semibold text-foreground">
+											Plan → Act → Check → Adapt
+										</span>{" "}
+										with full transparency over who — human or AI — did what.
+									</p>
+									<Separator className="my-3 opacity-50" />
+									<div className="flex items-center gap-2">
+										<GitMerge className="size-3.5 text-muted-foreground" />
+										<a
+											href="https://github.com/Paca-AI/paca"
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+										>
+											Open source · Apache-2.0
+										</a>
+									</div>
+								</CardContent>
+							</Card>
+						</div>
 					</div>
-				</div>
+				)}
 			</div>
+
+			<CreateProjectDialog open={createOpen} onOpenChange={setCreateOpen} />
 		</div>
 	);
 }

--- a/apps/web/src/routes/_authenticated/home/index.tsx
+++ b/apps/web/src/routes/_authenticated/home/index.tsx
@@ -32,6 +32,7 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import { currentUserQueryOptions } from "@/lib/auth-api";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
 	createProject,
 	type Project,
@@ -311,7 +312,10 @@ const GETTING_STARTED = [
 function HomePage() {
 	const { data: user } = useQuery(currentUserQueryOptions);
 	const { data: projectsResult } = useQuery(projectsQueryOptions());
+	const { hasPermission } = usePermissions();
 	const [createOpen, setCreateOpen] = useState(false);
+
+	const canCreate = hasPermission("projects.create");
 
 	const projects = projectsResult?.items ?? [];
 	const projectCount = projectsResult?.total ?? 0;
@@ -371,22 +375,16 @@ function HomePage() {
 						</p>
 					</div>
 					<div className="flex shrink-0 items-center gap-2">
-						<Button
-							size="sm"
-							variant="outline"
-							className="gap-1.5 border-border/70"
-						>
-							<Users className="size-3.5" />
-							Invite
-						</Button>
-						<Button
-							size="sm"
-							className="gap-1.5 shadow-sm shadow-primary/20"
-							onClick={() => setCreateOpen(true)}
-						>
-							<Plus className="size-3.5" />
-							New Project
-						</Button>
+						{canCreate ? (
+							<Button
+								size="sm"
+								className="gap-1.5 shadow-sm shadow-primary/20"
+								onClick={() => setCreateOpen(true)}
+							>
+								<Plus className="size-3.5" />
+								New Project
+							</Button>
+						) : null}
 					</div>
 				</div>
 			</div>
@@ -439,31 +437,35 @@ function HomePage() {
 									in your workspace
 								</p>
 							</div>
-							<Button
-								size="sm"
-								variant="outline"
-								className="gap-1.5 border-border/60"
-								onClick={() => setCreateOpen(true)}
-							>
-								<Plus className="size-3.5" />
-								New
-							</Button>
+							{canCreate ? (
+								<Button
+									size="sm"
+									variant="outline"
+									className="gap-1.5 border-border/60"
+									onClick={() => setCreateOpen(true)}
+								>
+									<Plus className="size-3.5" />
+									New
+								</Button>
+							) : null}
 						</div>
 						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 							{projects.map((project) => (
 								<ProjectCard key={project.id} project={project} />
 							))}
 							{/* Add project card */}
-							<button
-								type="button"
-								onClick={() => setCreateOpen(true)}
-								className="group flex min-h-30 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-border/60 bg-muted/10 p-5 text-muted-foreground/50 transition-all hover:border-primary/40 hover:bg-primary/3 hover:text-primary/70"
-							>
-								<div className="flex size-9 items-center justify-center rounded-xl border border-dashed border-current transition-colors">
-									<Plus className="size-4" />
-								</div>
-								<span className="text-xs font-medium">New project</span>
-							</button>
+							{canCreate ? (
+								<button
+									type="button"
+									onClick={() => setCreateOpen(true)}
+									className="group flex min-h-30 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-border/60 bg-muted/10 p-5 text-muted-foreground/50 transition-all hover:border-primary/40 hover:bg-primary/3 hover:text-primary/70"
+								>
+									<div className="flex size-9 items-center justify-center rounded-xl border border-dashed border-current transition-colors">
+										<Plus className="size-4" />
+									</div>
+									<span className="text-xs font-medium">New project</span>
+								</button>
+							) : null}
 						</div>
 					</div>
 				) : (
@@ -522,12 +524,16 @@ function HomePage() {
 								<CardContent className="pt-0">
 									<div className="space-y-2">
 										{[
-											{
-												icon: FolderKanban,
-												label: "New Project",
-												description: "Create a scrumban board",
-												onClick: () => setCreateOpen(true),
-											},
+											...(canCreate
+												? [
+														{
+															icon: FolderKanban,
+															label: "New Project",
+															description: "Create a scrumban board",
+															onClick: () => setCreateOpen(true),
+														},
+													]
+												: []),
 											{
 												icon: Users,
 												label: "Invite Team",

--- a/apps/web/src/routes/_authenticated/projects/$projectId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId.tsx
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { AlertCircle } from "lucide-react";
+
+import { projectQueryOptions } from "@/lib/project-api";
+
+export const Route = createFileRoute("/_authenticated/projects/$projectId")({
+	loader: async ({ context: { queryClient }, params: { projectId } }) => {
+		await queryClient
+			.ensureQueryData(projectQueryOptions(projectId))
+			.catch(() => {
+				throw redirect({ to: "/home" });
+			});
+	},
+	component: ProjectLayout,
+});
+
+function ProjectLayout() {
+	const { projectId } = Route.useParams();
+	const { data: project, isError } = useQuery(projectQueryOptions(projectId));
+
+	if (isError || !project) {
+		return (
+			<div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-muted-foreground">
+				<AlertCircle className="size-8 opacity-40" />
+				<p className="text-sm">Project not found or access denied.</p>
+			</div>
+		);
+	}
+
+	return <Outlet />;
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/docs/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/docs/index.tsx
@@ -1,0 +1,112 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { BookOpen, FileSearch, GitBranch, Sparkles } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+
+export const Route = createFileRoute(
+	"/_authenticated/projects/$projectId/docs/",
+)({
+	component: DocsPage,
+});
+
+const FEATURES = [
+	{
+		icon: BookOpen,
+		title: "Living Documentation",
+		description:
+			"Write and organize docs that live alongside your code and evolve with your project.",
+		color: "bg-violet-500/10 text-violet-500",
+	},
+	{
+		icon: Sparkles,
+		title: "AI-Generated Drafts",
+		description:
+			"Auto-generate technical specs, ADRs, and release notes from sprint data.",
+		color: "bg-amber-500/10 text-amber-500",
+	},
+	{
+		icon: GitBranch,
+		title: "Version History",
+		description:
+			"Full version history for every document with diff views and rollback support.",
+		color: "bg-blue-500/10 text-blue-500",
+	},
+	{
+		icon: FileSearch,
+		title: "Semantic Search",
+		description:
+			"Find any doc, decision, or requirement instantly with AI-powered semantic search.",
+		color: "bg-emerald-500/10 text-emerald-500",
+	},
+] as const;
+
+function DocsPage() {
+	return (
+		<div className="flex flex-col">
+			<div className="relative overflow-hidden border-b border-border/50">
+				<div
+					className="pointer-events-none absolute inset-0 opacity-50"
+					style={{
+						backgroundImage:
+							"radial-gradient(circle, color-mix(in oklch, var(--color-primary) 12%, transparent) 1px, transparent 1px)",
+						backgroundSize: "20px 20px",
+						maskImage:
+							"radial-gradient(ellipse 70% 100% at 0% 0%, black 20%, transparent 70%)",
+					}}
+				/>
+				<div className="relative px-6 py-8">
+					<div className="mb-2 flex items-center gap-2">
+						<Badge
+							variant="secondary"
+							className="gap-1.5 px-2.5 py-0.5 text-xs font-semibold border border-border/60"
+						>
+							<span className="size-1.5 rounded-full bg-secondary inline-block" />
+							Coming Soon
+						</Badge>
+					</div>
+					<h1 className="font-[Syne] text-2xl font-bold tracking-tight">
+						Docs
+					</h1>
+					<p className="mt-1.5 max-w-lg text-sm text-muted-foreground">
+						Collaborative documentation that grows with your project — specs,
+						ADRs, runbooks, and more.
+					</p>
+				</div>
+			</div>
+
+			<div className="p-6">
+				<div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-10 text-center mb-6">
+					<div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-violet-500/10 mb-4">
+						<BookOpen className="size-7 text-violet-500" />
+					</div>
+					<h2 className="font-[Syne] text-lg font-bold tracking-tight">
+						Documentation Hub
+					</h2>
+					<p className="mt-2 max-w-sm mx-auto text-sm text-muted-foreground leading-relaxed">
+						A living knowledge base for your project — AI-assisted,
+						version-controlled, and always up to date.
+					</p>
+				</div>
+
+				<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+					{FEATURES.map(({ icon: Icon, title, description, color }) => (
+						<div
+							key={title}
+							className="rounded-xl border border-border/50 bg-card p-4 transition-colors hover:bg-muted/30"
+						>
+							<div
+								className={`flex size-9 items-center justify-center rounded-lg ${color} mb-3`}
+							>
+								<Icon className="size-4" />
+							</div>
+							<p className="text-sm font-semibold">{title}</p>
+							<p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+								{description}
+							</p>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
@@ -1,0 +1,187 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+	BookOpen,
+	FileText,
+	LayoutDashboard,
+	Settings,
+	Sparkles,
+	Users,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { projectQueryOptions } from "@/lib/project-api";
+
+export const Route = createFileRoute("/_authenticated/projects/$projectId/")({
+	component: ProjectDashboardPage,
+});
+
+const COMING_SOON_FEATURES = [
+	{
+		icon: LayoutDashboard,
+		title: "Sprint Dashboard",
+		description:
+			"Track velocity, burndown, and cycle time across all your active sprints in real time.",
+		color: "bg-violet-500/10 text-violet-500",
+	},
+	{
+		icon: Sparkles,
+		title: "AI Agent Activity",
+		description:
+			"Watch AI agents triage tickets, write code, and comment on pull requests — all from one view.",
+		color: "bg-amber-500/10 text-amber-500",
+	},
+	{
+		icon: FileText,
+		title: "Release Notes",
+		description:
+			"Auto-generated changelogs and deployment timeline, updated with every sprint close.",
+		color: "bg-emerald-500/10 text-emerald-500",
+	},
+] as const;
+
+const PROJECT_PAGES = [
+	{
+		to: "/projects/$projectId/integrations",
+		icon: BookOpen,
+		label: "Integrations",
+		description: "Product backlog & sprints",
+	},
+	{
+		to: "/projects/$projectId/docs",
+		icon: FileText,
+		label: "Docs",
+		description: "Project documentation",
+	},
+	{
+		to: "/projects/$projectId/team",
+		icon: Users,
+		label: "Team",
+		description: "Manage project members",
+	},
+	{
+		to: "/projects/$projectId/settings",
+		icon: Settings,
+		label: "Settings",
+		description: "Project settings & roles",
+	},
+] as const;
+
+function ProjectDashboardPage() {
+	const { projectId } = Route.useParams();
+	const { data: project } = useQuery(projectQueryOptions(projectId));
+
+	return (
+		<div className="flex flex-col">
+			{/* Hero */}
+			<div className="relative overflow-hidden border-b border-border/50">
+				<div
+					className="pointer-events-none absolute inset-0"
+					style={{
+						backgroundImage:
+							"radial-gradient(circle, color-mix(in oklch, var(--color-primary) 15%, transparent) 1px, transparent 1px)",
+						backgroundSize: "24px 24px",
+						maskImage:
+							"radial-gradient(ellipse 80% 100% at 5% 0%, black 20%, transparent 75%)",
+					}}
+				/>
+				<div className="pointer-events-none absolute -top-12 left-0 size-64 rounded-full bg-primary/8 blur-3xl" />
+				<div className="relative px-6 py-10">
+					<div className="mb-3 flex items-center gap-2">
+						<Badge
+							variant="secondary"
+							className="gap-1.5 px-2.5 py-0.5 text-xs font-semibold border border-border/60"
+						>
+							<span className="size-1.5 rounded-full bg-primary inline-block animate-pulse" />
+							Dashboard · Coming Soon
+						</Badge>
+					</div>
+					<h1 className="font-[Syne] text-[2rem] font-bold tracking-tight leading-tight">
+						{project?.name ?? "Project"}{" "}
+						<span
+							className="bg-clip-text text-transparent"
+							style={{
+								backgroundImage:
+									"linear-gradient(135deg, var(--color-primary) 0%, color-mix(in oklch, var(--color-primary) 60%, var(--color-secondary)) 100%)",
+							}}
+						>
+							Dashboard
+						</span>
+					</h1>
+					{project?.description ? (
+						<p className="mt-2 max-w-lg text-sm text-muted-foreground leading-relaxed">
+							{project.description}
+						</p>
+					) : null}
+				</div>
+			</div>
+
+			<div className="flex flex-col gap-8 p-6">
+				{/* Coming soon callout */}
+				<div className="rounded-2xl border border-dashed border-primary/30 bg-primary/3 p-8 text-center">
+					<div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-primary/10">
+						<LayoutDashboard className="size-7 text-primary" />
+					</div>
+					<h2 className="mt-4 font-[Syne] text-xl font-bold tracking-tight">
+						Dashboard is on the way
+					</h2>
+					<p className="mt-2 max-w-md mx-auto text-sm text-muted-foreground leading-relaxed">
+						We're building a real-time sprint overview with burndown charts, AI
+						agent activity, and team velocity. Stay tuned for the launch.
+					</p>
+				</div>
+
+				{/* Feature previews */}
+				<div>
+					<h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+						What's coming
+					</h3>
+					<div className="grid gap-3 sm:grid-cols-3">
+						{COMING_SOON_FEATURES.map(
+							({ icon: Icon, title, description, color }) => (
+								<div
+									key={title}
+									className="rounded-xl border border-border/50 bg-muted/20 p-4 transition-colors hover:bg-muted/40"
+								>
+									<div
+										className={`flex size-9 items-center justify-center rounded-lg ${color} mb-3`}
+									>
+										<Icon className="size-4" />
+									</div>
+									<p className="text-sm font-semibold">{title}</p>
+									<p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+										{description}
+									</p>
+								</div>
+							),
+						)}
+					</div>
+				</div>
+
+				{/* Quick nav to other project pages */}
+				<div>
+					<h3 className="mb-3 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+						Explore this project
+					</h3>
+					<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+						{PROJECT_PAGES.map(({ to, icon: Icon, label, description }) => (
+							<Button
+								key={to}
+								variant="outline"
+								className="h-auto w-full flex-col items-start gap-1.5 p-4 text-left border-border/60 hover:border-primary/40 hover:bg-primary/5"
+								render={<Link to={to} params={{ projectId }} />}
+							>
+								<Icon className="size-4 text-muted-foreground" />
+								<span className="text-sm font-medium">{label}</span>
+								<span className="text-xs text-muted-foreground">
+									{description}
+								</span>
+							</Button>
+						))}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/integrations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/integrations/index.tsx
@@ -1,0 +1,122 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { KanbanSquare, ListTodo, Sparkles } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+
+export const Route = createFileRoute(
+	"/_authenticated/projects/$projectId/integrations/",
+)({
+	component: IntegrationsPage,
+});
+
+const FEATURES = [
+	{
+		icon: ListTodo,
+		title: "Product Backlog",
+		description:
+			"Capture user stories, epics, and tasks. Prioritize with drag-and-drop and estimate with story points.",
+		tag: "Backlog",
+		color: "bg-blue-500/10 text-blue-500",
+	},
+	{
+		icon: KanbanSquare,
+		title: "Sprint Board",
+		description:
+			"Run time-boxed iterations with a Scrum board. Move work through To-Do, In Progress, and Done columns.",
+		tag: "Sprints",
+		color: "bg-emerald-500/10 text-emerald-500",
+	},
+	{
+		icon: Sparkles,
+		title: "AI-Powered Planning",
+		description:
+			"Let AI agents groom your backlog, suggest sprint goals, and auto-estimate story complexity.",
+		tag: "AI",
+		color: "bg-amber-500/10 text-amber-500",
+	},
+] as const;
+
+function IntegrationsPage() {
+	return (
+		<div className="flex flex-col">
+			<div className="relative overflow-hidden border-b border-border/50">
+				<div
+					className="pointer-events-none absolute inset-0 opacity-60"
+					style={{
+						backgroundImage:
+							"radial-gradient(circle, color-mix(in oklch, var(--color-primary) 12%, transparent) 1px, transparent 1px)",
+						backgroundSize: "20px 20px",
+						maskImage:
+							"radial-gradient(ellipse 70% 100% at 0% 0%, black 20%, transparent 70%)",
+					}}
+				/>
+				<div className="relative px-6 py-8">
+					<div className="mb-2 flex items-center gap-2">
+						<Badge
+							variant="secondary"
+							className="gap-1.5 px-2.5 py-0.5 text-xs font-semibold border border-border/60"
+						>
+							<span className="size-1.5 rounded-full bg-secondary inline-block" />
+							Coming Soon
+						</Badge>
+					</div>
+					<h1 className="font-[Syne] text-2xl font-bold tracking-tight">
+						Integrations
+					</h1>
+					<p className="mt-1.5 max-w-lg text-sm text-muted-foreground">
+						Product backlog and sprint management — the core of your scrumban
+						workflow.
+					</p>
+				</div>
+			</div>
+
+			<div className="p-6">
+				<div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-10 text-center mb-6">
+					<div className="flex items-center justify-center gap-3 mb-4">
+						<div className="flex size-12 items-center justify-center rounded-xl bg-blue-500/10">
+							<ListTodo className="size-6 text-blue-500" />
+						</div>
+						<div className="h-px flex-1 max-w-8 bg-border/40" />
+						<div className="flex size-12 items-center justify-center rounded-xl bg-emerald-500/10">
+							<KanbanSquare className="size-6 text-emerald-500" />
+						</div>
+					</div>
+					<h2 className="font-[Syne] text-lg font-bold tracking-tight">
+						Backlog & Sprint Board
+					</h2>
+					<p className="mt-2 max-w-sm mx-auto text-sm text-muted-foreground leading-relaxed">
+						Full scrumban workflow with product backlog grooming, sprint
+						planning, and AI-assisted estimation.
+					</p>
+				</div>
+
+				<div className="grid gap-3 sm:grid-cols-3">
+					{FEATURES.map(({ icon: Icon, title, description, tag, color }) => (
+						<div
+							key={title}
+							className="rounded-xl border border-border/50 bg-card p-5 transition-colors hover:bg-muted/30"
+						>
+							<div className="flex items-start justify-between mb-3">
+								<div
+									className={`flex size-9 items-center justify-center rounded-lg ${color}`}
+								>
+									<Icon className="size-4" />
+								</div>
+								<Badge
+									variant="outline"
+									className="text-[10px] border-border/50"
+								>
+									{tag}
+								</Badge>
+							</div>
+							<p className="text-sm font-semibold">{title}</p>
+							<p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+								{description}
+							</p>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
@@ -511,8 +511,9 @@ function DangerZone({ projectId }: { projectId: string }) {
 	const deleteMutation = useMutation({
 		mutationFn: () => deleteProject(projectId),
 		onSuccess: async () => {
+			queryClient.removeQueries({ queryKey: ["projects", projectId] });
+			await navigate({ to: "/home" });
 			await queryClient.invalidateQueries({ queryKey: ["projects"] });
-			void navigate({ to: "/home" });
 		},
 	});
 

--- a/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
@@ -1,0 +1,690 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+	AlertTriangle,
+	Edit2,
+	Key,
+	Loader2,
+	Lock,
+	Plus,
+	Settings,
+	Shield,
+	Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import { DeleteProjectRoleDialog } from "@/components/projects/roles/DeleteProjectRoleDialog";
+import { ProjectRoleFormDialog } from "@/components/projects/roles/ProjectRoleFormDialog";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import {
+	deleteProject,
+	type ProjectRole,
+	projectQueryOptions,
+	projectRolesQueryOptions,
+	updateProject,
+} from "@/lib/project-api";
+
+export const Route = createFileRoute(
+	"/_authenticated/projects/$projectId/settings/",
+)({
+	loader: async ({ context: { queryClient }, params: { projectId } }) => {
+		await Promise.all([
+			queryClient.ensureQueryData(projectQueryOptions(projectId)),
+			queryClient.ensureQueryData(projectRolesQueryOptions(projectId)),
+		]);
+	},
+	component: SettingsPage,
+});
+
+// ── General Settings ──────────────────────────────────────────────────────────
+
+function GeneralSettings({ projectId }: { projectId: string }) {
+	const queryClient = useQueryClient();
+	const { data: project } = useQuery(projectQueryOptions(projectId));
+
+	const [name, setName] = useState(project?.name ?? "");
+	const [description, setDescription] = useState(project?.description ?? "");
+	const [nameError, setNameError] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [saved, setSaved] = useState(false);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			updateProject(projectId, {
+				name: name.trim(),
+				description: description.trim(),
+			}),
+		onSuccess: async (updated) => {
+			await queryClient.invalidateQueries({
+				queryKey: projectQueryOptions(projectId).queryKey,
+			});
+			// Also update the projects list cache
+			await queryClient.invalidateQueries({ queryKey: ["projects"] });
+			setName(updated.name);
+			setDescription(updated.description);
+			setError(null);
+			setNameError(null);
+			setSaved(true);
+			setTimeout(() => setSaved(false), 2500);
+		},
+		onError: (err: unknown) => {
+			const code = getApiErrorCode(err);
+			if (code === ApiErrorCode.ProjectNameTaken) {
+				setNameError("A project with this name already exists.");
+				return;
+			}
+			if (code === ApiErrorCode.ProjectNameInvalid) {
+				setNameError("Project name is empty or invalid.");
+				return;
+			}
+			setError("Failed to update project. Please try again.");
+		},
+	});
+
+	const isDirty =
+		name.trim() !== (project?.name ?? "") ||
+		description.trim() !== (project?.description ?? "");
+
+	return (
+		<div className="rounded-xl border border-border/60 bg-card p-6">
+			<h3 className="font-[Syne] text-base font-semibold mb-4">General</h3>
+			<div className="space-y-4 max-w-md">
+				<div className="space-y-1.5">
+					<Label htmlFor="project-name">Project name</Label>
+					<Input
+						id="project-name"
+						value={name}
+						onChange={(e) => {
+							setName(e.target.value);
+							setNameError(null);
+						}}
+						placeholder="My awesome project"
+						className={
+							nameError
+								? "border-destructive focus-visible:ring-destructive/30"
+								: ""
+						}
+					/>
+					{nameError ? (
+						<p className="text-xs text-destructive">{nameError}</p>
+					) : null}
+				</div>
+
+				<div className="space-y-1.5">
+					<Label htmlFor="project-description">Description</Label>
+					<Textarea
+						id="project-description"
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+						placeholder="Describe what this project is about…"
+						rows={3}
+						className="resize-none"
+					/>
+				</div>
+
+				{error ? (
+					<p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+						{error}
+					</p>
+				) : null}
+
+				<div className="flex items-center gap-2 pt-1">
+					<Button
+						size="sm"
+						disabled={!isDirty || mutation.isPending}
+						onClick={() => mutation.mutate()}
+						className="gap-1.5"
+					>
+						{mutation.isPending ? (
+							<Loader2 className="size-3.5 animate-spin" />
+						) : null}
+						Save changes
+					</Button>
+					{saved ? (
+						<span className="text-xs text-emerald-600 dark:text-emerald-400 font-medium">
+							Saved ✓
+						</span>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ── Roles Section ─────────────────────────────────────────────────────────────
+
+function activePermissions(perms: Record<string, unknown>): string[] {
+	return Object.entries(perms)
+		.filter(([, v]) => Boolean(v))
+		.map(([k]) => k);
+}
+
+function formatDate(iso: string) {
+	return new Date(iso).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function projectPermissionBadgeClass(key: string): string {
+	const domain = key.split(".").slice(0, 2).join(".");
+	if (domain === "projects") {
+		return "bg-primary/10 text-primary border-primary/20 dark:bg-primary/20";
+	}
+	if (domain === "project.members") {
+		return "bg-violet-50 text-violet-700 border-violet-200 dark:bg-violet-900/20 dark:text-violet-400 dark:border-violet-700/30";
+	}
+	if (domain === "project.roles") {
+		return "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-900/20 dark:text-sky-400 dark:border-sky-700/30";
+	}
+	if (domain === "tasks") {
+		return "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-700/30";
+	}
+	if (domain === "sprints") {
+		return "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400 dark:border-emerald-700/30";
+	}
+	return "bg-muted text-muted-foreground border-border";
+}
+
+function RolesTableSkeleton() {
+	return (
+		<div className="rounded-xl border overflow-hidden">
+			<div className="border-b bg-muted/40 px-5 py-3">
+				<div className="flex gap-4">
+					<Skeleton className="h-3.5 w-16" />
+					<Skeleton className="h-3.5 w-24" />
+					<Skeleton className="ml-auto h-3.5 w-14" />
+				</div>
+			</div>
+			{["row-1", "row-2", "row-3"].map((rowKey) => (
+				<div
+					key={rowKey}
+					className="flex items-center gap-4 border-b px-5 py-4 last:border-0"
+				>
+					<Skeleton className="h-5 w-36 rounded-md" />
+					<div className="flex flex-1 gap-1.5">
+						<Skeleton className="h-5 w-28 rounded-full" />
+						<Skeleton className="h-5 w-24 rounded-full" />
+					</div>
+					<Skeleton className="h-4 w-20" />
+					<div className="flex gap-1.5">
+						<Skeleton className="size-7 rounded-md" />
+						<Skeleton className="size-7 rounded-md" />
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+interface RoleRowProps {
+	role: ProjectRole;
+	onEdit: (role: ProjectRole) => void;
+	onDelete: (role: ProjectRole) => void;
+}
+
+function RoleTableRow({ role, onEdit, onDelete }: RoleRowProps) {
+	const isSystem = !role.project_id;
+	const active = activePermissions(role.permissions);
+
+	return (
+		<TableRow className="group">
+			<TableCell className="px-5">
+				<div className="flex items-center gap-2">
+					<Lock className="size-3.5 shrink-0 text-muted-foreground/40" />
+					<span className="font-mono text-sm font-medium">
+						{role.role_name}
+					</span>
+				</div>
+			</TableCell>
+			<TableCell className="px-5">
+				{active.length === 0 ? (
+					<span className="text-xs italic text-muted-foreground/60">
+						No permissions assigned
+					</span>
+				) : (
+					<div className="flex flex-wrap gap-1">
+						{active.map((permission) => (
+							<span
+								key={permission}
+								className={`inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[0.68rem] font-medium leading-none ${projectPermissionBadgeClass(permission)}`}
+							>
+								{permission}
+							</span>
+						))}
+					</div>
+				)}
+			</TableCell>
+			<TableCell className="px-5 text-sm text-muted-foreground">
+				{formatDate(role.created_at)}
+			</TableCell>
+			<TableCell className="px-5">
+				{!isSystem ? (
+					<div className="flex items-center justify-end gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							onClick={() => onEdit(role)}
+							title="Edit role"
+						>
+							<Edit2 className="size-3.5" />
+						</Button>
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							className="text-destructive hover:text-destructive hover:bg-destructive/10"
+							onClick={() => onDelete(role)}
+							title="Delete role"
+						>
+							<Trash2 className="size-3.5" />
+						</Button>
+					</div>
+				) : null}
+			</TableCell>
+		</TableRow>
+	);
+}
+
+function RolesSettings({ projectId }: { projectId: string }) {
+	const { data: roles, isLoading } = useQuery(
+		projectRolesQueryOptions(projectId),
+	);
+
+	const [createOpen, setCreateOpen] = useState(false);
+	const [editRole, setEditRole] = useState<ProjectRole | null>(null);
+	const [deleteRole, setDeleteRole] = useState<ProjectRole | null>(null);
+
+	const systemRoles = roles?.filter((r) => !r.project_id) ?? [];
+
+	return (
+		<div className="rounded-xl border border-border/60 bg-card p-6">
+			{/* Header */}
+			<div className="flex items-center justify-between mb-1">
+				<div>
+					<h3 className="font-[Syne] text-base font-semibold">Project Roles</h3>
+					<p className="text-xs text-muted-foreground mt-0.5">
+						Manage roles and permissions for members of this project.
+					</p>
+				</div>
+				<Button
+					size="sm"
+					variant="outline"
+					className="gap-1.5 border-border/60 shrink-0"
+					onClick={() => setCreateOpen(true)}
+				>
+					<Plus className="size-3.5" />
+					New role
+				</Button>
+			</div>
+
+			{/* Stats strip */}
+			{!isLoading && roles && roles.length > 0 ? (
+				<div className="flex items-center gap-5 rounded-xl border bg-muted/20 px-5 py-3 mt-4">
+					<div className="flex items-center gap-2">
+						<Shield className="size-4 text-primary" />
+						<span className="text-sm">
+							<span className="font-semibold tabular-nums">{roles.length}</span>
+							<span className="ml-1.5 text-muted-foreground">
+								{roles.length === 1 ? "role" : "roles"} defined
+							</span>
+						</span>
+					</div>
+					<div className="h-4 w-px bg-border" />
+					<div className="flex items-center gap-2">
+						<Key className="size-4 text-muted-foreground" />
+						<span className="text-sm">
+							<span className="font-semibold tabular-nums">
+								{roles.reduce(
+									(sum, r) => sum + activePermissions(r.permissions).length,
+									0,
+								)}
+							</span>
+							<span className="ml-1.5 text-muted-foreground">
+								permission grants across all roles
+							</span>
+						</span>
+					</div>
+				</div>
+			) : null}
+
+			{/* Table */}
+			{isLoading ? (
+				<RolesTableSkeleton />
+			) : !roles?.length ? (
+				<div className="flex flex-col items-center gap-4 rounded-xl border border-dashed bg-muted/20 py-16 text-center mt-4">
+					<div className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground/60">
+						<Shield className="size-6" />
+					</div>
+					<div>
+						<p className="text-sm font-medium">No roles defined yet</p>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Create your first role to start assigning permissions to members.
+						</p>
+					</div>
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={() => setCreateOpen(true)}
+					>
+						<Plus className="size-4" />
+						Create role
+					</Button>
+				</div>
+			) : (
+				<div className="overflow-x-auto rounded-xl border mt-4">
+					<Table>
+						<TableHeader>
+							<TableRow className="bg-muted/40 hover:bg-muted/40">
+								<TableHead className="w-44 px-5 text-xs font-semibold uppercase tracking-wide">
+									Name
+								</TableHead>
+								<TableHead className="px-5 text-xs font-semibold uppercase tracking-wide">
+									Permissions
+								</TableHead>
+								<TableHead className="w-32 px-5 text-xs font-semibold uppercase tracking-wide">
+									Created
+								</TableHead>
+								<TableHead className="w-20 px-5 text-xs font-semibold uppercase tracking-wide" />
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{roles.map((role) => (
+								<RoleTableRow
+									key={role.id}
+									role={role}
+									onEdit={setEditRole}
+									onDelete={setDeleteRole}
+								/>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			)}
+
+			{/* System roles note */}
+			{systemRoles.length > 0 ? (
+				<p className="text-xs text-muted-foreground/60 mt-3 flex items-center gap-1">
+					<Lock className="size-3 shrink-0" />
+					System roles are shared templates and cannot be edited or deleted.
+				</p>
+			) : null}
+
+			{/* Dialogs */}
+			<ProjectRoleFormDialog
+				projectId={projectId}
+				open={createOpen}
+				onOpenChange={setCreateOpen}
+			/>
+
+			{editRole ? (
+				<ProjectRoleFormDialog
+					projectId={projectId}
+					role={editRole}
+					open={!!editRole}
+					onOpenChange={(open) => {
+						if (!open) setEditRole(null);
+					}}
+				/>
+			) : null}
+
+			{deleteRole ? (
+				<DeleteProjectRoleDialog
+					projectId={projectId}
+					role={deleteRole}
+					open={!!deleteRole}
+					onOpenChange={(open) => {
+						if (!open) setDeleteRole(null);
+					}}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+// ── Danger Zone ───────────────────────────────────────────────────────────────
+
+function DangerZone({ projectId }: { projectId: string }) {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const { data: project } = useQuery(projectQueryOptions(projectId));
+	const [open, setOpen] = useState(false);
+	const [confirmName, setConfirmName] = useState("");
+
+	const deleteMutation = useMutation({
+		mutationFn: () => deleteProject(projectId),
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({ queryKey: ["projects"] });
+			void navigate({ to: "/home" });
+		},
+	});
+
+	return (
+		<div className="rounded-xl border border-destructive/30 bg-destructive/3 p-6">
+			<h3 className="font-[Syne] text-base font-semibold text-destructive mb-4">
+				Danger Zone
+			</h3>
+			<div className="flex items-center justify-between">
+				<div>
+					<p className="text-sm font-medium">Delete this project</p>
+					<p className="text-xs text-muted-foreground mt-0.5">
+						Permanently delete the project and all its data. This action cannot
+						be undone.
+					</p>
+				</div>
+				<Button
+					variant="destructive"
+					size="sm"
+					className="shrink-0 ml-4 gap-1.5"
+					onClick={() => setOpen(true)}
+				>
+					<Trash2 className="size-3.5" />
+					Delete project
+				</Button>
+			</div>
+
+			<Dialog
+				open={open}
+				onOpenChange={(o) => {
+					setOpen(o);
+					setConfirmName("");
+				}}
+			>
+				<DialogContent className="sm:max-w-sm">
+					<DialogHeader>
+						<div className="flex size-10 items-center justify-center rounded-full bg-destructive/10 mb-2">
+							<AlertTriangle className="size-5 text-destructive" />
+						</div>
+						<DialogTitle>Delete project</DialogTitle>
+						<DialogDescription>
+							This will permanently delete{" "}
+							<span className="font-semibold text-foreground">
+								{project?.name}
+							</span>{" "}
+							and all its data, including members, roles, and integrations. This
+							action cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-1.5">
+						<Label
+							htmlFor="confirm-name"
+							className="text-xs text-muted-foreground"
+						>
+							Type{" "}
+							<span className="font-semibold text-foreground">
+								{project?.name}
+							</span>{" "}
+							to confirm
+						</Label>
+						<Input
+							id="confirm-name"
+							value={confirmName}
+							onChange={(e) => setConfirmName(e.target.value)}
+							placeholder={project?.name}
+							autoComplete="off"
+						/>
+					</div>
+					{deleteMutation.isError ? (
+						<p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+							Failed to delete project. Please try again.
+						</p>
+					) : null}
+					<DialogFooter>
+						<DialogClose
+							render={
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={deleteMutation.isPending}
+								/>
+							}
+						>
+							Cancel
+						</DialogClose>
+						<Button
+							variant="destructive"
+							size="sm"
+							disabled={
+								confirmName !== project?.name || deleteMutation.isPending
+							}
+							onClick={() => deleteMutation.mutate()}
+						>
+							{deleteMutation.isPending ? (
+								<Loader2 className="size-3.5 animate-spin" />
+							) : (
+								<Trash2 className="size-3.5" />
+							)}
+							Delete permanently
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}
+
+// ── Settings Page ─────────────────────────────────────────────────────────────
+
+const NAV_ITEMS = [
+	{ id: "general", label: "General", icon: Settings },
+	{ id: "roles", label: "Roles", icon: Shield },
+	{ id: "danger", label: "Danger Zone", icon: AlertTriangle },
+] as const;
+
+function SettingsPage() {
+	const { projectId } = Route.useParams();
+	const { data: project } = useQuery(projectQueryOptions(projectId));
+	const [activeSection, setActiveSection] = useState<
+		"general" | "roles" | "danger"
+	>("general");
+
+	return (
+		<div className="flex flex-col min-h-0 flex-1">
+			{/* Header */}
+			<div className="relative overflow-hidden border-b border-border/50 shrink-0">
+				<div
+					className="pointer-events-none absolute inset-0 opacity-50"
+					style={{
+						backgroundImage:
+							"radial-gradient(circle, color-mix(in oklch, var(--color-primary) 12%, transparent) 1px, transparent 1px)",
+						backgroundSize: "20px 20px",
+						maskImage:
+							"radial-gradient(ellipse 70% 100% at 0% 0%, black 20%, transparent 70%)",
+					}}
+				/>
+				<div className="relative px-6 py-7 max-w-6xl mx-auto w-full">
+					<div className="flex items-center gap-2.5 mb-1">
+						<Settings className="size-4 text-muted-foreground" />
+						<h1 className="font-[Syne] text-2xl font-bold tracking-tight">
+							Settings
+						</h1>
+					</div>
+					<p className="text-sm text-muted-foreground">
+						{project?.name} · Configure project settings, roles, and permissions
+					</p>
+				</div>
+			</div>
+
+			{/* Body */}
+			<div className="flex-1 overflow-y-auto">
+				<div className="max-w-6xl mx-auto w-full px-6 py-8 flex gap-10 items-start">
+					{/* Sidebar nav — hidden on small screens */}
+					<aside className="hidden lg:flex flex-col gap-1 w-48 shrink-0 sticky top-8">
+						<p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60 px-3 mb-1">
+							Settings
+						</p>
+						{NAV_ITEMS.map(({ id, label, icon: Icon }) => (
+							<button
+								key={id}
+								type="button"
+								onClick={() => setActiveSection(id as typeof activeSection)}
+								className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors text-left ${
+									activeSection === id
+										? "bg-accent text-foreground"
+										: "text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+								} ${id === "danger" ? "mt-2 text-destructive/70 hover:text-destructive hover:bg-destructive/8" : ""}`}
+							>
+								<Icon className="size-3.5 shrink-0" />
+								{label}
+							</button>
+						))}
+					</aside>
+
+					{/* Content */}
+					<div className="flex-1 min-w-0">
+						{/* Mobile section picker */}
+						<div className="flex gap-1 mb-6 lg:hidden">
+							{NAV_ITEMS.map(({ id, label, icon: Icon }) => (
+								<button
+									key={id}
+									type="button"
+									onClick={() => setActiveSection(id as typeof activeSection)}
+									className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+										activeSection === id
+											? "bg-accent text-foreground"
+											: "text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+									}`}
+								>
+									<Icon className="size-3 shrink-0" />
+									{label}
+								</button>
+							))}
+						</div>
+
+						{activeSection === "general" && (
+							<GeneralSettings projectId={projectId} />
+						)}
+						{activeSection === "roles" && (
+							<RolesSettings projectId={projectId} />
+						)}
+						{activeSection === "danger" && <DangerZone projectId={projectId} />}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
@@ -12,11 +12,8 @@ import {
 	Trash2,
 } from "lucide-react";
 import { useState } from "react";
-
-import { usePermissions } from "@/hooks/use-permissions";
 import { DeleteProjectRoleDialog } from "@/components/projects/roles/DeleteProjectRoleDialog";
 import { ProjectRoleFormDialog } from "@/components/projects/roles/ProjectRoleFormDialog";
-
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -27,7 +24,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -40,6 +36,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
+import { usePermissions } from "@/hooks/use-permissions";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import { currentUserQueryOptions } from "@/lib/auth-api";
 import {
@@ -67,7 +64,13 @@ export const Route = createFileRoute(
 
 // ── General Settings ──────────────────────────────────────────────────────────
 
-function GeneralSettings({ projectId, canEdit }: { projectId: string; canEdit: boolean }) {
+function GeneralSettings({
+	projectId,
+	canEdit,
+}: {
+	projectId: string;
+	canEdit: boolean;
+}) {
 	const queryClient = useQueryClient();
 	const { data: project } = useQuery(projectQueryOptions(projectId));
 
@@ -262,7 +265,12 @@ interface RoleRowProps {
 	onDelete: (role: ProjectRole) => void;
 }
 
-function RoleTableRow({ role, canManageRoles, onEdit, onDelete }: RoleRowProps) {
+function RoleTableRow({
+	role,
+	canManageRoles,
+	onEdit,
+	onDelete,
+}: RoleRowProps) {
 	const isSystem = !role.project_id;
 	const active = activePermissions(role.permissions);
 
@@ -298,7 +306,7 @@ function RoleTableRow({ role, canManageRoles, onEdit, onDelete }: RoleRowProps) 
 				{formatDate(role.created_at)}
 			</TableCell>
 			<TableCell className="px-5">
-			{!isSystem && canManageRoles ? (
+				{!isSystem && canManageRoles ? (
 					<div className="flex items-center justify-end gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
 						<Button
 							variant="ghost"
@@ -324,7 +332,13 @@ function RoleTableRow({ role, canManageRoles, onEdit, onDelete }: RoleRowProps) 
 	);
 }
 
-function RolesSettings({ projectId, canManageRoles }: { projectId: string; canManageRoles: boolean }) {
+function RolesSettings({
+	projectId,
+	canManageRoles,
+}: {
+	projectId: string;
+	canManageRoles: boolean;
+}) {
 	const { data: roles, isLoading } = useQuery(
 		projectRolesQueryOptions(projectId),
 	);
@@ -647,7 +661,8 @@ function SettingsPage() {
 	);
 	const canDelete = hasPermission("projects.delete") || hasProjectDelete;
 	const canEditProject = hasPermission("projects.write") || hasProjectWrite;
-	const canManageRoles = hasPermission("project.roles.write") || hasProjectRolesWrite;
+	const canManageRoles =
+		hasPermission("project.roles.write") || hasProjectRolesWrite;
 
 	const visibleNavItems = canDelete
 		? NAV_ITEMS
@@ -734,11 +749,14 @@ function SettingsPage() {
 							<GeneralSettings projectId={projectId} canEdit={canEditProject} />
 						)}
 						{activeSection === "roles" && (
-							<RolesSettings projectId={projectId} canManageRoles={canManageRoles} />
+							<RolesSettings
+								projectId={projectId}
+								canManageRoles={canManageRoles}
+							/>
 						)}
-							{activeSection === "danger" && canDelete && (
-								<DangerZone projectId={projectId} />
-							)}
+						{activeSection === "danger" && canDelete && (
+							<DangerZone projectId={projectId} />
+						)}
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
+import { usePermissions } from "@/hooks/use-permissions";
 import { DeleteProjectRoleDialog } from "@/components/projects/roles/DeleteProjectRoleDialog";
 import { ProjectRoleFormDialog } from "@/components/projects/roles/ProjectRoleFormDialog";
 
@@ -40,9 +41,12 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import { currentUserQueryOptions } from "@/lib/auth-api";
 import {
 	deleteProject,
+	type ProjectMember,
 	type ProjectRole,
+	projectMembersQueryOptions,
 	projectQueryOptions,
 	projectRolesQueryOptions,
 	updateProject,
@@ -55,6 +59,7 @@ export const Route = createFileRoute(
 		await Promise.all([
 			queryClient.ensureQueryData(projectQueryOptions(projectId)),
 			queryClient.ensureQueryData(projectRolesQueryOptions(projectId)),
+			queryClient.ensureQueryData(projectMembersQueryOptions(projectId)),
 		]);
 	},
 	component: SettingsPage,
@@ -62,7 +67,7 @@ export const Route = createFileRoute(
 
 // ── General Settings ──────────────────────────────────────────────────────────
 
-function GeneralSettings({ projectId }: { projectId: string }) {
+function GeneralSettings({ projectId, canEdit }: { projectId: string; canEdit: boolean }) {
 	const queryClient = useQueryClient();
 	const { data: project } = useQuery(projectQueryOptions(projectId));
 
@@ -123,6 +128,7 @@ function GeneralSettings({ projectId }: { projectId: string }) {
 							setNameError(null);
 						}}
 						placeholder="My awesome project"
+						disabled={!canEdit}
 						className={
 							nameError
 								? "border-destructive focus-visible:ring-destructive/30"
@@ -142,6 +148,7 @@ function GeneralSettings({ projectId }: { projectId: string }) {
 						onChange={(e) => setDescription(e.target.value)}
 						placeholder="Describe what this project is about…"
 						rows={3}
+						disabled={!canEdit}
 						className="resize-none"
 					/>
 				</div>
@@ -152,24 +159,30 @@ function GeneralSettings({ projectId }: { projectId: string }) {
 					</p>
 				) : null}
 
-				<div className="flex items-center gap-2 pt-1">
-					<Button
-						size="sm"
-						disabled={!isDirty || mutation.isPending}
-						onClick={() => mutation.mutate()}
-						className="gap-1.5"
-					>
-						{mutation.isPending ? (
-							<Loader2 className="size-3.5 animate-spin" />
+				{canEdit ? (
+					<div className="flex items-center gap-2 pt-1">
+						<Button
+							size="sm"
+							disabled={!isDirty || mutation.isPending}
+							onClick={() => mutation.mutate()}
+							className="gap-1.5"
+						>
+							{mutation.isPending ? (
+								<Loader2 className="size-3.5 animate-spin" />
+							) : null}
+							Save changes
+						</Button>
+						{saved ? (
+							<span className="text-xs text-emerald-600 dark:text-emerald-400 font-medium">
+								Saved ✓
+							</span>
 						) : null}
-						Save changes
-					</Button>
-					{saved ? (
-						<span className="text-xs text-emerald-600 dark:text-emerald-400 font-medium">
-							Saved ✓
-						</span>
-					) : null}
-				</div>
+					</div>
+				) : (
+					<p className="text-xs text-muted-foreground">
+						You don't have permission to edit this project.
+					</p>
+				)}
 			</div>
 		</div>
 	);
@@ -244,11 +257,12 @@ function RolesTableSkeleton() {
 
 interface RoleRowProps {
 	role: ProjectRole;
+	canManageRoles: boolean;
 	onEdit: (role: ProjectRole) => void;
 	onDelete: (role: ProjectRole) => void;
 }
 
-function RoleTableRow({ role, onEdit, onDelete }: RoleRowProps) {
+function RoleTableRow({ role, canManageRoles, onEdit, onDelete }: RoleRowProps) {
 	const isSystem = !role.project_id;
 	const active = activePermissions(role.permissions);
 
@@ -284,7 +298,7 @@ function RoleTableRow({ role, onEdit, onDelete }: RoleRowProps) {
 				{formatDate(role.created_at)}
 			</TableCell>
 			<TableCell className="px-5">
-				{!isSystem ? (
+			{!isSystem && canManageRoles ? (
 					<div className="flex items-center justify-end gap-0.5 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100">
 						<Button
 							variant="ghost"
@@ -310,7 +324,7 @@ function RoleTableRow({ role, onEdit, onDelete }: RoleRowProps) {
 	);
 }
 
-function RolesSettings({ projectId }: { projectId: string }) {
+function RolesSettings({ projectId, canManageRoles }: { projectId: string; canManageRoles: boolean }) {
 	const { data: roles, isLoading } = useQuery(
 		projectRolesQueryOptions(projectId),
 	);
@@ -331,15 +345,17 @@ function RolesSettings({ projectId }: { projectId: string }) {
 						Manage roles and permissions for members of this project.
 					</p>
 				</div>
-				<Button
-					size="sm"
-					variant="outline"
-					className="gap-1.5 border-border/60 shrink-0"
-					onClick={() => setCreateOpen(true)}
-				>
-					<Plus className="size-3.5" />
-					New role
-				</Button>
+				{canManageRoles ? (
+					<Button
+						size="sm"
+						variant="outline"
+						className="gap-1.5 border-border/60 shrink-0"
+						onClick={() => setCreateOpen(true)}
+					>
+						<Plus className="size-3.5" />
+						New role
+					</Button>
+				) : null}
 			</div>
 
 			{/* Stats strip */}
@@ -386,14 +402,16 @@ function RolesSettings({ projectId }: { projectId: string }) {
 							Create your first role to start assigning permissions to members.
 						</p>
 					</div>
-					<Button
-						size="sm"
-						variant="outline"
-						onClick={() => setCreateOpen(true)}
-					>
-						<Plus className="size-4" />
-						Create role
-					</Button>
+					{canManageRoles ? (
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => setCreateOpen(true)}
+						>
+							<Plus className="size-4" />
+							Create role
+						</Button>
+					) : null}
 				</div>
 			) : (
 				<div className="overflow-x-auto rounded-xl border mt-4">
@@ -417,6 +435,7 @@ function RolesSettings({ projectId }: { projectId: string }) {
 								<RoleTableRow
 									key={role.id}
 									role={role}
+									canManageRoles={canManageRoles}
 									onEdit={setEditRole}
 									onDelete={setDeleteRole}
 								/>
@@ -598,6 +617,42 @@ const NAV_ITEMS = [
 function SettingsPage() {
 	const { projectId } = Route.useParams();
 	const { data: project } = useQuery(projectQueryOptions(projectId));
+	const { hasPermission } = usePermissions();
+	const { data: currentUser } = useQuery(currentUserQueryOptions);
+	const { data: members = [] } = useQuery(
+		projectMembersQueryOptions(projectId),
+	);
+	const { data: roles = [] } = useQuery(projectRolesQueryOptions(projectId));
+
+	const myMembership = (members as ProjectMember[]).find(
+		(m) => m.user_id === currentUser?.id,
+	);
+	const myRole = (roles as ProjectRole[]).find(
+		(r) => r.id === myMembership?.project_role_id,
+	);
+	const hasProjectDelete = Boolean(
+		(myRole?.permissions as Record<string, boolean> | undefined)?.[
+			"projects.delete"
+		],
+	);
+	const hasProjectWrite = Boolean(
+		(myRole?.permissions as Record<string, boolean> | undefined)?.[
+			"projects.write"
+		],
+	);
+	const hasProjectRolesWrite = Boolean(
+		(myRole?.permissions as Record<string, boolean> | undefined)?.[
+			"project.roles.write"
+		],
+	);
+	const canDelete = hasPermission("projects.delete") || hasProjectDelete;
+	const canEditProject = hasPermission("projects.write") || hasProjectWrite;
+	const canManageRoles = hasPermission("project.roles.write") || hasProjectRolesWrite;
+
+	const visibleNavItems = canDelete
+		? NAV_ITEMS
+		: NAV_ITEMS.filter((i) => i.id !== "danger");
+
 	const [activeSection, setActiveSection] = useState<
 		"general" | "roles" | "danger"
 	>("general");
@@ -637,7 +692,7 @@ function SettingsPage() {
 						<p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60 px-3 mb-1">
 							Settings
 						</p>
-						{NAV_ITEMS.map(({ id, label, icon: Icon }) => (
+						{visibleNavItems.map(({ id, label, icon: Icon }) => (
 							<button
 								key={id}
 								type="button"
@@ -658,7 +713,7 @@ function SettingsPage() {
 					<div className="flex-1 min-w-0">
 						{/* Mobile section picker */}
 						<div className="flex gap-1 mb-6 lg:hidden">
-							{NAV_ITEMS.map(({ id, label, icon: Icon }) => (
+							{visibleNavItems.map(({ id, label, icon: Icon }) => (
 								<button
 									key={id}
 									type="button"
@@ -676,12 +731,14 @@ function SettingsPage() {
 						</div>
 
 						{activeSection === "general" && (
-							<GeneralSettings projectId={projectId} />
+							<GeneralSettings projectId={projectId} canEdit={canEditProject} />
 						)}
 						{activeSection === "roles" && (
-							<RolesSettings projectId={projectId} />
+							<RolesSettings projectId={projectId} canManageRoles={canManageRoles} />
 						)}
-						{activeSection === "danger" && <DangerZone projectId={projectId} />}
+							{activeSection === "danger" && canDelete && (
+								<DangerZone projectId={projectId} />
+							)}
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -14,8 +14,6 @@ import {
 	Users,
 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
-
-import { usePermissions } from "@/hooks/use-permissions";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -46,6 +44,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { usePermissions } from "@/hooks/use-permissions";
 import { getUsers, type User } from "@/lib/admin-api";
 import { currentUserQueryOptions } from "@/lib/auth-api";
 import {
@@ -506,31 +505,31 @@ function MemberRow({
 					@{member.username}
 				</p>
 			</div>
-		{canManage ? (
-			<RoleChip member={member} projectId={projectId} roles={roles} />
-		) : (
-			<span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-secondary/50 px-2.5 py-1 text-xs font-medium text-secondary-foreground">
-				<Shield className="size-3 text-muted-foreground" />
-				{member.role_name}
-			</span>
-		)}
-		{canManage ? (
-			<DropdownMenu>
-				<DropdownMenuTrigger className="flex size-7 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
-					<MoreHorizontal className="size-4" />
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="end" className="w-44">
-					<DropdownMenuItem
-						className="text-destructive focus:text-destructive focus:bg-destructive/10"
-						onClick={() => onRemove(member)}
-					>
-						<Trash2 className="size-3.5 mr-2" />
-						Remove member
-					</DropdownMenuItem>
-				</DropdownMenuContent>
-			</DropdownMenu>
-		) : null}
-	</div>
+			{canManage ? (
+				<RoleChip member={member} projectId={projectId} roles={roles} />
+			) : (
+				<span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-secondary/50 px-2.5 py-1 text-xs font-medium text-secondary-foreground">
+					<Shield className="size-3 text-muted-foreground" />
+					{member.role_name}
+				</span>
+			)}
+			{canManage ? (
+				<DropdownMenu>
+					<DropdownMenuTrigger className="flex size-7 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
+						<MoreHorizontal className="size-4" />
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="w-44">
+						<DropdownMenuItem
+							className="text-destructive focus:text-destructive focus:bg-destructive/10"
+							onClick={() => onRemove(member)}
+						>
+							<Trash2 className="size-3.5 mr-2" />
+							Remove member
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			) : null}
+		</div>
 	);
 }
 
@@ -641,16 +640,16 @@ function TeamPage() {
 								Add teammates or AI agents to this project to get started.
 							</p>
 						</div>
-							{canManageMembers ? (
-								<Button
-									size="sm"
-									className="gap-1.5 mt-1"
-									onClick={() => setAddMemberOpen(true)}
-								>
-									<Plus className="size-3.5" />
-									Add first member
-								</Button>
-							) : null}
+						{canManageMembers ? (
+							<Button
+								size="sm"
+								className="gap-1.5 mt-1"
+								onClick={() => setAddMemberOpen(true)}
+							>
+								<Plus className="size-3.5" />
+								Add first member
+							</Button>
+						) : null}
 					</div>
 				) : (
 					<div>

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -1,0 +1,715 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import {
+	Bot,
+	Check,
+	ChevronDown,
+	Loader2,
+	MoreHorizontal,
+	Plus,
+	Search,
+	Shield,
+	Trash2,
+	UserRound,
+	Users,
+} from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getUsers, type User } from "@/lib/admin-api";
+import {
+	addProjectMember,
+	type ProjectMember,
+	type ProjectRole,
+	projectMembersQueryOptions,
+	projectQueryOptions,
+	projectRolesQueryOptions,
+	removeProjectMember,
+	updateProjectMemberRole,
+} from "@/lib/project-api";
+
+export const Route = createFileRoute(
+	"/_authenticated/projects/$projectId/team/",
+)({
+	loader: async ({ context: { queryClient }, params: { projectId } }) => {
+		await Promise.all([
+			queryClient.ensureQueryData(projectMembersQueryOptions(projectId)),
+			queryClient.ensureQueryData(projectRolesQueryOptions(projectId)),
+		]);
+	},
+	component: TeamPage,
+});
+
+function getInitials(name: string): string {
+	return name
+		.split(" ")
+		.filter(Boolean)
+		.map((n) => n[0])
+		.join("")
+		.toUpperCase()
+		.slice(0, 2);
+}
+
+// ── Add Member Dialog ──────────────────────────────────────────────────────────
+
+function UserPickerItem({
+	user,
+	selected,
+	onSelect,
+}: {
+	user: User;
+	selected: boolean;
+	onSelect: (user: User) => void;
+}) {
+	const display = user.full_name || user.username;
+	return (
+		<button
+			type="button"
+			className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent ${selected ? "bg-accent" : ""}`}
+			onClick={() => onSelect(user)}
+		>
+			<Avatar className="size-7 shrink-0">
+				<AvatarFallback className="text-[10px] bg-primary/10 text-primary font-semibold">
+					{getInitials(display)}
+				</AvatarFallback>
+			</Avatar>
+			<div className="min-w-0 flex-1">
+				<span className="font-medium truncate block">{display}</span>
+				{user.full_name && (
+					<span className="text-xs text-muted-foreground truncate block">
+						@{user.username}
+					</span>
+				)}
+			</div>
+			{selected && <Check className="size-4 shrink-0 text-primary" />}
+		</button>
+	);
+}
+
+function AddMemberDialog({
+	open,
+	onOpenChange,
+	projectId,
+	roles,
+	existingMemberIds,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	projectId: string;
+	roles: ProjectRole[];
+	existingMemberIds: Set<string>;
+}) {
+	const queryClient = useQueryClient();
+	const [selectedUser, setSelectedUser] = useState<User | null>(null);
+	const [selectedRoleId, setSelectedRoleId] = useState<string>("");
+	const [userSearch, setUserSearch] = useState("");
+	const [error, setError] = useState<string | null>(null);
+	const searchRef = useRef<HTMLInputElement>(null);
+
+	const { data: usersData, isLoading: isLoadingUsers } = useQuery({
+		queryKey: ["admin", "users", "all"],
+		queryFn: () => getUsers(1, 500),
+		enabled: open,
+	});
+
+	const filteredUsers = useMemo<User[]>(() => {
+		const items: User[] = usersData?.items ?? [];
+		const q = userSearch.toLowerCase();
+		return items
+			.filter((u) => !existingMemberIds.has(u.id))
+			.filter(
+				(u) =>
+					!q ||
+					u.username.toLowerCase().includes(q) ||
+					(u.full_name ?? "").toLowerCase().includes(q),
+			);
+	}, [usersData, existingMemberIds, userSearch]);
+
+	const addMutation = useMutation({
+		mutationFn: () => {
+			if (!selectedUser || !selectedRoleId) {
+				return Promise.reject(new Error("User and role are required"));
+			}
+
+			return addProjectMember(projectId, {
+				user_id: selectedUser.id,
+				project_role_id: selectedRoleId,
+			});
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({
+				queryKey: projectMembersQueryOptions(projectId).queryKey,
+			});
+			handleClose();
+		},
+		onError: (err: unknown) => {
+			const e = err as { response?: { data?: { error?: string } } };
+			setError(
+				e?.response?.data?.error ?? "Failed to add member. Please try again.",
+			);
+		},
+	});
+
+	function handleClose() {
+		setSelectedUser(null);
+		setSelectedRoleId("");
+		setUserSearch("");
+		setError(null);
+		onOpenChange(false);
+	}
+
+	const canSubmit = selectedUser && selectedRoleId && !addMutation.isPending;
+	const selectedUserId = selectedUser?.id ?? null;
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(v) => {
+				if (!v) handleClose();
+			}}
+		>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<div className="flex size-10 items-center justify-center rounded-full bg-primary/10 mb-2">
+						<Users className="size-5 text-primary" />
+					</div>
+					<DialogTitle>Add member</DialogTitle>
+					<DialogDescription>
+						Select a user and assign them a role in this project.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 py-1">
+					{/* User search */}
+					<div className="space-y-1.5">
+						<p className="text-sm font-medium">User</p>
+						{selectedUser ? (
+							<div className="flex items-center gap-3 rounded-lg border border-primary/40 bg-primary/5 px-3 py-2">
+								<Avatar className="size-7 shrink-0">
+									<AvatarFallback className="text-[10px] bg-primary/10 text-primary font-semibold">
+										{getInitials(
+											selectedUser.full_name || selectedUser.username,
+										)}
+									</AvatarFallback>
+								</Avatar>
+								<div className="min-w-0 flex-1">
+									<span className="text-sm font-medium">
+										{selectedUser.full_name || selectedUser.username}
+									</span>
+									{selectedUser.full_name && (
+										<span className="ml-2 text-xs text-muted-foreground">
+											@{selectedUser.username}
+										</span>
+									)}
+								</div>
+								<button
+									type="button"
+									className="text-xs text-muted-foreground hover:text-foreground"
+									onClick={() => {
+										setSelectedUser(null);
+										setTimeout(() => searchRef.current?.focus(), 50);
+									}}
+								>
+									Change
+								</button>
+							</div>
+						) : (
+							<div className="rounded-lg border border-border overflow-hidden">
+								<div className="flex items-center gap-2 px-3 py-2 border-b border-border/50">
+									<Search className="size-3.5 shrink-0 text-muted-foreground" />
+									<input
+										ref={searchRef}
+										className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+										placeholder="Search by name or username…"
+										value={userSearch}
+										onChange={(e) => setUserSearch(e.target.value)}
+										autoFocus
+									/>
+								</div>
+								<div className="max-h-44 overflow-y-auto p-1">
+									{isLoadingUsers ? (
+										<div className="flex items-center justify-center py-4">
+											<Loader2 className="size-4 animate-spin text-muted-foreground" />
+										</div>
+									) : filteredUsers.length === 0 ? (
+										<p className="py-4 text-center text-xs text-muted-foreground">
+											{userSearch
+												? "No users match your search."
+												: "No users available to add."}
+										</p>
+									) : (
+										filteredUsers.map((user: User) => (
+											<UserPickerItem
+												key={user.id}
+												user={user}
+												selected={selectedUserId === user.id}
+												onSelect={setSelectedUser}
+											/>
+										))
+									)}
+								</div>
+							</div>
+						)}
+					</div>
+
+					{/* Role picker */}
+					<div className="space-y-1.5">
+						<p className="text-sm font-medium">Role</p>
+						<Select
+							value={selectedRoleId}
+							onValueChange={(v) => {
+								if (v != null) setSelectedRoleId(v);
+							}}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Select a role…" />
+							</SelectTrigger>
+							<SelectContent>
+								{roles.map((role) => (
+									<SelectItem key={role.id} value={role.id}>
+										{role.role_name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					{error && (
+						<p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+							{error}
+						</p>
+					)}
+				</div>
+
+				<DialogFooter>
+					<DialogClose
+						render={
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={addMutation.isPending}
+							/>
+						}
+					>
+						Cancel
+					</DialogClose>
+					<Button
+						size="sm"
+						disabled={!canSubmit}
+						onClick={() => addMutation.mutate()}
+					>
+						{addMutation.isPending ? (
+							<Loader2 className="size-3.5 animate-spin" />
+						) : (
+							<Plus className="size-3.5" />
+						)}
+						Add member
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+// ── Role Chip (inline popover role picker) ────────────────────────────────────
+
+function RoleChip({
+	member,
+	projectId,
+	roles,
+}: {
+	member: ProjectMember;
+	projectId: string;
+	roles: ProjectRole[];
+}) {
+	const queryClient = useQueryClient();
+	const [open, setOpen] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const mutation = useMutation({
+		mutationFn: (roleId: string) =>
+			updateProjectMemberRole(projectId, member.user_id, {
+				project_role_id: roleId,
+			}),
+		onMutate: async (roleId) => {
+			await queryClient.cancelQueries({
+				queryKey: projectMembersQueryOptions(projectId).queryKey,
+			});
+			const previous = queryClient.getQueryData(
+				projectMembersQueryOptions(projectId).queryKey,
+			);
+			const newRole = roles.find((r) => r.id === roleId);
+			if (newRole) {
+				queryClient.setQueryData(
+					projectMembersQueryOptions(projectId).queryKey,
+					(old: ProjectMember[] | undefined) =>
+						old?.map((m) =>
+							m.user_id === member.user_id
+								? {
+										...m,
+										project_role_id: roleId,
+										role_name: newRole.role_name,
+									}
+								: m,
+						),
+				);
+			}
+			return { previous };
+		},
+		onError: (_err, _vars, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(
+					projectMembersQueryOptions(projectId).queryKey,
+					context.previous,
+				);
+			}
+			const e = _err as { response?: { data?: { error?: string } } };
+			setError(e?.response?.data?.error ?? "Failed to change role.");
+		},
+		onSuccess: () => {
+			setOpen(false);
+			setError(null);
+		},
+		onSettled: () => {
+			queryClient.invalidateQueries({
+				queryKey: projectMembersQueryOptions(projectId).queryKey,
+			});
+		},
+	});
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(v) => {
+				setOpen(v);
+				if (!v) setError(null);
+			}}
+		>
+			<PopoverTrigger
+				type="button"
+				aria-label="Change role"
+				disabled={mutation.isPending}
+				className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-secondary/50 px-2.5 py-1 text-xs font-medium text-secondary-foreground transition-all hover:bg-accent hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{mutation.isPending ? (
+					<Loader2 className="size-3 animate-spin text-muted-foreground" />
+				) : (
+					<Shield className="size-3 text-muted-foreground" />
+				)}
+				<span>{member.role_name}</span>
+				{!mutation.isPending && (
+					<ChevronDown className="size-3 text-muted-foreground/70" />
+				)}
+			</PopoverTrigger>
+			<PopoverContent className="w-52 p-1.5" align="end">
+				<p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+					Change role
+				</p>
+				<div className="mt-0.5 space-y-px">
+					{roles.map((role) => {
+						const isCurrent = role.id === member.project_role_id;
+						return (
+							<button
+								key={role.id}
+								type="button"
+								className={`flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent ${
+									isCurrent
+										? "font-medium text-foreground"
+										: "text-muted-foreground hover:text-foreground"
+								}`}
+								onClick={() => {
+									if (!isCurrent) mutation.mutate(role.id);
+									else setOpen(false);
+								}}
+							>
+								<Check
+									className={`size-3.5 shrink-0 text-primary transition-opacity ${
+										isCurrent ? "opacity-100" : "opacity-0"
+									}`}
+								/>
+								{role.role_name}
+							</button>
+						);
+					})}
+				</div>
+				{error && (
+					<p className="mt-1.5 rounded-md bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
+						{error}
+					</p>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+// ── Member Row ─────────────────────────────────────────────────────────────────
+
+function MemberRow({
+	member,
+	projectId,
+	roles,
+	onRemove,
+}: {
+	member: ProjectMember;
+	projectId: string;
+	roles: ProjectRole[];
+	onRemove: (member: ProjectMember) => void;
+}) {
+	const display = member.full_name || member.username;
+	const isBot =
+		member.username.startsWith("bot-") ||
+		member.role_name.toLowerCase().includes("agent");
+
+	return (
+		<div className="flex items-center gap-3 rounded-xl border border-border/50 bg-card px-4 py-3 transition-colors hover:bg-muted/30">
+			<Avatar className="size-9 shrink-0">
+				<AvatarFallback className="text-xs bg-primary/10 text-primary font-semibold">
+					{isBot ? <Bot className="size-4" /> : getInitials(display)}
+				</AvatarFallback>
+			</Avatar>
+			<div className="min-w-0 flex-1">
+				<p className="text-sm font-medium truncate">{display}</p>
+				<p className="text-xs text-muted-foreground truncate">
+					@{member.username}
+				</p>
+			</div>
+			<RoleChip member={member} projectId={projectId} roles={roles} />
+			<DropdownMenu>
+				<DropdownMenuTrigger className="flex size-7 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
+					<MoreHorizontal className="size-4" />
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="w-44">
+					<DropdownMenuItem
+						className="text-destructive focus:text-destructive focus:bg-destructive/10"
+						onClick={() => onRemove(member)}
+					>
+						<Trash2 className="size-3.5 mr-2" />
+						Remove member
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────────
+
+function TeamPage() {
+	const { projectId } = Route.useParams();
+	const queryClient = useQueryClient();
+	const [addMemberOpen, setAddMemberOpen] = useState(false);
+	const [removingMember, setRemovingMember] = useState<ProjectMember | null>(
+		null,
+	);
+
+	const { data: project } = useQuery(projectQueryOptions(projectId));
+	const { data: members, isLoading } = useQuery(
+		projectMembersQueryOptions(projectId),
+	);
+	const { data: roles = [] } = useQuery(projectRolesQueryOptions(projectId));
+
+	const existingMemberIds = useMemo(
+		() => new Set((members ?? []).map((m) => m.user_id)),
+		[members],
+	);
+
+	const removeMutation = useMutation({
+		mutationFn: () => {
+			if (!removingMember) return Promise.resolve();
+			return removeProjectMember(projectId, removingMember.user_id);
+		},
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({
+				queryKey: projectMembersQueryOptions(projectId).queryKey,
+			});
+			setRemovingMember(null);
+		},
+	});
+
+	return (
+		<div className="flex flex-col">
+			{/* Header */}
+			<div className="relative overflow-hidden border-b border-border/50">
+				<div
+					className="pointer-events-none absolute inset-0 opacity-50"
+					style={{
+						backgroundImage:
+							"radial-gradient(circle, color-mix(in oklch, var(--color-primary) 12%, transparent) 1px, transparent 1px)",
+						backgroundSize: "20px 20px",
+						maskImage:
+							"radial-gradient(ellipse 70% 100% at 0% 0%, black 20%, transparent 70%)",
+					}}
+				/>
+				<div className="relative flex items-end justify-between px-6 py-8">
+					<div>
+						<h1 className="font-[Syne] text-2xl font-bold tracking-tight">
+							Team
+						</h1>
+						<p className="mt-1 text-sm text-muted-foreground">
+							{project?.name} · Manage project members and roles
+						</p>
+					</div>
+					<Button
+						size="sm"
+						className="gap-1.5 shadow-sm shadow-primary/20"
+						onClick={() => setAddMemberOpen(true)}
+					>
+						<Plus className="size-3.5" />
+						Add Member
+					</Button>
+				</div>
+			</div>
+
+			{/* Content */}
+			<div className="p-6">
+				{isLoading ? (
+					<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+						{[...Array(4)].map((_, i) => (
+							<Skeleton
+								// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+								key={i}
+								className="h-16 w-full rounded-xl"
+							/>
+						))}
+					</div>
+				) : !members?.length ? (
+					<div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-border/60 bg-muted/10 py-14">
+						<div className="flex size-12 items-center justify-center rounded-xl bg-primary/10">
+							<Users className="size-6 text-primary" />
+						</div>
+						<div className="text-center">
+							<p className="text-sm font-medium">No members yet</p>
+							<p className="mt-0.5 text-xs text-muted-foreground">
+								Add teammates or AI agents to this project to get started.
+							</p>
+						</div>
+						<Button
+							size="sm"
+							className="gap-1.5 mt-1"
+							onClick={() => setAddMemberOpen(true)}
+						>
+							<Plus className="size-3.5" />
+							Add first member
+						</Button>
+					</div>
+				) : (
+					<div>
+						<div className="mb-3 flex items-center justify-between">
+							<p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+								{members.length} {members.length === 1 ? "member" : "members"}
+							</p>
+						</div>
+						<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+							{members.map((member) => (
+								<MemberRow
+									key={member.id}
+									member={member}
+									projectId={projectId}
+									roles={roles}
+									onRemove={setRemovingMember}
+								/>
+							))}
+						</div>
+					</div>
+				)}
+			</div>
+
+			{/* Add Member Dialog */}
+			<AddMemberDialog
+				open={addMemberOpen}
+				onOpenChange={setAddMemberOpen}
+				projectId={projectId}
+				roles={roles}
+				existingMemberIds={existingMemberIds}
+			/>
+
+			{/* Remove confirmation dialog */}
+			<Dialog
+				open={!!removingMember}
+				onOpenChange={(open) => {
+					if (!open) setRemovingMember(null);
+				}}
+			>
+				<DialogContent className="sm:max-w-sm">
+					<DialogHeader>
+						<div className="flex size-10 items-center justify-center rounded-full bg-destructive/10 mb-2">
+							<UserRound className="size-5 text-destructive" />
+						</div>
+						<DialogTitle>Remove member</DialogTitle>
+						<DialogDescription>
+							Remove{" "}
+							<span className="font-medium text-foreground">
+								{removingMember?.full_name || removingMember?.username}
+							</span>{" "}
+							from{" "}
+							<span className="font-medium text-foreground">
+								{project?.name}
+							</span>
+							? They will lose access immediately.
+						</DialogDescription>
+					</DialogHeader>
+					{removeMutation.isError ? (
+						<p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+							Failed to remove member. Please try again.
+						</p>
+					) : null}
+					<DialogFooter>
+						<DialogClose
+							render={
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={removeMutation.isPending}
+								/>
+							}
+						>
+							Cancel
+						</DialogClose>
+						<Button
+							variant="destructive"
+							size="sm"
+							disabled={removeMutation.isPending}
+							onClick={() => removeMutation.mutate()}
+						>
+							{removeMutation.isPending ? (
+								<Loader2 className="size-3.5 animate-spin" />
+							) : (
+								<Trash2 className="size-3.5" />
+							)}
+							Remove
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
+import { usePermissions } from "@/hooks/use-permissions";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -46,6 +47,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getUsers, type User } from "@/lib/admin-api";
+import { currentUserQueryOptions } from "@/lib/auth-api";
 import {
 	addProjectMember,
 	type ProjectMember,
@@ -477,11 +479,13 @@ function MemberRow({
 	member,
 	projectId,
 	roles,
+	canManage,
 	onRemove,
 }: {
 	member: ProjectMember;
 	projectId: string;
 	roles: ProjectRole[];
+	canManage: boolean;
 	onRemove: (member: ProjectMember) => void;
 }) {
 	const display = member.full_name || member.username;
@@ -502,7 +506,15 @@ function MemberRow({
 					@{member.username}
 				</p>
 			</div>
+		{canManage ? (
 			<RoleChip member={member} projectId={projectId} roles={roles} />
+		) : (
+			<span className="flex shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-secondary/50 px-2.5 py-1 text-xs font-medium text-secondary-foreground">
+				<Shield className="size-3 text-muted-foreground" />
+				{member.role_name}
+			</span>
+		)}
+		{canManage ? (
 			<DropdownMenu>
 				<DropdownMenuTrigger className="flex size-7 shrink-0 items-center justify-center rounded-md p-0 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
 					<MoreHorizontal className="size-4" />
@@ -517,7 +529,8 @@ function MemberRow({
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
-		</div>
+		) : null}
+	</div>
 	);
 }
 
@@ -531,11 +544,25 @@ function TeamPage() {
 		null,
 	);
 
+	const { hasPermission } = usePermissions();
+	const { data: currentUser } = useQuery(currentUserQueryOptions);
 	const { data: project } = useQuery(projectQueryOptions(projectId));
 	const { data: members, isLoading } = useQuery(
 		projectMembersQueryOptions(projectId),
 	);
 	const { data: roles = [] } = useQuery(projectRolesQueryOptions(projectId));
+
+	const myMembership = (members ?? []).find(
+		(m) => m.user_id === currentUser?.id,
+	);
+	const myRole = roles.find((r) => r.id === myMembership?.project_role_id);
+	const hasProjectMembersWrite = Boolean(
+		(myRole?.permissions as Record<string, boolean> | undefined)?.[
+			"project.members.write"
+		],
+	);
+	const canManageMembers =
+		hasPermission("project.members.write") || hasProjectMembersWrite;
 
 	const existingMemberIds = useMemo(
 		() => new Set((members ?? []).map((m) => m.user_id)),
@@ -578,14 +605,16 @@ function TeamPage() {
 							{project?.name} · Manage project members and roles
 						</p>
 					</div>
-					<Button
-						size="sm"
-						className="gap-1.5 shadow-sm shadow-primary/20"
-						onClick={() => setAddMemberOpen(true)}
-					>
-						<Plus className="size-3.5" />
-						Add Member
-					</Button>
+					{canManageMembers ? (
+						<Button
+							size="sm"
+							className="gap-1.5 shadow-sm shadow-primary/20"
+							onClick={() => setAddMemberOpen(true)}
+						>
+							<Plus className="size-3.5" />
+							Add Member
+						</Button>
+					) : null}
 				</div>
 			</div>
 
@@ -612,14 +641,16 @@ function TeamPage() {
 								Add teammates or AI agents to this project to get started.
 							</p>
 						</div>
-						<Button
-							size="sm"
-							className="gap-1.5 mt-1"
-							onClick={() => setAddMemberOpen(true)}
-						>
-							<Plus className="size-3.5" />
-							Add first member
-						</Button>
+							{canManageMembers ? (
+								<Button
+									size="sm"
+									className="gap-1.5 mt-1"
+									onClick={() => setAddMemberOpen(true)}
+								>
+									<Plus className="size-3.5" />
+									Add first member
+								</Button>
+							) : null}
 					</div>
 				) : (
 					<div>
@@ -635,6 +666,7 @@ function TeamPage() {
 									member={member}
 									projectId={projectId}
 									roles={roles}
+									canManage={canManageMembers}
 									onRemove={setRemovingMember}
 								/>
 							))}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -130,16 +130,18 @@ function AddMemberDialog({
 	existingMemberIds: Set<string>;
 }) {
 	const queryClient = useQueryClient();
+	const { can } = usePermissions();
 	const [selectedUser, setSelectedUser] = useState<User | null>(null);
 	const [selectedRoleId, setSelectedRoleId] = useState<string>("");
 	const [userSearch, setUserSearch] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const searchRef = useRef<HTMLInputElement>(null);
+	const canReadUsers = can("users.read");
 
 	const { data: usersData, isLoading: isLoadingUsers } = useQuery({
 		queryKey: ["admin", "users", "all"],
 		queryFn: () => getUsers(1, 500),
-		enabled: open,
+		enabled: open && canReadUsers,
 	});
 
 	const filteredUsers = useMemo<User[]>(() => {

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -130,7 +130,7 @@ function AddMemberDialog({
 	existingMemberIds: Set<string>;
 }) {
 	const queryClient = useQueryClient();
-	const { can } = usePermissions();
+	const { hasPermission: can } = usePermissions();
 	const [selectedUser, setSelectedUser] = useState<User | null>(null);
 	const [selectedRoleId, setSelectedRoleId] = useState<string>("");
 	const [userSearch, setUserSearch] = useState("");

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 		TanStackRouterVite({
 			routesDirectory: "./src/routes",
 			generatedRouteTree: "./src/routeTree.gen.ts",
+			autoCodeSplitting: true,
 		}),
 		react(),
 		tailwindcss(),

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -42,6 +42,25 @@ const (
 	CodePasswordChangeRequired Code = "AUTH_PASSWORD_CHANGE_REQUIRED"
 	// CodeInvalidCurrentPassword indicates the supplied current password is wrong.
 	CodeInvalidCurrentPassword Code = "USER_INVALID_CURRENT_PASSWORD"
+
+	// CodeProjectNotFound indicates the requested project does not exist.
+	CodeProjectNotFound Code = "PROJECT_NOT_FOUND"
+	// CodeProjectNameTaken indicates the project name is already in use.
+	CodeProjectNameTaken Code = "PROJECT_NAME_TAKEN"
+
+	// CodeProjectRoleNotFound indicates the requested project role does not exist.
+	CodeProjectRoleNotFound Code = "PROJECT_ROLE_NOT_FOUND"
+	// CodeProjectRoleNameTaken indicates the role name is already in use within the project.
+	CodeProjectRoleNameTaken Code = "PROJECT_ROLE_NAME_TAKEN"
+	// CodeProjectRoleNameInvalid indicates an invalid or empty role name.
+	CodeProjectRoleNameInvalid Code = "PROJECT_ROLE_NAME_INVALID"
+	// CodeProjectRoleHasMembers indicates the role cannot be deleted because members still use it.
+	CodeProjectRoleHasMembers Code = "PROJECT_ROLE_HAS_MEMBERS"
+
+	// CodeProjectMemberNotFound indicates the membership record was not found.
+	CodeProjectMemberNotFound Code = "PROJECT_MEMBER_NOT_FOUND"
+	// CodeProjectMemberAlreadyAdded indicates the user is already a member of the project.
+	CodeProjectMemberAlreadyAdded Code = "PROJECT_MEMBER_ALREADY_ADDED"
 )
 
 // Error carries a machine-readable Code alongside a human-readable Message.

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -47,6 +47,8 @@ const (
 	CodeProjectNotFound Code = "PROJECT_NOT_FOUND"
 	// CodeProjectNameTaken indicates the project name is already in use.
 	CodeProjectNameTaken Code = "PROJECT_NAME_TAKEN"
+	// CodeProjectNameInvalid indicates the project name is empty or invalid.
+	CodeProjectNameInvalid Code = "PROJECT_NAME_INVALID"
 
 	// CodeProjectRoleNotFound indicates the requested project role does not exist.
 	CodeProjectRoleNotFound Code = "PROJECT_ROLE_NOT_FOUND"

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -26,6 +26,7 @@ import (
 	redisRepo "github.com/paca/api/internal/repository/redis"
 	authsvc "github.com/paca/api/internal/service/auth"
 	globalrolesvc "github.com/paca/api/internal/service/globalrole"
+	projectsvc "github.com/paca/api/internal/service/project"
 	usersvc "github.com/paca/api/internal/service/user"
 	"github.com/paca/api/internal/transport/http/handler"
 	"github.com/paca/api/internal/transport/http/router"
@@ -71,6 +72,7 @@ func New(cfg *config.Config) (*App, error) {
 	// --- Repositories -------------------------------------------------------
 	userRepo := pgRepo.NewUserRepository(db)
 	globalRoleRepo := pgRepo.NewGlobalRoleRepository(db)
+	projectRepo := pgRepo.NewProjectRepository(db)
 	refreshStore := redisRepo.NewRefreshTokenStore(redisClient)
 
 	if err := db.AutoMigrate(
@@ -98,6 +100,7 @@ func New(cfg *config.Config) (*App, error) {
 	authService := authsvc.New(userRepo, tokenManager, refreshStore, cfg.JWT.RefreshTTL, cfg.JWT.RefreshSessionTTL)
 	userService := usersvc.New(userRepo, permissionStore, globalRoleRepo)
 	globalRoleService := globalrolesvc.New(globalRoleRepo)
+	projectService := projectsvc.New(projectRepo)
 
 	// --- Handlers -----------------------------------------------------------
 	cookieCfg := handler.CookieConfig{
@@ -114,6 +117,7 @@ func New(cfg *config.Config) (*App, error) {
 		Auth:         handler.NewAuthHandler(authService, cookieCfg),
 		User:         handler.NewUserHandler(userService, authService),
 		GlobalRole:   handler.NewGlobalRoleHandler(globalRoleService),
+		Project:      handler.NewProjectHandler(projectService),
 		Log:          log,
 	}
 

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -117,7 +117,7 @@ func New(cfg *config.Config) (*App, error) {
 		Auth:         handler.NewAuthHandler(authService, cookieCfg),
 		User:         handler.NewUserHandler(userService, authService),
 		GlobalRole:   handler.NewGlobalRoleHandler(globalRoleService),
-		Project:      handler.NewProjectHandler(projectService),
+		Project:      handler.NewProjectHandler(projectService, authorizer),
 		Log:          log,
 	}
 

--- a/services/api/internal/domain/project/entity.go
+++ b/services/api/internal/domain/project/entity.go
@@ -1,0 +1,18 @@
+// Package projectdom defines the project aggregate and its domain contracts.
+package projectdom
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Project is the core project aggregate.
+type Project struct {
+	ID          uuid.UUID
+	Name        string
+	Description string
+	Settings    map[string]any
+	CreatedBy   *uuid.UUID
+	CreatedAt   time.Time
+}

--- a/services/api/internal/domain/project/errors.go
+++ b/services/api/internal/domain/project/errors.go
@@ -6,6 +6,7 @@ import "errors"
 var (
 	ErrNotFound           = errors.New("project: not found")
 	ErrNameTaken          = errors.New("project: name already in use")
+	ErrNameInvalid        = errors.New("project: name is empty or invalid")
 	ErrMemberAlreadyAdded = errors.New("project: user is already a member")
 	ErrMemberNotFound     = errors.New("project: member not found")
 	ErrRoleNotFound       = errors.New("project: role not found")

--- a/services/api/internal/domain/project/errors.go
+++ b/services/api/internal/domain/project/errors.go
@@ -1,0 +1,15 @@
+package projectdom
+
+import "errors"
+
+// Sentinel domain errors for the project aggregate.
+var (
+	ErrNotFound           = errors.New("project: not found")
+	ErrNameTaken          = errors.New("project: name already in use")
+	ErrMemberAlreadyAdded = errors.New("project: user is already a member")
+	ErrMemberNotFound     = errors.New("project: member not found")
+	ErrRoleNotFound       = errors.New("project: role not found")
+	ErrRoleNameTaken      = errors.New("project: role name already in use")
+	ErrRoleNameInvalid    = errors.New("project: role name is empty or invalid")
+	ErrRoleHasMembers     = errors.New("project: role still has members assigned")
+)

--- a/services/api/internal/domain/project/member.go
+++ b/services/api/internal/domain/project/member.go
@@ -1,0 +1,20 @@
+package projectdom
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ProjectMember represents a user's membership in a project with an assigned role.
+type ProjectMember struct {
+	ID            uuid.UUID
+	ProjectID     uuid.UUID
+	UserID        uuid.UUID
+	ProjectRoleID uuid.UUID
+	// Populated by JOIN for display purposes.
+	Username  string
+	FullName  string
+	RoleName  string
+	CreatedAt time.Time
+}

--- a/services/api/internal/domain/project/member_repository.go
+++ b/services/api/internal/domain/project/member_repository.go
@@ -11,5 +11,6 @@ type MemberRepository interface {
 	ListMembers(ctx context.Context, projectID uuid.UUID) ([]*ProjectMember, error)
 	FindMember(ctx context.Context, projectID, userID uuid.UUID) (*ProjectMember, error)
 	AddMember(ctx context.Context, m *ProjectMember) error
+	UpdateMemberRole(ctx context.Context, projectID, userID, roleID uuid.UUID) error
 	RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error
 }

--- a/services/api/internal/domain/project/member_repository.go
+++ b/services/api/internal/domain/project/member_repository.go
@@ -1,0 +1,15 @@
+package projectdom
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// MemberRepository defines persistence operations for project members.
+type MemberRepository interface {
+	ListMembers(ctx context.Context, projectID uuid.UUID) ([]*ProjectMember, error)
+	FindMember(ctx context.Context, projectID, userID uuid.UUID) (*ProjectMember, error)
+	AddMember(ctx context.Context, m *ProjectMember) error
+	RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error
+}

--- a/services/api/internal/domain/project/member_service.go
+++ b/services/api/internal/domain/project/member_service.go
@@ -1,0 +1,20 @@
+package projectdom
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// AddMemberInput carries fields for adding a user to a project.
+type AddMemberInput struct {
+	UserID        uuid.UUID
+	ProjectRoleID uuid.UUID
+}
+
+// MemberService defines member management use cases.
+type MemberService interface {
+	ListMembers(ctx context.Context, projectID uuid.UUID) ([]*ProjectMember, error)
+	AddMember(ctx context.Context, projectID uuid.UUID, in AddMemberInput) (*ProjectMember, error)
+	RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error
+}

--- a/services/api/internal/domain/project/member_service.go
+++ b/services/api/internal/domain/project/member_service.go
@@ -12,9 +12,15 @@ type AddMemberInput struct {
 	ProjectRoleID uuid.UUID
 }
 
+// UpdateMemberRoleInput carries fields for changing a member's role.
+type UpdateMemberRoleInput struct {
+	ProjectRoleID uuid.UUID
+}
+
 // MemberService defines member management use cases.
 type MemberService interface {
 	ListMembers(ctx context.Context, projectID uuid.UUID) ([]*ProjectMember, error)
 	AddMember(ctx context.Context, projectID uuid.UUID, in AddMemberInput) (*ProjectMember, error)
+	UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, in UpdateMemberRoleInput) (*ProjectMember, error)
 	RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error
 }

--- a/services/api/internal/domain/project/repository.go
+++ b/services/api/internal/domain/project/repository.go
@@ -1,0 +1,25 @@
+package projectdom
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Repository is the combined persistence contract for the project aggregate.
+// It composes the per-entity sub-interfaces so a single concrete implementation
+// can satisfy all of them.
+type Repository interface {
+	ProjectRepository
+	MemberRepository
+	RoleRepository
+}
+
+// ProjectRepository defines persistence operations for projects.
+type ProjectRepository interface {
+	List(ctx context.Context, offset, limit int) ([]*Project, int64, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*Project, error)
+	Create(ctx context.Context, p *Project) error
+	Update(ctx context.Context, p *Project) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/services/api/internal/domain/project/repository.go
+++ b/services/api/internal/domain/project/repository.go
@@ -18,6 +18,8 @@ type Repository interface {
 // ProjectRepository defines persistence operations for projects.
 type ProjectRepository interface {
 	List(ctx context.Context, offset, limit int) ([]*Project, int64, error)
+	// ListAccessible returns only projects the given user is a member of.
+	ListAccessible(ctx context.Context, userID uuid.UUID, offset, limit int) ([]*Project, int64, error)
 	FindByID(ctx context.Context, id uuid.UUID) (*Project, error)
 	Create(ctx context.Context, p *Project) error
 	Update(ctx context.Context, p *Project) error

--- a/services/api/internal/domain/project/role.go
+++ b/services/api/internal/domain/project/role.go
@@ -1,0 +1,18 @@
+package projectdom
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ProjectRole defines a role scoped to a specific project (project_id IS NOT NULL)
+// or a global template role (project_id IS NULL).
+type ProjectRole struct {
+	ID          uuid.UUID
+	ProjectID   *uuid.UUID
+	RoleName    string
+	Permissions map[string]any
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/services/api/internal/domain/project/role_repository.go
+++ b/services/api/internal/domain/project/role_repository.go
@@ -1,0 +1,18 @@
+package projectdom
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// RoleRepository defines persistence operations for project roles.
+type RoleRepository interface {
+	ListRoles(ctx context.Context, projectID uuid.UUID) ([]*ProjectRole, error)
+	FindRoleByID(ctx context.Context, id uuid.UUID) (*ProjectRole, error)
+	FindRoleByName(ctx context.Context, projectID uuid.UUID, name string) (*ProjectRole, error)
+	CreateRole(ctx context.Context, r *ProjectRole) error
+	UpdateRole(ctx context.Context, r *ProjectRole) error
+	DeleteRole(ctx context.Context, id uuid.UUID) error
+	CountMembersWithRole(ctx context.Context, roleID uuid.UUID) (int64, error)
+}

--- a/services/api/internal/domain/project/role_service.go
+++ b/services/api/internal/domain/project/role_service.go
@@ -1,0 +1,27 @@
+package projectdom
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// CreateRoleInput carries fields for creating a project-scoped role.
+type CreateRoleInput struct {
+	RoleName    string
+	Permissions map[string]any
+}
+
+// UpdateRoleInput carries mutable fields for a project role.
+type UpdateRoleInput struct {
+	RoleName    string
+	Permissions map[string]any
+}
+
+// RoleService defines role management use cases.
+type RoleService interface {
+	ListRoles(ctx context.Context, projectID uuid.UUID) ([]*ProjectRole, error)
+	CreateRole(ctx context.Context, projectID uuid.UUID, in CreateRoleInput) (*ProjectRole, error)
+	UpdateRole(ctx context.Context, projectID, roleID uuid.UUID, in UpdateRoleInput) (*ProjectRole, error)
+	DeleteRole(ctx context.Context, projectID, roleID uuid.UUID) error
+}

--- a/services/api/internal/domain/project/service.go
+++ b/services/api/internal/domain/project/service.go
@@ -1,0 +1,39 @@
+package projectdom
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// CreateProjectInput carries fields required to create a new project.
+type CreateProjectInput struct {
+	Name        string
+	Description string
+	Settings    map[string]any
+	CreatedBy   *uuid.UUID
+}
+
+// UpdateProjectInput carries mutable project fields.
+type UpdateProjectInput struct {
+	Name        string
+	Description string
+	Settings    map[string]any
+}
+
+// Service is the combined project management service contract.
+// It composes the per-concern sub-interfaces.
+type Service interface {
+	ProjectService
+	MemberService
+	RoleService
+}
+
+// ProjectService defines project CRUD use cases.
+type ProjectService interface {
+	List(ctx context.Context, page, pageSize int) ([]*Project, int64, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*Project, error)
+	Create(ctx context.Context, in CreateProjectInput) (*Project, error)
+	Update(ctx context.Context, id uuid.UUID, in UpdateProjectInput) (*Project, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/services/api/internal/domain/project/service.go
+++ b/services/api/internal/domain/project/service.go
@@ -32,6 +32,8 @@ type Service interface {
 // ProjectService defines project CRUD use cases.
 type ProjectService interface {
 	List(ctx context.Context, page, pageSize int) ([]*Project, int64, error)
+	// ListAccessible returns only the projects the given user is a member of.
+	ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*Project, int64, error)
 	GetByID(ctx context.Context, id uuid.UUID) (*Project, error)
 	Create(ctx context.Context, in CreateProjectInput) (*Project, error)
 	Update(ctx context.Context, id uuid.UUID, in UpdateProjectInput) (*Project, error)

--- a/services/api/internal/platform/authz/permissions.go
+++ b/services/api/internal/platform/authz/permissions.go
@@ -17,9 +17,11 @@ const (
 	PermissionGlobalRolesAssign Permission = "global_roles.assign"
 	PermissionGlobalRolesAll    Permission = "global_roles.*"
 
-	PermissionProjectsRead  Permission = "projects.read"
-	PermissionProjectsWrite Permission = "projects.write"
-	PermissionProjectsAll   Permission = "projects.*"
+	PermissionProjectsRead   Permission = "projects.read"
+	PermissionProjectsWrite  Permission = "projects.write"
+	PermissionProjectsCreate Permission = "projects.create"
+	PermissionProjectsDelete Permission = "projects.delete"
+	PermissionProjectsAll    Permission = "projects.*"
 
 	PermissionProjectMembersRead  Permission = "project.members.read"
 	PermissionProjectMembersWrite Permission = "project.members.write"

--- a/services/api/internal/repository/postgres/project_repository.go
+++ b/services/api/internal/repository/postgres/project_repository.go
@@ -1,0 +1,459 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"gorm.io/gorm"
+)
+
+// --- GORM models ------------------------------------------------------------
+
+type projectRecord struct {
+	ID          string `gorm:"primarykey;type:uuid"`
+	Name        string `gorm:"not null"`
+	Description string
+	Settings    []byte  `gorm:"type:jsonb;not null"`
+	CreatedBy   *string `gorm:"type:uuid"`
+	CreatedAt   time.Time
+}
+
+func (projectRecord) TableName() string { return "projects" }
+
+type projectRoleRecord struct {
+	ID          string  `gorm:"primarykey;type:uuid"`
+	ProjectID   *string `gorm:"type:uuid;column:project_id"`
+	RoleName    string  `gorm:"column:role_name;not null"`
+	Permissions []byte  `gorm:"type:jsonb;not null"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+func (projectRoleRecord) TableName() string { return "project_roles" }
+
+// projectMemberReadRow is the result of the SELECT … JOIN query.
+type projectMemberReadRow struct {
+	ID            string
+	ProjectID     string
+	UserID        string
+	ProjectRoleID string
+	Username      string
+	FullName      string
+	RoleName      string
+}
+
+// --- Repository -------------------------------------------------------------
+
+// ProjectRepository is the GORM implementation of projectdom.Repository.
+type ProjectRepository struct {
+	db *gorm.DB
+}
+
+// NewProjectRepository returns a new ProjectRepository.
+func NewProjectRepository(db *gorm.DB) *ProjectRepository {
+	return &ProjectRepository{db: db}
+}
+
+// --- Projects ---------------------------------------------------------------
+
+// List returns a page of projects and the total count.
+func (r *ProjectRepository) List(ctx context.Context, offset, limit int) ([]*projectdom.Project, int64, error) {
+	var total int64
+	if err := r.db.WithContext(ctx).Table("projects").Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("project repo: list count: %w", err)
+	}
+
+	var records []projectRecord
+	if err := r.db.WithContext(ctx).
+		Order("created_at ASC").
+		Offset(offset).
+		Limit(limit).
+		Find(&records).Error; err != nil {
+		return nil, 0, fmt.Errorf("project repo: list: %w", err)
+	}
+
+	projects := make([]*projectdom.Project, 0, len(records))
+	for i := range records {
+		p, err := toProjectEntity(&records[i])
+		if err != nil {
+			return nil, 0, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, total, nil
+}
+
+// FindByID returns a project by its primary key.
+func (r *ProjectRepository) FindByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	var record projectRecord
+	result := r.db.WithContext(ctx).First(&record, "id = ?", id.String())
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, projectdom.ErrNotFound
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("project repo: find by id: %w", result.Error)
+	}
+	return toProjectEntity(&record)
+}
+
+// Create persists a new project.
+func (r *ProjectRepository) Create(ctx context.Context, p *projectdom.Project) error {
+	rec, err := fromProjectEntity(p)
+	if err != nil {
+		return err
+	}
+	if err := r.db.WithContext(ctx).Create(rec).Error; err != nil {
+		if isUniqueViolation(err) {
+			return projectdom.ErrNameTaken
+		}
+		return fmt.Errorf("project repo: create: %w", err)
+	}
+	return nil
+}
+
+// Update saves changes to a project.
+func (r *ProjectRepository) Update(ctx context.Context, p *projectdom.Project) error {
+	settings, err := json.Marshal(p.Settings)
+	if err != nil {
+		return fmt.Errorf("project repo: marshal settings: %w", err)
+	}
+
+	var createdBy *string
+	if p.CreatedBy != nil {
+		s := p.CreatedBy.String()
+		createdBy = &s
+	}
+
+	result := r.db.WithContext(ctx).
+		Model(&projectRecord{}).
+		Where("id = ?", p.ID.String()).
+		Updates(map[string]any{
+			"name":        p.Name,
+			"description": p.Description,
+			"settings":    settings,
+			"created_by":  createdBy,
+		})
+	if result.Error != nil {
+		if isUniqueViolation(result.Error) {
+			return projectdom.ErrNameTaken
+		}
+		return fmt.Errorf("project repo: update: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return projectdom.ErrNotFound
+	}
+	return nil
+}
+
+// Delete removes a project by ID. The DB schema cascades deletes to child tables.
+func (r *ProjectRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	result := r.db.WithContext(ctx).Delete(&projectRecord{}, "id = ?", id.String())
+	if result.Error != nil {
+		return fmt.Errorf("project repo: delete: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return projectdom.ErrNotFound
+	}
+	return nil
+}
+
+// --- Project Roles ----------------------------------------------------------
+
+// ListRoles returns project-scoped roles for a given project.
+func (r *ProjectRepository) ListRoles(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	var records []projectRoleRecord
+	if err := r.db.WithContext(ctx).
+		Where("project_id = ?", projectID.String()).
+		Order("role_name ASC").
+		Find(&records).Error; err != nil {
+		return nil, fmt.Errorf("project repo: list roles: %w", err)
+	}
+
+	roles := make([]*projectdom.ProjectRole, 0, len(records))
+	for i := range records {
+		role, err := toProjectRoleEntity(&records[i])
+		if err != nil {
+			return nil, err
+		}
+		roles = append(roles, role)
+	}
+	return roles, nil
+}
+
+// FindRoleByID returns a project role by its primary key.
+func (r *ProjectRepository) FindRoleByID(ctx context.Context, id uuid.UUID) (*projectdom.ProjectRole, error) {
+	var record projectRoleRecord
+	result := r.db.WithContext(ctx).First(&record, "id = ?", id.String())
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, projectdom.ErrRoleNotFound
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("project repo: find role by id: %w", result.Error)
+	}
+	return toProjectRoleEntity(&record)
+}
+
+// FindRoleByName returns a role by name within the given project scope.
+func (r *ProjectRepository) FindRoleByName(ctx context.Context, projectID uuid.UUID, name string) (*projectdom.ProjectRole, error) {
+	var record projectRoleRecord
+	result := r.db.WithContext(ctx).
+		Where("project_id = ? AND role_name = ?", projectID.String(), name).
+		First(&record)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, projectdom.ErrRoleNotFound
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("project repo: find role by name: %w", result.Error)
+	}
+	return toProjectRoleEntity(&record)
+}
+
+// CreateRole persists a new project role.
+func (r *ProjectRepository) CreateRole(ctx context.Context, role *projectdom.ProjectRole) error {
+	rec, err := fromProjectRoleEntity(role)
+	if err != nil {
+		return err
+	}
+	if err := r.db.WithContext(ctx).Create(rec).Error; err != nil {
+		if isUniqueViolation(err) {
+			return projectdom.ErrRoleNameTaken
+		}
+		return fmt.Errorf("project repo: create role: %w", err)
+	}
+	return nil
+}
+
+// UpdateRole saves changes to a project role.
+func (r *ProjectRepository) UpdateRole(ctx context.Context, role *projectdom.ProjectRole) error {
+	perms, err := json.Marshal(role.Permissions)
+	if err != nil {
+		return fmt.Errorf("project repo: marshal role permissions: %w", err)
+	}
+	result := r.db.WithContext(ctx).
+		Model(&projectRoleRecord{}).
+		Where("id = ?", role.ID.String()).
+		Updates(map[string]any{
+			"role_name":   role.RoleName,
+			"permissions": perms,
+			"updated_at":  role.UpdatedAt,
+		})
+	if result.Error != nil {
+		if isUniqueViolation(result.Error) {
+			return projectdom.ErrRoleNameTaken
+		}
+		return fmt.Errorf("project repo: update role: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return projectdom.ErrRoleNotFound
+	}
+	return nil
+}
+
+// DeleteRole removes a project role.
+func (r *ProjectRepository) DeleteRole(ctx context.Context, id uuid.UUID) error {
+	result := r.db.WithContext(ctx).Delete(&projectRoleRecord{}, "id = ?", id.String())
+	if result.Error != nil {
+		return fmt.Errorf("project repo: delete role: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return projectdom.ErrRoleNotFound
+	}
+	return nil
+}
+
+// CountMembersWithRole returns the number of project members assigned to the role.
+func (r *ProjectRepository) CountMembersWithRole(ctx context.Context, roleID uuid.UUID) (int64, error) {
+	var count int64
+	if err := r.db.WithContext(ctx).
+		Table("project_members").
+		Where("project_role_id = ?", roleID.String()).
+		Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("project repo: count members with role: %w", err)
+	}
+	return count, nil
+}
+
+// --- Project Members --------------------------------------------------------
+
+const projectMemberCols = `
+	pm.id, pm.project_id, pm.user_id, pm.project_role_id,
+	u.username, u.full_name, pr.role_name`
+
+// ListMembers returns all members of a project enriched with user and role info.
+func (r *ProjectRepository) ListMembers(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	var rows []projectMemberReadRow
+	if err := r.db.WithContext(ctx).
+		Table("project_members pm").
+		Select(projectMemberCols).
+		Joins("JOIN users u ON u.id = pm.user_id AND u.deleted_at IS NULL").
+		Joins("JOIN project_roles pr ON pr.id = pm.project_role_id").
+		Where("pm.project_id = ?", projectID.String()).
+		Order("u.username ASC").
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("project repo: list members: %w", err)
+	}
+
+	members := make([]*projectdom.ProjectMember, 0, len(rows))
+	for i := range rows {
+		members = append(members, toMemberEntity(&rows[i]))
+	}
+	return members, nil
+}
+
+// FindMember returns a single member record for the given project + user combo.
+func (r *ProjectRepository) FindMember(ctx context.Context, projectID, userID uuid.UUID) (*projectdom.ProjectMember, error) {
+	var row projectMemberReadRow
+	result := r.db.WithContext(ctx).
+		Table("project_members pm").
+		Select(projectMemberCols).
+		Joins("JOIN users u ON u.id = pm.user_id AND u.deleted_at IS NULL").
+		Joins("JOIN project_roles pr ON pr.id = pm.project_role_id").
+		Where("pm.project_id = ? AND pm.user_id = ?", projectID.String(), userID.String()).
+		Scan(&row)
+	if result.Error != nil {
+		return nil, fmt.Errorf("project repo: find member: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return nil, projectdom.ErrMemberNotFound
+	}
+	return toMemberEntity(&row), nil
+}
+
+// AddMember inserts a project_members row.
+func (r *ProjectRepository) AddMember(ctx context.Context, m *projectdom.ProjectMember) error {
+	rec := map[string]any{
+		"id":              m.ID.String(),
+		"project_id":      m.ProjectID.String(),
+		"user_id":         m.UserID.String(),
+		"project_role_id": m.ProjectRoleID.String(),
+	}
+	if err := r.db.WithContext(ctx).Table("project_members").Create(rec).Error; err != nil {
+		if isUniqueViolation(err) {
+			return projectdom.ErrMemberAlreadyAdded
+		}
+		return fmt.Errorf("project repo: add member: %w", err)
+	}
+	return nil
+}
+
+// RemoveMember deletes the membership row for the given project + user.
+func (r *ProjectRepository) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
+	result := r.db.WithContext(ctx).
+		Table("project_members").
+		Where("project_id = ? AND user_id = ?", projectID.String(), userID.String()).
+		Delete(nil)
+	if result.Error != nil {
+		return fmt.Errorf("project repo: remove member: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return projectdom.ErrMemberNotFound
+	}
+	return nil
+}
+
+// --- Mapping helpers --------------------------------------------------------
+
+func toProjectEntity(rec *projectRecord) (*projectdom.Project, error) {
+	id, _ := uuid.Parse(rec.ID)
+	var settings map[string]any
+	if err := json.Unmarshal(rec.Settings, &settings); err != nil {
+		settings = map[string]any{}
+	}
+	var createdBy *uuid.UUID
+	if rec.CreatedBy != nil {
+		if uid, err := uuid.Parse(*rec.CreatedBy); err == nil {
+			createdBy = &uid
+		}
+	}
+	return &projectdom.Project{
+		ID:          id,
+		Name:        rec.Name,
+		Description: rec.Description,
+		Settings:    settings,
+		CreatedBy:   createdBy,
+		CreatedAt:   rec.CreatedAt,
+	}, nil
+}
+
+func fromProjectEntity(p *projectdom.Project) (*projectRecord, error) {
+	settings, err := json.Marshal(p.Settings)
+	if err != nil {
+		return nil, fmt.Errorf("project repo: marshal settings: %w", err)
+	}
+	var createdBy *string
+	if p.CreatedBy != nil {
+		s := p.CreatedBy.String()
+		createdBy = &s
+	}
+	return &projectRecord{
+		ID:          p.ID.String(),
+		Name:        p.Name,
+		Description: p.Description,
+		Settings:    settings,
+		CreatedBy:   createdBy,
+		CreatedAt:   p.CreatedAt,
+	}, nil
+}
+
+func toProjectRoleEntity(rec *projectRoleRecord) (*projectdom.ProjectRole, error) {
+	id, _ := uuid.Parse(rec.ID)
+	var perms map[string]any
+	if err := json.Unmarshal(rec.Permissions, &perms); err != nil {
+		perms = map[string]any{}
+	}
+	var projectID *uuid.UUID
+	if rec.ProjectID != nil {
+		if uid, err := uuid.Parse(*rec.ProjectID); err == nil {
+			projectID = &uid
+		}
+	}
+	return &projectdom.ProjectRole{
+		ID:          id,
+		ProjectID:   projectID,
+		RoleName:    rec.RoleName,
+		Permissions: perms,
+		CreatedAt:   rec.CreatedAt,
+		UpdatedAt:   rec.UpdatedAt,
+	}, nil
+}
+
+func fromProjectRoleEntity(r *projectdom.ProjectRole) (*projectRoleRecord, error) {
+	perms, err := json.Marshal(r.Permissions)
+	if err != nil {
+		return nil, fmt.Errorf("project role repo: marshal permissions: %w", err)
+	}
+	var projectID *string
+	if r.ProjectID != nil {
+		s := r.ProjectID.String()
+		projectID = &s
+	}
+	return &projectRoleRecord{
+		ID:          r.ID.String(),
+		ProjectID:   projectID,
+		RoleName:    r.RoleName,
+		Permissions: perms,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}, nil
+}
+
+func toMemberEntity(row *projectMemberReadRow) *projectdom.ProjectMember {
+	id, _ := uuid.Parse(row.ID)
+	projectID, _ := uuid.Parse(row.ProjectID)
+	userID, _ := uuid.Parse(row.UserID)
+	roleID, _ := uuid.Parse(row.ProjectRoleID)
+	return &projectdom.ProjectMember{
+		ID:            id,
+		ProjectID:     projectID,
+		UserID:        userID,
+		ProjectRoleID: roleID,
+		Username:      row.Username,
+		FullName:      row.FullName,
+		RoleName:      row.RoleName,
+	}
+}

--- a/services/api/internal/repository/postgres/project_repository.go
+++ b/services/api/internal/repository/postgres/project_repository.go
@@ -407,10 +407,15 @@ func (r *ProjectRepository) RemoveMember(ctx context.Context, projectID, userID 
 // --- Mapping helpers --------------------------------------------------------
 
 func toProjectEntity(rec *projectRecord) (*projectdom.Project, error) {
-	id, _ := uuid.Parse(rec.ID)
-	var settings map[string]any
-	if err := json.Unmarshal(rec.Settings, &settings); err != nil {
-		settings = map[string]any{}
+	id, err := uuid.Parse(rec.ID)
+	if err != nil {
+		return nil, fmt.Errorf("project repo: parse id: %w", err)
+	}
+	settings := map[string]any{}
+	if len(rec.Settings) > 0 {
+		if err := json.Unmarshal(rec.Settings, &settings); err != nil {
+			return nil, fmt.Errorf("project repo: unmarshal settings: %w", err)
+		}
 	}
 	var createdBy *uuid.UUID
 	if rec.CreatedBy != nil {
@@ -449,10 +454,15 @@ func fromProjectEntity(p *projectdom.Project) (*projectRecord, error) {
 }
 
 func toProjectRoleEntity(rec *projectRoleRecord) (*projectdom.ProjectRole, error) {
-	id, _ := uuid.Parse(rec.ID)
-	var perms map[string]any
-	if err := json.Unmarshal(rec.Permissions, &perms); err != nil {
-		perms = map[string]any{}
+	id, err := uuid.Parse(rec.ID)
+	if err != nil {
+		return nil, fmt.Errorf("project role repo: parse id: %w", err)
+	}
+	perms := map[string]any{}
+	if len(rec.Permissions) > 0 {
+		if err := json.Unmarshal(rec.Permissions, &perms); err != nil {
+			return nil, fmt.Errorf("project role repo: unmarshal permissions: %w", err)
+		}
 	}
 	var projectID *uuid.UUID
 	if rec.ProjectID != nil {

--- a/services/api/internal/repository/postgres/project_repository.go
+++ b/services/api/internal/repository/postgres/project_repository.go
@@ -88,6 +88,39 @@ func (r *ProjectRepository) List(ctx context.Context, offset, limit int) ([]*pro
 	return projects, total, nil
 }
 
+// ListAccessible returns the projects that the given user is a member of.
+func (r *ProjectRepository) ListAccessible(ctx context.Context, userID uuid.UUID, offset, limit int) ([]*projectdom.Project, int64, error) {
+	var total int64
+	if err := r.db.WithContext(ctx).
+		Table("projects").
+		Joins("JOIN project_members ON project_members.project_id = projects.id").
+		Where("project_members.user_id = ?", userID.String()).
+		Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("project repo: list accessible count: %w", err)
+	}
+
+	var records []projectRecord
+	if err := r.db.WithContext(ctx).
+		Joins("JOIN project_members ON project_members.project_id = projects.id").
+		Where("project_members.user_id = ?", userID.String()).
+		Order("projects.created_at ASC").
+		Offset(offset).
+		Limit(limit).
+		Find(&records).Error; err != nil {
+		return nil, 0, fmt.Errorf("project repo: list accessible: %w", err)
+	}
+
+	projects := make([]*projectdom.Project, 0, len(records))
+	for i := range records {
+		p, err := toProjectEntity(&records[i])
+		if err != nil {
+			return nil, 0, err
+		}
+		projects = append(projects, p)
+	}
+	return projects, total, nil
+}
+
 // FindByID returns a project by its primary key.
 func (r *ProjectRepository) FindByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
 	var record projectRecord

--- a/services/api/internal/repository/postgres/project_repository.go
+++ b/services/api/internal/repository/postgres/project_repository.go
@@ -341,6 +341,21 @@ func (r *ProjectRepository) AddMember(ctx context.Context, m *projectdom.Project
 	return nil
 }
 
+// UpdateMemberRole changes the role of an existing project member.
+func (r *ProjectRepository) UpdateMemberRole(ctx context.Context, projectID, userID, roleID uuid.UUID) error {
+	result := r.db.WithContext(ctx).
+		Table("project_members").
+		Where("project_id = ? AND user_id = ?", projectID.String(), userID.String()).
+		Update("project_role_id", roleID.String())
+	if result.Error != nil {
+		return fmt.Errorf("project repo: update member role: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return projectdom.ErrMemberNotFound
+	}
+	return nil
+}
+
 // RemoveMember deletes the membership row for the given project + user.
 func (r *ProjectRepository) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
 	result := r.db.WithContext(ctx).

--- a/services/api/internal/service/project/project_member_service.go
+++ b/services/api/internal/service/project/project_member_service.go
@@ -57,6 +57,31 @@ func (s *Service) AddMember(ctx context.Context, projectID uuid.UUID, in project
 	return added, nil
 }
 
+// UpdateMemberRole changes the role of an existing project member.
+func (s *Service) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+	if _, err := s.repo.FindMember(ctx, projectID, userID); err != nil {
+		return nil, err
+	}
+
+	role, err := s.repo.FindRoleByID(ctx, in.ProjectRoleID)
+	if err != nil {
+		return nil, err
+	}
+	// Ensure the role belongs to this project (or is a template).
+	if role.ProjectID != nil && *role.ProjectID != projectID {
+		return nil, projectdom.ErrRoleNotFound
+	}
+
+	if err := s.repo.UpdateMemberRole(ctx, projectID, userID, in.ProjectRoleID); err != nil {
+		return nil, err
+	}
+
+	return s.repo.FindMember(ctx, projectID, userID)
+}
+
 // RemoveMember removes a user from the project.
 func (s *Service) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
 	if _, err := s.repo.FindByID(ctx, projectID); err != nil {

--- a/services/api/internal/service/project/project_member_service.go
+++ b/services/api/internal/service/project/project_member_service.go
@@ -52,7 +52,7 @@ func (s *Service) AddMember(ctx context.Context, projectID uuid.UUID, in project
 	// Re-fetch to populate username/role name via JOIN.
 	added, err := s.repo.FindMember(ctx, projectID, in.UserID)
 	if err != nil {
-		return m, nil
+		return nil, err
 	}
 	return added, nil
 }

--- a/services/api/internal/service/project/project_member_service.go
+++ b/services/api/internal/service/project/project_member_service.go
@@ -1,0 +1,69 @@
+package projectsvc
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// ListMembers returns all members of the given project.
+func (s *Service) ListMembers(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+	return s.repo.ListMembers(ctx, projectID)
+}
+
+// AddMember adds a user to a project with the specified role.
+func (s *Service) AddMember(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+
+	role, err := s.repo.FindRoleByID(ctx, in.ProjectRoleID)
+	if err != nil {
+		return nil, err
+	}
+	// Ensure the role belongs to this project (or is a template).
+	if role.ProjectID != nil && *role.ProjectID != projectID {
+		return nil, projectdom.ErrRoleNotFound
+	}
+
+	_, err = s.repo.FindMember(ctx, projectID, in.UserID)
+	if err == nil {
+		return nil, projectdom.ErrMemberAlreadyAdded
+	}
+	if !errors.Is(err, projectdom.ErrMemberNotFound) {
+		return nil, err
+	}
+
+	m := &projectdom.ProjectMember{
+		ID:            uuid.New(),
+		ProjectID:     projectID,
+		UserID:        in.UserID,
+		ProjectRoleID: in.ProjectRoleID,
+	}
+	if err := s.repo.AddMember(ctx, m); err != nil {
+		return nil, err
+	}
+
+	// Re-fetch to populate username/role name via JOIN.
+	added, err := s.repo.FindMember(ctx, projectID, in.UserID)
+	if err != nil {
+		return m, nil
+	}
+	return added, nil
+}
+
+// RemoveMember removes a user from the project.
+func (s *Service) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return err
+	}
+	if _, err := s.repo.FindMember(ctx, projectID, userID); err != nil {
+		return err
+	}
+	return s.repo.RemoveMember(ctx, projectID, userID)
+}

--- a/services/api/internal/service/project/project_member_service_test.go
+++ b/services/api/internal/service/project/project_member_service_test.go
@@ -1,0 +1,220 @@
+package projectsvc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+type memberServiceRepoMock struct {
+	findByID         func(ctx context.Context, id uuid.UUID) (*projectdom.Project, error)
+	findMember       func(ctx context.Context, projectID, userID uuid.UUID) (*projectdom.ProjectMember, error)
+	findRoleByID     func(ctx context.Context, id uuid.UUID) (*projectdom.ProjectRole, error)
+	updateMemberRole func(ctx context.Context, projectID, userID, roleID uuid.UUID) error
+}
+
+func (m *memberServiceRepoMock) List(context.Context, int, int) ([]*projectdom.Project, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *memberServiceRepoMock) FindByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	if m.findByID != nil {
+		return m.findByID(ctx, id)
+	}
+	return nil, projectdom.ErrNotFound
+}
+
+func (m *memberServiceRepoMock) Create(context.Context, *projectdom.Project) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) Update(context.Context, *projectdom.Project) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) Delete(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) ListMembers(context.Context, uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	return nil, nil
+}
+
+func (m *memberServiceRepoMock) FindMember(ctx context.Context, projectID, userID uuid.UUID) (*projectdom.ProjectMember, error) {
+	if m.findMember != nil {
+		return m.findMember(ctx, projectID, userID)
+	}
+	return nil, projectdom.ErrMemberNotFound
+}
+
+func (m *memberServiceRepoMock) AddMember(context.Context, *projectdom.ProjectMember) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) UpdateMemberRole(ctx context.Context, projectID, userID, roleID uuid.UUID) error {
+	if m.updateMemberRole != nil {
+		return m.updateMemberRole(ctx, projectID, userID, roleID)
+	}
+	return nil
+}
+
+func (m *memberServiceRepoMock) RemoveMember(context.Context, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) ListRoles(context.Context, uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	return nil, nil
+}
+
+func (m *memberServiceRepoMock) FindRoleByID(ctx context.Context, id uuid.UUID) (*projectdom.ProjectRole, error) {
+	if m.findRoleByID != nil {
+		return m.findRoleByID(ctx, id)
+	}
+	return nil, projectdom.ErrRoleNotFound
+}
+
+func (m *memberServiceRepoMock) FindRoleByName(context.Context, uuid.UUID, string) (*projectdom.ProjectRole, error) {
+	return nil, projectdom.ErrRoleNotFound
+}
+
+func (m *memberServiceRepoMock) CreateRole(context.Context, *projectdom.ProjectRole) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) UpdateRole(context.Context, *projectdom.ProjectRole) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) DeleteRole(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (m *memberServiceRepoMock) CountMembersWithRole(context.Context, uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
+var _ projectdom.Repository = (*memberServiceRepoMock)(nil)
+
+func TestUpdateMemberRole_Success(t *testing.T) {
+	projectID := uuid.New()
+	userID := uuid.New()
+	oldRoleID := uuid.New()
+	newRoleID := uuid.New()
+	findMemberCalls := 0
+
+	repo := &memberServiceRepoMock{
+		findByID: func(_ context.Context, id uuid.UUID) (*projectdom.Project, error) {
+			return &projectdom.Project{ID: id}, nil
+		},
+		findMember: func(_ context.Context, pid, uid uuid.UUID) (*projectdom.ProjectMember, error) {
+			findMemberCalls++
+			roleID := oldRoleID
+			if findMemberCalls > 1 {
+				roleID = newRoleID
+			}
+			return &projectdom.ProjectMember{
+				ID:            uuid.New(),
+				ProjectID:     pid,
+				UserID:        uid,
+				ProjectRoleID: roleID,
+			}, nil
+		},
+		findRoleByID: func(_ context.Context, id uuid.UUID) (*projectdom.ProjectRole, error) {
+			return &projectdom.ProjectRole{ID: id, ProjectID: &projectID}, nil
+		},
+		updateMemberRole: func(_ context.Context, pid, uid, rid uuid.UUID) error {
+			if pid != projectID || uid != userID || rid != newRoleID {
+				t.Fatalf("unexpected ids in update call")
+			}
+			return nil
+		},
+	}
+
+	svc := New(repo)
+	member, err := svc.UpdateMemberRole(context.Background(), projectID, userID, projectdom.UpdateMemberRoleInput{
+		ProjectRoleID: newRoleID,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if member.ProjectRoleID != newRoleID {
+		t.Fatalf("expected role id %s, got %s", newRoleID, member.ProjectRoleID)
+	}
+	if findMemberCalls != 2 {
+		t.Fatalf("expected find member to be called twice, got %d", findMemberCalls)
+	}
+}
+
+func TestUpdateMemberRole_ProjectNotFound(t *testing.T) {
+	repo := &memberServiceRepoMock{
+		findByID: func(context.Context, uuid.UUID) (*projectdom.Project, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	}
+
+	svc := New(repo)
+	_, err := svc.UpdateMemberRole(context.Background(), uuid.New(), uuid.New(), projectdom.UpdateMemberRoleInput{
+		ProjectRoleID: uuid.New(),
+	})
+	if !errors.Is(err, projectdom.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestUpdateMemberRole_RoleFromDifferentProject(t *testing.T) {
+	projectID := uuid.New()
+	otherProjectID := uuid.New()
+	repo := &memberServiceRepoMock{
+		findByID: func(_ context.Context, id uuid.UUID) (*projectdom.Project, error) {
+			return &projectdom.Project{ID: id}, nil
+		},
+		findMember: func(_ context.Context, pid, uid uuid.UUID) (*projectdom.ProjectMember, error) {
+			return &projectdom.ProjectMember{ProjectID: pid, UserID: uid}, nil
+		},
+		findRoleByID: func(_ context.Context, id uuid.UUID) (*projectdom.ProjectRole, error) {
+			return &projectdom.ProjectRole{ID: id, ProjectID: &otherProjectID}, nil
+		},
+		updateMemberRole: func(_ context.Context, _, _, _ uuid.UUID) error {
+			t.Fatal("update should not be called for role from different project")
+			return nil
+		},
+	}
+
+	svc := New(repo)
+	_, err := svc.UpdateMemberRole(context.Background(), projectID, uuid.New(), projectdom.UpdateMemberRoleInput{
+		ProjectRoleID: uuid.New(),
+	})
+	if !errors.Is(err, projectdom.ErrRoleNotFound) {
+		t.Fatalf("expected ErrRoleNotFound, got %v", err)
+	}
+}
+
+func TestUpdateMemberRole_UpdateError(t *testing.T) {
+	projectID := uuid.New()
+	userID := uuid.New()
+	repo := &memberServiceRepoMock{
+		findByID: func(_ context.Context, id uuid.UUID) (*projectdom.Project, error) {
+			return &projectdom.Project{ID: id}, nil
+		},
+		findMember: func(_ context.Context, pid, uid uuid.UUID) (*projectdom.ProjectMember, error) {
+			return &projectdom.ProjectMember{ProjectID: pid, UserID: uid}, nil
+		},
+		findRoleByID: func(_ context.Context, id uuid.UUID) (*projectdom.ProjectRole, error) {
+			return &projectdom.ProjectRole{ID: id, ProjectID: &projectID}, nil
+		},
+		updateMemberRole: func(_ context.Context, _, _, _ uuid.UUID) error {
+			return projectdom.ErrMemberNotFound
+		},
+	}
+
+	svc := New(repo)
+	_, err := svc.UpdateMemberRole(context.Background(), projectID, userID, projectdom.UpdateMemberRoleInput{
+		ProjectRoleID: uuid.New(),
+	})
+	if !errors.Is(err, projectdom.ErrMemberNotFound) {
+		t.Fatalf("expected ErrMemberNotFound, got %v", err)
+	}
+}

--- a/services/api/internal/service/project/project_member_service_test.go
+++ b/services/api/internal/service/project/project_member_service_test.go
@@ -20,6 +20,10 @@ func (m *memberServiceRepoMock) List(context.Context, int, int) ([]*projectdom.P
 	return nil, 0, nil
 }
 
+func (m *memberServiceRepoMock) ListAccessible(_ context.Context, _ uuid.UUID, _, _ int) ([]*projectdom.Project, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *memberServiceRepoMock) FindByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
 	if m.findByID != nil {
 		return m.findByID(ctx, id)

--- a/services/api/internal/service/project/project_role_service.go
+++ b/services/api/internal/service/project/project_role_service.go
@@ -1,0 +1,116 @@
+package projectsvc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// ListRoles returns all roles defined for a project.
+func (s *Service) ListRoles(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+	return s.repo.ListRoles(ctx, projectID)
+}
+
+// CreateRole adds a new role definition to a project.
+func (s *Service) CreateRole(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(in.RoleName)
+	if name == "" {
+		return nil, projectdom.ErrRoleNameInvalid
+	}
+
+	if _, err := s.repo.FindRoleByName(ctx, projectID, name); err == nil {
+		return nil, projectdom.ErrRoleNameTaken
+	} else if !errors.Is(err, projectdom.ErrRoleNotFound) {
+		return nil, err
+	}
+
+	now := time.Now()
+	r := &projectdom.ProjectRole{
+		ID:          uuid.New(),
+		ProjectID:   &projectID,
+		RoleName:    name,
+		Permissions: cloneSettings(in.Permissions),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.repo.CreateRole(ctx, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// UpdateRole modifies a project-scoped role.
+func (s *Service) UpdateRole(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+
+	r, err := s.repo.FindRoleByID(ctx, roleID)
+	if err != nil {
+		return nil, err
+	}
+	// Ensure the role belongs to this project.
+	if r.ProjectID == nil || *r.ProjectID != projectID {
+		return nil, projectdom.ErrRoleNotFound
+	}
+
+	name := strings.TrimSpace(in.RoleName)
+	if name == "" {
+		return nil, projectdom.ErrRoleNameInvalid
+	}
+	if !strings.EqualFold(name, r.RoleName) {
+		existing, err := s.repo.FindRoleByName(ctx, projectID, name)
+		if err == nil && existing.ID != r.ID {
+			return nil, projectdom.ErrRoleNameTaken
+		}
+		if err != nil && !errors.Is(err, projectdom.ErrRoleNotFound) {
+			return nil, err
+		}
+	}
+
+	r.RoleName = name
+	if in.Permissions != nil {
+		r.Permissions = cloneSettings(in.Permissions)
+	}
+	r.UpdatedAt = time.Now()
+
+	if err := s.repo.UpdateRole(ctx, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// DeleteRole removes a project-scoped role. It fails if members still have this role.
+func (s *Service) DeleteRole(ctx context.Context, projectID, roleID uuid.UUID) error {
+	if _, err := s.repo.FindByID(ctx, projectID); err != nil {
+		return err
+	}
+
+	r, err := s.repo.FindRoleByID(ctx, roleID)
+	if err != nil {
+		return err
+	}
+	if r.ProjectID == nil || *r.ProjectID != projectID {
+		return projectdom.ErrRoleNotFound
+	}
+
+	count, err := s.repo.CountMembersWithRole(ctx, roleID)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return projectdom.ErrRoleHasMembers
+	}
+	return s.repo.DeleteRole(ctx, roleID)
+}

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -1,0 +1,103 @@
+// Package projectsvc implements project management application services.
+package projectsvc
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// Service is the concrete implementation of projectdom.Service.
+type Service struct {
+	repo projectdom.Repository
+}
+
+// New returns a configured project service.
+func New(repo projectdom.Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// List returns a page of projects and the total count.
+func (s *Service) List(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	offset := (page - 1) * pageSize
+	return s.repo.List(ctx, offset, pageSize)
+}
+
+// GetByID returns the project with the given ID.
+func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	return s.repo.FindByID(ctx, id)
+}
+
+// Create defines and persists a new project.
+func (s *Service) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		return nil, projectdom.ErrNameTaken
+	}
+
+	now := time.Now()
+	p := &projectdom.Project{
+		ID:          uuid.New(),
+		Name:        name,
+		Description: strings.TrimSpace(in.Description),
+		Settings:    cloneSettings(in.Settings),
+		CreatedBy:   in.CreatedBy,
+		CreatedAt:   now,
+	}
+
+	if err := s.repo.Create(ctx, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// Update modifies an existing project's mutable fields.
+func (s *Service) Update(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+	p, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(in.Name)
+	if name != "" {
+		p.Name = name
+	}
+	p.Description = strings.TrimSpace(in.Description)
+	if in.Settings != nil {
+		p.Settings = cloneSettings(in.Settings)
+	}
+
+	if err := s.repo.Update(ctx, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// Delete removes a project and all cascading records defined in the DB schema.
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	return s.repo.Delete(ctx, id)
+}
+
+func cloneSettings(in map[string]any) map[string]any {
+	if in == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -71,7 +71,10 @@ func (s *Service) Update(ctx context.Context, id uuid.UUID, in projectdom.Update
 	if name != "" {
 		p.Name = name
 	}
-	p.Description = strings.TrimSpace(in.Description)
+	desc := strings.TrimSpace(in.Description)
+	if desc != "" {
+		p.Description = desc
+	}
 	if in.Settings != nil {
 		p.Settings = cloneSettings(in.Settings)
 	}

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -32,6 +32,18 @@ func (s *Service) List(ctx context.Context, page, pageSize int) ([]*projectdom.P
 	return s.repo.List(ctx, offset, pageSize)
 }
 
+// ListAccessible returns only the projects the given user is a member of.
+func (s *Service) ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	offset := (page - 1) * pageSize
+	return s.repo.ListAccessible(ctx, userID, offset, pageSize)
+}
+
 // GetByID returns the project with the given ID.
 func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
 	return s.repo.FindByID(ctx, id)

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -41,7 +41,7 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Projec
 func (s *Service) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
-		return nil, projectdom.ErrNameTaken
+		return nil, projectdom.ErrNameInvalid
 	}
 
 	now := time.Now()

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -37,7 +37,9 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Projec
 	return s.repo.FindByID(ctx, id)
 }
 
-// Create defines and persists a new project.
+// Create defines and persists a new project, bootstraps the three default
+// project-scoped roles (admin, editor, viewer), and adds the creator as the
+// project admin.
 func (s *Service) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
@@ -57,6 +59,74 @@ func (s *Service) Create(ctx context.Context, in projectdom.CreateProjectInput) 
 	if err := s.repo.Create(ctx, p); err != nil {
 		return nil, err
 	}
+
+	// Bootstrap the three default project-scoped roles.
+	defaultRoles := []*projectdom.ProjectRole{
+		{
+			ID:        uuid.New(),
+			ProjectID: &p.ID,
+			RoleName:  "Admin",
+			Permissions: map[string]any{
+				"projects.*":        true,
+				"project.members.*": true,
+				"project.roles.*":   true,
+				"tasks.*":           true,
+				"sprints.*":         true,
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		{
+			ID:        uuid.New(),
+			ProjectID: &p.ID,
+			RoleName:  "Editor",
+			Permissions: map[string]any{
+				"projects.read": true,
+				"tasks.read":    true,
+				"tasks.write":   true,
+				"sprints.read":  true,
+				"sprints.write": true,
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		{
+			ID:        uuid.New(),
+			ProjectID: &p.ID,
+			RoleName:  "Viewer",
+			Permissions: map[string]any{
+				"projects.read": true,
+				"tasks.read":    true,
+				"sprints.read":  true,
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	}
+
+	var adminRoleID uuid.UUID
+	for _, r := range defaultRoles {
+		if err := s.repo.CreateRole(ctx, r); err != nil {
+			return nil, err
+		}
+		if r.RoleName == "Admin" {
+			adminRoleID = r.ID
+		}
+	}
+
+	// Add the creator as a project admin.
+	if in.CreatedBy != nil {
+		m := &projectdom.ProjectMember{
+			ID:            uuid.New(),
+			ProjectID:     p.ID,
+			UserID:        *in.CreatedBy,
+			ProjectRoleID: adminRoleID,
+		}
+		if err := s.repo.AddMember(ctx, m); err != nil {
+			return nil, err
+		}
+	}
+
 	return p, nil
 }
 

--- a/services/api/internal/transport/http/dto/project_dto.go
+++ b/services/api/internal/transport/http/dto/project_dto.go
@@ -9,14 +9,14 @@ import (
 
 // --- Project DTOs -----------------------------------------------------------
 
-// CreateProjectRequest is the body for POST /v1/admin/projects.
+// CreateProjectRequest is the body for POST /projects.
 type CreateProjectRequest struct {
 	Name        string         `json:"name" binding:"required"`
 	Description string         `json:"description"`
 	Settings    map[string]any `json:"settings"`
 }
 
-// UpdateProjectRequest is the body for PATCH /v1/admin/projects/:projectId.
+// UpdateProjectRequest is the body for PATCH /projects/:projectId.
 type UpdateProjectRequest struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description"`

--- a/services/api/internal/transport/http/dto/project_dto.go
+++ b/services/api/internal/transport/http/dto/project_dto.go
@@ -1,0 +1,50 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// --- Project DTOs -----------------------------------------------------------
+
+// CreateProjectRequest is the body for POST /v1/admin/projects.
+type CreateProjectRequest struct {
+	Name        string         `json:"name" binding:"required"`
+	Description string         `json:"description"`
+	Settings    map[string]any `json:"settings"`
+}
+
+// UpdateProjectRequest is the body for PATCH /v1/admin/projects/:projectId.
+type UpdateProjectRequest struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Settings    map[string]any `json:"settings"`
+}
+
+// ProjectResponse is the public representation of a project.
+type ProjectResponse struct {
+	ID          uuid.UUID      `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Settings    map[string]any `json:"settings"`
+	CreatedBy   *uuid.UUID     `json:"created_by,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+}
+
+// ProjectFromEntity maps a domain Project to a ProjectResponse DTO.
+func ProjectFromEntity(p *projectdom.Project) ProjectResponse {
+	settings := p.Settings
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	return ProjectResponse{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		Settings:    settings,
+		CreatedBy:   p.CreatedBy,
+		CreatedAt:   p.CreatedAt,
+	}
+}

--- a/services/api/internal/transport/http/dto/project_member_dto.go
+++ b/services/api/internal/transport/http/dto/project_member_dto.go
@@ -1,0 +1,38 @@
+package dto
+
+import (
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// --- Project Member DTOs ----------------------------------------------------
+
+// AddProjectMemberRequest is the body for POST /v1/projects/:projectId/members.
+type AddProjectMemberRequest struct {
+	UserID        uuid.UUID `json:"user_id" binding:"required"`
+	ProjectRoleID uuid.UUID `json:"project_role_id" binding:"required"`
+}
+
+// ProjectMemberResponse is the public representation of a project membership.
+type ProjectMemberResponse struct {
+	ID            uuid.UUID `json:"id"`
+	ProjectID     uuid.UUID `json:"project_id"`
+	UserID        uuid.UUID `json:"user_id"`
+	ProjectRoleID uuid.UUID `json:"project_role_id"`
+	Username      string    `json:"username"`
+	FullName      string    `json:"full_name"`
+	RoleName      string    `json:"role_name"`
+}
+
+// ProjectMemberFromEntity maps a domain ProjectMember to a ProjectMemberResponse DTO.
+func ProjectMemberFromEntity(m *projectdom.ProjectMember) ProjectMemberResponse {
+	return ProjectMemberResponse{
+		ID:            m.ID,
+		ProjectID:     m.ProjectID,
+		UserID:        m.UserID,
+		ProjectRoleID: m.ProjectRoleID,
+		Username:      m.Username,
+		FullName:      m.FullName,
+		RoleName:      m.RoleName,
+	}
+}

--- a/services/api/internal/transport/http/dto/project_member_dto.go
+++ b/services/api/internal/transport/http/dto/project_member_dto.go
@@ -13,6 +13,11 @@ type AddProjectMemberRequest struct {
 	ProjectRoleID uuid.UUID `json:"project_role_id" binding:"required"`
 }
 
+// UpdateProjectMemberRoleRequest is the body for PATCH /v1/projects/:projectId/members/:userId.
+type UpdateProjectMemberRoleRequest struct {
+	ProjectRoleID uuid.UUID `json:"project_role_id" binding:"required"`
+}
+
 // ProjectMemberResponse is the public representation of a project membership.
 type ProjectMemberResponse struct {
 	ID            uuid.UUID `json:"id"`

--- a/services/api/internal/transport/http/dto/project_role_dto.go
+++ b/services/api/internal/transport/http/dto/project_role_dto.go
@@ -1,0 +1,48 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// --- Project Role DTOs ------------------------------------------------------
+
+// CreateProjectRoleRequest is the body for POST /v1/projects/:projectId/roles.
+type CreateProjectRoleRequest struct {
+	RoleName    string         `json:"role_name" binding:"required"`
+	Permissions map[string]any `json:"permissions"`
+}
+
+// UpdateProjectRoleRequest is the body for PATCH /v1/projects/:projectId/roles/:roleId.
+type UpdateProjectRoleRequest struct {
+	RoleName    string         `json:"role_name" binding:"required"`
+	Permissions map[string]any `json:"permissions"`
+}
+
+// ProjectRoleResponse is the public representation of a project role.
+type ProjectRoleResponse struct {
+	ID          uuid.UUID      `json:"id"`
+	ProjectID   *uuid.UUID     `json:"project_id,omitempty"`
+	RoleName    string         `json:"role_name"`
+	Permissions map[string]any `json:"permissions"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+}
+
+// ProjectRoleFromEntity maps a domain ProjectRole to a ProjectRoleResponse DTO.
+func ProjectRoleFromEntity(r *projectdom.ProjectRole) ProjectRoleResponse {
+	perms := r.Permissions
+	if perms == nil {
+		perms = map[string]any{}
+	}
+	return ProjectRoleResponse{
+		ID:          r.ID,
+		ProjectID:   r.ProjectID,
+		RoleName:    r.RoleName,
+		Permissions: perms,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}
+}

--- a/services/api/internal/transport/http/handler/project_handler.go
+++ b/services/api/internal/transport/http/handler/project_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/paca/api/internal/apierr"
 	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/platform/authz"
 	"github.com/paca/api/internal/transport/http/dto"
 	"github.com/paca/api/internal/transport/http/middleware"
 	"github.com/paca/api/internal/transport/http/presenter"
@@ -14,22 +15,52 @@ import (
 
 // ProjectHandler handles project management endpoints.
 type ProjectHandler struct {
-	svc projectdom.Service
+	svc        projectdom.Service
+	authorizer *authz.Authorizer
 }
 
-// NewProjectHandler returns a ProjectHandler wired to the service.
-func NewProjectHandler(svc projectdom.Service) *ProjectHandler {
-	return &ProjectHandler{svc: svc}
+// NewProjectHandler returns a ProjectHandler wired to the service and authorizer.
+func NewProjectHandler(svc projectdom.Service, authorizer *authz.Authorizer) *ProjectHandler {
+	return &ProjectHandler{svc: svc, authorizer: authorizer}
 }
 
-// ListProjects handles GET /admin/projects.
+// ListProjects handles GET /projects.
+// Users with the global projects.read permission receive all projects.
+// All other authenticated users receive only the projects they are a member of.
 func (h *ProjectHandler) ListProjects(c *gin.Context) {
+	claims := middleware.ClaimsFrom(c)
 	page, pageSize := pagingParams(c)
-	projects, total, err := h.svc.List(c.Request.Context(), page, pageSize)
+
+	var (
+		projects []*projectdom.Project
+		total    int64
+		err      error
+	)
+
+	userID, parseErr := uuid.Parse(claims.Subject)
+	if parseErr != nil {
+		presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid subject claim"))
+		return
+	}
+
+	hasGlobalRead, authzErr := h.authorizer.HasPermissions(
+		c.Request.Context(), userID, nil, claims.Role, authz.PermissionProjectsRead,
+	)
+	if authzErr != nil {
+		presenter.Error(c, authzErr)
+		return
+	}
+
+	if hasGlobalRead {
+		projects, total, err = h.svc.List(c.Request.Context(), page, pageSize)
+	} else {
+		projects, total, err = h.svc.ListAccessible(c.Request.Context(), userID, page, pageSize)
+	}
 	if err != nil {
 		presenter.Error(c, err)
 		return
 	}
+
 	resp := make([]dto.ProjectResponse, 0, len(projects))
 	for _, p := range projects {
 		resp = append(resp, dto.ProjectFromEntity(p))
@@ -37,7 +68,7 @@ func (h *ProjectHandler) ListProjects(c *gin.Context) {
 	presenter.OK(c, gin.H{"items": resp, "total": total, "page": page, "page_size": pageSize})
 }
 
-// GetProject handles GET /admin/projects/:projectId.
+// GetProject handles GET /projects/:projectId.
 func (h *ProjectHandler) GetProject(c *gin.Context) {
 	id, err := parseProjectID(c)
 	if err != nil {
@@ -52,7 +83,7 @@ func (h *ProjectHandler) GetProject(c *gin.Context) {
 	presenter.OK(c, dto.ProjectFromEntity(p))
 }
 
-// CreateProject handles POST /admin/projects.
+// CreateProject handles POST /projects.
 func (h *ProjectHandler) CreateProject(c *gin.Context) {
 	var req dto.CreateProjectRequest
 	if !middleware.BindJSON(c, &req) {
@@ -80,7 +111,7 @@ func (h *ProjectHandler) CreateProject(c *gin.Context) {
 	presenter.Created(c, dto.ProjectFromEntity(p))
 }
 
-// UpdateProject handles PATCH /admin/projects/:projectId.
+// UpdateProject handles PATCH /projects/:projectId.
 func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 	id, err := parseProjectID(c)
 	if err != nil {
@@ -105,7 +136,7 @@ func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 	presenter.OK(c, dto.ProjectFromEntity(p))
 }
 
-// DeleteProject handles DELETE /admin/projects/:projectId.
+// DeleteProject handles DELETE /projects/:projectId.
 func (h *ProjectHandler) DeleteProject(c *gin.Context) {
 	id, err := parseProjectID(c)
 	if err != nil {

--- a/services/api/internal/transport/http/handler/project_handler.go
+++ b/services/api/internal/transport/http/handler/project_handler.go
@@ -1,0 +1,142 @@
+package handler
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/paca/api/internal/apierr"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/transport/http/dto"
+	"github.com/paca/api/internal/transport/http/middleware"
+	"github.com/paca/api/internal/transport/http/presenter"
+)
+
+// ProjectHandler handles project management endpoints.
+type ProjectHandler struct {
+	svc projectdom.Service
+}
+
+// NewProjectHandler returns a ProjectHandler wired to the service.
+func NewProjectHandler(svc projectdom.Service) *ProjectHandler {
+	return &ProjectHandler{svc: svc}
+}
+
+// ListProjects handles GET /admin/projects.
+func (h *ProjectHandler) ListProjects(c *gin.Context) {
+	page, pageSize := pagingParams(c)
+	projects, total, err := h.svc.List(c.Request.Context(), page, pageSize)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	resp := make([]dto.ProjectResponse, 0, len(projects))
+	for _, p := range projects {
+		resp = append(resp, dto.ProjectFromEntity(p))
+	}
+	presenter.OK(c, gin.H{"items": resp, "total": total, "page": page, "page_size": pageSize})
+}
+
+// GetProject handles GET /admin/projects/:projectId.
+func (h *ProjectHandler) GetProject(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	p, err := h.svc.GetByID(c.Request.Context(), id)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, dto.ProjectFromEntity(p))
+}
+
+// CreateProject handles POST /admin/projects.
+func (h *ProjectHandler) CreateProject(c *gin.Context) {
+	var req dto.CreateProjectRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	claims := middleware.ClaimsFrom(c)
+	var createdBy *uuid.UUID
+	if claims != nil {
+		if uid, err := uuid.Parse(claims.Subject); err == nil {
+			createdBy = &uid
+		}
+	}
+
+	p, err := h.svc.Create(c.Request.Context(), projectdom.CreateProjectInput{
+		Name:        req.Name,
+		Description: req.Description,
+		Settings:    req.Settings,
+		CreatedBy:   createdBy,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.Created(c, dto.ProjectFromEntity(p))
+}
+
+// UpdateProject handles PATCH /admin/projects/:projectId.
+func (h *ProjectHandler) UpdateProject(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+
+	var req dto.UpdateProjectRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	p, err := h.svc.Update(c.Request.Context(), id, projectdom.UpdateProjectInput{
+		Name:        req.Name,
+		Description: req.Description,
+		Settings:    req.Settings,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, dto.ProjectFromEntity(p))
+}
+
+// DeleteProject handles DELETE /admin/projects/:projectId.
+func (h *ProjectHandler) DeleteProject(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	if err := h.svc.Delete(c.Request.Context(), id); err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, gin.H{"message": "project deleted"})
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func parseProjectID(c *gin.Context) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param("projectId"))
+	if err != nil {
+		return uuid.Nil, apierr.New(apierr.CodeBadRequest, "invalid project id")
+	}
+	return id, nil
+}
+
+func pagingParams(c *gin.Context) (page, pageSize int) {
+	page, _ = strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ = strconv.Atoi(c.DefaultQuery("page_size", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+	return page, pageSize
+}

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -29,6 +29,7 @@ type mockProjectSvc struct {
 	delete       func(ctx context.Context, id uuid.UUID) error
 	listMembers  func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error)
 	addMember    func(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error)
+	updateMember func(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error)
 	removeMember func(ctx context.Context, projectID, userID uuid.UUID) error
 	listRoles    func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error)
 	createRole   func(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error)
@@ -85,6 +86,13 @@ func (m *mockProjectSvc) AddMember(ctx context.Context, projectID uuid.UUID, in 
 	return nil, errors.New("mock: addMember not configured")
 }
 
+func (m *mockProjectSvc) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+	if m.updateMember != nil {
+		return m.updateMember(ctx, projectID, userID, in)
+	}
+	return nil, errors.New("mock: updateMember not configured")
+}
+
 func (m *mockProjectSvc) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
 	if m.removeMember != nil {
 		return m.removeMember(ctx, projectID, userID)
@@ -139,6 +147,7 @@ func newProjectRouter(svc projectdom.Service) *gin.Engine {
 	// Project member routes
 	r.GET("/projects/:projectId/members", h.ListMembers)
 	r.POST("/projects/:projectId/members", h.AddMember)
+	r.PATCH("/projects/:projectId/members/:userId", h.UpdateMemberRole)
 	r.DELETE("/projects/:projectId/members/:userId", h.RemoveMember)
 	// Project role routes
 	r.GET("/projects/:projectId/roles", h.ListRoles)
@@ -717,6 +726,98 @@ func TestAddMember_MemberAlreadyAdded(t *testing.T) {
 		t.Fatalf("expected 409, got %d", w.Code)
 	}
 	if code := errorCode(t, w); code != "PROJECT_MEMBER_ALREADY_ADDED" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestUpdateMemberRole_Success(t *testing.T) {
+	projID := uuid.New()
+	userID := uuid.New()
+	roleID := uuid.New()
+	memberID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		updateMember: func(_ context.Context, pid, uid uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+			if pid != projID {
+				t.Fatalf("expected project id %s, got %s", projID, pid)
+			}
+			if uid != userID {
+				t.Fatalf("expected user id %s, got %s", userID, uid)
+			}
+			if in.ProjectRoleID != roleID {
+				t.Fatalf("expected role id %s, got %s", roleID, in.ProjectRoleID)
+			}
+			return &projectdom.ProjectMember{
+				ID:            memberID,
+				ProjectID:     pid,
+				UserID:        uid,
+				ProjectRoleID: in.ProjectRoleID,
+			}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/members/%s", projID, userID),
+		jsonBody(t, map[string]any{"project_role_id": roleID}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateMemberRole_BadProjectID(t *testing.T) {
+	userID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/not-a-uuid/members/%s", userID),
+		jsonBody(t, map[string]any{"project_role_id": uuid.New()}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateMemberRole_BadUserID(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/members/not-a-uuid", projID),
+		jsonBody(t, map[string]any{"project_role_id": uuid.New()}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateMemberRole_MemberNotFound(t *testing.T) {
+	projID := uuid.New()
+	userID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		updateMember: func(_ context.Context, _, _ uuid.UUID, _ projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+			return nil, projectdom.ErrMemberNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/members/%s", projID, userID),
+		jsonBody(t, map[string]any{"project_role_id": uuid.New()}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_MEMBER_NOT_FOUND" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestUpdateMemberRole_RoleNotFound(t *testing.T) {
+	projID := uuid.New()
+	userID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		updateMember: func(_ context.Context, _, _ uuid.UUID, _ projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+			return nil, projectdom.ErrRoleNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/members/%s", projID, userID),
+		jsonBody(t, map[string]any{"project_role_id": uuid.New()}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_ROLE_NOT_FOUND" {
 		t.Fatalf("unexpected error_code: %s", code)
 	}
 }

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -247,6 +247,23 @@ func TestCreateProject_MissingName(t *testing.T) {
 	}
 }
 
+func TestCreateProject_WhitespaceName(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{
+		create: func(_ context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+			return nil, projectdom.ErrNameInvalid
+		},
+	})
+
+	w := do(t, r, http.MethodPost, "/admin/projects",
+		jsonBody(t, map[string]any{"name": "   "}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(t, w); code != "PROJECT_NAME_INVALID" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
 func TestCreateProject_MalformedJSON(t *testing.T) {
 	r := newProjectRouter(&mockProjectSvc{})
 

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -3,9 +3,11 @@ package handler_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -302,6 +304,39 @@ func TestUpdateProject_Success(t *testing.T) {
 		jsonBody(t, map[string]any{"name": "updated"}))
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateProject_PreservesOmittedFields(t *testing.T) {
+	projID := uuid.New()
+	const existingDesc = "existing description"
+	r := newProjectRouter(&mockProjectSvc{
+		update: func(_ context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+			// Simulate service PATCH semantics: only overwrite description when provided.
+			desc := existingDesc
+			if strings.TrimSpace(in.Description) != "" {
+				desc = strings.TrimSpace(in.Description)
+			}
+			return &projectdom.Project{ID: id, Name: in.Name, Description: desc}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/admin/projects/%s", projID),
+		jsonBody(t, map[string]any{"name": "updated"}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var env struct {
+		Data struct {
+			Description string `json:"description"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if env.Data.Description != existingDesc {
+		t.Fatalf("expected description %q to be preserved, got %q", existingDesc, env.Data.Description)
 	}
 }
 

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -12,9 +12,13 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	domainauth "github.com/paca/api/internal/domain/auth"
 	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/platform/authz"
 	"github.com/paca/api/internal/transport/http/handler"
+	"github.com/paca/api/internal/transport/http/middleware"
 )
 
 // ---------------------------------------------------------------------------
@@ -22,24 +26,32 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockProjectSvc struct {
-	list         func(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error)
-	getByID      func(ctx context.Context, id uuid.UUID) (*projectdom.Project, error)
-	create       func(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error)
-	update       func(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error)
-	delete       func(ctx context.Context, id uuid.UUID) error
-	listMembers  func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error)
-	addMember    func(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error)
-	updateMember func(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error)
-	removeMember func(ctx context.Context, projectID, userID uuid.UUID) error
-	listRoles    func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error)
-	createRole   func(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error)
-	updateRole   func(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error)
-	deleteRole   func(ctx context.Context, projectID, roleID uuid.UUID) error
+	list           func(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error)
+	listAccessible func(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error)
+	getByID        func(ctx context.Context, id uuid.UUID) (*projectdom.Project, error)
+	create         func(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error)
+	update         func(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error)
+	delete         func(ctx context.Context, id uuid.UUID) error
+	listMembers    func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error)
+	addMember      func(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error)
+	updateMember   func(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error)
+	removeMember   func(ctx context.Context, projectID, userID uuid.UUID) error
+	listRoles      func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error)
+	createRole     func(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error)
+	updateRole     func(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error)
+	deleteRole     func(ctx context.Context, projectID, roleID uuid.UUID) error
 }
 
 func (m *mockProjectSvc) List(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error) {
 	if m.list != nil {
 		return m.list(ctx, page, pageSize)
+	}
+	return []*projectdom.Project{}, 0, nil
+}
+
+func (m *mockProjectSvc) ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	if m.listAccessible != nil {
+		return m.listAccessible(ctx, userID, page, pageSize)
 	}
 	return []*projectdom.Project{}, 0, nil
 }
@@ -135,9 +147,29 @@ var _ projectdom.Service = (*mockProjectSvc)(nil)
 // router helper
 // ---------------------------------------------------------------------------
 
+// adminClaimsMiddleware injects a synthetic ADMIN claims into the gin context so
+// unit tests can exercise the handler without a real JWT stack.
+func adminClaimsMiddleware() gin.HandlerFunc {
+	claims := &domainauth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: uuid.New().String(),
+		},
+		Role: "ADMIN",
+		Kind: "access",
+	}
+	return func(c *gin.Context) {
+		c.Set(middleware.ClaimsContextKey(), claims)
+		c.Next()
+	}
+}
+
 func newProjectRouter(svc projectdom.Service) *gin.Engine {
+	// Use a real Authorizer with nil store — legacy ADMIN role grants everything
+	// without any database calls.
+	authorizer := authz.NewAuthorizer(nil)
 	r := gin.New()
-	h := handler.NewProjectHandler(svc)
+	r.Use(adminClaimsMiddleware())
+	h := handler.NewProjectHandler(svc, authorizer)
 	// Admin project CRUD
 	r.GET("/admin/projects", h.ListProjects)
 	r.POST("/admin/projects", h.CreateProject)

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -1,0 +1,721 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/transport/http/handler"
+)
+
+// ---------------------------------------------------------------------------
+// mock
+// ---------------------------------------------------------------------------
+
+type mockProjectSvc struct {
+	list         func(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error)
+	getByID      func(ctx context.Context, id uuid.UUID) (*projectdom.Project, error)
+	create       func(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error)
+	update       func(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error)
+	delete       func(ctx context.Context, id uuid.UUID) error
+	listMembers  func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error)
+	addMember    func(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error)
+	removeMember func(ctx context.Context, projectID, userID uuid.UUID) error
+	listRoles    func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error)
+	createRole   func(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error)
+	updateRole   func(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error)
+	deleteRole   func(ctx context.Context, projectID, roleID uuid.UUID) error
+}
+
+func (m *mockProjectSvc) List(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	if m.list != nil {
+		return m.list(ctx, page, pageSize)
+	}
+	return []*projectdom.Project{}, 0, nil
+}
+
+func (m *mockProjectSvc) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	if m.getByID != nil {
+		return m.getByID(ctx, id)
+	}
+	return nil, projectdom.ErrNotFound
+}
+
+func (m *mockProjectSvc) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+	if m.create != nil {
+		return m.create(ctx, in)
+	}
+	return nil, errors.New("mock: create not configured")
+}
+
+func (m *mockProjectSvc) Update(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+	if m.update != nil {
+		return m.update(ctx, id, in)
+	}
+	return nil, projectdom.ErrNotFound
+}
+
+func (m *mockProjectSvc) Delete(ctx context.Context, id uuid.UUID) error {
+	if m.delete != nil {
+		return m.delete(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockProjectSvc) ListMembers(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	if m.listMembers != nil {
+		return m.listMembers(ctx, projectID)
+	}
+	return []*projectdom.ProjectMember{}, nil
+}
+
+func (m *mockProjectSvc) AddMember(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+	if m.addMember != nil {
+		return m.addMember(ctx, projectID, in)
+	}
+	return nil, errors.New("mock: addMember not configured")
+}
+
+func (m *mockProjectSvc) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
+	if m.removeMember != nil {
+		return m.removeMember(ctx, projectID, userID)
+	}
+	return nil
+}
+
+func (m *mockProjectSvc) ListRoles(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	if m.listRoles != nil {
+		return m.listRoles(ctx, projectID)
+	}
+	return []*projectdom.ProjectRole{}, nil
+}
+
+func (m *mockProjectSvc) CreateRole(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+	if m.createRole != nil {
+		return m.createRole(ctx, projectID, in)
+	}
+	return nil, errors.New("mock: createRole not configured")
+}
+
+func (m *mockProjectSvc) UpdateRole(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
+	if m.updateRole != nil {
+		return m.updateRole(ctx, projectID, roleID, in)
+	}
+	return nil, projectdom.ErrRoleNotFound
+}
+
+func (m *mockProjectSvc) DeleteRole(ctx context.Context, projectID, roleID uuid.UUID) error {
+	if m.deleteRole != nil {
+		return m.deleteRole(ctx, projectID, roleID)
+	}
+	return nil
+}
+
+// compile-time interface check
+var _ projectdom.Service = (*mockProjectSvc)(nil)
+
+// ---------------------------------------------------------------------------
+// router helper
+// ---------------------------------------------------------------------------
+
+func newProjectRouter(svc projectdom.Service) *gin.Engine {
+	r := gin.New()
+	h := handler.NewProjectHandler(svc)
+	// Admin project CRUD
+	r.GET("/admin/projects", h.ListProjects)
+	r.POST("/admin/projects", h.CreateProject)
+	r.GET("/admin/projects/:projectId", h.GetProject)
+	r.PATCH("/admin/projects/:projectId", h.UpdateProject)
+	r.DELETE("/admin/projects/:projectId", h.DeleteProject)
+	// Project member routes
+	r.GET("/projects/:projectId/members", h.ListMembers)
+	r.POST("/projects/:projectId/members", h.AddMember)
+	r.DELETE("/projects/:projectId/members/:userId", h.RemoveMember)
+	// Project role routes
+	r.GET("/projects/:projectId/roles", h.ListRoles)
+	r.POST("/projects/:projectId/roles", h.CreateRole)
+	r.PATCH("/projects/:projectId/roles/:roleId", h.UpdateRole)
+	r.DELETE("/projects/:projectId/roles/:roleId", h.DeleteRole)
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Project CRUD
+// ---------------------------------------------------------------------------
+
+func TestListProjects_Success(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		list: func(_ context.Context, _, _ int) ([]*projectdom.Project, int64, error) {
+			return []*projectdom.Project{
+				{ID: projID, Name: "alpha", CreatedAt: time.Now()},
+			}, 1, nil
+		},
+	})
+
+	w := do(t, r, http.MethodGet, "/admin/projects", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListProjects_ServiceError(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{
+		list: func(_ context.Context, _, _ int) ([]*projectdom.Project, int64, error) {
+			return nil, 0, errors.New("db error")
+		},
+	})
+
+	w := do(t, r, http.MethodGet, "/admin/projects", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetProject_Success(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		getByID: func(_ context.Context, id uuid.UUID) (*projectdom.Project, error) {
+			if id != projID {
+				return nil, projectdom.ErrNotFound
+			}
+			return &projectdom.Project{ID: projID, Name: "alpha"}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodGet, fmt.Sprintf("/admin/projects/%s", projID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetProject_BadID(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodGet, "/admin/projects/not-a-uuid", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetProject_NotFound(t *testing.T) {
+	id := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		getByID: func(_ context.Context, _ uuid.UUID) (*projectdom.Project, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodGet, fmt.Sprintf("/admin/projects/%s", id), nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_NOT_FOUND" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestCreateProject_Success(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		create: func(_ context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+			return &projectdom.Project{ID: projID, Name: in.Name, Description: in.Description}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPost, "/admin/projects",
+		jsonBody(t, map[string]any{"name": "beta", "description": "a project"}))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateProject_MissingName(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPost, "/admin/projects",
+		jsonBody(t, map[string]any{"description": "no name"}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateProject_MalformedJSON(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPost, "/admin/projects", bytes.NewBufferString("{bad json"))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateProject_NameTaken(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{
+		create: func(_ context.Context, _ projectdom.CreateProjectInput) (*projectdom.Project, error) {
+			return nil, projectdom.ErrNameTaken
+		},
+	})
+
+	w := do(t, r, http.MethodPost, "/admin/projects",
+		jsonBody(t, map[string]any{"name": "alpha"}))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_NAME_TAKEN" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestUpdateProject_Success(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		update: func(_ context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+			return &projectdom.Project{ID: id, Name: in.Name}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/admin/projects/%s", projID),
+		jsonBody(t, map[string]any{"name": "updated"}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateProject_BadID(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPatch, "/admin/projects/not-a-uuid",
+		jsonBody(t, map[string]any{"name": "updated"}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateProject_NotFound(t *testing.T) {
+	id := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		update: func(_ context.Context, _ uuid.UUID, _ projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/admin/projects/%s", id),
+		jsonBody(t, map[string]any{"name": "updated"}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteProject_Success(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		delete: func(_ context.Context, _ uuid.UUID) error { return nil },
+	})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/admin/projects/%s", projID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestDeleteProject_BadID(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodDelete, "/admin/projects/not-a-uuid", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDeleteProject_NotFound(t *testing.T) {
+	id := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		delete: func(_ context.Context, _ uuid.UUID) error { return projectdom.ErrNotFound },
+	})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/admin/projects/%s", id), nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Project Role
+// ---------------------------------------------------------------------------
+
+func TestListRoles_Success(t *testing.T) {
+	projID := uuid.New()
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		listRoles: func(_ context.Context, _ uuid.UUID) ([]*projectdom.ProjectRole, error) {
+			return []*projectdom.ProjectRole{
+				{ID: roleID, ProjectID: &projID, RoleName: "viewer"},
+			}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodGet, fmt.Sprintf("/projects/%s/roles", projID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListRoles_BadProjectID(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodGet, "/projects/not-a-uuid/roles", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListRoles_ProjectNotFound(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		listRoles: func(_ context.Context, _ uuid.UUID) ([]*projectdom.ProjectRole, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodGet, fmt.Sprintf("/projects/%s/roles", projID), nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestCreateRole_Success(t *testing.T) {
+	projID := uuid.New()
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		createRole: func(_ context.Context, pid uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+			return &projectdom.ProjectRole{ID: roleID, ProjectID: &pid, RoleName: in.RoleName}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/roles", projID),
+		jsonBody(t, map[string]any{"role_name": "viewer", "permissions": map[string]any{}}))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateRole_MissingRoleName(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/roles", projID),
+		jsonBody(t, map[string]any{"permissions": map[string]any{}}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateRole_ProjectNotFound(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		createRole: func(_ context.Context, _ uuid.UUID, _ projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/roles", projID),
+		jsonBody(t, map[string]any{"role_name": "viewer"}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestCreateRole_RoleNameTaken(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		createRole: func(_ context.Context, _ uuid.UUID, _ projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+			return nil, projectdom.ErrRoleNameTaken
+		},
+	})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/roles", projID),
+		jsonBody(t, map[string]any{"role_name": "viewer"}))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_ROLE_NAME_TAKEN" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestUpdateRole_Success(t *testing.T) {
+	projID := uuid.New()
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		updateRole: func(_ context.Context, pid, rid uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
+			return &projectdom.ProjectRole{ID: rid, ProjectID: &pid, RoleName: in.RoleName}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/roles/%s", projID, roleID),
+		jsonBody(t, map[string]any{"role_name": "editor", "permissions": map[string]any{}}))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateRole_BadProjectID(t *testing.T) {
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/not-a-uuid/roles/%s", roleID),
+		jsonBody(t, map[string]any{"role_name": "editor"}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateRole_BadRoleID(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/roles/not-a-uuid", projID),
+		jsonBody(t, map[string]any{"role_name": "editor"}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateRole_RoleNotFound(t *testing.T) {
+	projID := uuid.New()
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		updateRole: func(_ context.Context, _, _ uuid.UUID, _ projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
+			return nil, projectdom.ErrRoleNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodPatch, fmt.Sprintf("/projects/%s/roles/%s", projID, roleID),
+		jsonBody(t, map[string]any{"role_name": "editor"}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_ROLE_NOT_FOUND" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestDeleteRole_Success(t *testing.T) {
+	projID := uuid.New()
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		deleteRole: func(_ context.Context, _, _ uuid.UUID) error { return nil },
+	})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/%s/roles/%s", projID, roleID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestDeleteRole_BadProjectID(t *testing.T) {
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/not-a-uuid/roles/%s", roleID), nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDeleteRole_BadRoleID(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/%s/roles/not-a-uuid", projID), nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDeleteRole_RoleHasMembers(t *testing.T) {
+	projID := uuid.New()
+	roleID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		deleteRole: func(_ context.Context, _, _ uuid.UUID) error {
+			return projectdom.ErrRoleHasMembers
+		},
+	})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/%s/roles/%s", projID, roleID), nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_ROLE_HAS_MEMBERS" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Project Members
+// ---------------------------------------------------------------------------
+
+func TestListMembers_Success(t *testing.T) {
+	projID := uuid.New()
+	memberID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		listMembers: func(_ context.Context, _ uuid.UUID) ([]*projectdom.ProjectMember, error) {
+			return []*projectdom.ProjectMember{
+				{ID: memberID, ProjectID: projID, UserID: uuid.New()},
+			}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodGet, fmt.Sprintf("/projects/%s/members", projID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListMembers_BadProjectID(t *testing.T) {
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodGet, "/projects/not-a-uuid/members", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListMembers_ProjectNotFound(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		listMembers: func(_ context.Context, _ uuid.UUID) ([]*projectdom.ProjectMember, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodGet, fmt.Sprintf("/projects/%s/members", projID), nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestAddMember_Success(t *testing.T) {
+	projID := uuid.New()
+	userID := uuid.New()
+	roleID := uuid.New()
+	memberID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		addMember: func(_ context.Context, pid uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+			return &projectdom.ProjectMember{
+				ID:            memberID,
+				ProjectID:     pid,
+				UserID:        in.UserID,
+				ProjectRoleID: in.ProjectRoleID,
+			}, nil
+		},
+	})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/members", projID),
+		jsonBody(t, map[string]any{"user_id": userID, "project_role_id": roleID}))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAddMember_MalformedJSON(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/members", projID),
+		bytes.NewBufferString("{bad"))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAddMember_ProjectNotFound(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		addMember: func(_ context.Context, _ uuid.UUID, _ projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+			return nil, projectdom.ErrNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/members", projID),
+		jsonBody(t, map[string]any{"user_id": uuid.New(), "project_role_id": uuid.New()}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestAddMember_MemberAlreadyAdded(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		addMember: func(_ context.Context, _ uuid.UUID, _ projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+			return nil, projectdom.ErrMemberAlreadyAdded
+		},
+	})
+
+	w := do(t, r, http.MethodPost, fmt.Sprintf("/projects/%s/members", projID),
+		jsonBody(t, map[string]any{"user_id": uuid.New(), "project_role_id": uuid.New()}))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_MEMBER_ALREADY_ADDED" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}
+
+func TestRemoveMember_Success(t *testing.T) {
+	projID := uuid.New()
+	userID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		removeMember: func(_ context.Context, _, _ uuid.UUID) error { return nil },
+	})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/%s/members/%s", projID, userID), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRemoveMember_BadProjectID(t *testing.T) {
+	userID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/not-a-uuid/members/%s", userID), nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRemoveMember_BadUserID(t *testing.T) {
+	projID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/%s/members/not-a-uuid", projID), nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRemoveMember_MemberNotFound(t *testing.T) {
+	projID := uuid.New()
+	userID := uuid.New()
+	r := newProjectRouter(&mockProjectSvc{
+		removeMember: func(_ context.Context, _, _ uuid.UUID) error {
+			return projectdom.ErrMemberNotFound
+		},
+	})
+
+	w := do(t, r, http.MethodDelete, fmt.Sprintf("/projects/%s/members/%s", projID, userID), nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "PROJECT_MEMBER_NOT_FOUND" {
+		t.Fatalf("unexpected error_code: %s", code)
+	}
+}

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -251,7 +251,7 @@ func TestCreateProject_MissingName(t *testing.T) {
 
 func TestCreateProject_WhitespaceName(t *testing.T) {
 	r := newProjectRouter(&mockProjectSvc{
-		create: func(_ context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+		create: func(_ context.Context, _ projectdom.CreateProjectInput) (*projectdom.Project, error) {
 			return nil, projectdom.ErrNameInvalid
 		},
 	})

--- a/services/api/internal/transport/http/handler/project_member_handler.go
+++ b/services/api/internal/transport/http/handler/project_member_handler.go
@@ -53,6 +53,34 @@ func (h *ProjectHandler) AddMember(c *gin.Context) {
 	presenter.Created(c, dto.ProjectMemberFromEntity(m))
 }
 
+// UpdateMemberRole handles PATCH /projects/:projectId/members/:userId.
+func (h *ProjectHandler) UpdateMemberRole(c *gin.Context) {
+	projectID, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	userID, err := uuid.Parse(c.Param("userId"))
+	if err != nil {
+		presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid user id"))
+		return
+	}
+
+	var req dto.UpdateProjectMemberRoleRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	m, err := h.svc.UpdateMemberRole(c.Request.Context(), projectID, userID, projectdom.UpdateMemberRoleInput{
+		ProjectRoleID: req.ProjectRoleID,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, dto.ProjectMemberFromEntity(m))
+}
+
 // RemoveMember handles DELETE /projects/:projectId/members/:userId.
 func (h *ProjectHandler) RemoveMember(c *gin.Context) {
 	projectID, err := parseProjectID(c)

--- a/services/api/internal/transport/http/handler/project_member_handler.go
+++ b/services/api/internal/transport/http/handler/project_member_handler.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/paca/api/internal/apierr"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/transport/http/dto"
+	"github.com/paca/api/internal/transport/http/middleware"
+	"github.com/paca/api/internal/transport/http/presenter"
+)
+
+// ListMembers handles GET /projects/:projectId/members.
+func (h *ProjectHandler) ListMembers(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	members, err := h.svc.ListMembers(c.Request.Context(), id)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	resp := make([]dto.ProjectMemberResponse, 0, len(members))
+	for _, m := range members {
+		resp = append(resp, dto.ProjectMemberFromEntity(m))
+	}
+	presenter.OK(c, resp)
+}
+
+// AddMember handles POST /projects/:projectId/members.
+func (h *ProjectHandler) AddMember(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+
+	var req dto.AddProjectMemberRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	m, err := h.svc.AddMember(c.Request.Context(), id, projectdom.AddMemberInput{
+		UserID:        req.UserID,
+		ProjectRoleID: req.ProjectRoleID,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.Created(c, dto.ProjectMemberFromEntity(m))
+}
+
+// RemoveMember handles DELETE /projects/:projectId/members/:userId.
+func (h *ProjectHandler) RemoveMember(c *gin.Context) {
+	projectID, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	userID, err := uuid.Parse(c.Param("userId"))
+	if err != nil {
+		presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid user id"))
+		return
+	}
+	if err := h.svc.RemoveMember(c.Request.Context(), projectID, userID); err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, gin.H{"message": "member removed"})
+}

--- a/services/api/internal/transport/http/handler/project_role_handler.go
+++ b/services/api/internal/transport/http/handler/project_role_handler.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/paca/api/internal/apierr"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/transport/http/dto"
+	"github.com/paca/api/internal/transport/http/middleware"
+	"github.com/paca/api/internal/transport/http/presenter"
+)
+
+// ListRoles handles GET /projects/:projectId/roles.
+func (h *ProjectHandler) ListRoles(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	roles, err := h.svc.ListRoles(c.Request.Context(), id)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	resp := make([]dto.ProjectRoleResponse, 0, len(roles))
+	for _, r := range roles {
+		resp = append(resp, dto.ProjectRoleFromEntity(r))
+	}
+	presenter.OK(c, resp)
+}
+
+// CreateRole handles POST /projects/:projectId/roles.
+func (h *ProjectHandler) CreateRole(c *gin.Context) {
+	id, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+
+	var req dto.CreateProjectRoleRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	role, err := h.svc.CreateRole(c.Request.Context(), id, projectdom.CreateRoleInput{
+		RoleName:    req.RoleName,
+		Permissions: req.Permissions,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.Created(c, dto.ProjectRoleFromEntity(role))
+}
+
+// UpdateRole handles PATCH /projects/:projectId/roles/:roleId.
+func (h *ProjectHandler) UpdateRole(c *gin.Context) {
+	projectID, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	roleID, err := uuid.Parse(c.Param("roleId"))
+	if err != nil {
+		presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid role id"))
+		return
+	}
+
+	var req dto.UpdateProjectRoleRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	role, err := h.svc.UpdateRole(c.Request.Context(), projectID, roleID, projectdom.UpdateRoleInput{
+		RoleName:    req.RoleName,
+		Permissions: req.Permissions,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, dto.ProjectRoleFromEntity(role))
+}
+
+// DeleteRole handles DELETE /projects/:projectId/roles/:roleId.
+func (h *ProjectHandler) DeleteRole(c *gin.Context) {
+	projectID, err := parseProjectID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	roleID, err := uuid.Parse(c.Param("roleId"))
+	if err != nil {
+		presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid role id"))
+		return
+	}
+	if err := h.svc.DeleteRole(c.Request.Context(), projectID, roleID); err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, gin.H{"message": "project role deleted"})
+}

--- a/services/api/internal/transport/http/middleware/authn.go
+++ b/services/api/internal/transport/http/middleware/authn.go
@@ -68,3 +68,7 @@ func ClaimsFrom(c *gin.Context) *domainauth.Claims {
 	claims, _ := v.(*domainauth.Claims)
 	return claims
 }
+
+// ClaimsContextKey returns the context key used to store JWT claims.
+// Intended for use in tests that need to inject synthetic claims.
+func ClaimsContextKey() string { return claimsKey }

--- a/services/api/internal/transport/http/middleware/authz.go
+++ b/services/api/internal/transport/http/middleware/authz.go
@@ -114,6 +114,7 @@ func RequireAnyPermissions(authorizer *authz.Authorizer, groups ...PermissionGro
 			return
 		}
 
+		var firstScopeErr error
 		for _, group := range groups {
 			resolver := group.Scope
 			if resolver == nil {
@@ -121,7 +122,11 @@ func RequireAnyPermissions(authorizer *authz.Authorizer, groups ...PermissionGro
 			}
 			projectID, err := resolver(c)
 			if err != nil {
-				// Scope resolution error (e.g. malformed project ID in param): skip group.
+				// Capture the first scope-resolution error; still try remaining groups
+				// (a later global-scope group may succeed without needing projectId).
+				if firstScopeErr == nil {
+					firstScopeErr = err
+				}
 				continue
 			}
 			allowed, err := authorizer.HasPermissions(c.Request.Context(), userID, projectID, claims.Role, group.Permissions...)
@@ -135,6 +140,12 @@ func RequireAnyPermissions(authorizer *authz.Authorizer, groups ...PermissionGro
 			}
 		}
 
+		// Surface the scope-resolution error (e.g. 400 for an invalid projectId)
+		// rather than hiding it behind a generic 403 Forbidden.
+		if firstScopeErr != nil {
+			presenter.Error(c, firstScopeErr)
+			return
+		}
 		presenter.Error(c, apierr.New(apierr.CodeForbidden, "insufficient permissions"))
 	}
 }

--- a/services/api/internal/transport/http/middleware/authz.go
+++ b/services/api/internal/transport/http/middleware/authz.go
@@ -81,3 +81,60 @@ func RequirePermissions(authorizer *authz.Authorizer, scope ScopeResolver, permi
 func Authz(authorizer *authz.Authorizer, permissions ...authz.Permission) gin.HandlerFunc {
 	return RequirePermissions(authorizer, GlobalScope(), permissions...)
 }
+
+// PermissionGroup pairs a scope resolver with the permissions required in that scope.
+// Used with RequireAnyPermissions to express OR-style authorization policies.
+type PermissionGroup struct {
+	Scope       ScopeResolver
+	Permissions []authz.Permission
+}
+
+// RequireAnyPermissions grants access if the user satisfies at least one of the
+// provided PermissionGroups. Groups are evaluated in order; the first satisfied
+// group short-circuits the check. If no group is satisfied, 403 is returned.
+//
+// Typical use: allow access when the caller holds a broad global permission
+// (e.g. projects.read) OR a narrower project-scoped one.
+func RequireAnyPermissions(authorizer *authz.Authorizer, groups ...PermissionGroup) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims := ClaimsFrom(c)
+		if claims == nil {
+			presenter.Error(c, apierr.New(apierr.CodeUnauthenticated, "unauthenticated"))
+			return
+		}
+
+		if authorizer == nil {
+			presenter.Error(c, apierr.New(apierr.CodeInternalError, "authorization not configured"))
+			return
+		}
+
+		userID, err := uuid.Parse(claims.Subject)
+		if err != nil {
+			presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid subject claim"))
+			return
+		}
+
+		for _, group := range groups {
+			resolver := group.Scope
+			if resolver == nil {
+				resolver = GlobalScope()
+			}
+			projectID, err := resolver(c)
+			if err != nil {
+				// Scope resolution error (e.g. malformed project ID in param): skip group.
+				continue
+			}
+			allowed, err := authorizer.HasPermissions(c.Request.Context(), userID, projectID, claims.Role, group.Permissions...)
+			if err != nil {
+				presenter.Error(c, err)
+				return
+			}
+			if allowed {
+				c.Next()
+				return
+			}
+		}
+
+		presenter.Error(c, apierr.New(apierr.CodeForbidden, "insufficient permissions"))
+	}
+}

--- a/services/api/internal/transport/http/middleware/authz_test.go
+++ b/services/api/internal/transport/http/middleware/authz_test.go
@@ -107,3 +107,113 @@ func TestRequirePermissions_ProjectScope(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// RequireAnyPermissions
+// ---------------------------------------------------------------------------
+
+func TestRequireAnyPermissions_Unauthenticated(t *testing.T) {
+	r := gin.New()
+	r.GET("/resource",
+		RequireAnyPermissions(authz.NewAuthorizer(nil),
+			PermissionGroup{Scope: GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/resource", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRequireAnyPermissions_Forbidden(t *testing.T) {
+	// User has neither global projects.read nor project-scoped members.read.
+	r := gin.New()
+	store := &mockPermissionStore{globalPerms: []authz.Permission{authz.PermissionUsersRead}}
+	r.GET("/projects/:projectId/members",
+		withClaims("USER"),
+		RequireAnyPermissions(authz.NewAuthorizer(store),
+			PermissionGroup{Scope: GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/members", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireAnyPermissions_AllowedByFirstGroup_GlobalProjectsRead(t *testing.T) {
+	// User has global projects.read → should be allowed even without project-scoped members.read.
+	r := gin.New()
+	store := &mockPermissionStore{globalPerms: []authz.Permission{authz.PermissionProjectsRead}}
+	r.GET("/projects/:projectId/members",
+		withClaims("USER"),
+		RequireAnyPermissions(authz.NewAuthorizer(store),
+			PermissionGroup{Scope: GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/members", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequireAnyPermissions_AllowedBySecondGroup_ProjectScopedRead(t *testing.T) {
+	// User does NOT have global projects.read but does have project-scoped members.read.
+	r := gin.New()
+	store := &mockPermissionStore{projectPerms: []authz.Permission{authz.PermissionProjectMembersRead}}
+	r.GET("/projects/:projectId/members",
+		withClaims("USER"),
+		RequireAnyPermissions(authz.NewAuthorizer(store),
+			PermissionGroup{Scope: GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/members", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequireAnyPermissions_AllowedByWildcard_GlobalProjectsAll(t *testing.T) {
+	// User has global projects.* → satisfies projects.read via wildcard expansion.
+	r := gin.New()
+	store := &mockPermissionStore{globalPerms: []authz.Permission{authz.PermissionProjectsAll}}
+	r.GET("/projects/:projectId/members",
+		withClaims("USER"),
+		RequireAnyPermissions(authz.NewAuthorizer(store),
+			PermissionGroup{Scope: GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/members", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}

--- a/services/api/internal/transport/http/middleware/authz_test.go
+++ b/services/api/internal/transport/http/middleware/authz_test.go
@@ -217,3 +217,48 @@ func TestRequireAnyPermissions_AllowedByWildcard_GlobalProjectsAll(t *testing.T)
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+func TestRequireAnyPermissions_InvalidProjectID_Returns400(t *testing.T) {
+	// A request with an invalid (non-UUID) projectId should return 400, not 403.
+	// The project-scoped group's resolver fails; no global-scope group is present.
+	r := gin.New()
+	store := &mockPermissionStore{}
+	r.GET("/projects/:projectId/members",
+		withClaims("USER"),
+		RequireAnyPermissions(authz.NewAuthorizer(store),
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/not-a-uuid/members", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRequireAnyPermissions_InvalidProjectID_GlobalGroupSucceeds(t *testing.T) {
+	// Even when the project-scoped group's resolver fails (bad UUID), a preceding
+	// global-scope group that satisfies the permission check should allow access.
+	r := gin.New()
+	store := &mockPermissionStore{globalPerms: []authz.Permission{authz.PermissionProjectsRead}}
+	r.GET("/projects/:projectId/members",
+		withClaims("USER"),
+		RequireAnyPermissions(authz.NewAuthorizer(store),
+			PermissionGroup{Scope: GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/not-a-uuid/members", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -102,6 +102,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusNotFound, apierr.CodeProjectNotFound
 	case errors.Is(err, projectdom.ErrNameTaken):
 		return http.StatusConflict, apierr.CodeProjectNameTaken
+	case errors.Is(err, projectdom.ErrNameInvalid):
+		return http.StatusBadRequest, apierr.CodeProjectNameInvalid
 	case errors.Is(err, projectdom.ErrRoleNotFound):
 		return http.StatusNotFound, apierr.CodeProjectRoleNotFound
 	case errors.Is(err, projectdom.ErrRoleNameTaken):
@@ -145,6 +147,8 @@ func httpStatusForCode(code apierr.Code) int {
 		return http.StatusNotFound
 	case apierr.CodeProjectNameTaken:
 		return http.StatusConflict
+	case apierr.CodeProjectNameInvalid:
+		return http.StatusBadRequest
 	case apierr.CodeProjectRoleNotFound:
 		return http.StatusNotFound
 	case apierr.CodeProjectRoleNameTaken:

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -10,6 +10,7 @@ import (
 	"github.com/paca/api/internal/apierr"
 	domainauth "github.com/paca/api/internal/domain/auth"
 	globalroledom "github.com/paca/api/internal/domain/globalrole"
+	projectdom "github.com/paca/api/internal/domain/project"
 	userdom "github.com/paca/api/internal/domain/user"
 )
 
@@ -97,6 +98,22 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeGlobalRoleNameInvalid
 	case errors.Is(err, globalroledom.ErrHasAssignedUsers):
 		return http.StatusConflict, apierr.CodeGlobalRoleHasUsers
+	case errors.Is(err, projectdom.ErrNotFound):
+		return http.StatusNotFound, apierr.CodeProjectNotFound
+	case errors.Is(err, projectdom.ErrNameTaken):
+		return http.StatusConflict, apierr.CodeProjectNameTaken
+	case errors.Is(err, projectdom.ErrRoleNotFound):
+		return http.StatusNotFound, apierr.CodeProjectRoleNotFound
+	case errors.Is(err, projectdom.ErrRoleNameTaken):
+		return http.StatusConflict, apierr.CodeProjectRoleNameTaken
+	case errors.Is(err, projectdom.ErrRoleNameInvalid):
+		return http.StatusBadRequest, apierr.CodeProjectRoleNameInvalid
+	case errors.Is(err, projectdom.ErrRoleHasMembers):
+		return http.StatusConflict, apierr.CodeProjectRoleHasMembers
+	case errors.Is(err, projectdom.ErrMemberNotFound):
+		return http.StatusNotFound, apierr.CodeProjectMemberNotFound
+	case errors.Is(err, projectdom.ErrMemberAlreadyAdded):
+		return http.StatusConflict, apierr.CodeProjectMemberAlreadyAdded
 	default:
 		return http.StatusInternalServerError, apierr.CodeInternalError
 	}
@@ -123,6 +140,22 @@ func httpStatusForCode(code apierr.Code) int {
 	case apierr.CodeGlobalRoleNameInvalid:
 		return http.StatusBadRequest
 	case apierr.CodeGlobalRoleHasUsers:
+		return http.StatusConflict
+	case apierr.CodeProjectNotFound:
+		return http.StatusNotFound
+	case apierr.CodeProjectNameTaken:
+		return http.StatusConflict
+	case apierr.CodeProjectRoleNotFound:
+		return http.StatusNotFound
+	case apierr.CodeProjectRoleNameTaken:
+		return http.StatusConflict
+	case apierr.CodeProjectRoleNameInvalid:
+		return http.StatusBadRequest
+	case apierr.CodeProjectRoleHasMembers:
+		return http.StatusConflict
+	case apierr.CodeProjectMemberNotFound:
+		return http.StatusNotFound
+	case apierr.CodeProjectMemberAlreadyAdded:
 		return http.StatusConflict
 	case apierr.CodeBadRequest:
 		return http.StatusBadRequest

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -158,6 +158,10 @@ func New(deps Deps) *gin.Engine {
 					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
 					deps.Project.AddMember,
 				)
+				members.PATCH("/:userId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+					deps.Project.UpdateMemberRole,
+				)
 				members.DELETE("/:userId",
 					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
 					deps.Project.RemoveMember,

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -23,6 +23,7 @@ type Deps struct {
 	Auth         *handler.AuthHandler
 	User         *handler.UserHandler
 	GlobalRole   *handler.GlobalRoleHandler
+	Project      *handler.ProjectHandler
 	Log          *slog.Logger
 }
 
@@ -118,6 +119,70 @@ func New(deps Deps) *gin.Engine {
 				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionGlobalRolesAssign),
 				deps.GlobalRole.ReplaceUserRoles,
 			)
+
+			// Project management — requires projects.* permissions
+			admin.GET("/projects",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsRead),
+				deps.Project.ListProjects,
+			)
+			admin.POST("/projects",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsWrite),
+				deps.Project.CreateProject,
+			)
+			admin.GET("/projects/:projectId",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsRead),
+				deps.Project.GetProject,
+			)
+			admin.PATCH("/projects/:projectId",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsWrite),
+				deps.Project.UpdateProject,
+			)
+			admin.DELETE("/projects/:projectId",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsWrite),
+				deps.Project.DeleteProject,
+			)
+		}
+
+		// Project-scoped routes — accessible to project members with appropriate roles.
+		projects := v1.Group("/projects/:projectId")
+		projects.Use(httpmw.Authn(deps.TokenManager))
+		projects.Use(httpmw.RequireFreshPassword())
+		{
+			members := projects.Group("/members")
+			{
+				members.GET("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersRead),
+					deps.Project.ListMembers,
+				)
+				members.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+					deps.Project.AddMember,
+				)
+				members.DELETE("/:userId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+					deps.Project.RemoveMember,
+				)
+			}
+
+			roles := projects.Group("/roles")
+			{
+				roles.GET("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesRead),
+					deps.Project.ListRoles,
+				)
+				roles.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+					deps.Project.CreateRole,
+				)
+				roles.PATCH("/:roleId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+					deps.Project.UpdateRole,
+				)
+				roles.DELETE("/:roleId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+					deps.Project.DeleteRole,
+				)
+			}
 		}
 	}
 

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -119,73 +119,91 @@ func New(deps Deps) *gin.Engine {
 				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionGlobalRolesAssign),
 				deps.GlobalRole.ReplaceUserRoles,
 			)
-
-			// Project management — requires projects.* permissions
-			admin.GET("/projects",
-				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsRead),
-				deps.Project.ListProjects,
-			)
-			admin.POST("/projects",
-				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsWrite),
-				deps.Project.CreateProject,
-			)
-			admin.GET("/projects/:projectId",
-				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsRead),
-				deps.Project.GetProject,
-			)
-			admin.PATCH("/projects/:projectId",
-				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsWrite),
-				deps.Project.UpdateProject,
-			)
-			admin.DELETE("/projects/:projectId",
-				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsWrite),
-				deps.Project.DeleteProject,
-			)
 		}
 
-		// Project-scoped routes — accessible to project members with appropriate roles.
-		projects := v1.Group("/projects/:projectId")
+		// Project routes — list/create are collection-level; all other actions are
+		// project-scoped and accessible to members with appropriate roles.
+		projects := v1.Group("/projects")
 		projects.Use(httpmw.Authn(deps.TokenManager))
 		projects.Use(httpmw.RequireFreshPassword())
 		{
-			members := projects.Group("/members")
-			{
-				members.GET("",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersRead),
-					deps.Project.ListMembers,
-				)
-				members.POST("",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
-					deps.Project.AddMember,
-				)
-				members.PATCH("/:userId",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
-					deps.Project.UpdateMemberRole,
-				)
-				members.DELETE("/:userId",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
-					deps.Project.RemoveMember,
-				)
-			}
+			// Collection routes
+			// ListProjects self-selects: global projects.read → all projects,
+			// otherwise → only the caller's accessible projects.
+			projects.GET("", deps.Project.ListProjects)
+			projects.POST("",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsCreate),
+				deps.Project.CreateProject,
+			)
 
-			roles := projects.Group("/roles")
+			// Single-project routes
+			project := projects.Group("/:projectId")
 			{
-				roles.GET("",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesRead),
-					deps.Project.ListRoles,
+				project.GET("",
+					// Allow: global projects.read OR project-scoped projects.read
+					// (any project member role with projects.read can view the project).
+					httpmw.RequireAnyPermissions(deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+					),
+					deps.Project.GetProject,
 				)
-				roles.POST("",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
-					deps.Project.CreateRole,
+				project.PATCH("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsWrite),
+					deps.Project.UpdateProject,
 				)
-				roles.PATCH("/:roleId",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
-					deps.Project.UpdateRole,
+				project.DELETE("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsDelete),
+					deps.Project.DeleteProject,
 				)
-				roles.DELETE("/:roleId",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
-					deps.Project.DeleteRole,
-				)
+
+				members := project.Group("/members")
+				{
+					members.GET("",
+						// Allow: global projects.read (view-all grant) OR project-scoped members.read.
+						httpmw.RequireAnyPermissions(deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
+						),
+						deps.Project.ListMembers,
+					)
+					members.POST("",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+						deps.Project.AddMember,
+					)
+					members.PATCH("/:userId",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+						deps.Project.UpdateMemberRole,
+					)
+					members.DELETE("/:userId",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+						deps.Project.RemoveMember,
+					)
+				}
+
+				roles := project.Group("/roles")
+				{
+					roles.GET("",
+						// Allow: global projects.read (view-all grant) OR project-scoped roles.read.
+						httpmw.RequireAnyPermissions(deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectRolesRead}},
+						),
+						deps.Project.ListRoles,
+					)
+					roles.POST("",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+						deps.Project.CreateRole,
+					)
+					roles.PATCH("/:roleId",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+						deps.Project.UpdateRole,
+					)
+					roles.DELETE("/:roleId",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+						deps.Project.DeleteRole,
+					)
+				}
 			}
 		}
 	}

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -187,7 +187,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 		Auth:         handler.NewAuthHandler(authService, cookieCfg),
 		User:         handler.NewUserHandler(userService),
 		GlobalRole:   handler.NewGlobalRoleHandler(globalRoleService),
-		Project:      handler.NewProjectHandler(projectService),
+		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(authzStore)),
 		Log:          log,
 	})
 

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -31,6 +31,7 @@ import (
 	redisRepo "github.com/paca/api/internal/repository/redis"
 	authsvc "github.com/paca/api/internal/service/auth"
 	globalrolesvc "github.com/paca/api/internal/service/globalrole"
+	projectsvc "github.com/paca/api/internal/service/project"
 	usersvc "github.com/paca/api/internal/service/user"
 	"github.com/paca/api/internal/transport/http/handler"
 	"github.com/paca/api/internal/transport/http/router"
@@ -52,6 +53,8 @@ type e2eEnv struct {
 	userService *usersvc.Service
 	userRepo    *pgRepo.UserRepository
 	roleRepo    *pgRepo.GlobalRoleRepository
+	projectRepo *pgRepo.ProjectRepository
+	projectSvc  *projectsvc.Service
 }
 
 func newE2EEnv(t *testing.T) *e2eEnv {
@@ -168,6 +171,8 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	authService := authsvc.New(userRepo, tm, refreshStore, e2eRefreshTTL, e2eRefreshSessionTTL)
 	userService := usersvc.New(userRepo, authzStore, roleRepo)
 	globalRoleService := globalrolesvc.New(roleRepo)
+	projectRepo := pgRepo.NewProjectRepository(db)
+	projectService := projectsvc.New(projectRepo)
 
 	cookieCfg := handler.CookieConfig{
 		Secure:            false,
@@ -182,6 +187,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 		Auth:         handler.NewAuthHandler(authService, cookieCfg),
 		User:         handler.NewUserHandler(userService),
 		GlobalRole:   handler.NewGlobalRoleHandler(globalRoleService),
+		Project:      handler.NewProjectHandler(projectService),
 		Log:          log,
 	})
 
@@ -203,6 +209,8 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 		userService: userService,
 		userRepo:    userRepo,
 		roleRepo:    roleRepo,
+		projectRepo: projectRepo,
+		projectSvc:  projectService,
 	}
 }
 

--- a/services/api/test/e2e/project_management_test.go
+++ b/services/api/test/e2e/project_management_test.go
@@ -54,7 +54,7 @@ func projectAdminLogin(t *testing.T, env *e2eEnv, username, password string) (*h
 func createProjectViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, name, description string) string {
 	t.Helper()
 	body := jsonBody(t, map[string]any{"name": name, "description": description})
-	req := mustRequest(env.ctx, t, http.MethodPost, env.base+"/api/v1/admin/projects", body)
+	req := mustRequest(env.ctx, t, http.MethodPost, env.base+"/api/v1/projects", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp := mustDo(t, client, req)
@@ -108,7 +108,7 @@ func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
 
 	t.Run("get_project", func(t *testing.T) {
 		req := mustRequest(env.ctx, t, http.MethodGet,
-			env.base+"/api/v1/admin/projects/"+projID, nil)
+			env.base+"/api/v1/projects/"+projID, nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := mustDo(t, client, req)
 		defer func() { _ = resp.Body.Close() }()
@@ -122,7 +122,7 @@ func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
 	})
 
 	t.Run("list_projects", func(t *testing.T) {
-		req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/admin/projects", nil)
+		req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/projects", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := mustDo(t, client, req)
 		defer func() { _ = resp.Body.Close() }()
@@ -142,7 +142,7 @@ func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
 			"description": "updated description",
 		})
 		req := mustRequest(env.ctx, t, http.MethodPatch,
-			env.base+"/api/v1/admin/projects/"+projID, body)
+			env.base+"/api/v1/projects/"+projID, body)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := mustDo(t, client, req)
@@ -158,7 +158,7 @@ func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
 
 	t.Run("delete_project", func(t *testing.T) {
 		req := mustRequest(env.ctx, t, http.MethodDelete,
-			env.base+"/api/v1/admin/projects/"+projID, nil)
+			env.base+"/api/v1/projects/"+projID, nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := mustDo(t, client, req)
 		defer func() { _ = resp.Body.Close() }()
@@ -167,7 +167,7 @@ func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
 
 	t.Run("get_deleted_project_returns_not_found", func(t *testing.T) {
 		req := mustRequest(env.ctx, t, http.MethodGet,
-			env.base+"/api/v1/admin/projects/"+projID, nil)
+			env.base+"/api/v1/projects/"+projID, nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := mustDo(t, client, req)
 		defer func() { _ = resp.Body.Close() }()
@@ -182,7 +182,7 @@ func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
 
 func TestE2EProject_Unauthenticated(t *testing.T) {
 	env := newE2EEnv(t)
-	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/admin/projects", nil)
+	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/projects", nil)
 	resp := mustDo(t, env.client, req)
 	defer func() { _ = resp.Body.Close() }()
 	assertStatus(t, resp, http.StatusUnauthorized)
@@ -202,7 +202,7 @@ func TestE2EProject_InsufficientPermission(t *testing.T) {
 	loginResp := login(env.ctx, t, client, env.base, "plain-user", "plainpass1")
 	_ = loginResp.Body.Close()
 
-	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/admin/projects", nil)
+	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/projects", nil)
 	resp := mustDo(t, client, req)
 	defer func() { _ = resp.Body.Close() }()
 	assertStatus(t, resp, http.StatusForbidden)
@@ -488,7 +488,7 @@ func TestE2EProject_DeleteCascadesRolesAndMembers(t *testing.T) {
 
 	// Delete the project — DB cascade constraints remove roles and members.
 	req := mustRequest(env.ctx, t, http.MethodDelete,
-		env.base+"/api/v1/admin/projects/"+projID, nil)
+		env.base+"/api/v1/projects/"+projID, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp := mustDo(t, client, req)
 	defer func() { _ = resp.Body.Close() }()
@@ -496,7 +496,7 @@ func TestE2EProject_DeleteCascadesRolesAndMembers(t *testing.T) {
 
 	// Confirm the project is gone.
 	req = mustRequest(env.ctx, t, http.MethodGet,
-		env.base+"/api/v1/admin/projects/"+projID, nil)
+		env.base+"/api/v1/projects/"+projID, nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp = mustDo(t, client, req)
 	defer func() { _ = resp.Body.Close() }()

--- a/services/api/test/e2e/project_management_test.go
+++ b/services/api/test/e2e/project_management_test.go
@@ -1,0 +1,474 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	globalroledom "github.com/paca/api/internal/domain/globalrole"
+	projectdom "github.com/paca/api/internal/domain/project"
+)
+
+// seedProjectAdminUser creates a user and assigns them a global role that grants
+// all project, project-role and project-member permissions.
+func seedProjectAdminUser(t *testing.T, env *e2eEnv, username, password string) {
+	t.Helper()
+	seedUser(t, env, username, password, "Project Admin")
+	roleName := "PROJECT_ADMIN_" + uuid.NewString()
+	if err := env.roleRepo.Create(env.ctx, &globalroledom.GlobalRole{
+		ID:   uuid.New(),
+		Name: roleName,
+		Permissions: map[string]any{
+			"projects.read":         true,
+			"projects.write":        true,
+			"project.roles.read":    true,
+			"project.roles.write":   true,
+			"project.members.read":  true,
+			"project.members.write": true,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create project-admin role: %v", err)
+	}
+	assignGlobalRolesByName(t, env, username, roleName)
+}
+
+// projectAdminLogin creates a fresh HTTP client with a cookie jar, logs in as
+// the given user, and returns the client together with the access token value.
+func projectAdminLogin(t *testing.T, env *e2eEnv, username, password string) (*http.Client, string) {
+	t.Helper()
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar, Timeout: 30 * time.Second}
+	resp := login(env.ctx, t, client, env.base, username, password)
+	defer func() { _ = resp.Body.Close() }()
+	token := cookieValue(resp, "access_token")
+	return client, token
+}
+
+// createProjectViaAPI creates a project via the admin API and returns its ID.
+func createProjectViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, name, description string) string {
+	t.Helper()
+	body := jsonBody(t, map[string]any{"name": name, "description": description})
+	req := mustRequest(env.ctx, t, http.MethodPost, env.base+"/api/v1/admin/projects", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	id, _ := data["id"].(string)
+	return id
+}
+
+// createProjectRoleViaAPI creates a project-scoped role and returns its ID.
+func createProjectRoleViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, projectID, roleName string) string {
+	t.Helper()
+	body := jsonBody(t, map[string]any{
+		"role_name":   roleName,
+		"permissions": map[string]any{"read": true},
+	})
+	url := fmt.Sprintf("%s/api/v1/projects/%s/roles", env.base, projectID)
+	req := mustRequest(env.ctx, t, http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	id, _ := data["id"].(string)
+	return id
+}
+
+// ---------------------------------------------------------------------------
+// Admin project CRUD
+// ---------------------------------------------------------------------------
+
+func TestE2EProjectManagement_AdminProjectCRUD(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "crud-admin", "crudpass1")
+	client, token := projectAdminLogin(t, env, "crud-admin", "crudpass1")
+
+	var projID string
+
+	t.Run("create_project", func(t *testing.T) {
+		projID = createProjectViaAPI(t, env, client, token, "My E2E Project", "A test project")
+		if projID == "" {
+			t.Fatal("expected non-empty project id")
+		}
+	})
+
+	t.Run("get_project", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/admin/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if id, _ := data["id"].(string); id != projID {
+			t.Errorf("expected id %q, got %q", projID, id)
+		}
+	})
+
+	t.Run("list_projects", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/admin/projects", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		total, _ := data["total"].(float64)
+		if total < 1 {
+			t.Errorf("expected total >= 1, got %v", total)
+		}
+	})
+
+	t.Run("update_project", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"name":        "My E2E Project Updated",
+			"description": "updated description",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			env.base+"/api/v1/admin/projects/"+projID, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if name, _ := data["name"].(string); name != "My E2E Project Updated" {
+			t.Errorf("expected updated name, got %q", name)
+		}
+	})
+
+	t.Run("delete_project", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			env.base+"/api/v1/admin/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	t.Run("get_deleted_project_returns_not_found", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/admin/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+		assertErrorCode(t, resp, "PROJECT_NOT_FOUND")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Unauthenticated access
+// ---------------------------------------------------------------------------
+
+func TestE2EProject_Unauthenticated(t *testing.T) {
+	env := newE2EEnv(t)
+	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/admin/projects", nil)
+	resp := mustDo(t, env.client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusUnauthorized)
+}
+
+// ---------------------------------------------------------------------------
+// Insufficient permissions
+// ---------------------------------------------------------------------------
+
+func TestE2EProject_InsufficientPermission(t *testing.T) {
+	env := newE2EEnv(t)
+	// A plain USER should not have projects.read permission unless their global
+	// role grants it. Seed a user with only the default USER role.
+	seedUser(t, env, "plain-user", "plainpass1", "Plain User")
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar, Timeout: 30 * time.Second}
+	loginResp := login(env.ctx, t, client, env.base, "plain-user", "plainpass1")
+	_ = loginResp.Body.Close()
+
+	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/admin/projects", nil)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusForbidden)
+	assertErrorCode(t, resp, "FORBIDDEN")
+}
+
+// ---------------------------------------------------------------------------
+// Project role management
+// ---------------------------------------------------------------------------
+
+func TestE2EProjectRoles_FullLifecycle(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "roles-admin", "rolespass1")
+	client, token := projectAdminLogin(t, env, "roles-admin", "rolespass1")
+	projID := createProjectViaAPI(t, env, client, token, "roles-project-"+uuid.NewString(), "")
+
+	var roleID string
+
+	t.Run("create_role", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"role_name":   "viewer",
+			"permissions": map[string]any{"read": true},
+		})
+		url := fmt.Sprintf("%s/api/v1/projects/%s/roles", env.base, projID)
+		req := mustRequest(env.ctx, t, http.MethodPost, url, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if rn, _ := data["role_name"].(string); rn != "viewer" {
+			t.Errorf("expected role_name 'viewer', got %q", rn)
+		}
+		roleID, _ = data["id"].(string)
+	})
+
+	t.Run("list_roles", func(t *testing.T) {
+		url := fmt.Sprintf("%s/api/v1/projects/%s/roles", env.base, projID)
+		req := mustRequest(env.ctx, t, http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		roles, ok := env2.Data.([]any)
+		if !ok {
+			t.Fatalf("expected roles array, got %T", env2.Data)
+		}
+		if len(roles) < 1 {
+			t.Error("expected at least one role")
+		}
+	})
+
+	t.Run("create_duplicate_role_conflict", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"role_name": "viewer"})
+		url := fmt.Sprintf("%s/api/v1/projects/%s/roles", env.base, projID)
+		req := mustRequest(env.ctx, t, http.MethodPost, url, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusConflict)
+		assertErrorCode(t, resp, "PROJECT_ROLE_NAME_TAKEN")
+	})
+
+	t.Run("update_role", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"role_name":   "contributor",
+			"permissions": map[string]any{"read": true, "write": true},
+		})
+		url := fmt.Sprintf("%s/api/v1/projects/%s/roles/%s", env.base, projID, roleID)
+		req := mustRequest(env.ctx, t, http.MethodPatch, url, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if rn, _ := data["role_name"].(string); rn != "contributor" {
+			t.Errorf("expected updated role_name 'contributor', got %q", rn)
+		}
+	})
+
+	t.Run("delete_role", func(t *testing.T) {
+		url := fmt.Sprintf("%s/api/v1/projects/%s/roles/%s", env.base, projID, roleID)
+		req := mustRequest(env.ctx, t, http.MethodDelete, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Delete role blocked when members still assigned
+// ---------------------------------------------------------------------------
+
+func TestE2EProjectRoles_DeleteRoleWithMembersConflict(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "roles-conflict-admin", "rcpass123")
+	client, token := projectAdminLogin(t, env, "roles-conflict-admin", "rcpass123")
+	projID := createProjectViaAPI(t, env, client, token, "roles-conflict-"+uuid.NewString(), "")
+	roleID := createProjectRoleViaAPI(t, env, client, token, projID, "locked-role")
+
+	// Seed a real user so the FK constraint on project_members is satisfied.
+	seedUser(t, env, "locked-role-member", "memberpass1", "Locked Member")
+	memberUser, err := env.userRepo.FindByUsername(env.ctx, "locked-role-member")
+	if err != nil {
+		t.Fatalf("find locked-role-member: %v", err)
+	}
+
+	// Seed a member directly via repo so the role cannot be deleted.
+	projUUID, _ := uuid.Parse(projID)
+	roleUUID, _ := uuid.Parse(roleID)
+	if err := env.projectRepo.AddMember(context.Background(), &projectdom.ProjectMember{
+		ID:            uuid.New(),
+		ProjectID:     projUUID,
+		UserID:        memberUser.ID,
+		ProjectRoleID: roleUUID,
+	}); err != nil {
+		t.Fatalf("seed project member: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/projects/%s/roles/%s", env.base, projID, roleID)
+	req := mustRequest(env.ctx, t, http.MethodDelete, url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusConflict)
+	assertErrorCode(t, resp, "PROJECT_ROLE_HAS_MEMBERS")
+}
+
+// ---------------------------------------------------------------------------
+// Project member management
+// ---------------------------------------------------------------------------
+
+func TestE2EProjectMembers_FullLifecycle(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "members-admin", "mbrpass1")
+	client, token := projectAdminLogin(t, env, "members-admin", "mbrpass1")
+	projID := createProjectViaAPI(t, env, client, token, "members-project-"+uuid.NewString(), "")
+	roleID := createProjectRoleViaAPI(t, env, client, token, projID, "member-role")
+
+	// Seed a separate user to add as a project member.
+	memberUsername := "member-user-" + uuid.NewString()
+	seedUser(t, env, memberUsername, "mbrpass1", "Member User")
+	memberUser, err := env.userRepo.FindByUsername(env.ctx, memberUsername)
+	if err != nil {
+		t.Fatalf("find member user: %v", err)
+	}
+	memberUserID := memberUser.ID.String()
+
+	membersURL := fmt.Sprintf("%s/api/v1/projects/%s/members", env.base, projID)
+
+	t.Run("add_member", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodPost, membersURL,
+			jsonBody(t, map[string]any{"user_id": memberUserID, "project_role_id": roleID}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if uid, _ := data["user_id"].(string); uid != memberUserID {
+			t.Errorf("expected user_id %q, got %q", memberUserID, uid)
+		}
+	})
+
+	t.Run("list_members", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, membersURL, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		members, ok := env2.Data.([]any)
+		if !ok {
+			t.Fatalf("expected members array, got %T", env2.Data)
+		}
+		if len(members) < 1 {
+			t.Error("expected at least one member")
+		}
+	})
+
+	t.Run("add_duplicate_member_conflict", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodPost, membersURL,
+			jsonBody(t, map[string]any{"user_id": memberUserID, "project_role_id": roleID}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusConflict)
+		assertErrorCode(t, resp, "PROJECT_MEMBER_ALREADY_ADDED")
+	})
+
+	t.Run("remove_member", func(t *testing.T) {
+		url := membersURL + "/" + memberUserID
+		req := mustRequest(env.ctx, t, http.MethodDelete, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	t.Run("remove_nonexistent_member_not_found", func(t *testing.T) {
+		url := membersURL + "/" + memberUserID
+		req := mustRequest(env.ctx, t, http.MethodDelete, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+		assertErrorCode(t, resp, "PROJECT_MEMBER_NOT_FOUND")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Cross-resource: delete project cascades roles and members
+// ---------------------------------------------------------------------------
+
+func TestE2EProject_DeleteCascadesRolesAndMembers(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "cascade-admin", "cascadepass1")
+	client, token := projectAdminLogin(t, env, "cascade-admin", "cascadepass1")
+	projID := createProjectViaAPI(t, env, client, token, "cascade-project-"+uuid.NewString(), "")
+	roleID := createProjectRoleViaAPI(t, env, client, token, projID, "cascade-role")
+
+	// Seed a real user so the FK constraint on project_members is satisfied.
+	seedUser(t, env, "cascade-member", "memberpass1", "Cascade Member")
+	cascadeMember, err := env.userRepo.FindByUsername(env.ctx, "cascade-member")
+	if err != nil {
+		t.Fatalf("find cascade-member: %v", err)
+	}
+
+	projUUID, _ := uuid.Parse(projID)
+	roleUUID, _ := uuid.Parse(roleID)
+	if err := env.projectRepo.AddMember(context.Background(), &projectdom.ProjectMember{
+		ID:            uuid.New(),
+		ProjectID:     projUUID,
+		UserID:        cascadeMember.ID,
+		ProjectRoleID: roleUUID,
+	}); err != nil {
+		t.Fatalf("seed project member: %v", err)
+	}
+
+	// Delete the project — DB cascade constraints remove roles and members.
+	req := mustRequest(env.ctx, t, http.MethodDelete,
+		env.base+"/api/v1/admin/projects/"+projID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+
+	// Confirm the project is gone.
+	req = mustRequest(env.ctx, t, http.MethodGet,
+		env.base+"/api/v1/admin/projects/"+projID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp = mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusNotFound)
+}

--- a/services/api/test/e2e/project_management_test.go
+++ b/services/api/test/e2e/project_management_test.go
@@ -351,6 +351,7 @@ func TestE2EProjectMembers_FullLifecycle(t *testing.T) {
 	client, token := projectAdminLogin(t, env, "members-admin", "mbrpass1")
 	projID := createProjectViaAPI(t, env, client, token, "members-project-"+uuid.NewString(), "")
 	roleID := createProjectRoleViaAPI(t, env, client, token, projID, "member-role")
+	updatedRoleID := createProjectRoleViaAPI(t, env, client, token, projID, "member-role-updated")
 
 	// Seed a separate user to add as a project member.
 	memberUsername := "member-user-" + uuid.NewString()
@@ -405,6 +406,35 @@ func TestE2EProjectMembers_FullLifecycle(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 		assertStatus(t, resp, http.StatusConflict)
 		assertErrorCode(t, resp, "PROJECT_MEMBER_ALREADY_ADDED")
+	})
+
+	t.Run("update_member_role", func(t *testing.T) {
+		url := membersURL + "/" + memberUserID
+		req := mustRequest(env.ctx, t, http.MethodPatch, url,
+			jsonBody(t, map[string]any{"project_role_id": updatedRoleID}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if rid, _ := data["project_role_id"].(string); rid != updatedRoleID {
+			t.Errorf("expected project_role_id %q, got %q", updatedRoleID, rid)
+		}
+	})
+
+	t.Run("update_member_role_missing_member", func(t *testing.T) {
+		url := membersURL + "/" + uuid.NewString()
+		req := mustRequest(env.ctx, t, http.MethodPatch, url,
+			jsonBody(t, map[string]any{"project_role_id": updatedRoleID}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+		assertErrorCode(t, resp, "PROJECT_MEMBER_NOT_FOUND")
 	})
 
 	t.Run("remove_member", func(t *testing.T) {

--- a/services/api/test/e2e/project_management_test.go
+++ b/services/api/test/e2e/project_management_test.go
@@ -23,8 +23,10 @@ func seedProjectAdminUser(t *testing.T, env *e2eEnv, username, password string) 
 		ID:   uuid.New(),
 		Name: roleName,
 		Permissions: map[string]any{
+			"projects.create":       true,
 			"projects.read":         true,
 			"projects.write":        true,
+			"projects.delete":       true,
 			"project.roles.read":    true,
 			"project.roles.write":   true,
 			"project.members.read":  true,
@@ -194,19 +196,40 @@ func TestE2EProject_Unauthenticated(t *testing.T) {
 
 func TestE2EProject_InsufficientPermission(t *testing.T) {
 	env := newE2EEnv(t)
-	// A plain USER should not have projects.read permission unless their global
-	// role grants it. Seed a user with only the default USER role.
+	// A plain USER has no projects.create permission. They can list projects
+	// (receiving an empty list) but cannot create one.
 	seedUser(t, env, "plain-user", "plainpass1", "Plain User")
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Jar: jar, Timeout: 30 * time.Second}
 	loginResp := login(env.ctx, t, client, env.base, "plain-user", "plainpass1")
+	token := cookieValue(loginResp, "access_token")
 	_ = loginResp.Body.Close()
 
-	req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/projects", nil)
-	resp := mustDo(t, client, req)
-	defer func() { _ = resp.Body.Close() }()
-	assertStatus(t, resp, http.StatusForbidden)
-	assertErrorCode(t, resp, "FORBIDDEN")
+	t.Run("list_projects_returns_empty", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/projects", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		total, _ := data["total"].(float64)
+		if total != 0 {
+			t.Errorf("expected 0 projects for plain user, got %v", total)
+		}
+	})
+
+	t.Run("create_project_forbidden", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "should-fail", "description": ""})
+		req := mustRequest(env.ctx, t, http.MethodPost, env.base+"/api/v1/projects", body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -501,4 +524,409 @@ func TestE2EProject_DeleteCascadesRolesAndMembers(t *testing.T) {
 	resp = mustDo(t, client, req)
 	defer func() { _ = resp.Body.Close() }()
 	assertStatus(t, resp, http.StatusNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// Role-based access control workflow tests
+// ---------------------------------------------------------------------------
+
+// createProjectRoleWithPermsViaAPI creates a project-scoped role with arbitrary
+// permissions and returns its ID.
+func createProjectRoleWithPermsViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, projectID, roleName string, permissions map[string]any) string {
+	t.Helper()
+	body := jsonBody(t, map[string]any{
+		"role_name":   roleName,
+		"permissions": permissions,
+	})
+	url := fmt.Sprintf("%s/api/v1/projects/%s/roles", env.base, projectID)
+	req := mustRequest(env.ctx, t, http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	id, _ := data["id"].(string)
+	return id
+}
+
+// loginUser creates a fresh HTTP client, logs in, and returns the client plus
+// access token extracted from the response cookie.
+func loginUser(t *testing.T, env *e2eEnv, username, password string) (*http.Client, string) {
+	t.Helper()
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar, Timeout: 30 * time.Second}
+	resp := login(env.ctx, t, client, env.base, username, password)
+	defer func() { _ = resp.Body.Close() }()
+	return client, cookieValue(resp, "access_token")
+}
+
+// addMemberViaAPI adds a user as a project member using the given auth token.
+func addMemberViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, projectID, userID, roleID string) {
+	t.Helper()
+	url := fmt.Sprintf("%s/api/v1/projects/%s/members", env.base, projectID)
+	req := mustRequest(env.ctx, t, http.MethodPost, url,
+		jsonBody(t, map[string]any{"user_id": userID, "project_role_id": roleID}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+}
+
+// TestE2EProject_ProjectViewerAccess verifies that a project member with a
+// viewer-only role (projects.read) can GET the project but cannot update or
+// delete it, and that the project appears in their accessible list.
+func TestE2EProject_ProjectViewerAccess(t *testing.T) {
+	env := newE2EEnv(t)
+
+	seedProjectAdminUser(t, env, "viewer-access-admin", "adminpass1")
+	adminClient, adminToken := projectAdminLogin(t, env, "viewer-access-admin", "adminpass1")
+	projID := createProjectViaAPI(t, env, adminClient, adminToken, "viewer-access-project-"+uuid.NewString(), "")
+
+	// Create a project role that only grants projects.read.
+	viewerRoleID := createProjectRoleWithPermsViaAPI(t, env, adminClient, adminToken, projID, "read-only",
+		map[string]any{"projects.read": true})
+
+	// Seed a plain user and add them as a project member with the viewer role.
+	seedUser(t, env, "viewer-access-user", "viewerpass1", "Viewer Access User")
+	viewerUser, err := env.userRepo.FindByUsername(env.ctx, "viewer-access-user")
+	if err != nil {
+		t.Fatalf("find viewer user: %v", err)
+	}
+	addMemberViaAPI(t, env, adminClient, adminToken, projID, viewerUser.ID.String(), viewerRoleID)
+
+	viewerClient, viewerToken := loginUser(t, env, "viewer-access-user", "viewerpass1")
+
+	t.Run("viewer_can_get_project", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if id, _ := data["id"].(string); id != projID {
+			t.Errorf("expected project id %q, got %q", projID, id)
+		}
+	})
+
+	t.Run("viewer_cannot_update_project", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "hacked", "description": ""})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			env.base+"/api/v1/projects/"+projID, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("viewer_cannot_delete_project", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			env.base+"/api/v1/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("project_appears_in_viewer_accessible_list", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/projects", nil)
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		total, _ := data["total"].(float64)
+		if total < 1 {
+			t.Errorf("expected viewer to see at least 1 accessible project, got %v", total)
+		}
+	})
+}
+
+// TestE2EProject_NonMemberForbidden verifies that an authenticated user who is
+// not a project member and has no global projects.read cannot access any
+// project-specific endpoint.
+func TestE2EProject_NonMemberForbidden(t *testing.T) {
+	env := newE2EEnv(t)
+
+	seedProjectAdminUser(t, env, "non-member-admin", "adminpass2")
+	adminClient, adminToken := projectAdminLogin(t, env, "non-member-admin", "adminpass2")
+	projID := createProjectViaAPI(t, env, adminClient, adminToken, "non-member-project-"+uuid.NewString(), "")
+
+	// Seed a plain user with no project membership.
+	seedUser(t, env, "non-member-user", "nonmbrpass1", "Non Member User")
+	nmClient, nmToken := loginUser(t, env, "non-member-user", "nonmbrpass1")
+
+	t.Run("get_project_forbidden", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+nmToken)
+		resp := mustDo(t, nmClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("update_project_forbidden", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "hacked"})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			env.base+"/api/v1/projects/"+projID, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+nmToken)
+		resp := mustDo(t, nmClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("delete_project_forbidden", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			env.base+"/api/v1/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+nmToken)
+		resp := mustDo(t, nmClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("non_member_project_not_in_accessible_list", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/projects", nil)
+		req.Header.Set("Authorization", "Bearer "+nmToken)
+		resp := mustDo(t, nmClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		total, _ := data["total"].(float64)
+		if total != 0 {
+			t.Errorf("expected non-member to see 0 projects, got %v", total)
+		}
+	})
+}
+
+// TestE2EProject_MemberRolePermissionsEnforced verifies that project members
+// can only perform the operations their project role grants. A "manager" role
+// (with members.write, roles.write, projects.write) is compared against a
+// "viewer" role (projects.read only).
+func TestE2EProject_MemberRolePermissionsEnforced(t *testing.T) {
+	env := newE2EEnv(t)
+
+	seedProjectAdminUser(t, env, "perm-test-admin", "adminpass3")
+	adminClient, adminToken := projectAdminLogin(t, env, "perm-test-admin", "adminpass3")
+	projID := createProjectViaAPI(t, env, adminClient, adminToken, "perm-test-project-"+uuid.NewString(), "")
+
+	managerRoleID := createProjectRoleWithPermsViaAPI(t, env, adminClient, adminToken, projID, "proj-manager",
+		map[string]any{
+			"projects.read":         true,
+			"projects.write":        true,
+			"project.members.read":  true,
+			"project.members.write": true,
+			"project.roles.read":    true,
+			"project.roles.write":   true,
+		})
+	viewerRoleID := createProjectRoleWithPermsViaAPI(t, env, adminClient, adminToken, projID, "proj-viewer",
+		map[string]any{"projects.read": true})
+
+	// Seed and add manager user.
+	seedUser(t, env, "perm-mgr-user", "mgrpass1", "Perm Manager User")
+	mgrUser, err := env.userRepo.FindByUsername(env.ctx, "perm-mgr-user")
+	if err != nil {
+		t.Fatalf("find manager user: %v", err)
+	}
+	addMemberViaAPI(t, env, adminClient, adminToken, projID, mgrUser.ID.String(), managerRoleID)
+
+	// Seed and add viewer user.
+	seedUser(t, env, "perm-viewer-user", "viewerpass2", "Perm Viewer User")
+	viewerUser, err := env.userRepo.FindByUsername(env.ctx, "perm-viewer-user")
+	if err != nil {
+		t.Fatalf("find viewer user: %v", err)
+	}
+	addMemberViaAPI(t, env, adminClient, adminToken, projID, viewerUser.ID.String(), viewerRoleID)
+
+	// Seed an extra user to use as the add/remove target.
+	seedUser(t, env, "perm-extra-user", "extrapass1", "Extra User")
+	extraUser, err := env.userRepo.FindByUsername(env.ctx, "perm-extra-user")
+	if err != nil {
+		t.Fatalf("find extra user: %v", err)
+	}
+
+	mgrClient, mgrToken := loginUser(t, env, "perm-mgr-user", "mgrpass1")
+	viewerClient, viewerToken := loginUser(t, env, "perm-viewer-user", "viewerpass2")
+
+	membersURL := fmt.Sprintf("%s/api/v1/projects/%s/members", env.base, projID)
+	rolesURL := fmt.Sprintf("%s/api/v1/projects/%s/roles", env.base, projID)
+
+	t.Run("manager_can_update_project", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "updated-by-manager", "description": "mgr update"})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			env.base+"/api/v1/projects/"+projID, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+mgrToken)
+		resp := mustDo(t, mgrClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	t.Run("viewer_cannot_update_project", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "hacked-by-viewer", "description": ""})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			env.base+"/api/v1/projects/"+projID, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("manager_can_add_member", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodPost, membersURL,
+			jsonBody(t, map[string]any{"user_id": extraUser.ID.String(), "project_role_id": viewerRoleID}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+mgrToken)
+		resp := mustDo(t, mgrClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+	})
+
+	t.Run("viewer_cannot_add_member", func(t *testing.T) {
+		// extraUser is already a member, but 403 is checked before the conflict.
+		req := mustRequest(env.ctx, t, http.MethodPost, membersURL,
+			jsonBody(t, map[string]any{"user_id": extraUser.ID.String(), "project_role_id": viewerRoleID}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("manager_can_remove_member", func(t *testing.T) {
+		url := membersURL + "/" + extraUser.ID.String()
+		req := mustRequest(env.ctx, t, http.MethodDelete, url, nil)
+		req.Header.Set("Authorization", "Bearer "+mgrToken)
+		resp := mustDo(t, mgrClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	t.Run("viewer_cannot_remove_member", func(t *testing.T) {
+		// Target the manager user — authz check happens before existence check.
+		url := membersURL + "/" + mgrUser.ID.String()
+		req := mustRequest(env.ctx, t, http.MethodDelete, url, nil)
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+
+	t.Run("manager_can_create_project_role", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"role_name":   "mgr-created-role",
+			"permissions": map[string]any{"projects.read": true},
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost, rolesURL, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+mgrToken)
+		resp := mustDo(t, mgrClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+	})
+
+	t.Run("viewer_cannot_create_project_role", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"role_name":   "viewer-attempted-role",
+			"permissions": map[string]any{"projects.read": true},
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost, rolesURL, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+viewerToken)
+		resp := mustDo(t, viewerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+		assertErrorCode(t, resp, "FORBIDDEN")
+	})
+}
+
+// TestE2EProject_GlobalReadSeesAllProjects verifies that a user with a global
+// projects.read permission can see ALL projects (not just their own) in the
+// list, as well as access individual project details.
+func TestE2EProject_GlobalReadSeesAllProjects(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Admin A creates a project.
+	seedProjectAdminUser(t, env, "global-read-admin-a", "adminpassA")
+	clientA, tokenA := projectAdminLogin(t, env, "global-read-admin-a", "adminpassA")
+	projID := createProjectViaAPI(t, env, clientA, tokenA, "global-read-project-"+uuid.NewString(), "")
+
+	// Seed user B who has global projects.read but is NOT a member of A's project.
+	seedUser(t, env, "global-read-user-b", "adminpassB", "Global Read User B")
+	roleName := "GLOBAL_READ_" + uuid.NewString()
+	if err := env.roleRepo.Create(env.ctx, &globalroledom.GlobalRole{
+		ID:   uuid.New(),
+		Name: roleName,
+		Permissions: map[string]any{
+			"projects.read": true,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create global-read role: %v", err)
+	}
+	assignGlobalRolesByName(t, env, "global-read-user-b", roleName)
+
+	clientB, tokenB := loginUser(t, env, "global-read-user-b", "adminpassB")
+
+	t.Run("global_read_user_can_list_all_projects", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, env.base+"/api/v1/projects", nil)
+		req.Header.Set("Authorization", "Bearer "+tokenB)
+		resp := mustDo(t, clientB, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, _ := data["items"].([]any)
+		found := false
+		for _, item := range items {
+			if m, ok := item.(map[string]any); ok {
+				if id, _ := m["id"].(string); id == projID {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected global-read user to see project %q in list", projID)
+		}
+	})
+
+	t.Run("global_read_user_can_get_project_directly", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			env.base+"/api/v1/projects/"+projID, nil)
+		req.Header.Set("Authorization", "Bearer "+tokenB)
+		resp := mustDo(t, clientB, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if id, _ := data["id"].(string); id != projID {
+			t.Errorf("expected project id %q, got %q", projID, id)
+		}
+	})
 }

--- a/services/api/test/integration/project_test.go
+++ b/services/api/test/integration/project_test.go
@@ -1,0 +1,554 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/platform/authz"
+	jwttoken "github.com/paca/api/internal/platform/token"
+	authsvc "github.com/paca/api/internal/service/auth"
+	projectsvc "github.com/paca/api/internal/service/project"
+	usersvc "github.com/paca/api/internal/service/user"
+	"github.com/paca/api/internal/transport/http/handler"
+	"github.com/paca/api/internal/transport/http/router"
+)
+
+type fakeProjectRepo struct {
+	mu sync.RWMutex
+
+	projects map[uuid.UUID]*projectdom.Project
+	roles    map[uuid.UUID]*projectdom.ProjectRole
+	members  map[string]*projectdom.ProjectMember
+}
+
+func newFakeProjectRepo() *fakeProjectRepo {
+	return &fakeProjectRepo{
+		projects: make(map[uuid.UUID]*projectdom.Project),
+		roles:    make(map[uuid.UUID]*projectdom.ProjectRole),
+		members:  make(map[string]*projectdom.ProjectMember),
+	}
+}
+
+func memberKey(projectID, userID uuid.UUID) string {
+	return projectID.String() + ":" + userID.String()
+}
+
+func cloneProject(in *projectdom.Project) *projectdom.Project {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Settings != nil {
+		out.Settings = make(map[string]any, len(in.Settings))
+		for k, v := range in.Settings {
+			out.Settings[k] = v
+		}
+	}
+	return &out
+}
+
+func cloneRole(in *projectdom.ProjectRole) *projectdom.ProjectRole {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.ProjectID != nil {
+		pid := *in.ProjectID
+		out.ProjectID = &pid
+	}
+	if in.Permissions != nil {
+		out.Permissions = make(map[string]any, len(in.Permissions))
+		for k, v := range in.Permissions {
+			out.Permissions[k] = v
+		}
+	}
+	return &out
+}
+
+func cloneMember(in *projectdom.ProjectMember) *projectdom.ProjectMember {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func (r *fakeProjectRepo) List(_ context.Context, offset, limit int) ([]*projectdom.Project, int64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	all := make([]*projectdom.Project, 0, len(r.projects))
+	for _, p := range r.projects {
+		all = append(all, cloneProject(p))
+	}
+	total := int64(len(all))
+	if offset >= len(all) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], total, nil
+}
+
+func (r *fakeProjectRepo) FindByID(_ context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	p, ok := r.projects[id]
+	if !ok {
+		return nil, projectdom.ErrNotFound
+	}
+	return cloneProject(p), nil
+}
+
+func (r *fakeProjectRepo) Create(_ context.Context, p *projectdom.Project) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, existing := range r.projects {
+		if existing.Name == p.Name {
+			return projectdom.ErrNameTaken
+		}
+	}
+	r.projects[p.ID] = cloneProject(p)
+	return nil
+}
+
+func (r *fakeProjectRepo) Update(_ context.Context, p *projectdom.Project) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.projects[p.ID]; !ok {
+		return projectdom.ErrNotFound
+	}
+	for _, existing := range r.projects {
+		if existing.ID != p.ID && existing.Name == p.Name {
+			return projectdom.ErrNameTaken
+		}
+	}
+	r.projects[p.ID] = cloneProject(p)
+	return nil
+}
+
+func (r *fakeProjectRepo) Delete(_ context.Context, id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.projects[id]; !ok {
+		return projectdom.ErrNotFound
+	}
+	delete(r.projects, id)
+	for roleID, role := range r.roles {
+		if role.ProjectID != nil && *role.ProjectID == id {
+			delete(r.roles, roleID)
+		}
+	}
+	for key, m := range r.members {
+		if m.ProjectID == id {
+			delete(r.members, key)
+		}
+	}
+	return nil
+}
+
+func (r *fakeProjectRepo) ListRoles(_ context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]*projectdom.ProjectRole, 0)
+	for _, role := range r.roles {
+		if role.ProjectID != nil && *role.ProjectID == projectID {
+			out = append(out, cloneRole(role))
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeProjectRepo) FindRoleByID(_ context.Context, id uuid.UUID) (*projectdom.ProjectRole, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	role, ok := r.roles[id]
+	if !ok {
+		return nil, projectdom.ErrRoleNotFound
+	}
+	return cloneRole(role), nil
+}
+
+func (r *fakeProjectRepo) FindRoleByName(_ context.Context, projectID uuid.UUID, name string) (*projectdom.ProjectRole, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, role := range r.roles {
+		if role.ProjectID != nil && *role.ProjectID == projectID && role.RoleName == name {
+			return cloneRole(role), nil
+		}
+	}
+	return nil, projectdom.ErrRoleNotFound
+}
+
+func (r *fakeProjectRepo) CreateRole(_ context.Context, role *projectdom.ProjectRole) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, existing := range r.roles {
+		if existing.ProjectID != nil && role.ProjectID != nil && *existing.ProjectID == *role.ProjectID && existing.RoleName == role.RoleName {
+			return projectdom.ErrRoleNameTaken
+		}
+	}
+	r.roles[role.ID] = cloneRole(role)
+	return nil
+}
+
+func (r *fakeProjectRepo) UpdateRole(_ context.Context, role *projectdom.ProjectRole) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.roles[role.ID]; !ok {
+		return projectdom.ErrRoleNotFound
+	}
+	r.roles[role.ID] = cloneRole(role)
+	return nil
+}
+
+func (r *fakeProjectRepo) DeleteRole(_ context.Context, id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.roles[id]; !ok {
+		return projectdom.ErrRoleNotFound
+	}
+	delete(r.roles, id)
+	return nil
+}
+
+func (r *fakeProjectRepo) CountMembersWithRole(_ context.Context, roleID uuid.UUID) (int64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var count int64
+	for _, m := range r.members {
+		if m.ProjectRoleID == roleID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (r *fakeProjectRepo) ListMembers(_ context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]*projectdom.ProjectMember, 0)
+	for _, m := range r.members {
+		if m.ProjectID == projectID {
+			out = append(out, cloneMember(m))
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeProjectRepo) FindMember(_ context.Context, projectID, userID uuid.UUID) (*projectdom.ProjectMember, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	m, ok := r.members[memberKey(projectID, userID)]
+	if !ok {
+		return nil, projectdom.ErrMemberNotFound
+	}
+	return cloneMember(m), nil
+}
+
+func (r *fakeProjectRepo) AddMember(_ context.Context, m *projectdom.ProjectMember) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	k := memberKey(m.ProjectID, m.UserID)
+	if _, ok := r.members[k]; ok {
+		return projectdom.ErrMemberAlreadyAdded
+	}
+	r.members[k] = cloneMember(m)
+	return nil
+}
+
+func (r *fakeProjectRepo) RemoveMember(_ context.Context, projectID, userID uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	k := memberKey(projectID, userID)
+	if _, ok := r.members[k]; !ok {
+		return projectdom.ErrMemberNotFound
+	}
+	delete(r.members, k)
+	return nil
+}
+
+type projectPermStore struct {
+	globalPerms  []authz.Permission
+	projectPerms map[uuid.UUID][]authz.Permission
+}
+
+func (s *projectPermStore) ListGlobalPermissions(context.Context, uuid.UUID) ([]authz.Permission, error) {
+	return append([]authz.Permission(nil), s.globalPerms...), nil
+}
+
+func (s *projectPermStore) ListProjectPermissions(_ context.Context, _ uuid.UUID, projectID uuid.UUID) ([]authz.Permission, error) {
+	perms := s.projectPerms[projectID]
+	return append([]authz.Permission(nil), perms...), nil
+}
+
+func buildProjectTestRouter(repo *fakeProjectRepo, store *projectPermStore) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	tm := jwttoken.New(testSecret, 15*time.Minute, 168*time.Hour)
+	refreshStore := &fakeRefreshStore{}
+	userRepo := newFakeUserRepo()
+	authService := authsvc.New(userRepo, tm, refreshStore, 168*time.Hour, 24*time.Hour)
+	userService := usersvc.New(userRepo)
+	projectService := projectsvc.New(repo)
+	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	return router.New(router.Deps{
+		TokenManager: tm,
+		Authorizer:   authz.NewAuthorizer(store),
+		Health:       handler.NewHealthHandler(),
+		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
+		User:         handler.NewUserHandler(userService),
+		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:      handler.NewProjectHandler(projectService),
+		Log:          log,
+	})
+}
+
+func issueProjectToken(t *testing.T, subject string) string {
+	t.Helper()
+	tm := jwttoken.New(testSecret, 15*time.Minute, 168*time.Hour)
+	tok, err := tm.IssueAccess(subject, "project-user", "USER", "fam-project", false)
+	if err != nil {
+		t.Fatalf("issue project token: %v", err)
+	}
+	return tok
+}
+
+func serve(r *gin.Engine, req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func authedJSONReq(ctx context.Context, method, url, token string, body any) *http.Request {
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		b, _ := json.Marshal(body)
+		reader = bytes.NewReader(b)
+	}
+	req := httptest.NewRequestWithContext(ctx, method, url, reader)
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req
+}
+
+func projectIDFromCreate(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode create project response: %v", err)
+	}
+	id, _ := env.Data["id"].(string)
+	if id == "" {
+		t.Fatal("missing project id")
+	}
+	return id
+}
+
+func roleIDFromCreate(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode create role response: %v", err)
+	}
+	id, _ := env.Data["id"].(string)
+	if id == "" {
+		t.Fatal("missing role id")
+	}
+	return id
+}
+
+func TestIntegrationProjectManagement_AdminCRUD(t *testing.T) {
+	repo := newFakeProjectRepo()
+	store := &projectPermStore{
+		globalPerms: []authz.Permission{authz.PermissionProjectsRead, authz.PermissionProjectsWrite},
+	}
+	r := buildProjectTestRouter(repo, store)
+	tok := issueProjectToken(t, uuid.NewString())
+
+	createReq := authedJSONReq(t.Context(), http.MethodPost, "/api/v1/admin/projects", tok, map[string]any{
+		"name":        "Project Alpha",
+		"description": "first",
+	})
+	createW := serve(r, createReq)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d (%s)", createW.Code, createW.Body.String())
+	}
+	projectID := projectIDFromCreate(t, createW)
+
+	listW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/admin/projects", tok, nil))
+	if listW.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d (%s)", listW.Code, listW.Body.String())
+	}
+
+	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/admin/projects/"+projectID, tok, nil))
+	if getW.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d (%s)", getW.Code, getW.Body.String())
+	}
+
+	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, "/api/v1/admin/projects/"+projectID, tok, map[string]any{
+		"name":        "Project Alpha Updated",
+		"description": "updated",
+	}))
+	if patchW.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d (%s)", patchW.Code, patchW.Body.String())
+	}
+
+	delW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, "/api/v1/admin/projects/"+projectID, tok, nil))
+	if delW.Code != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d (%s)", delW.Code, delW.Body.String())
+	}
+
+	getDeletedW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/admin/projects/"+projectID, tok, nil))
+	if getDeletedW.Code != http.StatusNotFound {
+		t.Fatalf("get deleted: expected 404, got %d (%s)", getDeletedW.Code, getDeletedW.Body.String())
+	}
+	if code := decodeErrorCode(t, getDeletedW); code != "PROJECT_NOT_FOUND" {
+		t.Fatalf("expected PROJECT_NOT_FOUND, got %q", code)
+	}
+}
+
+func TestIntegrationProjectManagement_AuthzGuards(t *testing.T) {
+	repo := newFakeProjectRepo()
+	store := &projectPermStore{globalPerms: []authz.Permission{authz.PermissionProjectsRead}}
+	r := buildProjectTestRouter(repo, store)
+	tok := issueProjectToken(t, uuid.NewString())
+
+	writeW := serve(r, authedJSONReq(t.Context(), http.MethodPost, "/api/v1/admin/projects", tok, map[string]any{"name": "No Write"}))
+	if writeW.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without projects.write, got %d (%s)", writeW.Code, writeW.Body.String())
+	}
+	if code := decodeErrorCode(t, writeW); code != "FORBIDDEN" {
+		t.Fatalf("expected FORBIDDEN, got %q", code)
+	}
+
+	unauthW := serve(r, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/admin/projects", nil))
+	if unauthW.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d (%s)", unauthW.Code, unauthW.Body.String())
+	}
+}
+
+func TestIntegrationProjectRolesAndMembers_Flow(t *testing.T) {
+	repo := newFakeProjectRepo()
+	projectID := uuid.New()
+	repo.projects[projectID] = &projectdom.Project{ID: projectID, Name: "Proj", CreatedAt: time.Now()}
+
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {
+				authz.PermissionProjectRolesRead,
+				authz.PermissionProjectRolesWrite,
+				authz.PermissionProjectMembersRead,
+				authz.PermissionProjectMembersWrite,
+			},
+		},
+	}
+	r := buildProjectTestRouter(repo, store)
+	tok := issueProjectToken(t, uuid.NewString())
+
+	createRoleURL := fmt.Sprintf("/api/v1/projects/%s/roles", projectID)
+	createRoleW := serve(r, authedJSONReq(t.Context(), http.MethodPost, createRoleURL, tok, map[string]any{
+		"role_name":   "developer",
+		"permissions": map[string]any{"tasks.read": true},
+	}))
+	if createRoleW.Code != http.StatusCreated {
+		t.Fatalf("create role: expected 201, got %d (%s)", createRoleW.Code, createRoleW.Body.String())
+	}
+	roleID := roleIDFromCreate(t, createRoleW)
+
+	dupRoleW := serve(r, authedJSONReq(t.Context(), http.MethodPost, createRoleURL, tok, map[string]any{
+		"role_name": "developer",
+	}))
+	if dupRoleW.Code != http.StatusConflict {
+		t.Fatalf("duplicate role: expected 409, got %d (%s)", dupRoleW.Code, dupRoleW.Body.String())
+	}
+	if code := decodeErrorCode(t, dupRoleW); code != "PROJECT_ROLE_NAME_TAKEN" {
+		t.Fatalf("expected PROJECT_ROLE_NAME_TAKEN, got %q", code)
+	}
+
+	memberUserID := uuid.New()
+	membersURL := fmt.Sprintf("/api/v1/projects/%s/members", projectID)
+	addMemberW := serve(r, authedJSONReq(t.Context(), http.MethodPost, membersURL, tok, map[string]any{
+		"user_id":         memberUserID,
+		"project_role_id": roleID,
+	}))
+	if addMemberW.Code != http.StatusCreated {
+		t.Fatalf("add member: expected 201, got %d (%s)", addMemberW.Code, addMemberW.Body.String())
+	}
+
+	dupMemberW := serve(r, authedJSONReq(t.Context(), http.MethodPost, membersURL, tok, map[string]any{
+		"user_id":         memberUserID,
+		"project_role_id": roleID,
+	}))
+	if dupMemberW.Code != http.StatusConflict {
+		t.Fatalf("duplicate member: expected 409, got %d (%s)", dupMemberW.Code, dupMemberW.Body.String())
+	}
+	if code := decodeErrorCode(t, dupMemberW); code != "PROJECT_MEMBER_ALREADY_ADDED" {
+		t.Fatalf("expected PROJECT_MEMBER_ALREADY_ADDED, got %q", code)
+	}
+
+	deleteRoleURL := fmt.Sprintf("/api/v1/projects/%s/roles/%s", projectID, roleID)
+	deleteRoleWhileAssignedW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, deleteRoleURL, tok, nil))
+	if deleteRoleWhileAssignedW.Code != http.StatusConflict {
+		t.Fatalf("delete role in use: expected 409, got %d (%s)", deleteRoleWhileAssignedW.Code, deleteRoleWhileAssignedW.Body.String())
+	}
+	if code := decodeErrorCode(t, deleteRoleWhileAssignedW); code != "PROJECT_ROLE_HAS_MEMBERS" {
+		t.Fatalf("expected PROJECT_ROLE_HAS_MEMBERS, got %q", code)
+	}
+
+	removeMemberURL := fmt.Sprintf("/api/v1/projects/%s/members/%s", projectID, memberUserID)
+	removeW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, removeMemberURL, tok, nil))
+	if removeW.Code != http.StatusOK {
+		t.Fatalf("remove member: expected 200, got %d (%s)", removeW.Code, removeW.Body.String())
+	}
+
+	removeMissingW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, removeMemberURL, tok, nil))
+	if removeMissingW.Code != http.StatusNotFound {
+		t.Fatalf("remove missing member: expected 404, got %d (%s)", removeMissingW.Code, removeMissingW.Body.String())
+	}
+	if code := decodeErrorCode(t, removeMissingW); code != "PROJECT_MEMBER_NOT_FOUND" {
+		t.Fatalf("expected PROJECT_MEMBER_NOT_FOUND, got %q", code)
+	}
+
+	deleteRoleW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, deleteRoleURL, tok, nil))
+	if deleteRoleW.Code != http.StatusOK {
+		t.Fatalf("delete role: expected 200, got %d (%s)", deleteRoleW.Code, deleteRoleW.Body.String())
+	}
+}

--- a/services/api/test/integration/project_test.go
+++ b/services/api/test/integration/project_test.go
@@ -297,6 +297,20 @@ func (r *fakeProjectRepo) RemoveMember(_ context.Context, projectID, userID uuid
 	return nil
 }
 
+func (r *fakeProjectRepo) UpdateMemberRole(_ context.Context, projectID, userID, roleID uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	k := memberKey(projectID, userID)
+	m, ok := r.members[k]
+	if !ok {
+		return projectdom.ErrMemberNotFound
+	}
+	m.ProjectRoleID = roleID
+	r.members[k] = cloneMember(m)
+	return nil
+}
+
 type projectPermStore struct {
 	globalPerms  []authz.Permission
 	projectPerms map[uuid.UUID][]authz.Permission
@@ -524,7 +538,44 @@ func TestIntegrationProjectRolesAndMembers_Flow(t *testing.T) {
 		t.Fatalf("expected PROJECT_MEMBER_ALREADY_ADDED, got %q", code)
 	}
 
-	deleteRoleURL := fmt.Sprintf("/api/v1/projects/%s/roles/%s", projectID, roleID)
+	updatedRoleW := serve(r, authedJSONReq(t.Context(), http.MethodPost, createRoleURL, tok, map[string]any{
+		"role_name": "qa",
+	}))
+	if updatedRoleW.Code != http.StatusCreated {
+		t.Fatalf("create second role: expected 201, got %d (%s)", updatedRoleW.Code, updatedRoleW.Body.String())
+	}
+	updatedRoleID := roleIDFromCreate(t, updatedRoleW)
+
+	updateMemberURL := fmt.Sprintf("/api/v1/projects/%s/members/%s", projectID, memberUserID)
+	updateMemberW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, updateMemberURL, tok, map[string]any{
+		"project_role_id": updatedRoleID,
+	}))
+	if updateMemberW.Code != http.StatusOK {
+		t.Fatalf("update member role: expected 200, got %d (%s)", updateMemberW.Code, updateMemberW.Body.String())
+	}
+
+	var updateMemberEnv struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(updateMemberW.Body).Decode(&updateMemberEnv); err != nil {
+		t.Fatalf("decode update member response: %v", err)
+	}
+	if got, _ := updateMemberEnv.Data["project_role_id"].(string); got != updatedRoleID {
+		t.Fatalf("expected updated role id %q, got %q", updatedRoleID, got)
+	}
+
+	missingMemberW := serve(r, authedJSONReq(t.Context(), http.MethodPatch,
+		fmt.Sprintf("/api/v1/projects/%s/members/%s", projectID, uuid.New()), tok, map[string]any{
+			"project_role_id": updatedRoleID,
+		}))
+	if missingMemberW.Code != http.StatusNotFound {
+		t.Fatalf("update missing member: expected 404, got %d (%s)", missingMemberW.Code, missingMemberW.Body.String())
+	}
+	if code := decodeErrorCode(t, missingMemberW); code != "PROJECT_MEMBER_NOT_FOUND" {
+		t.Fatalf("expected PROJECT_MEMBER_NOT_FOUND, got %q", code)
+	}
+
+	deleteRoleURL := fmt.Sprintf("/api/v1/projects/%s/roles/%s", projectID, updatedRoleID)
 	deleteRoleWhileAssignedW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, deleteRoleURL, tok, nil))
 	if deleteRoleWhileAssignedW.Code != http.StatusConflict {
 		t.Fatalf("delete role in use: expected 409, got %d (%s)", deleteRoleWhileAssignedW.Code, deleteRoleWhileAssignedW.Body.String())

--- a/services/api/test/integration/project_test.go
+++ b/services/api/test/integration/project_test.go
@@ -104,6 +104,30 @@ func (r *fakeProjectRepo) List(_ context.Context, offset, limit int) ([]*project
 	return all[offset:end], total, nil
 }
 
+func (r *fakeProjectRepo) ListAccessible(_ context.Context, userID uuid.UUID, offset, limit int) ([]*projectdom.Project, int64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	all := make([]*projectdom.Project, 0)
+	for _, p := range r.projects {
+		for _, m := range r.members {
+			if m.ProjectID == p.ID && m.UserID == userID {
+				all = append(all, cloneProject(p))
+				break
+			}
+		}
+	}
+	total := int64(len(all))
+	if offset >= len(all) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], total, nil
+}
+
 func (r *fakeProjectRepo) FindByID(_ context.Context, id uuid.UUID) (*projectdom.Project, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -342,7 +366,7 @@ func buildProjectTestRouter(repo *fakeProjectRepo, store *projectPermStore) *gin
 		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
 		User:         handler.NewUserHandler(userService),
 		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
-		Project:      handler.NewProjectHandler(projectService),
+		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
 		Log:          log,
 	})
 }
@@ -412,12 +436,17 @@ func roleIDFromCreate(t *testing.T, w *httptest.ResponseRecorder) string {
 func TestIntegrationProjectManagement_AdminCRUD(t *testing.T) {
 	repo := newFakeProjectRepo()
 	store := &projectPermStore{
-		globalPerms: []authz.Permission{authz.PermissionProjectsRead, authz.PermissionProjectsWrite},
+		globalPerms: []authz.Permission{
+			authz.PermissionProjectsRead,
+			authz.PermissionProjectsWrite,
+			authz.PermissionProjectsCreate,
+			authz.PermissionProjectsDelete,
+		},
 	}
 	r := buildProjectTestRouter(repo, store)
 	tok := issueProjectToken(t, uuid.NewString())
 
-	createReq := authedJSONReq(t.Context(), http.MethodPost, "/api/v1/admin/projects", tok, map[string]any{
+	createReq := authedJSONReq(t.Context(), http.MethodPost, "/api/v1/projects", tok, map[string]any{
 		"name":        "Project Alpha",
 		"description": "first",
 	})
@@ -427,17 +456,17 @@ func TestIntegrationProjectManagement_AdminCRUD(t *testing.T) {
 	}
 	projectID := projectIDFromCreate(t, createW)
 
-	listW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/admin/projects", tok, nil))
+	listW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/projects", tok, nil))
 	if listW.Code != http.StatusOK {
 		t.Fatalf("list: expected 200, got %d (%s)", listW.Code, listW.Body.String())
 	}
 
-	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/admin/projects/"+projectID, tok, nil))
+	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/projects/"+projectID, tok, nil))
 	if getW.Code != http.StatusOK {
 		t.Fatalf("get: expected 200, got %d (%s)", getW.Code, getW.Body.String())
 	}
 
-	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, "/api/v1/admin/projects/"+projectID, tok, map[string]any{
+	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, "/api/v1/projects/"+projectID, tok, map[string]any{
 		"name":        "Project Alpha Updated",
 		"description": "updated",
 	}))
@@ -445,12 +474,12 @@ func TestIntegrationProjectManagement_AdminCRUD(t *testing.T) {
 		t.Fatalf("update: expected 200, got %d (%s)", patchW.Code, patchW.Body.String())
 	}
 
-	delW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, "/api/v1/admin/projects/"+projectID, tok, nil))
+	delW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, "/api/v1/projects/"+projectID, tok, nil))
 	if delW.Code != http.StatusOK {
 		t.Fatalf("delete: expected 200, got %d (%s)", delW.Code, delW.Body.String())
 	}
 
-	getDeletedW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/admin/projects/"+projectID, tok, nil))
+	getDeletedW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/projects/"+projectID, tok, nil))
 	if getDeletedW.Code != http.StatusNotFound {
 		t.Fatalf("get deleted: expected 404, got %d (%s)", getDeletedW.Code, getDeletedW.Body.String())
 	}
@@ -465,15 +494,15 @@ func TestIntegrationProjectManagement_AuthzGuards(t *testing.T) {
 	r := buildProjectTestRouter(repo, store)
 	tok := issueProjectToken(t, uuid.NewString())
 
-	writeW := serve(r, authedJSONReq(t.Context(), http.MethodPost, "/api/v1/admin/projects", tok, map[string]any{"name": "No Write"}))
+	writeW := serve(r, authedJSONReq(t.Context(), http.MethodPost, "/api/v1/projects", tok, map[string]any{"name": "No Write"}))
 	if writeW.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 without projects.write, got %d (%s)", writeW.Code, writeW.Body.String())
+		t.Fatalf("expected 403 without projects.create, got %d (%s)", writeW.Code, writeW.Body.String())
 	}
 	if code := decodeErrorCode(t, writeW); code != "FORBIDDEN" {
 		t.Fatalf("expected FORBIDDEN, got %q", code)
 	}
 
-	unauthW := serve(r, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/admin/projects", nil))
+	unauthW := serve(r, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/projects", nil))
 	if unauthW.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 without token, got %d (%s)", unauthW.Code, unauthW.Body.String())
 	}


### PR DESCRIPTION
- [x] Add `ErrNameInvalid` to project domain errors
- [x] Update `project_service.go` to return `ErrNameInvalid` when name is empty after trim
- [x] Add `CodeProjectNameInvalid` to `apierr/codes.go`
- [x] Map `ErrNameInvalid` → `CodeProjectNameInvalid` → 400 in `presenter/response.go`
- [x] Add a test for whitespace-only project name (400 response)
- [x] Add `TestUpdateProject_PreservesOmittedFields` to verify PATCH semantics don't wipe existing description
- [x] Fix `RequireAnyPermissions` to surface scope-resolution errors (400) instead of hiding them behind 403
- [x] Add regression tests for invalid-param case in `RequireAnyPermissions`
- [x] Fix incorrect endpoint path comments in `project_dto.go` (`POST /projects`, `PATCH /projects/:projectId`)
- [x] Fix `toProjectEntity` to return error on UUID parse failure and JSON unmarshal failure
- [x] Fix `toProjectRoleEntity` to return error on UUID parse failure and JSON unmarshal failure
- [x] All tests pass