### PR TITLE
37 epic bdd scenario

### DIFF
--- a/apps/e2e/features/projects/bdd-scenarios.feature
+++ b/apps/e2e/features/projects/bdd-scenarios.feature
@@ -1,0 +1,53 @@
+@ui @task-detail @bdd-scenarios
+Feature: BDD Scenarios on task detail
+  A task can carry one or more BDD (Behavior-Driven Development) scenarios
+  that describe the expected behaviour in Given / When / Then format.
+  Scenarios are managed directly from the task detail modal and are
+  persisted per task.  Only members with the "tasks.write" permission can
+  create, edit, or delete scenarios; read-only members may view them.
+
+  @authenticated
+  Rule: CRUD operations on BDD scenarios
+
+    Background:
+      Given the user already has a stored authenticated session
+      And a project exists with at least one task
+
+    Scenario: Creating a BDD scenario with a title
+      When the user opens the task detail modal
+      And clicks "Add scenario" in the BDD Scenarios section
+      And enters a scenario title "User can log in"
+      And clicks "Create scenario"
+      Then the new scenario "User can log in" appears in the BDD Scenarios section
+
+    Scenario: Creating a scenario with Given / When / Then clauses
+      When the user opens the task detail modal
+      And clicks "Add scenario" in the BDD Scenarios section
+      And enters a scenario title "Successful login"
+      And expands the Given / When / Then form
+      And fills in the Given clause "a registered user"
+      And fills in the When clause "the user submits valid credentials"
+      And fills in the Then clause "the user is redirected to the dashboard"
+      And clicks "Create scenario"
+      Then the scenario "Successful login" appears in the list
+      And expanding the scenario reveals the Given, When, and Then clauses
+
+    Scenario: Editing a BDD scenario title inline
+      Given a BDD scenario "Old Title" exists on the task
+      When the user opens the task detail modal
+      And clicks on the title "Old Title" inside the scenario card
+      And changes the title to "New Title"
+      And blurs the title field
+      Then the scenario card shows the updated title "New Title"
+
+    Scenario: Deleting a BDD scenario
+      Given a BDD scenario "To Be Deleted" exists on the task
+      When the user opens the task detail modal
+      And hovers over the "To Be Deleted" scenario card
+      And clicks the delete icon on that card
+      Then the "To Be Deleted" scenario no longer appears in the list
+
+    Scenario: Empty state when no scenarios exist
+      When the user opens the task detail modal
+      And the task has no BDD scenarios
+      Then the BDD Scenarios section shows the "No BDD scenarios yet" message

--- a/apps/e2e/tests/projects/bdd-scenarios.spec.ts
+++ b/apps/e2e/tests/projects/bdd-scenarios.spec.ts
@@ -1,0 +1,327 @@
+// spec: features/projects/bdd-scenarios.feature
+// seed: tests/seed.spec.ts
+
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost';
+const USERNAME = process.env.E2E_USERNAME ?? 'admin';
+const PASSWORD = process.env.E2E_PASSWORD ?? 'e2e-admin-password';
+const TEST_PROJECT_PREFIX = 'E2E_BDD_';
+const RUN_ID = Date.now().toString(36).slice(-5).toUpperCase();
+
+// ─── API types ────────────────────────────────────────────────────────────────
+
+interface TaskStatus {
+  id: string;
+  category: string;
+}
+
+interface Task {
+  id: string;
+  title: string;
+}
+
+interface BDDScenario {
+  id: string;
+  title: string;
+  given: string;
+  when: string;
+  then: string;
+}
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+async function authRequest(request: APIRequestContext): Promise<void> {
+  await request.post(`${BASE_URL}/api/v1/auth/login`, {
+    data: { username: USERNAME, password: PASSWORD, rememberMe: false },
+  });
+}
+
+async function cleanupTestProjects(request: APIRequestContext): Promise<void> {
+  await authRequest(request);
+  let page = 1;
+  while (true) {
+    const resp = await request.get(`${BASE_URL}/api/v1/projects?page=${page}&page_size=100`);
+    if (!resp.ok()) break;
+    const body = await resp.json();
+    const items: Array<{ id: string; name: string }> = body?.data?.items ?? [];
+    if (items.length === 0) break;
+    await Promise.all(
+      items
+        .filter((p) => p.name.startsWith(TEST_PROJECT_PREFIX))
+        .map((p) => request.delete(`${BASE_URL}/api/v1/projects/${p.id}`)),
+    );
+    const { page: cur, page_size, total } = body.data;
+    if (cur * page_size >= total) break;
+    page++;
+  }
+}
+
+async function createProject(request: APIRequestContext, name: string): Promise<string> {
+  const resp = await request.post(`${BASE_URL}/api/v1/projects`, { data: { name } });
+  return (await resp.json()).data.id as string;
+}
+
+async function getTaskStatuses(request: APIRequestContext, projectId: string): Promise<TaskStatus[]> {
+  const resp = await request.get(`${BASE_URL}/api/v1/projects/${projectId}/task-statuses`);
+  return ((await resp.json())?.data?.items ?? []) as TaskStatus[];
+}
+
+async function createTask(
+  request: APIRequestContext,
+  projectId: string,
+  title: string,
+  statusId?: string,
+): Promise<Task> {
+  const resp = await request.post(`${BASE_URL}/api/v1/projects/${projectId}/tasks`, {
+    data: { title, status_id: statusId ?? null },
+  });
+  return (await resp.json()).data as Task;
+}
+
+async function createBDDScenario(
+  request: APIRequestContext,
+  projectId: string,
+  taskId: string,
+  payload: { title: string; given?: string; when?: string; then?: string },
+): Promise<BDDScenario> {
+  const resp = await request.post(
+    `${BASE_URL}/api/v1/projects/${projectId}/tasks/${taskId}/bdd-scenarios`,
+    { data: { title: payload.title, given: payload.given ?? '', when: payload.when ?? '', then: payload.then ?? '' } },
+  );
+  return (await resp.json()).data as BDDScenario;
+}
+
+// ─── UI helpers ───────────────────────────────────────────────────────────────
+
+async function signIn(page: Page): Promise<void> {
+  await page.goto(`${BASE_URL}/`);
+  await page.getByRole('textbox', { name: 'Username' }).fill(USERNAME);
+  await page.getByRole('textbox', { name: 'Password' }).fill(PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/i })).toBeVisible();
+}
+
+async function openTaskDetail(page: Page, projectId: string, taskId: string): Promise<void> {
+  await page.goto(`${BASE_URL}/projects/${projectId}/interactions/backlog`);
+  // Navigate via URL query param that opens the task detail modal
+  await page.goto(`${BASE_URL}/projects/${projectId}/interactions/backlog?taskId=${taskId}`);
+  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// =============================================================================
+// Rule: Empty state
+// =============================================================================
+
+test.describe('BDD Scenarios — empty state', () => {
+  let projectId: string;
+  let task: Task;
+
+  test.beforeEach(async ({ request, context }) => {
+    await cleanupTestProjects(request);
+    projectId = await createProject(request, `${TEST_PROJECT_PREFIX}EMPTY_${RUN_ID}`);
+    const statuses = await getTaskStatuses(request, projectId);
+    const todo = statuses.find((s) => s.category === 'todo');
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    await context.clearCookies();
+    await context.clearPermissions();
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupTestProjects(request);
+  });
+
+  test('shows empty state message when the task has no BDD scenarios', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    await expect(page.getByText('No BDD scenarios yet')).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// =============================================================================
+// Rule: Creating BDD scenarios
+// =============================================================================
+
+test.describe('BDD Scenarios — create', () => {
+  let projectId: string;
+  let task: Task;
+
+  test.beforeEach(async ({ request, context }) => {
+    await cleanupTestProjects(request);
+    projectId = await createProject(request, `${TEST_PROJECT_PREFIX}CREATE_${RUN_ID}`);
+    const statuses = await getTaskStatuses(request, projectId);
+    const todo = statuses.find((s) => s.category === 'todo');
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    await context.clearCookies();
+    await context.clearPermissions();
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupTestProjects(request);
+  });
+
+  test('creates a BDD scenario with a title only', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    await page.getByRole('button', { name: 'Add scenario' }).click();
+    await page.getByPlaceholder('Scenario title…').fill('User can log in');
+    await page.getByRole('button', { name: 'Create scenario' }).click();
+
+    await expect(page.getByText('User can log in')).toBeVisible({ timeout: 8_000 });
+    // Empty state message should be gone
+    await expect(page.getByText('No BDD scenarios yet')).not.toBeVisible();
+  });
+
+  test('creates a BDD scenario with Given / When / Then clauses', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    await page.getByRole('button', { name: 'Add scenario' }).click();
+    await page.getByPlaceholder('Scenario title…').fill('Successful login');
+
+    // Expand Given/When/Then
+    await page.getByRole('button', { name: /Add Given \/ When \/ Then/i }).click();
+
+    await page.getByPlaceholder(/initial context or precondition/i).fill('a registered user');
+    await page.getByPlaceholder(/action or event that occurs/i).fill('the user submits valid credentials');
+    await page.getByPlaceholder(/expected outcome or result/i).fill('the user is redirected to the dashboard');
+
+    await page.getByRole('button', { name: 'Create scenario' }).click();
+
+    await expect(page.getByText('Successful login')).toBeVisible({ timeout: 8_000 });
+
+    // Expand to verify clauses
+    await page.getByText('Successful login').click();
+    await expect(page.getByText('a registered user')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('the user submits valid credentials')).toBeVisible();
+    await expect(page.getByText('the user is redirected to the dashboard')).toBeVisible();
+  });
+
+  test('does not create a scenario without a title (button stays disabled)', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    await page.getByRole('button', { name: 'Add scenario' }).click();
+    // Leave title blank
+    const createBtn = page.getByRole('button', { name: 'Create scenario' });
+    await expect(createBtn).toBeDisabled();
+  });
+});
+
+// =============================================================================
+// Rule: Editing BDD scenarios
+// =============================================================================
+
+test.describe('BDD Scenarios — update', () => {
+  let projectId: string;
+  let task: Task;
+  let scenario: BDDScenario;
+
+  test.beforeEach(async ({ request, context }) => {
+    await cleanupTestProjects(request);
+    projectId = await createProject(request, `${TEST_PROJECT_PREFIX}UPDATE_${RUN_ID}`);
+    const statuses = await getTaskStatuses(request, projectId);
+    const todo = statuses.find((s) => s.category === 'todo');
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    scenario = await createBDDScenario(request, projectId, task.id, {
+      title: 'Original Title',
+      given: 'the app is running',
+    });
+    await context.clearCookies();
+    await context.clearPermissions();
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupTestProjects(request);
+  });
+
+  test('edits the scenario title inline', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    // Verify the original title is present
+    await expect(page.getByText('Original Title')).toBeVisible({ timeout: 10_000 });
+
+    // Click the displayed title text to enter title-edit mode
+    await page.getByText('Original Title').click();
+
+    const titleInput = page.locator('input[value="Original Title"]');
+    await titleInput.clear();
+    await titleInput.fill('Updated Title');
+    await titleInput.blur();
+
+    await expect(page.getByText('Updated Title')).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText('Original Title')).not.toBeVisible();
+  });
+
+  test('saves Given / When / Then clauses after expanding a scenario', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    await expect(page.getByText('Original Title')).toBeVisible({ timeout: 10_000 });
+
+    // Expand the scenario
+    await page.getByText('Original Title').click();
+
+    // The "Given" textarea should have the pre-filled value
+    const givenTextarea = page.getByPlaceholder(/initial context or precondition/i);
+    await expect(givenTextarea).toHaveValue('the app is running', { timeout: 5_000 });
+
+    // Update the When clause and save
+    await page.getByPlaceholder(/action or event that occurs/i).fill('the user clicks submit');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Collapse and re-expand to confirm persistence across renders
+    await page.getByText('Original Title').click(); // collapse
+    await page.getByText('Original Title').click(); // expand again
+
+    await expect(page.getByPlaceholder(/action or event that occurs/i)).toHaveValue(
+      'the user clicks submit',
+      { timeout: 5_000 },
+    );
+  });
+});
+
+// =============================================================================
+// Rule: Deleting BDD scenarios
+// =============================================================================
+
+test.describe('BDD Scenarios — delete', () => {
+  let projectId: string;
+  let task: Task;
+
+  test.beforeEach(async ({ request, context }) => {
+    await cleanupTestProjects(request);
+    projectId = await createProject(request, `${TEST_PROJECT_PREFIX}DELETE_${RUN_ID}`);
+    const statuses = await getTaskStatuses(request, projectId);
+    const todo = statuses.find((s) => s.category === 'todo');
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    await createBDDScenario(request, projectId, task.id, { title: 'To Be Deleted' });
+    await context.clearCookies();
+    await context.clearPermissions();
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupTestProjects(request);
+  });
+
+  test('deletes a BDD scenario via the delete icon', async ({ page }) => {
+    await signIn(page);
+    await openTaskDetail(page, projectId, task.id);
+
+    await expect(page.getByText('To Be Deleted')).toBeVisible({ timeout: 10_000 });
+
+    // Hover over card to reveal the delete button
+    const scenarioCard = page.locator('[data-testid="bdd-scenario-card"]').filter({ hasText: 'To Be Deleted' });
+    await scenarioCard.hover();
+
+    await page.getByRole('button', { name: 'Delete scenario' }).click();
+
+    await expect(page.getByText('To Be Deleted')).not.toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText('No BDD scenarios yet')).toBeVisible();
+  });
+});

--- a/apps/e2e/tests/projects/bdd-scenarios.spec.ts
+++ b/apps/e2e/tests/projects/bdd-scenarios.spec.ts
@@ -104,6 +104,7 @@ async function createBDDScenario(
         title: payload.title,
         given: payload.given ?? '',
         when: payload.when ?? '',
+        // biome-ignore lint/suspicious/noThenProperty: "then" is a BDD domain field
         then: payload.then ?? '',
       },
     },

--- a/apps/e2e/tests/projects/bdd-scenarios.spec.ts
+++ b/apps/e2e/tests/projects/bdd-scenarios.spec.ts
@@ -16,6 +16,12 @@ interface TaskStatus {
   category: string;
 }
 
+interface TaskType {
+  id: string;
+  name: string;
+  is_system: boolean;
+}
+
 interface Task {
   id: string;
   title: string;
@@ -67,14 +73,20 @@ async function getTaskStatuses(request: APIRequestContext, projectId: string): P
   return ((await resp.json())?.data?.items ?? []) as TaskStatus[];
 }
 
+async function getTaskTypes(request: APIRequestContext, projectId: string): Promise<TaskType[]> {
+  const resp = await request.get(`${BASE_URL}/api/v1/projects/${projectId}/task-types`);
+  return ((await resp.json())?.data?.items ?? []) as TaskType[];
+}
+
 async function createTask(
   request: APIRequestContext,
   projectId: string,
   title: string,
   statusId?: string,
+  taskTypeId?: string,
 ): Promise<Task> {
   const resp = await request.post(`${BASE_URL}/api/v1/projects/${projectId}/tasks`, {
-    data: { title, status_id: statusId ?? null },
+    data: { title, status_id: statusId ?? null, task_type_id: taskTypeId ?? null },
   });
   return (await resp.json()).data as Task;
 }
@@ -87,7 +99,14 @@ async function createBDDScenario(
 ): Promise<BDDScenario> {
   const resp = await request.post(
     `${BASE_URL}/api/v1/projects/${projectId}/tasks/${taskId}/bdd-scenarios`,
-    { data: { title: payload.title, given: payload.given ?? '', when: payload.when ?? '', then: payload.then ?? '' } },
+    {
+      data: {
+        title: payload.title,
+        given: payload.given ?? '',
+        when: payload.when ?? '',
+        then: payload.then ?? '',
+      },
+    },
   );
   return (await resp.json()).data as BDDScenario;
 }
@@ -103,8 +122,6 @@ async function signIn(page: Page): Promise<void> {
 }
 
 async function openTaskDetail(page: Page, projectId: string, taskId: string): Promise<void> {
-  await page.goto(`${BASE_URL}/projects/${projectId}/interactions/backlog`);
-  // Navigate via URL query param that opens the task detail modal
   await page.goto(`${BASE_URL}/projects/${projectId}/interactions/backlog?taskId=${taskId}`);
   await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10_000 });
 }
@@ -112,7 +129,7 @@ async function openTaskDetail(page: Page, projectId: string, taskId: string): Pr
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 // =============================================================================
-// Rule: Empty state
+// Rule: CRUD operations on BDD scenarios — Empty state
 // =============================================================================
 
 test.describe('BDD Scenarios — empty state', () => {
@@ -123,8 +140,10 @@ test.describe('BDD Scenarios — empty state', () => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}EMPTY_${RUN_ID}`);
     const statuses = await getTaskStatuses(request, projectId);
+    const taskTypes = await getTaskTypes(request, projectId);
     const todo = statuses.find((s) => s.category === 'todo');
-    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    const normalType = taskTypes.find((t) => !t.is_system);
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id, normalType?.id);
     await context.clearCookies();
     await context.clearPermissions();
   });
@@ -133,16 +152,18 @@ test.describe('BDD Scenarios — empty state', () => {
     await cleanupTestProjects(request);
   });
 
-  test('shows empty state message when the task has no BDD scenarios', async ({ page }) => {
+  test('Empty state when no scenarios exist', async ({ page }) => {
     await signIn(page);
+    // the user opens the task detail modal
     await openTaskDetail(page, projectId, task.id);
 
+    // the task has no BDD scenarios — verify the empty state message
     await expect(page.getByText('No BDD scenarios yet')).toBeVisible({ timeout: 10_000 });
   });
 });
 
 // =============================================================================
-// Rule: Creating BDD scenarios
+// Rule: CRUD operations on BDD scenarios — Creating
 // =============================================================================
 
 test.describe('BDD Scenarios — create', () => {
@@ -153,8 +174,10 @@ test.describe('BDD Scenarios — create', () => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}CREATE_${RUN_ID}`);
     const statuses = await getTaskStatuses(request, projectId);
+    const taskTypes = await getTaskTypes(request, projectId);
     const todo = statuses.find((s) => s.category === 'todo');
-    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    const normalType = taskTypes.find((t) => !t.is_system);
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id, normalType?.id);
     await context.clearCookies();
     await context.clearPermissions();
   });
@@ -163,74 +186,88 @@ test.describe('BDD Scenarios — create', () => {
     await cleanupTestProjects(request);
   });
 
-  test('creates a BDD scenario with a title only', async ({ page }) => {
+  test('Creating a BDD scenario with a title', async ({ page }) => {
     await signIn(page);
+    // the user opens the task detail modal
     await openTaskDetail(page, projectId, task.id);
 
+    // clicks "Add scenario" in the BDD Scenarios section
     await page.getByRole('button', { name: 'Add scenario' }).click();
-    await page.getByPlaceholder('Scenario title…').fill('User can log in');
+
+    // enters a scenario title "User can log in"
+    await page.getByRole('textbox', { name: 'Scenario title\u2026' }).fill('User can log in');
+
+    // clicks "Create scenario"
     await page.getByRole('button', { name: 'Create scenario' }).click();
 
-    await expect(page.getByText('User can log in')).toBeVisible({ timeout: 8_000 });
-    // Empty state message should be gone
+    // the new scenario "User can log in" appears in the BDD Scenarios section
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'User can log in' }),
+    ).toBeVisible({ timeout: 8_000 });
     await expect(page.getByText('No BDD scenarios yet')).not.toBeVisible();
   });
 
-  test('creates a BDD scenario with Given / When / Then clauses', async ({ page }) => {
+  test('Creating a scenario with Given / When / Then clauses', async ({ page }) => {
     await signIn(page);
+    // the user opens the task detail modal
     await openTaskDetail(page, projectId, task.id);
 
+    // clicks "Add scenario" in the BDD Scenarios section
     await page.getByRole('button', { name: 'Add scenario' }).click();
-    await page.getByPlaceholder('Scenario title…').fill('Successful login');
 
-    // Expand Given/When/Then
-    await page.getByRole('button', { name: /Add Given \/ When \/ Then/i }).click();
+    // enters a scenario title "Successful login"
+    await page.getByRole('textbox', { name: 'Scenario title\u2026' }).fill('Successful login');
 
-    await page.getByPlaceholder(/initial context or precondition/i).fill('a registered user');
-    await page.getByPlaceholder(/action or event that occurs/i).fill('the user submits valid credentials');
-    await page.getByPlaceholder(/expected outcome or result/i).fill('the user is redirected to the dashboard');
+    // Given / When / Then fields are directly visible in the create form — fills in all clauses
+    // fills in the Given clause "a registered user"
+    await page.getByRole('textbox', { name: 'the initial context or precondition\u2026' }).fill('a registered user');
 
+    // fills in the When clause "the user submits valid credentials"
+    await page.getByRole('textbox', { name: 'the action or event that occurs\u2026' }).fill('the user submits valid credentials');
+
+    // fills in the Then clause "the user is redirected to the dashboard"
+    await page.getByRole('textbox', { name: 'the expected outcome or result\u2026' }).fill('the user is redirected to the dashboard');
+
+    // clicks "Create scenario"
     await page.getByRole('button', { name: 'Create scenario' }).click();
 
-    await expect(page.getByText('Successful login')).toBeVisible({ timeout: 8_000 });
+    // the scenario "Successful login" appears in the list
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'Successful login' }),
+    ).toBeVisible({ timeout: 8_000 });
 
-    // Expand to verify clauses
-    await page.getByText('Successful login').click();
-    await expect(page.getByText('a registered user')).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText('the user submits valid credentials')).toBeVisible();
-    await expect(page.getByText('the user is redirected to the dashboard')).toBeVisible();
-  });
-
-  test('does not create a scenario without a title (button stays disabled)', async ({ page }) => {
-    await signIn(page);
-    await openTaskDetail(page, projectId, task.id);
-
-    await page.getByRole('button', { name: 'Add scenario' }).click();
-    // Leave title blank
-    const createBtn = page.getByRole('button', { name: 'Create scenario' });
-    await expect(createBtn).toBeDisabled();
+    // expanding the scenario reveals the Given, When, and Then clauses
+    await page.getByTestId('bdd-scenario-card').locator('div').filter({ hasText: /^Successful login$/ }).click();
+    await expect(
+      page.getByRole('textbox', { name: 'the initial context or precondition\u2026' }),
+    ).toHaveValue('a registered user', { timeout: 5_000 });
+    await expect(
+      page.getByRole('textbox', { name: 'the action or event that occurs\u2026' }),
+    ).toHaveValue('the user submits valid credentials');
+    await expect(
+      page.getByRole('textbox', { name: 'the expected outcome or result\u2026' }),
+    ).toHaveValue('the user is redirected to the dashboard');
   });
 });
 
 // =============================================================================
-// Rule: Editing BDD scenarios
+// Rule: CRUD operations on BDD scenarios — Editing
 // =============================================================================
 
 test.describe('BDD Scenarios — update', () => {
   let projectId: string;
   let task: Task;
-  let scenario: BDDScenario;
 
   test.beforeEach(async ({ request, context }) => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}UPDATE_${RUN_ID}`);
     const statuses = await getTaskStatuses(request, projectId);
+    const taskTypes = await getTaskTypes(request, projectId);
     const todo = statuses.find((s) => s.category === 'todo');
-    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
-    scenario = await createBDDScenario(request, projectId, task.id, {
-      title: 'Original Title',
-      given: 'the app is running',
-    });
+    const normalType = taskTypes.find((t) => !t.is_system);
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id, normalType?.id);
+    // a BDD scenario "Old Title" exists on the task
+    await createBDDScenario(request, projectId, task.id, { title: 'Old Title' });
     await context.clearCookies();
     await context.clearPermissions();
   });
@@ -239,55 +276,38 @@ test.describe('BDD Scenarios — update', () => {
     await cleanupTestProjects(request);
   });
 
-  test('edits the scenario title inline', async ({ page }) => {
+  test('Editing a BDD scenario title inline', async ({ page }) => {
     await signIn(page);
+    // the user opens the task detail modal
     await openTaskDetail(page, projectId, task.id);
 
-    // Verify the original title is present
-    await expect(page.getByText('Original Title')).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'Old Title' }),
+    ).toBeVisible({ timeout: 10_000 });
 
-    // Click the displayed title text to enter title-edit mode
-    await page.getByText('Original Title').click();
+    // clicks on the title "Old Title" inside the scenario card to enter edit mode
+    await page.getByTestId('bdd-scenario-card').locator('div').filter({ hasText: /^Old Title$/ }).click();
 
-    const titleInput = page.locator('input[value="Original Title"]');
+    // changes the title to "New Title"
+    const titleInput = page.getByTestId('bdd-scenario-card').locator('input');
     await titleInput.clear();
-    await titleInput.fill('Updated Title');
+    await titleInput.fill('New Title');
+
+    // blurs the title field — triggers auto-save
     await titleInput.blur();
 
-    await expect(page.getByText('Updated Title')).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByText('Original Title')).not.toBeVisible();
-  });
-
-  test('saves Given / When / Then clauses after expanding a scenario', async ({ page }) => {
-    await signIn(page);
-    await openTaskDetail(page, projectId, task.id);
-
-    await expect(page.getByText('Original Title')).toBeVisible({ timeout: 10_000 });
-
-    // Expand the scenario
-    await page.getByText('Original Title').click();
-
-    // The "Given" textarea should have the pre-filled value
-    const givenTextarea = page.getByPlaceholder(/initial context or precondition/i);
-    await expect(givenTextarea).toHaveValue('the app is running', { timeout: 5_000 });
-
-    // Update the When clause and save
-    await page.getByPlaceholder(/action or event that occurs/i).fill('the user clicks submit');
-    await page.getByRole('button', { name: 'Save' }).click();
-
-    // Collapse and re-expand to confirm persistence across renders
-    await page.getByText('Original Title').click(); // collapse
-    await page.getByText('Original Title').click(); // expand again
-
-    await expect(page.getByPlaceholder(/action or event that occurs/i)).toHaveValue(
-      'the user clicks submit',
-      { timeout: 5_000 },
-    );
+    // the scenario card shows the updated title "New Title"
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'New Title' }),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'Old Title' }),
+    ).not.toBeVisible();
   });
 });
 
 // =============================================================================
-// Rule: Deleting BDD scenarios
+// Rule: CRUD operations on BDD scenarios — Deleting
 // =============================================================================
 
 test.describe('BDD Scenarios — delete', () => {
@@ -298,8 +318,11 @@ test.describe('BDD Scenarios — delete', () => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}DELETE_${RUN_ID}`);
     const statuses = await getTaskStatuses(request, projectId);
+    const taskTypes = await getTaskTypes(request, projectId);
     const todo = statuses.find((s) => s.category === 'todo');
-    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id);
+    const normalType = taskTypes.find((t) => !t.is_system);
+    task = await createTask(request, projectId, `${TEST_PROJECT_PREFIX}TASK_${RUN_ID}`, todo?.id, normalType?.id);
+    // a BDD scenario "To Be Deleted" exists on the task
     await createBDDScenario(request, projectId, task.id, { title: 'To Be Deleted' });
     await context.clearCookies();
     await context.clearPermissions();
@@ -309,19 +332,26 @@ test.describe('BDD Scenarios — delete', () => {
     await cleanupTestProjects(request);
   });
 
-  test('deletes a BDD scenario via the delete icon', async ({ page }) => {
+  test('Deleting a BDD scenario', async ({ page }) => {
     await signIn(page);
+    // the user opens the task detail modal
     await openTaskDetail(page, projectId, task.id);
 
-    await expect(page.getByText('To Be Deleted')).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'To Be Deleted' }),
+    ).toBeVisible({ timeout: 10_000 });
 
-    // Hover over card to reveal the delete button
-    const scenarioCard = page.locator('[data-testid="bdd-scenario-card"]').filter({ hasText: 'To Be Deleted' });
+    // hovers over the "To Be Deleted" scenario card
+    const scenarioCard = page.getByTestId('bdd-scenario-card').filter({ hasText: 'To Be Deleted' });
     await scenarioCard.hover();
 
+    // clicks the delete icon on that card
     await page.getByRole('button', { name: 'Delete scenario' }).click();
 
-    await expect(page.getByText('To Be Deleted')).not.toBeVisible({ timeout: 8_000 });
+    // the "To Be Deleted" scenario no longer appears in the list
+    await expect(
+      page.getByTestId('bdd-scenario-card').filter({ hasText: 'To Be Deleted' }),
+    ).not.toBeVisible({ timeout: 8_000 });
     await expect(page.getByText('No BDD scenarios yet')).toBeVisible();
   });
 });

--- a/apps/e2e/tests/projects/interaction-views.spec.ts
+++ b/apps/e2e/tests/projects/interaction-views.spec.ts
@@ -158,14 +158,14 @@ const navigateToSprint = async (page: Page, projectId: string, sprintId: string)
 
 test.describe('Entering an interaction opens its default view', () => {
   let projectId: string;
-  let boardViewId: string;
+  let _boardViewId: string;
 
   test.beforeEach(async ({ request, context }) => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}VIEWS_${RUN_ID}`);
     // Project already has a default Table view; only add a Board view
     const boardView = await createBacklogView(request, projectId, 'Board', 'board');
-    boardViewId = boardView.id;
+    _boardViewId = boardView.id;
     await context.clearCookies();
     await context.clearPermissions();
   });
@@ -577,12 +577,12 @@ test.describe('Table view layout and task display', () => {
 test.describe('Creating a task from the board view', () => {
   test.setTimeout(60_000);
   let projectId: string;
-  let statuses: TaskStatus[];
+  let _statuses: TaskStatus[];
 
   test.beforeEach(async ({ request, context }) => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}CREATE_B_${RUN_ID}`);
-    statuses = await getTaskStatuses(request, projectId);
+    _statuses = await getTaskStatuses(request, projectId);
     await createBacklogView(request, projectId, 'Board', 'board');
     await context.clearCookies();
     await context.clearPermissions();
@@ -663,12 +663,12 @@ test.describe('Creating a task from the board view', () => {
 test.describe('Creating a task from the table view', () => {
   test.setTimeout(60_000);
   let projectId: string;
-  let statuses: TaskStatus[];
+  let _statuses: TaskStatus[];
 
   test.beforeEach(async ({ request, context }) => {
     await cleanupTestProjects(request);
     projectId = await createProject(request, `${TEST_PROJECT_PREFIX}CREATE_T_${RUN_ID}`);
-    statuses = await getTaskStatuses(request, projectId);
+    _statuses = await getTaskStatuses(request, projectId);
     // Project already has a default Table view; no additional view creation needed
     await context.clearCookies();
     await context.clearPermissions();
@@ -853,6 +853,7 @@ test.describe('Managing views (create, rename, delete)', () => {
       if (!renameItem) throw new Error('Rename view menuitem not found');
       const propsKey = Object.keys(renameItem).find((k) => k.startsWith('__reactProps'));
       if (!propsKey) throw new Error('No React props found on menuitem');
+      // biome-ignore lint/suspicious/noExplicitAny: React internal props require dynamic access
       const props = (renameItem as any)[propsKey];
       if (props.onSelect) props.onSelect(new Event('select'));
     });
@@ -896,6 +897,7 @@ test.describe('Managing views (create, rename, delete)', () => {
       if (!deleteItem) throw new Error('Delete view menuitem not found');
       const propsKey = Object.keys(deleteItem).find((k) => k.startsWith('__reactProps'));
       if (!propsKey) throw new Error('No React props found on menuitem');
+      // biome-ignore lint/suspicious/noExplicitAny: React internal props require dynamic access
       const props = (deleteItem as any)[propsKey];
       if (props.onSelect) props.onSelect(new Event('select'));
     });
@@ -1260,7 +1262,7 @@ test.describe('Manual task sort order within a view', () => {
     await page.getByRole('button', { name: 'Manual Table' }).click();
 
     // Task row should show a drag handle (GripVertical icon)
-    const taskRow = page.getByText(`${TEST_PROJECT_PREFIX}DRAG_ROW`).locator('xpath=ancestor::div[contains(@class,"group")]');
+    const _taskRow = page.getByText(`${TEST_PROJECT_PREFIX}DRAG_ROW`).locator('xpath=ancestor::div[contains(@class,"group")]');
     // The drag handle is a sibling element with the grip icon
     await expect(page.locator('[class*="cursor-grab"]').first()).toBeVisible();
   });

--- a/apps/e2e/tests/seed.spec.ts
+++ b/apps/e2e/tests/seed.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test.describe('Test group', () => {
-  test('seed', async ({ page }) => {
+  test('seed', async () => {
     // generate code here.
   });
 });

--- a/apps/web/src/components/projects/interactions/task-detail/bdd-scenarios-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/bdd-scenarios-section.tsx
@@ -1,0 +1,385 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, FlaskConical, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+	bddScenariosQueryOptions,
+	createBDDScenario,
+	deleteBDDScenario,
+	updateBDDScenario,
+	type BDDScenario,
+} from "@/lib/interaction-api";
+import { cn } from "@/lib/utils";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface BDDSectionProps {
+	projectId: string;
+	taskId: string;
+	canEdit?: boolean;
+}
+
+// ── Editor row for a single clause (Given / When / Then) ──────────────────────
+
+function ClauseRow({
+	label,
+	color,
+	value,
+	placeholder,
+	onChange,
+	onBlur,
+	disabled,
+}: {
+	label: string;
+	color: string;
+	value: string;
+	placeholder: string;
+	onChange: (v: string) => void;
+	onBlur?: () => void;
+	disabled?: boolean;
+}) {
+	return (
+		<div className="flex gap-2.5 items-start">
+			<span
+				className={cn(
+					"mt-0.75 shrink-0 rounded px-1.5 py-0.5 text-[9px] font-bold tracking-wider uppercase",
+					color,
+				)}
+			>
+				{label}
+			</span>
+			<textarea
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				onBlur={onBlur}
+				disabled={disabled}
+				rows={1}
+				placeholder={placeholder}
+				className="flex-1 min-h-7 resize-none bg-transparent text-[12.5px] leading-relaxed text-foreground/90 outline-none placeholder:text-muted-foreground/40 disabled:opacity-60 focus:placeholder:text-muted-foreground/60 transition-colors py-0.5"
+				style={{ fieldSizing: "content" } as React.CSSProperties}
+			/>
+		</div>
+	);
+}
+
+// ── Single scenario card ───────────────────────────────────────────────────────
+
+function ScenarioCard({
+	scenario,
+	projectId,
+	taskId,
+	canEdit,
+}: {
+	scenario: BDDScenario;
+	projectId: string;
+	taskId: string;
+	canEdit: boolean;
+}) {
+	const qc = useQueryClient();
+	const [expanded, setExpanded] = useState(false);
+	const [editTitle, setEditTitle] = useState(false);
+	const [titleDraft, setTitleDraft] = useState(scenario.title);
+
+	// Debounced clause drafts (updated locally then flushed on blur)
+	const [given, setGiven] = useState(scenario.given);
+	const [when, setWhen] = useState(scenario.when);
+	const [then, setThen] = useState(scenario.then);
+
+	const qKey = bddScenariosQueryOptions(projectId, taskId).queryKey;
+
+	const updateMut = useMutation({
+		mutationFn: (payload: Parameters<typeof updateBDDScenario>[3]) =>
+			updateBDDScenario(projectId, taskId, scenario.id, payload),
+		onSuccess: () => qc.invalidateQueries({ queryKey: qKey }),
+	});
+
+	const deleteMut = useMutation({
+		mutationFn: () => deleteBDDScenario(projectId, taskId, scenario.id),
+		onSuccess: () => qc.invalidateQueries({ queryKey: qKey }),
+	});
+
+	const flushClause = (field: "given" | "when" | "then", val: string) => {
+		const original = scenario[field];
+		if (val.trim() !== original.trim()) {
+			updateMut.mutate({ [field]: val });
+		}
+	};
+
+	return (
+		<div data-testid="bdd-scenario-card" className="rounded-xl border border-border/25 bg-card/50 overflow-hidden">
+			{/* Header row — clicking anywhere toggles expand/collapse */}
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: chevron + title area provide keyboard access */}
+			<div
+				className="flex items-center gap-2 px-4 py-3 group/scenario cursor-pointer select-none"
+				onClick={() => setExpanded((x) => !x)}
+				aria-expanded={expanded}
+			>
+			{expanded ? (
+				<ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
+			) : (
+				<ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+			)}
+
+			{editTitle && canEdit ? (
+				<input
+					autoFocus
+					value={titleDraft}
+					onChange={(e) => setTitleDraft(e.target.value)}
+					onBlur={() => {
+						setEditTitle(false);
+						const trimmed = titleDraft.trim();
+						if (trimmed && trimmed !== scenario.title) {
+							updateMut.mutate({ title: trimmed });
+						} else {
+							setTitleDraft(scenario.title);
+						}
+					}}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" || e.key === "Escape") {
+							e.currentTarget.blur();
+						}
+					}}
+					onClick={(e) => e.stopPropagation()}
+					className="flex-1 bg-transparent text-[13px] font-semibold text-foreground outline-none"
+				/>
+			) : (
+				<span
+					className={cn(
+						"flex-1 text-[13px] font-semibold text-foreground truncate",
+						canEdit && "hover:cursor-text",
+					)}
+					onClick={(e) => {
+						if (!canEdit) return;
+						e.stopPropagation();
+						setExpanded(true);
+						setEditTitle(true);
+					}}
+				>
+					{scenario.title || <span className="italic text-muted-foreground/60">Untitled scenario</span>}
+				</span>
+			)}
+
+			{canEdit && (
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						deleteMut.mutate();
+					}}
+					disabled={deleteMut.isPending}
+					className="opacity-0 group-hover/scenario:opacity-100 ml-1 shrink-0 rounded-md p-1 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-all duration-150"
+					aria-label="Delete scenario"
+				>
+					<Trash2 className="size-3.5" />
+				</button>
+			)}
+			</div>
+
+			{/* Expanded body: Given / When / Then */}
+			{expanded && (
+				<div className="px-4 pb-4 pt-0 space-y-2 border-t border-border/15">
+					<div className="pt-3 space-y-2">
+						<ClauseRow
+							label="Given"
+							color="bg-sky-500/15 text-sky-600 dark:text-sky-400"
+							value={given}
+							placeholder="the initial context or precondition…"
+							onChange={setGiven}
+							onBlur={() => flushClause("given", given)}
+							disabled={!canEdit}
+						/>
+						<ClauseRow
+							label="When"
+							color="bg-violet-500/15 text-violet-600 dark:text-violet-400"
+							value={when}
+							placeholder="the action or event that occurs…"
+							onChange={setWhen}
+							onBlur={() => flushClause("when", when)}
+							disabled={!canEdit}
+						/>
+						<ClauseRow
+							label="Then"
+							color="bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+							value={then}
+							placeholder="the expected outcome or result…"
+							onChange={setThen}
+							onBlur={() => flushClause("then", then)}
+							disabled={!canEdit}
+						/>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ── New scenario quick-add form ────────────────────────────────────────────────
+
+function NewScenarioForm({
+	projectId,
+	taskId,
+	onDone,
+}: {
+	projectId: string;
+	taskId: string;
+	onDone: () => void;
+}) {
+	const qc = useQueryClient();
+	const [title, setTitle] = useState("");
+	const [given, setGiven] = useState("");
+	const [when, setWhen] = useState("");
+	const [then, setThen] = useState("");
+
+	const qKey = bddScenariosQueryOptions(projectId, taskId).queryKey;
+
+	const createMut = useMutation({
+		mutationFn: () =>
+			createBDDScenario(projectId, taskId, {
+				title: title.trim(),
+				given: given.trim(),
+				when: when.trim(),
+				then: then.trim(),
+			}),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: qKey });
+			onDone();
+		},
+	});
+
+	const canSave = title.trim().length > 0 && !createMut.isPending;
+
+	return (
+		<div className="rounded-xl border border-primary/25 bg-card/60 ring-1 ring-primary/20 p-4 space-y-3">
+			<input
+				autoFocus
+				value={title}
+				onChange={(e) => setTitle(e.target.value)}
+				placeholder="Scenario title…"
+				className="w-full bg-transparent text-[13px] font-semibold text-foreground outline-none placeholder:text-muted-foreground/50 focus:placeholder:text-muted-foreground/70 transition-colors"
+				onKeyDown={(e) => {
+					if (e.key === "Enter" && canSave) createMut.mutate();
+					if (e.key === "Escape") onDone();
+				}}
+			/>
+
+			<div className="space-y-2 pt-1">
+				<ClauseRow
+					label="Given"
+					color="bg-sky-500/15 text-sky-600 dark:text-sky-400"
+					value={given}
+					placeholder="the initial context or precondition…"
+					onChange={setGiven}
+				/>
+				<ClauseRow
+					label="When"
+					color="bg-violet-500/15 text-violet-600 dark:text-violet-400"
+					value={when}
+					placeholder="the action or event that occurs…"
+					onChange={setWhen}
+				/>
+				<ClauseRow
+					label="Then"
+					color="bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+					value={then}
+					placeholder="the expected outcome or result…"
+					onChange={setThen}
+				/>
+			</div>
+
+			<div className="flex items-center justify-end gap-2 pt-1">
+				<button
+					type="button"
+					onClick={onDone}
+					className="text-[11px] font-semibold text-muted-foreground/70 hover:text-foreground px-2.5 py-1.5 rounded-lg hover:bg-muted/40 transition-all duration-150"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onClick={() => createMut.mutate()}
+					disabled={!canSave}
+					className="text-[11px] font-semibold px-2.5 py-1.5 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-40 transition-all duration-150"
+				>
+					{createMut.isPending ? "Creating…" : "Create scenario"}
+				</button>
+			</div>
+		</div>
+	);
+}
+
+// ── Section header ─────────────────────────────────────────────────────────────
+
+export function BDDScenariosSection({
+	projectId,
+	taskId,
+	canEdit = true,
+}: BDDSectionProps) {
+	const [adding, setAdding] = useState(false);
+
+	const { data: scenarios = [], isLoading } = useQuery(
+		bddScenariosQueryOptions(projectId, taskId),
+	);
+
+	return (
+		<div className="space-y-3">
+			{/* Section heading */}
+			<div className="flex items-center justify-between">
+				<h3 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70 flex items-center gap-2">
+					<span>BDD Scenarios</span>
+					{scenarios.length > 0 && (
+						<span className="font-bold tabular-nums rounded-full bg-muted/50 px-1.5 py-0.5 text-[10px]">
+							{scenarios.length}
+						</span>
+					)}
+					<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
+				</h3>
+
+				{canEdit && !adding && (
+					<button
+						type="button"
+						onClick={() => setAdding(true)}
+						className="flex items-center gap-1.5 rounded-lg bg-muted/40 text-muted-foreground/80 hover:bg-muted/60 hover:text-foreground px-2.5 py-1.5 text-[11px] font-semibold transition-all duration-150"
+					>
+						<Plus className="size-3" />
+						Add scenario
+					</button>
+				)}
+			</div>
+
+			{/* List */}
+			{isLoading ? (
+				<div className="flex items-center gap-3 px-1 py-3 text-muted-foreground/45">
+					<FlaskConical className="size-4 opacity-50" />
+					<p className="text-[13px] italic">Loading…</p>
+				</div>
+			) : scenarios.length > 0 ? (
+				<div className="space-y-2">
+					{scenarios.map((s) => (
+						<ScenarioCard
+							key={s.id}
+							scenario={s}
+							projectId={projectId}
+							taskId={taskId}
+							canEdit={canEdit}
+						/>
+					))}
+				</div>
+			) : (
+				!adding && (
+					<div className="flex items-center gap-3 px-1 py-3 text-muted-foreground/45">
+						<FlaskConical className="size-4 opacity-70" />
+						<p className="text-[13px] italic">No BDD scenarios yet</p>
+					</div>
+				)
+			)}
+
+			{/* Inline creation form */}
+			{adding && (
+				<NewScenarioForm
+					projectId={projectId}
+					taskId={taskId}
+					onDone={() => setAdding(false)}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/interactions/task-detail/bdd-scenarios-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/bdd-scenarios-section.tsx
@@ -1,12 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ChevronDown, ChevronRight, FlaskConical, Plus, Trash2 } from "lucide-react";
+import {
+	ChevronDown,
+	ChevronRight,
+	FlaskConical,
+	Plus,
+	Trash2,
+} from "lucide-react";
 import { useState } from "react";
 import {
+	type BDDScenario,
 	bddScenariosQueryOptions,
 	createBDDScenario,
 	deleteBDDScenario,
 	updateBDDScenario,
-	type BDDScenario,
 } from "@/lib/interaction-api";
 import { cn } from "@/lib/utils";
 
@@ -105,73 +111,84 @@ function ScenarioCard({
 	};
 
 	return (
-		<div data-testid="bdd-scenario-card" className="rounded-xl border border-border/25 bg-card/50 overflow-hidden">
-			{/* Header row — clicking anywhere toggles expand/collapse */}
-			{/* biome-ignore lint/a11y/useKeyWithClickEvents: chevron + title area provide keyboard access */}
-			<div
-				className="flex items-center gap-2 px-4 py-3 group/scenario cursor-pointer select-none"
-				onClick={() => setExpanded((x) => !x)}
-				aria-expanded={expanded}
-			>
-			{expanded ? (
-				<ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
-			) : (
-				<ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
-			)}
-
-			{editTitle && canEdit ? (
-				<input
-					autoFocus
-					value={titleDraft}
-					onChange={(e) => setTitleDraft(e.target.value)}
-					onBlur={() => {
-						setEditTitle(false);
-						const trimmed = titleDraft.trim();
-						if (trimmed && trimmed !== scenario.title) {
-							updateMut.mutate({ title: trimmed });
-						} else {
-							setTitleDraft(scenario.title);
-						}
-					}}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === "Escape") {
-							e.currentTarget.blur();
-						}
-					}}
-					onClick={(e) => e.stopPropagation()}
-					className="flex-1 bg-transparent text-[13px] font-semibold text-foreground outline-none"
-				/>
-			) : (
-				<span
-					className={cn(
-						"flex-1 text-[13px] font-semibold text-foreground truncate",
-						canEdit && "hover:cursor-text",
-					)}
-					onClick={(e) => {
-						if (!canEdit) return;
-						e.stopPropagation();
-						setExpanded(true);
-						setEditTitle(true);
-					}}
-				>
-					{scenario.title || <span className="italic text-muted-foreground/60">Untitled scenario</span>}
-				</span>
-			)}
-
-			{canEdit && (
+		<div
+			data-testid="bdd-scenario-card"
+			className="rounded-xl border border-border/25 bg-card/50 overflow-hidden"
+		>
+			{/* Header row */}
+			<div className="flex items-center gap-2 px-4 py-3 group/scenario">
+				{/* Expand/collapse button */}
 				<button
 					type="button"
-					onClick={(e) => {
-						e.stopPropagation();
-						deleteMut.mutate();
-					}}
-					disabled={deleteMut.isPending}
-					className="opacity-0 group-hover/scenario:opacity-100 ml-1 shrink-0 rounded-md p-1 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-all duration-150"
-					aria-label="Delete scenario"
+					className="shrink-0 p-0 text-muted-foreground/70 cursor-pointer"
+					onClick={() => setExpanded((x) => !x)}
+					aria-expanded={expanded}
+					aria-label={expanded ? "Collapse scenario" : "Expand scenario"}
 				>
-					<Trash2 className="size-3.5" />
+					{expanded ? (
+						<ChevronDown className="size-3.5" />
+					) : (
+						<ChevronRight className="size-3.5" />
+					)}
 				</button>
-			)}
+
+				{/* Title area */}
+				{editTitle && canEdit ? (
+					<input
+						ref={(el) => {
+							el?.focus();
+						}}
+						value={titleDraft}
+						onChange={(e) => setTitleDraft(e.target.value)}
+						onBlur={() => {
+							setEditTitle(false);
+							const trimmed = titleDraft.trim();
+							if (trimmed && trimmed !== scenario.title) {
+								updateMut.mutate({ title: trimmed });
+							} else {
+								setTitleDraft(scenario.title);
+							}
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === "Escape") {
+								e.currentTarget.blur();
+							}
+						}}
+						className="flex-1 bg-transparent text-[13px] font-semibold text-foreground outline-none"
+					/>
+				) : (
+					<button
+						type="button"
+						disabled={!canEdit}
+						className={cn(
+							"flex-1 text-left text-[13px] font-semibold text-foreground truncate",
+							canEdit && "hover:cursor-text",
+						)}
+						onClick={() => {
+							if (!canEdit) return;
+							setExpanded(true);
+							setEditTitle(true);
+						}}
+					>
+						{scenario.title || (
+							<span className="italic text-muted-foreground/60">
+								Untitled scenario
+							</span>
+						)}
+					</button>
+				)}
+
+				{canEdit && (
+					<button
+						type="button"
+						onClick={() => deleteMut.mutate()}
+						disabled={deleteMut.isPending}
+						className="opacity-0 group-hover/scenario:opacity-100 ml-1 shrink-0 rounded-md p-1 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-all duration-150"
+						aria-label="Delete scenario"
+					>
+						<Trash2 className="size-3.5" />
+					</button>
+				)}
 			</div>
 
 			{/* Expanded body: Given / When / Then */}
@@ -237,6 +254,7 @@ function NewScenarioForm({
 				title: title.trim(),
 				given: given.trim(),
 				when: when.trim(),
+				// biome-ignore lint/suspicious/noThenProperty: "then" is a BDD domain field
 				then: then.trim(),
 			}),
 		onSuccess: () => {
@@ -250,7 +268,9 @@ function NewScenarioForm({
 	return (
 		<div className="rounded-xl border border-primary/25 bg-card/60 ring-1 ring-primary/20 p-4 space-y-3">
 			<input
-				autoFocus
+				ref={(el) => {
+					el?.focus();
+				}}
 				value={title}
 				onChange={(e) => setTitle(e.target.value)}
 				placeholder="Scenario title…"

--- a/apps/web/src/components/projects/interactions/task-detail/bdd-scenarios-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/bdd-scenarios-section.tsx
@@ -6,7 +6,7 @@ import {
 	Plus,
 	Trash2,
 } from "lucide-react";
-import { useState } from "react";
+import { type CSSProperties, useState } from "react";
 import {
 	type BDDScenario,
 	bddScenariosQueryOptions,
@@ -54,6 +54,7 @@ function ClauseRow({
 				{label}
 			</span>
 			<textarea
+				aria-label={label}
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 				onBlur={onBlur}
@@ -61,7 +62,7 @@ function ClauseRow({
 				rows={1}
 				placeholder={placeholder}
 				className="flex-1 min-h-7 resize-none bg-transparent text-[12.5px] leading-relaxed text-foreground/90 outline-none placeholder:text-muted-foreground/40 disabled:opacity-60 focus:placeholder:text-muted-foreground/60 transition-colors py-0.5"
-				style={{ fieldSizing: "content" } as React.CSSProperties}
+				style={{ fieldSizing: "content" } as CSSProperties}
 			/>
 		</div>
 	);
@@ -138,6 +139,7 @@ function ScenarioCard({
 						ref={(el) => {
 							el?.focus();
 						}}
+						aria-label="Scenario title"
 						value={titleDraft}
 						onChange={(e) => setTitleDraft(e.target.value)}
 						onBlur={() => {
@@ -271,6 +273,7 @@ function NewScenarioForm({
 				ref={(el) => {
 					el?.focus();
 				}}
+				aria-label="Scenario title"
 				value={title}
 				onChange={(e) => setTitle(e.target.value)}
 				placeholder="Scenario title…"

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -344,14 +344,14 @@ export function TaskDetailModal({
 							canEdit={canEdit}
 							onUpdate={handleUpdate}
 						/>
-							{/* BDD Scenarios */}
-							{projectId && (
-								<BDDScenariosSection
-									projectId={projectId}
-									taskId={task.id}
-									canEdit={canEdit}
-								/>
-							)}
+						{/* BDD Scenarios */}
+						{projectId && (
+							<BDDScenariosSection
+								projectId={projectId}
+								taskId={task.id}
+								canEdit={canEdit}
+							/>
+						)}
 						{/* Subtasks / Tasks section – hidden for subtasks */}
 						{taskRole !== "subtask" && (
 							<SubtasksSection

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -24,6 +24,7 @@ import { getTaskTypeIconComponent } from "../../task-types/task-type-icons";
 import { getPriority } from "../priority";
 import { ActivityPane } from "./activity-pane";
 import { AttachmentsSection } from "./attachments-section";
+import { BDDScenariosSection } from "./bdd-scenarios-section";
 import { ChecklistsSection } from "./checklists-section";
 import { DescriptionSection } from "./description-section";
 import { mapApiFieldToUi } from "./helpers";
@@ -343,7 +344,14 @@ export function TaskDetailModal({
 							canEdit={canEdit}
 							onUpdate={handleUpdate}
 						/>
-
+							{/* BDD Scenarios */}
+							{projectId && (
+								<BDDScenariosSection
+									projectId={projectId}
+									taskId={task.id}
+									canEdit={canEdit}
+								/>
+							)}
 						{/* Subtasks / Tasks section – hidden for subtasks */}
 						{taskRole !== "subtask" && (
 							<SubtasksSection

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -677,9 +677,7 @@ export async function updateBDDScenario(
 	scenarioId: string,
 	payload: UpdateBDDScenarioPayload,
 ): Promise<BDDScenario> {
-	const { data } = await apiClient.instance.patch<
-		SuccessEnvelope<BDDScenario>
-	>(
+	const { data } = await apiClient.instance.patch<SuccessEnvelope<BDDScenario>>(
 		`/projects/${projectId}/tasks/${taskId}/bdd-scenarios/${scenarioId}`,
 		payload,
 	);
@@ -703,4 +701,3 @@ export const bddScenariosQueryOptions = (projectId: string, taskId: string) =>
 		staleTime: 15_000,
 		enabled: !!projectId && !!taskId,
 	});
-

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -607,4 +607,100 @@ export const epicChildTasksQueryOptions = (projectId: string, epicId: string) =>
 		staleTime: 15_000,
 	});
 
-// end of interaction-api
+// ── BDD Scenarios API ─────────────────────────────────────────────────────────
+
+export interface BDDScenario {
+	id: string;
+	task_id: string;
+	title: string;
+	given: string;
+	when: string;
+	then: string;
+	created_at: string;
+	updated_at: string;
+}
+
+interface BDDScenarioListResult {
+	items: BDDScenario[];
+}
+
+export async function listBDDScenarios(
+	projectId: string,
+	taskId: string,
+): Promise<BDDScenario[]> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<BDDScenarioListResult>
+	>(`/projects/${projectId}/tasks/${taskId}/bdd-scenarios`);
+	return data.data.items;
+}
+
+export async function getBDDScenario(
+	projectId: string,
+	taskId: string,
+	scenarioId: string,
+): Promise<BDDScenario> {
+	const { data } = await apiClient.instance.get<SuccessEnvelope<BDDScenario>>(
+		`/projects/${projectId}/tasks/${taskId}/bdd-scenarios/${scenarioId}`,
+	);
+	return data.data;
+}
+
+export interface CreateBDDScenarioPayload {
+	title: string;
+	given?: string;
+	when?: string;
+	then?: string;
+}
+
+export async function createBDDScenario(
+	projectId: string,
+	taskId: string,
+	payload: CreateBDDScenarioPayload,
+): Promise<BDDScenario> {
+	const { data } = await apiClient.instance.post<SuccessEnvelope<BDDScenario>>(
+		`/projects/${projectId}/tasks/${taskId}/bdd-scenarios`,
+		payload,
+	);
+	return data.data;
+}
+
+export interface UpdateBDDScenarioPayload {
+	title?: string;
+	given?: string;
+	when?: string;
+	then?: string;
+}
+
+export async function updateBDDScenario(
+	projectId: string,
+	taskId: string,
+	scenarioId: string,
+	payload: UpdateBDDScenarioPayload,
+): Promise<BDDScenario> {
+	const { data } = await apiClient.instance.patch<
+		SuccessEnvelope<BDDScenario>
+	>(
+		`/projects/${projectId}/tasks/${taskId}/bdd-scenarios/${scenarioId}`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function deleteBDDScenario(
+	projectId: string,
+	taskId: string,
+	scenarioId: string,
+): Promise<void> {
+	await apiClient.instance.delete(
+		`/projects/${projectId}/tasks/${taskId}/bdd-scenarios/${scenarioId}`,
+	);
+}
+
+export const bddScenariosQueryOptions = (projectId: string, taskId: string) =>
+	queryOptions({
+		queryKey: ["projects", projectId, "tasks", taskId, "bdd-scenarios"],
+		queryFn: () => listBDDScenarios(projectId, taskId),
+		staleTime: 15_000,
+		enabled: !!projectId && !!taskId,
+	});
+

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -8,7 +8,7 @@ Interactive diagram: [https://dbdiagram.io/d/Paca-69c212ae78c6c4bc7a4fc190](http
 
 | File | Purpose |
 |---|---|
-| `000001_init.sql` | Full consolidated schema: `global_roles`, `users`, projects, project roles/members, task configuration (`task_types`, `task_statuses`), `sprints`, `sprint_views` (with `view_type`, `config`, `position`), `view_task_positions` (manual task order), `custom_field_definitions`, `tasks` (with `start_date`, `due_date`, `tags`), `task_attachments`, `task_checklists`, `task_checklist_items`, seed data. On project creation the seed inserts three user-manageable task types (Bug, Story, Task — where Task is `is_default = true`) and two system task types (Epic, Subtask — where `is_system = true`). The API now seeds one backlog Table view with `config.column_by = "sprint"` and non-system task types, plus one timeline Roadmap view filtered to Epics; sprint creation seeds Board and Table views scoped to that sprint. |
+| `000001_init.sql` | Full consolidated schema: `global_roles`, `users`, projects, project roles/members, task configuration (`task_types`, `task_statuses`), `sprints`, `sprint_views` (with `view_type`, `config`, `position`), `view_task_positions` (manual task order), `custom_field_definitions`, `tasks` (with `start_date`, `due_date`, `tags`), `task_attachments`, `task_checklists`, `task_checklist_items`, `bdd_scenarios` (id, task_id, title, given_text, when_text, then_text, timestamps — no position field), seed data. On project creation the seed inserts three user-manageable task types (Bug, Story, Task — where Task is `is_default = true`) and two system task types (Epic, Subtask — where `is_system = true`). The API now seeds one backlog Table view with `config.column_by = "sprint"` and non-system task types, plus one timeline Roadmap view filtered to Epics; sprint creation seeds Board and Table views scoped to that sprint. |
 | `000002_add_view_context.sql` | Adds `view_context TEXT NOT NULL` to `sprint_views` with a `CHECK` constraint (`'sprint'\|'backlog'\|'timeline'`). Replaces the previous `is_timeline` boolean approach. Back-fills existing sprint rows to `'sprint'` and project-level (backlog) rows to `'backlog'`. Adds a partial index `idx_sprint_views_context` on `(project_id, view_context) WHERE sprint_id IS NULL` to speed up project-level view lookups. |
 
 ## Schema (DBML)
@@ -292,10 +292,4 @@ Ref: project_members.id < task_attachments.uploaded_by
 Ref: sprints.id < sprint_views.sprint_id
 Ref: sprint_views.id < view_task_positions.view_id
 Ref: tasks.id < view_task_positions.task_id
-Ref: tasks.id < task_checklists.task_id
-Ref: project_members.id < task_checklists.created_by
-Ref: task_checklists.id < task_checklist_items.checklist_id
-Ref: project_members.id < task_checklist_items.checked_by
-Ref: project_members.id < task_checklist_items.assignee_id
-Ref: project_members.id < task_checklist_items.created_by
 ```

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -117,6 +117,11 @@ const (
 	CodeCustomFieldTypeInvalid Code = "CUSTOM_FIELD_TYPE_INVALID"
 	// CodeCustomFieldNameInvalid indicates an empty or invalid display name.
 	CodeCustomFieldNameInvalid Code = "CUSTOM_FIELD_NAME_INVALID"
+
+	// CodeBDDScenarioNotFound indicates the requested BDD scenario does not exist.
+	CodeBDDScenarioNotFound Code = "BDD_SCENARIO_NOT_FOUND"
+	// CodeBDDScenarioTitleInvalid indicates an empty or invalid BDD scenario title.
+	CodeBDDScenarioTitleInvalid Code = "BDD_SCENARIO_TITLE_INVALID"
 )
 
 // Error carries a machine-readable Code alongside a human-readable Message.

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -32,6 +32,7 @@ import (
 	usersvc "github.com/paca/api/internal/service/user"
 	"github.com/paca/api/internal/transport/http/handler"
 	"github.com/paca/api/internal/transport/http/router"
+	"github.com/paca/api/migrations"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
@@ -77,15 +78,16 @@ func New(cfg *config.Config) (*App, error) {
 	viewRepo := pgRepo.NewViewRepository(db)
 	refreshStore := redisRepo.NewRefreshTokenStore(redisClient)
 
-	if err := db.AutoMigrate(
-		&userModel{},
-		&projectModel{},
-		&projectRoleModel{},
-		&projectMemberModel{},
-		&globalRoleModel{},
-		&userGlobalRoleModel{},
-	); err != nil {
-		return nil, fmt.Errorf("bootstrap: migrate role tables: %w", err)
+	// --- Schema migration (non-production only) -----------------------------
+	// In development the embedded SQL migrations are run on every startup so
+	// that a fresh database is always in the correct state without requiring
+	// a manual migration step.  All statements use CREATE TABLE IF NOT EXISTS
+	// / INSERT … ON CONFLICT so they are idempotent and safe to re-run.
+	if cfg.Env != "production" {
+		if err := database.RunMigrationsFS(db, migrations.FS); err != nil {
+			return nil, fmt.Errorf("bootstrap: auto-migrate: %w", err)
+		}
+		log.Info("schema migrations applied")
 	}
 
 	// --- Admin seeding -------------------------------------------------------
@@ -144,54 +146,8 @@ func New(cfg *config.Config) (*App, error) {
 	return &App{server: srv, publisher: publisher, log: log}, nil
 }
 
-// userModel is used only for startup AutoMigrate to ensure the users table
-// has the role_id and must_change_password columns in development without
-// running SQL migrations.
-type userModel struct {
-	ID                 string `gorm:"primarykey;type:uuid"`
-	Username           string `gorm:"uniqueIndex;not null"`
-	PasswordHash       string `gorm:"not null"`
-	FullName           string `gorm:"column:full_name"`
-	RoleID             string `gorm:"column:role_id;type:uuid;not null"`
-	MustChangePassword bool   `gorm:"column:must_change_password;not null;default:false"`
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
-	DeletedAt          gorm.DeletedAt `gorm:"index"`
-}
-
-func (userModel) TableName() string { return "users" }
-
-// globalRoleModel is used only for startup AutoMigrate to ensure the planned
-// admin tables exist in development environments.
-type globalRoleModel struct {
-	ID          string `gorm:"primarykey;type:uuid"`
-	Name        string `gorm:"uniqueIndex;not null"`
-	Permissions []byte `gorm:"type:jsonb;not null"`
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-}
-
-func (globalRoleModel) TableName() string { return "global_roles" }
-
-// userGlobalRoleModel keeps the user-role relationship table aligned.
-type userGlobalRoleModel struct {
-	UserID string `gorm:"primaryKey;type:uuid;column:user_id"`
-	RoleID string `gorm:"primaryKey;type:uuid;column:role_id"`
-}
-
-func (userGlobalRoleModel) TableName() string { return "user_global_roles" }
-
-type projectModel struct {
-	ID          string `gorm:"primarykey;type:uuid"`
-	Name        string `gorm:"not null"`
-	Description string
-	Settings    []byte `gorm:"type:jsonb;not null"`
-	CreatedBy   *string
-	CreatedAt   time.Time
-}
-
-func (projectModel) TableName() string { return "projects" }
-
+// projectRoleModel is the GORM model used by seedDefaultProjectRoleTemplates
+// to upsert canonical project-role permission sets on startup.
 type projectRoleModel struct {
 	ID          string  `gorm:"primarykey;type:uuid"`
 	ProjectID   *string `gorm:"type:uuid;column:project_id;index"`
@@ -202,15 +158,6 @@ type projectRoleModel struct {
 }
 
 func (projectRoleModel) TableName() string { return "project_roles" }
-
-type projectMemberModel struct {
-	ID            string `gorm:"primarykey;type:uuid"`
-	ProjectID     string `gorm:"type:uuid;column:project_id;index"`
-	UserID        string `gorm:"type:uuid;column:user_id;index"`
-	ProjectRoleID string `gorm:"type:uuid;column:project_role_id;index"`
-}
-
-func (projectMemberModel) TableName() string { return "project_members" }
 
 // Run starts the HTTP server.  It returns when the server stops.
 func (a *App) Run() error {

--- a/services/api/internal/domain/task/entity.go
+++ b/services/api/internal/domain/task/entity.go
@@ -95,6 +95,18 @@ type CustomFieldDefinition struct {
 	UpdatedAt   time.Time
 }
 
+// BDDScenario captures the Given / When / Then acceptance criteria for a Task.
+type BDDScenario struct {
+	ID        uuid.UUID
+	TaskID    uuid.UUID
+	Title     string
+	Given     string
+	When      string
+	Then      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 // Task is the core work item aggregate.
 type Task struct {
 	ID           uuid.UUID

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -21,4 +21,7 @@ var (
 	ErrCustomFieldKeyTaken    = errors.New("custom field: key already in use within project")
 	ErrCustomFieldTypeInvalid = errors.New("custom field: invalid field type")
 	ErrCustomFieldNameInvalid = errors.New("custom field: display name is empty or invalid")
+
+	ErrBDDScenarioNotFound     = errors.New("bdd scenario: not found")
+	ErrBDDScenarioTitleInvalid = errors.New("bdd scenario: title is empty or invalid")
 )

--- a/services/api/internal/domain/task/repository.go
+++ b/services/api/internal/domain/task/repository.go
@@ -12,6 +12,7 @@ type Repository interface {
 	TaskStatusRepository
 	TaskRepository
 	CustomFieldDefinitionRepository
+	BDDScenarioRepository
 }
 
 // TaskTypeRepository defines persistence operations for task types.
@@ -70,4 +71,13 @@ type CustomFieldDefinitionRepository interface {
 	CreateCustomFieldDefinition(ctx context.Context, f *CustomFieldDefinition) error
 	UpdateCustomFieldDefinition(ctx context.Context, f *CustomFieldDefinition) error
 	DeleteCustomFieldDefinition(ctx context.Context, id uuid.UUID) error
+}
+
+// BDDScenarioRepository defines persistence operations for BDD scenarios.
+type BDDScenarioRepository interface {
+	ListBDDScenarios(ctx context.Context, taskID uuid.UUID) ([]*BDDScenario, error)
+	FindBDDScenarioByID(ctx context.Context, id uuid.UUID) (*BDDScenario, error)
+	CreateBDDScenario(ctx context.Context, s *BDDScenario) error
+	UpdateBDDScenario(ctx context.Context, s *BDDScenario) error
+	DeleteBDDScenario(ctx context.Context, id uuid.UUID) error
 }

--- a/services/api/internal/domain/task/service.go
+++ b/services/api/internal/domain/task/service.go
@@ -13,6 +13,7 @@ type Service interface {
 	TaskStatusService
 	TaskService
 	CustomFieldDefinitionService
+	BDDScenarioService
 }
 
 // --- Task Type Service -----------------------------------------------------
@@ -159,4 +160,33 @@ type UpdateCustomFieldDefinitionInput struct {
 	FieldType   *FieldType
 	Options     []string
 	IsRequired  *bool
+}
+
+// --- BDD Scenario Service --------------------------------------------------
+
+// BDDScenarioService defines BDD scenario use cases.
+type BDDScenarioService interface {
+	ListBDDScenarios(ctx context.Context, taskID uuid.UUID) ([]*BDDScenario, error)
+	GetBDDScenario(ctx context.Context, id uuid.UUID) (*BDDScenario, error)
+	CreateBDDScenario(ctx context.Context, in CreateBDDScenarioInput) (*BDDScenario, error)
+	UpdateBDDScenario(ctx context.Context, id uuid.UUID, in UpdateBDDScenarioInput) (*BDDScenario, error)
+	DeleteBDDScenario(ctx context.Context, id uuid.UUID) error
+}
+
+// CreateBDDScenarioInput carries fields required to create a BDD scenario.
+type CreateBDDScenarioInput struct {
+	TaskID uuid.UUID
+	Title  string
+	Given  string
+	When   string
+	Then   string
+}
+
+// UpdateBDDScenarioInput carries mutable BDD scenario fields.
+// A nil pointer means the field was absent and should not be overwritten.
+type UpdateBDDScenarioInput struct {
+	Title *string
+	Given *string
+	When  *string
+	Then  *string
 }

--- a/services/api/internal/platform/database/migrations.go
+++ b/services/api/internal/platform/database/migrations.go
@@ -3,6 +3,7 @@ package database
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -31,6 +32,33 @@ func RunMigrations(db *gorm.DB, migrationsDir string) error {
 
 		if err := db.Exec(string(data)).Error; err != nil {
 			return fmt.Errorf("migrations: exec %q: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+// RunMigrationsFS executes all *.sql files found in the root of fsys (in
+// lexicographic order) against db.  Use this with an embedded FS for
+// zero-configuration startup migration in non-production environments.
+func RunMigrationsFS(db *gorm.DB, fsys fs.FS) error {
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return fmt.Errorf("migrations: read dir: %w", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".sql" {
+			continue
+		}
+
+		data, err := fs.ReadFile(fsys, e.Name())
+		if err != nil {
+			return fmt.Errorf("migrations: read %q: %w", e.Name(), err)
+		}
+
+		if err := db.Exec(string(data)).Error; err != nil {
+			return fmt.Errorf("migrations: exec %q: %w", e.Name(), err)
 		}
 	}
 

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -240,7 +240,6 @@ func (r *TaskRepository) UpdateTaskStatus(ctx context.Context, s *taskdom.TaskSt
 	updates := map[string]any{
 		"name":       s.Name,
 		"color":      s.Color,
-		"position":   s.Position,
 		"category":   string(s.Category),
 		"updated_at": s.UpdatedAt,
 	}
@@ -732,4 +731,119 @@ func strPtrToUUIDPtr(s *string) *uuid.UUID {
 		return nil
 	}
 	return &u
+}
+
+// --- BDD Scenarios ----------------------------------------------------------
+
+type bddScenarioRecord struct {
+	ID        string    `gorm:"primarykey;type:uuid"`
+	TaskID    string    `gorm:"type:uuid;not null;column:task_id"`
+	Title     string    `gorm:"not null;default:''"`
+	GivenText string    `gorm:"not null;default:'';column:given_text"`
+	WhenText  string    `gorm:"not null;default:'';column:when_text"`
+	ThenText  string    `gorm:"not null;default:'';column:then_text"`
+	CreatedAt time.Time `gorm:"not null"`
+	UpdatedAt time.Time `gorm:"not null"`
+}
+
+func (bddScenarioRecord) TableName() string { return "bdd_scenarios" }
+
+func toBDDScenarioEntity(r *bddScenarioRecord) *taskdom.BDDScenario {
+	id, _ := uuid.Parse(r.ID)
+	taskID, _ := uuid.Parse(r.TaskID)
+	return &taskdom.BDDScenario{
+		ID:     id,
+		TaskID: taskID,
+		Title:  r.Title,
+		Given:  r.GivenText,
+		When:   r.WhenText,
+		Then:   r.ThenText,
+
+		CreatedAt: r.CreatedAt,
+		UpdatedAt: r.UpdatedAt,
+	}
+}
+
+// ListBDDScenarios returns all BDD scenarios for a task ordered by position.
+func (r *TaskRepository) ListBDDScenarios(ctx context.Context, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	var records []bddScenarioRecord
+	if err := r.db.WithContext(ctx).
+		Where("task_id = ?", taskID.String()).
+		Order("created_at ASC").
+		Find(&records).Error; err != nil {
+		return nil, fmt.Errorf("bdd scenario repo: list: %w", err)
+	}
+	out := make([]*taskdom.BDDScenario, 0, len(records))
+	for i := range records {
+		out = append(out, toBDDScenarioEntity(&records[i]))
+	}
+	return out, nil
+}
+
+// FindBDDScenarioByID returns the BDD scenario with the given ID.
+func (r *TaskRepository) FindBDDScenarioByID(ctx context.Context, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	var rec bddScenarioRecord
+	err := r.db.WithContext(ctx).Where("id = ?", id.String()).First(&rec).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, taskdom.ErrBDDScenarioNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("bdd scenario repo: find by id: %w", err)
+	}
+	return toBDDScenarioEntity(&rec), nil
+}
+
+// CreateBDDScenario persists a new BDD scenario.
+func (r *TaskRepository) CreateBDDScenario(ctx context.Context, s *taskdom.BDDScenario) error {
+	rec := &bddScenarioRecord{
+		ID:        s.ID.String(),
+		TaskID:    s.TaskID.String(),
+		Title:     s.Title,
+		GivenText: s.Given,
+		WhenText:  s.When,
+		ThenText:  s.Then,
+
+		CreatedAt: s.CreatedAt,
+		UpdatedAt: s.UpdatedAt,
+	}
+	if err := r.db.WithContext(ctx).Create(rec).Error; err != nil {
+		return fmt.Errorf("bdd scenario repo: create: %w", err)
+	}
+	return nil
+}
+
+// UpdateBDDScenario persists changes to an existing BDD scenario.
+func (r *TaskRepository) UpdateBDDScenario(ctx context.Context, s *taskdom.BDDScenario) error {
+	updates := map[string]any{
+		"title":      s.Title,
+		"given_text": s.Given,
+		"when_text":  s.When,
+		"then_text":  s.Then,
+		"updated_at": s.UpdatedAt,
+	}
+	res := r.db.WithContext(ctx).
+		Model(&bddScenarioRecord{}).
+		Where("id = ?", s.ID.String()).
+		Updates(updates)
+	if res.Error != nil {
+		return fmt.Errorf("bdd scenario repo: update: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	return nil
+}
+
+// DeleteBDDScenario removes a BDD scenario by ID.
+func (r *TaskRepository) DeleteBDDScenario(ctx context.Context, id uuid.UUID) error {
+	res := r.db.WithContext(ctx).
+		Where("id = ?", id.String()).
+		Delete(&bddScenarioRecord{})
+	if res.Error != nil {
+		return fmt.Errorf("bdd scenario repo: delete: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	return nil
 }

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -764,7 +764,7 @@ func toBDDScenarioEntity(r *bddScenarioRecord) *taskdom.BDDScenario {
 	}
 }
 
-// ListBDDScenarios returns all BDD scenarios for a task ordered by position.
+// ListBDDScenarios returns all BDD scenarios for a task ordered by creation date.
 func (r *TaskRepository) ListBDDScenarios(ctx context.Context, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
 	var records []bddScenarioRecord
 	if err := r.db.WithContext(ctx).

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -138,6 +138,7 @@ func (s *Service) CreateTaskStatus(ctx context.Context, in taskdom.CreateTaskSta
 		ProjectID: in.ProjectID,
 		Name:      name,
 		Color:     in.Color,
+		Position:  in.Position,
 		Category:  in.Category,
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -138,7 +138,6 @@ func (s *Service) CreateTaskStatus(ctx context.Context, in taskdom.CreateTaskSta
 		ProjectID: in.ProjectID,
 		Name:      name,
 		Color:     in.Color,
-		Position:  in.Position,
 		Category:  in.Category,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -399,4 +398,75 @@ func (s *Service) DeleteCustomFieldDefinition(ctx context.Context, id uuid.UUID)
 		return err
 	}
 	return s.repo.DeleteCustomFieldDefinition(ctx, id)
+}
+
+// --- BDD Scenarios ---------------------------------------------------------
+
+// ListBDDScenarios returns all BDD scenarios for the given task.
+func (s *Service) ListBDDScenarios(ctx context.Context, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	return s.repo.ListBDDScenarios(ctx, taskID)
+}
+
+// GetBDDScenario returns the BDD scenario with the given ID.
+func (s *Service) GetBDDScenario(ctx context.Context, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	return s.repo.FindBDDScenarioByID(ctx, id)
+}
+
+// CreateBDDScenario creates a new BDD scenario for the given task.
+func (s *Service) CreateBDDScenario(ctx context.Context, in taskdom.CreateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	// Verify that the parent task exists.
+	if _, err := s.repo.FindTaskByID(ctx, in.TaskID); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	scenario := &taskdom.BDDScenario{
+		ID:        uuid.New(),
+		TaskID:    in.TaskID,
+		Title:     in.Title,
+		Given:     in.Given,
+		When:      in.When,
+		Then:      in.Then,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.repo.CreateBDDScenario(ctx, scenario); err != nil {
+		return nil, err
+	}
+	return scenario, nil
+}
+
+// UpdateBDDScenario applies partial updates to an existing BDD scenario.
+func (s *Service) UpdateBDDScenario(ctx context.Context, id uuid.UUID, in taskdom.UpdateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	scenario, err := s.repo.FindBDDScenarioByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if in.Title != nil {
+		scenario.Title = *in.Title
+	}
+	if in.Given != nil {
+		scenario.Given = *in.Given
+	}
+	if in.When != nil {
+		scenario.When = *in.When
+	}
+	if in.Then != nil {
+		scenario.Then = *in.Then
+	}
+	scenario.UpdatedAt = time.Now()
+
+	if err := s.repo.UpdateBDDScenario(ctx, scenario); err != nil {
+		return nil, err
+	}
+	return scenario, nil
+}
+
+// DeleteBDDScenario removes a BDD scenario by ID.
+func (s *Service) DeleteBDDScenario(ctx context.Context, id uuid.UUID) error {
+	if _, err := s.repo.FindBDDScenarioByID(ctx, id); err != nil {
+		return err
+	}
+	return s.repo.DeleteBDDScenario(ctx, id)
 }

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -450,7 +450,11 @@ func (s *Service) UpdateBDDScenario(ctx context.Context, id uuid.UUID, in taskdo
 	}
 
 	if in.Title != nil {
-		scenario.Title = *in.Title
+		title := strings.TrimSpace(*in.Title)
+		if title == "" {
+			return nil, taskdom.ErrBDDScenarioTitleInvalid
+		}
+		scenario.Title = title
 	}
 	if in.Given != nil {
 		scenario.Given = *in.Given

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -420,11 +420,16 @@ func (s *Service) CreateBDDScenario(ctx context.Context, in taskdom.CreateBDDSce
 		return nil, err
 	}
 
+	title := strings.TrimSpace(in.Title)
+	if title == "" {
+		return nil, taskdom.ErrBDDScenarioTitleInvalid
+	}
+
 	now := time.Now()
 	scenario := &taskdom.BDDScenario{
 		ID:        uuid.New(),
 		TaskID:    in.TaskID,
-		Title:     in.Title,
+		Title:     title,
 		Given:     in.Given,
 		When:      in.When,
 		Then:      in.Then,

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -24,6 +24,7 @@ type fakeTaskRepo struct {
 	tasks        map[uuid.UUID]*taskdom.Task
 	customFields map[uuid.UUID]*taskdom.CustomFieldDefinition
 	counters     map[uuid.UUID]int64 // project-scoped task number counters
+	bddScenarios map[uuid.UUID]*taskdom.BDDScenario
 }
 
 func newFakeTaskRepo() *fakeTaskRepo {
@@ -33,6 +34,7 @@ func newFakeTaskRepo() *fakeTaskRepo {
 		tasks:        make(map[uuid.UUID]*taskdom.Task),
 		customFields: make(map[uuid.UUID]*taskdom.CustomFieldDefinition),
 		counters:     make(map[uuid.UUID]int64),
+		bddScenarios: make(map[uuid.UUID]*taskdom.BDDScenario),
 	}
 }
 
@@ -252,6 +254,61 @@ func (r *fakeTaskRepo) DeleteTask(_ context.Context, id uuid.UUID) error {
 // BulkMoveSprintTasks is not exercised by task service tests but must satisfy
 // the taskdom.TaskRepository interface.
 func (r *fakeTaskRepo) BulkMoveSprintTasks(_ context.Context, _, _ uuid.UUID, _ *uuid.UUID) error {
+	return nil
+}
+
+// -- BDDScenario methods --
+
+func (r *fakeTaskRepo) ListBDDScenarios(_ context.Context, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*taskdom.BDDScenario, 0)
+	for _, s := range r.bddScenarios {
+		if s.TaskID == taskID {
+			cp := *s
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeTaskRepo) FindBDDScenarioByID(_ context.Context, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.bddScenarios[id]
+	if !ok {
+		return nil, taskdom.ErrBDDScenarioNotFound
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (r *fakeTaskRepo) CreateBDDScenario(_ context.Context, s *taskdom.BDDScenario) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := *s
+	r.bddScenarios[s.ID] = &cp
+	return nil
+}
+
+func (r *fakeTaskRepo) UpdateBDDScenario(_ context.Context, s *taskdom.BDDScenario) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.bddScenarios[s.ID]; !ok {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	cp := *s
+	r.bddScenarios[s.ID] = &cp
+	return nil
+}
+
+func (r *fakeTaskRepo) DeleteBDDScenario(_ context.Context, id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.bddScenarios[id]; !ok {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	delete(r.bddScenarios, id)
 	return nil
 }
 

--- a/services/api/internal/transport/http/dto/task_dto.go
+++ b/services/api/internal/transport/http/dto/task_dto.go
@@ -351,3 +351,49 @@ func CustomFieldDefinitionFromEntity(f *taskdom.CustomFieldDefinition) CustomFie
 		UpdatedAt:   f.UpdatedAt,
 	}
 }
+
+// --- BDD Scenarios ----------------------------------------------------------
+
+// CreateBDDScenarioRequest is the body for
+// POST /projects/:projectId/tasks/:taskId/bdd-scenarios.
+type CreateBDDScenarioRequest struct {
+	Title string `json:"title"    binding:"required"`
+	Given string `json:"given"`
+	When  string `json:"when"`
+	Then  string `json:"then"`
+}
+
+// UpdateBDDScenarioRequest is the body for
+// PATCH /projects/:projectId/tasks/:taskId/bdd-scenarios/:scenarioId.
+type UpdateBDDScenarioRequest struct {
+	Title *string `json:"title"`
+	Given *string `json:"given"`
+	When  *string `json:"when"`
+	Then  *string `json:"then"`
+}
+
+// BDDScenarioResponse is the public representation of a BDD scenario.
+type BDDScenarioResponse struct {
+	ID        uuid.UUID `json:"id"`
+	TaskID    uuid.UUID `json:"task_id"`
+	Title     string    `json:"title"`
+	Given     string    `json:"given"`
+	When      string    `json:"when"`
+	Then      string    `json:"then"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// BDDScenarioFromEntity maps a domain BDDScenario to a DTO.
+func BDDScenarioFromEntity(s *taskdom.BDDScenario) BDDScenarioResponse {
+	return BDDScenarioResponse{
+		ID:        s.ID,
+		TaskID:    s.TaskID,
+		Title:     s.Title,
+		Given:     s.Given,
+		When:      s.When,
+		Then:      s.Then,
+		CreatedAt: s.CreatedAt,
+		UpdatedAt: s.UpdatedAt,
+	}
+}

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -758,3 +758,115 @@ func (h *TaskHandler) ListTimelineTasks(c *gin.Context) {
 	}
 	presenter.OK(c, gin.H{"items": resp, "total": total, "page": page, "page_size": pageSize})
 }
+
+// --- BDD Scenarios ----------------------------------------------------------
+
+// parseBDDScenarioID parses the :scenarioId path parameter.
+func parseBDDScenarioID(c *gin.Context) (uuid.UUID, error) {
+	id, err := uuid.Parse(c.Param("scenarioId"))
+	if err != nil {
+		return uuid.Nil, apierr.New(apierr.CodeBadRequest, "invalid scenario id")
+	}
+	return id, nil
+}
+
+// ListBDDScenarios handles GET /projects/:projectId/tasks/:taskId/bdd-scenarios.
+func (h *TaskHandler) ListBDDScenarios(c *gin.Context) {
+	taskID, err := parseTaskID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	scenarios, err := h.svc.ListBDDScenarios(c.Request.Context(), taskID)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	resp := make([]dto.BDDScenarioResponse, 0, len(scenarios))
+	for _, s := range scenarios {
+		resp = append(resp, dto.BDDScenarioFromEntity(s))
+	}
+	presenter.OK(c, gin.H{"items": resp})
+}
+
+// CreateBDDScenario handles POST /projects/:projectId/tasks/:taskId/bdd-scenarios.
+func (h *TaskHandler) CreateBDDScenario(c *gin.Context) {
+	taskID, err := parseTaskID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+
+	var req dto.CreateBDDScenarioRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	scenario, err := h.svc.CreateBDDScenario(c.Request.Context(), taskdom.CreateBDDScenarioInput{
+		TaskID: taskID,
+		Title:  req.Title,
+		Given:  req.Given,
+		When:   req.When,
+		Then:   req.Then,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.Created(c, dto.BDDScenarioFromEntity(scenario))
+}
+
+// GetBDDScenario handles GET /projects/:projectId/tasks/:taskId/bdd-scenarios/:scenarioId.
+func (h *TaskHandler) GetBDDScenario(c *gin.Context) {
+	scenarioID, err := parseBDDScenarioID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	scenario, err := h.svc.GetBDDScenario(c.Request.Context(), scenarioID)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, dto.BDDScenarioFromEntity(scenario))
+}
+
+// UpdateBDDScenario handles PATCH /projects/:projectId/tasks/:taskId/bdd-scenarios/:scenarioId.
+func (h *TaskHandler) UpdateBDDScenario(c *gin.Context) {
+	scenarioID, err := parseBDDScenarioID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+
+	var req dto.UpdateBDDScenarioRequest
+	if !middleware.BindJSON(c, &req) {
+		return
+	}
+
+	scenario, err := h.svc.UpdateBDDScenario(c.Request.Context(), scenarioID, taskdom.UpdateBDDScenarioInput{
+		Title: req.Title,
+		Given: req.Given,
+		When:  req.When,
+		Then:  req.Then,
+	})
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, dto.BDDScenarioFromEntity(scenario))
+}
+
+// DeleteBDDScenario handles DELETE /projects/:projectId/tasks/:taskId/bdd-scenarios/:scenarioId.
+func (h *TaskHandler) DeleteBDDScenario(c *gin.Context) {
+	scenarioID, err := parseBDDScenarioID(c)
+	if err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	if err := h.svc.DeleteBDDScenario(c.Request.Context(), scenarioID); err != nil {
+		presenter.Error(c, err)
+		return
+	}
+	presenter.OK(c, gin.H{"message": "bdd scenario deleted"})
+}

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -26,14 +26,16 @@ type fakeTaskSvc struct {
 	mu            sync.RWMutex
 	tasks         map[uuid.UUID]*taskdom.Task
 	types         map[uuid.UUID]*taskdom.TaskType
+	bddScenarios  map[uuid.UUID]*taskdom.BDDScenario
 	lastProjectID uuid.UUID
 	lastFilter    taskdom.TaskFilter
 }
 
 func newFakeTaskSvc() *fakeTaskSvc {
 	return &fakeTaskSvc{
-		tasks: make(map[uuid.UUID]*taskdom.Task),
-		types: make(map[uuid.UUID]*taskdom.TaskType),
+		tasks:        make(map[uuid.UUID]*taskdom.Task),
+		types:        make(map[uuid.UUID]*taskdom.TaskType),
+		bddScenarios: make(map[uuid.UUID]*taskdom.BDDScenario),
 	}
 }
 
@@ -204,6 +206,87 @@ func (f *fakeTaskSvc) UpdateCustomFieldDefinition(_ context.Context, _ uuid.UUID
 
 func (f *fakeTaskSvc) DeleteCustomFieldDefinition(_ context.Context, _ uuid.UUID) error { return nil }
 
+// -- BDDScenarioService --
+
+func (f *fakeTaskSvc) ListBDDScenarios(_ context.Context, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	var out []*taskdom.BDDScenario
+	for _, s := range f.bddScenarios {
+		if s.TaskID == taskID {
+			cp := *s
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeTaskSvc) GetBDDScenario(_ context.Context, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	s, ok := f.bddScenarios[id]
+	if !ok {
+		return nil, taskdom.ErrBDDScenarioNotFound
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (f *fakeTaskSvc) CreateBDDScenario(_ context.Context, in taskdom.CreateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	if in.Title == "" {
+		return nil, taskdom.ErrBDDScenarioTitleInvalid
+	}
+	now := time.Now()
+	s := &taskdom.BDDScenario{
+		ID:     uuid.New(),
+		TaskID: in.TaskID,
+		Title:  in.Title,
+		Given:  in.Given,
+		When:   in.When,
+		Then:   in.Then,
+
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	f.mu.Lock()
+	f.bddScenarios[s.ID] = s
+	f.mu.Unlock()
+	return s, nil
+}
+
+func (f *fakeTaskSvc) UpdateBDDScenario(_ context.Context, id uuid.UUID, in taskdom.UpdateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.bddScenarios[id]
+	if !ok {
+		return nil, taskdom.ErrBDDScenarioNotFound
+	}
+	if in.Title != nil {
+		s.Title = *in.Title
+	}
+	if in.Given != nil {
+		s.Given = *in.Given
+	}
+	if in.When != nil {
+		s.When = *in.When
+	}
+	if in.Then != nil {
+		s.Then = *in.Then
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (f *fakeTaskSvc) DeleteBDDScenario(_ context.Context, id uuid.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.bddScenarios[id]; !ok {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	delete(f.bddScenarios, id)
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Fake view service (no-op)
 // ---------------------------------------------------------------------------
@@ -271,6 +354,12 @@ func buildTaskHandlerRouter(svc *fakeTaskSvc) *gin.Engine {
 	projectGroup.GET("/tasks/:taskId", h.GetTask)
 	projectGroup.PATCH("/tasks/:taskId", h.UpdateTask)
 	projectGroup.DELETE("/tasks/:taskId", h.DeleteTask)
+	// BDD scenarios
+	projectGroup.GET("/tasks/:taskId/bdd-scenarios", h.ListBDDScenarios)
+	projectGroup.POST("/tasks/:taskId/bdd-scenarios", h.CreateBDDScenario)
+	projectGroup.GET("/tasks/:taskId/bdd-scenarios/:scenarioId", h.GetBDDScenario)
+	projectGroup.PATCH("/tasks/:taskId/bdd-scenarios/:scenarioId", h.UpdateBDDScenario)
+	projectGroup.DELETE("/tasks/:taskId/bdd-scenarios/:scenarioId", h.DeleteBDDScenario)
 	return r
 }
 
@@ -689,5 +778,205 @@ func TestTaskHandler_GetTaskByNumber_InvalidNumberReturns400(t *testing.T) {
 	)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid task number, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BDD Scenario handler tests
+// ---------------------------------------------------------------------------
+
+func TestBDDScenarioHandler_CreateAndList(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+
+	// Pre-seed a task so the fake service's GetTask can resolve it.
+	task := &taskdom.Task{ID: taskID, ProjectID: projectID, Title: "feat", Tags: []string{}, CustomFields: map[string]any{}}
+	svc.mu.Lock()
+	svc.tasks[taskID] = task
+	svc.mu.Unlock()
+
+	// Create a BDD scenario.
+	createW := doTaskRequest(r, http.MethodPost,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID),
+		map[string]any{"title": "User login", "given": "the user is on login page", "when": "they submit valid credentials", "then": "they are redirected"},
+	)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", createW.Code, createW.Body.String())
+	}
+
+	// List BDD scenarios.
+	listW := doTaskRequest(r, http.MethodGet,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID),
+		nil,
+	)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", listW.Code, listW.Body.String())
+	}
+	var listEnv struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(listW.Body.Bytes(), &listEnv); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(listEnv.Data.Items) != 1 {
+		t.Fatalf("expected 1 scenario, got %d", len(listEnv.Data.Items))
+	}
+}
+
+func TestBDDScenarioHandler_CreateMissingTitle(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+
+	w := doTaskRequest(r, http.MethodPost,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID),
+		map[string]any{"given": "some context"},
+	)
+	// binding:"required" on Title → 400
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing title, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBDDScenarioHandler_GetNotFound(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+
+	w := doTaskRequest(r, http.MethodGet,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, uuid.New()),
+		nil,
+	)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBDDScenarioHandler_UpdateAndGet(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+
+	task := &taskdom.Task{ID: taskID, ProjectID: projectID, Title: "feat", Tags: []string{}, CustomFields: map[string]any{}}
+	svc.mu.Lock()
+	svc.tasks[taskID] = task
+	svc.mu.Unlock()
+
+	// Create.
+	createW := doTaskRequest(r, http.MethodPost,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID),
+		map[string]any{"title": "Original"},
+	)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d", createW.Code)
+	}
+	var createEnv struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	json.Unmarshal(createW.Body.Bytes(), &createEnv)
+	scenarioID := createEnv.Data.ID
+
+	// Patch title.
+	newTitle := "Updated title"
+	patchW := doTaskRequest(r, http.MethodPatch,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID),
+		map[string]any{"title": newTitle},
+	)
+	if patchW.Code != http.StatusOK {
+		t.Fatalf("patch: expected 200, got %d: %s", patchW.Code, patchW.Body.String())
+	}
+
+	// Get and verify updated title.
+	getW := doTaskRequest(r, http.MethodGet,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID),
+		nil,
+	)
+	if getW.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d", getW.Code)
+	}
+	var getEnv struct {
+		Data struct {
+			Title string `json:"title"`
+		} `json:"data"`
+	}
+	json.Unmarshal(getW.Body.Bytes(), &getEnv)
+	if getEnv.Data.Title != newTitle {
+		t.Errorf("expected title %q, got %q", newTitle, getEnv.Data.Title)
+	}
+}
+
+func TestBDDScenarioHandler_Delete(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+
+	task := &taskdom.Task{ID: taskID, ProjectID: projectID, Title: "feat", Tags: []string{}, CustomFields: map[string]any{}}
+	svc.mu.Lock()
+	svc.tasks[taskID] = task
+	svc.mu.Unlock()
+
+	// Create.
+	createW := doTaskRequest(r, http.MethodPost,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID),
+		map[string]any{"title": "To delete"},
+	)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d", createW.Code)
+	}
+	var createEnv struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	json.Unmarshal(createW.Body.Bytes(), &createEnv)
+	scenarioID := createEnv.Data.ID
+
+	// Delete.
+	delW := doTaskRequest(r, http.MethodDelete,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID),
+		nil,
+	)
+	if delW.Code != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d: %s", delW.Code, delW.Body.String())
+	}
+
+	// List should now be empty.
+	listW := doTaskRequest(r, http.MethodGet,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID),
+		nil,
+	)
+	var listEnv struct {
+		Data struct {
+			Items []any `json:"items"`
+		} `json:"data"`
+	}
+	json.Unmarshal(listW.Body.Bytes(), &listEnv)
+	if len(listEnv.Data.Items) != 0 {
+		t.Errorf("expected 0 items after delete, got %d", len(listEnv.Data.Items))
+	}
+}
+
+func TestBDDScenarioHandler_DeleteNotFound(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+
+	w := doTaskRequest(r, http.MethodDelete,
+		fmt.Sprintf("/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, uuid.New()),
+		nil,
+	)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -882,7 +882,9 @@ func TestBDDScenarioHandler_UpdateAndGet(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(createW.Body.Bytes(), &createEnv)
+	if err := json.Unmarshal(createW.Body.Bytes(), &createEnv); err != nil {
+		t.Fatalf("json.Unmarshal createEnv: %v", err)
+	}
 	scenarioID := createEnv.Data.ID
 
 	// Patch title.
@@ -908,7 +910,9 @@ func TestBDDScenarioHandler_UpdateAndGet(t *testing.T) {
 			Title string `json:"title"`
 		} `json:"data"`
 	}
-	json.Unmarshal(getW.Body.Bytes(), &getEnv)
+	if err := json.Unmarshal(getW.Body.Bytes(), &getEnv); err != nil {
+		t.Fatalf("json.Unmarshal getEnv: %v", err)
+	}
 	if getEnv.Data.Title != newTitle {
 		t.Errorf("expected title %q, got %q", newTitle, getEnv.Data.Title)
 	}
@@ -938,7 +942,9 @@ func TestBDDScenarioHandler_Delete(t *testing.T) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(createW.Body.Bytes(), &createEnv)
+	if err := json.Unmarshal(createW.Body.Bytes(), &createEnv); err != nil {
+		t.Fatalf("json.Unmarshal createEnv: %v", err)
+	}
 	scenarioID := createEnv.Data.ID
 
 	// Delete.
@@ -960,7 +966,9 @@ func TestBDDScenarioHandler_Delete(t *testing.T) {
 			Items []any `json:"items"`
 		} `json:"data"`
 	}
-	json.Unmarshal(listW.Body.Bytes(), &listEnv)
+	if err := json.Unmarshal(listW.Body.Bytes(), &listEnv); err != nil {
+		t.Fatalf("json.Unmarshal listEnv: %v", err)
+	}
 	if len(listEnv.Data.Items) != 0 {
 		t.Errorf("expected 0 items after delete, got %d", len(listEnv.Data.Items))
 	}

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -221,7 +221,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeTaskStatusNotFound,
 		apierr.CodeSprintNotFound,
 		apierr.CodeViewNotFound,
-		apierr.CodeCustomFieldNotFound:
+		apierr.CodeCustomFieldNotFound,
+		apierr.CodeBDDScenarioNotFound:
 		return http.StatusNotFound
 	case apierr.CodeTaskTitleInvalid,
 		apierr.CodeTaskTypeNameInvalid,
@@ -234,7 +235,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeViewReorderInvalid,
 		apierr.CodeCustomFieldKeyInvalid,
 		apierr.CodeCustomFieldTypeInvalid,
-		apierr.CodeCustomFieldNameInvalid:
+		apierr.CodeCustomFieldNameInvalid,
+		apierr.CodeBDDScenarioTitleInvalid:
 		return http.StatusBadRequest
 	case apierr.CodeViewIsLastView,
 		apierr.CodeSprintAlreadyComplete,

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -166,6 +166,10 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeCustomFieldTypeInvalid
 	case errors.Is(err, taskdom.ErrCustomFieldNameInvalid):
 		return http.StatusBadRequest, apierr.CodeCustomFieldNameInvalid
+	case errors.Is(err, taskdom.ErrBDDScenarioNotFound):
+		return http.StatusNotFound, apierr.CodeBDDScenarioNotFound
+	case errors.Is(err, taskdom.ErrBDDScenarioTitleInvalid):
+		return http.StatusBadRequest, apierr.CodeBDDScenarioTitleInvalid
 	default:
 		return http.StatusInternalServerError, apierr.CodeInternalError
 	}

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -383,6 +383,37 @@ func New(deps Deps) *gin.Engine {
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
 						deps.Task.DeleteTask,
 					)
+
+					// BDD scenarios — task-level acceptance criteria
+					bddScenarios := tasks.Group("/:taskId/bdd-scenarios")
+					{
+						bddScenarios.GET("",
+							httpmw.RequireAnyPermissions(deps.Authorizer,
+								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+							),
+							deps.Task.ListBDDScenarios,
+						)
+						bddScenarios.POST("",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+							deps.Task.CreateBDDScenario,
+						)
+						bddScenarios.GET("/:scenarioId",
+							httpmw.RequireAnyPermissions(deps.Authorizer,
+								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+							),
+							deps.Task.GetBDDScenario,
+						)
+						bddScenarios.PATCH("/:scenarioId",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+							deps.Task.UpdateBDDScenario,
+						)
+						bddScenarios.DELETE("/:scenarioId",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+							deps.Task.DeleteBDDScenario,
+						)
+					}
 				}
 
 				// Custom field definitions — project-level schema

--- a/services/api/migrations/000001_init.sql
+++ b/services/api/migrations/000001_init.sql
@@ -369,4 +369,37 @@ CREATE TABLE IF NOT EXISTS task_checklist_items (
 
 CREATE INDEX IF NOT EXISTS idx_task_checklist_items_checklist_id ON task_checklist_items (checklist_id, position);
 
+-- -------------------------------------------------------------------------
+-- USER GLOBAL ROLES (join table)
+-- Tracks the many-to-many relationship between users and global roles.
+-- In practice the schema enforces a single role per user via users.role_id,
+-- but this table is kept for potential future multi-role support.
+-- -------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_global_roles (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES global_roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, role_id)
+);
+
+-- -------------------------------------------------------------------------
+-- BDD SCENARIOS
+-- BDD scenarios capture the Given / When / Then acceptance criteria for a
+-- task.  Each scenario belongs to exactly one task and is deleted when the
+-- task is deleted (ON DELETE CASCADE).
+-- -------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS bdd_scenarios (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id     UUID         NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    title       VARCHAR      NOT NULL DEFAULT '',
+    given_text  TEXT         NOT NULL DEFAULT '',
+    when_text   TEXT         NOT NULL DEFAULT '',
+    then_text   TEXT         NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bdd_scenarios_task_id ON bdd_scenarios (task_id);
+
 COMMIT;

--- a/services/api/migrations/000001_init.sql
+++ b/services/api/migrations/000001_init.sql
@@ -370,19 +370,6 @@ CREATE TABLE IF NOT EXISTS task_checklist_items (
 CREATE INDEX IF NOT EXISTS idx_task_checklist_items_checklist_id ON task_checklist_items (checklist_id, position);
 
 -- -------------------------------------------------------------------------
--- USER GLOBAL ROLES (join table)
--- Tracks the many-to-many relationship between users and global roles.
--- In practice the schema enforces a single role per user via users.role_id,
--- but this table is kept for potential future multi-role support.
--- -------------------------------------------------------------------------
-
-CREATE TABLE IF NOT EXISTS user_global_roles (
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    role_id UUID NOT NULL REFERENCES global_roles(id) ON DELETE CASCADE,
-    PRIMARY KEY (user_id, role_id)
-);
-
--- -------------------------------------------------------------------------
 -- BDD SCENARIOS
 -- BDD scenarios capture the Given / When / Then acceptance criteria for a
 -- task.  Each scenario belongs to exactly one task and is deleted when the

--- a/services/api/migrations/embed.go
+++ b/services/api/migrations/embed.go
@@ -1,0 +1,10 @@
+// Package migrations embeds all SQL migration files so that the binary can
+// apply them at startup without needing access to the source tree at runtime.
+package migrations
+
+import "embed"
+
+// FS holds all *.sql files from this directory.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/services/api/test/e2e/bdd_scenarios_test.go
+++ b/services/api/test/e2e/bdd_scenarios_test.go
@@ -1,0 +1,347 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func createTaskForBDDViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, projectID string) string {
+	t.Helper()
+	body := jsonBody(t, map[string]any{"title": "bdd-task-" + uuid.NewString()})
+	req := mustRequest(env.ctx, t, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks", env.base, projectID), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	id, _ := data["id"].(string)
+	return id
+}
+
+func createBDDScenarioViaAPI(
+	t *testing.T,
+	env *e2eEnv,
+	client *http.Client,
+	token, projectID, taskID string,
+	payload map[string]any,
+) string {
+	t.Helper()
+	body := jsonBody(t, payload)
+	req := mustRequest(env.ctx, t, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projectID, taskID), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	id, _ := data["id"].(string)
+	return id
+}
+
+// ---------------------------------------------------------------------------
+// BDD Scenario CRUD
+// ---------------------------------------------------------------------------
+
+func TestE2EBDDScenarios_CRUD(t *testing.T) {
+	env := newE2EEnv(t)
+	seedTaskMemberUser(t, env, "bdd-crud-user", "bddpass1")
+	client, token := taskMemberLogin(t, env, "bdd-crud-user", "bddpass1")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+	taskID := createTaskForBDDViaAPI(t, env, client, token, projID)
+
+	var scenarioID string
+
+	t.Run("empty_list", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projID, taskID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, _ := data["items"].([]any)
+		if len(items) != 0 {
+			t.Errorf("expected 0 scenarios initially, got %d", len(items))
+		}
+	})
+
+	t.Run("create", func(t *testing.T) {
+		scenarioID = createBDDScenarioViaAPI(t, env, client, token, projID, taskID, map[string]any{
+			"title": "User can log in",
+			"given": "the login page is open",
+			"when":  "the user enters valid credentials",
+			"then":  "the user is redirected to the dashboard",
+		})
+		if scenarioID == "" {
+			t.Fatal("expected non-empty scenario id")
+		}
+	})
+
+	t.Run("list_after_create", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projID, taskID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, _ := data["items"].([]any)
+		if len(items) != 1 {
+			t.Errorf("expected 1 scenario after create, got %d", len(items))
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		if scenarioID == "" {
+			t.Skip("create sub-test did not produce a scenario ID")
+		}
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, scenarioID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if title, _ := data["title"].(string); title != "User can log in" {
+			t.Errorf("expected title 'User can log in', got %q", title)
+		}
+		if given, _ := data["given"].(string); given != "the login page is open" {
+			t.Errorf("expected given 'the login page is open', got %q", given)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		if scenarioID == "" {
+			t.Skip("create sub-test did not produce a scenario ID")
+		}
+		body := jsonBody(t, map[string]any{
+			"title": "User can log in (updated)",
+			"when":  "the user enters valid credentials and clicks Sign in",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, scenarioID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if title, _ := data["title"].(string); title != "User can log in (updated)" {
+			t.Errorf("expected updated title, got %q", title)
+		}
+		if when, _ := data["when"].(string); when != "the user enters valid credentials and clicks Sign in" {
+			t.Errorf("expected updated when clause, got %q", when)
+		}
+		// Given should be unchanged.
+		if given, _ := data["given"].(string); given != "the login page is open" {
+			t.Errorf("expected given to be unchanged, got %q", given)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		if scenarioID == "" {
+			t.Skip("create sub-test did not produce a scenario ID")
+		}
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, scenarioID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	t.Run("get_after_delete_returns_404", func(t *testing.T) {
+		if scenarioID == "" {
+			t.Skip("create sub-test did not produce a scenario ID")
+		}
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, scenarioID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+		assertErrorCode(t, resp, "BDD_SCENARIO_NOT_FOUND")
+	})
+
+	t.Run("list_after_delete_is_empty", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projID, taskID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, _ := data["items"].([]any)
+		if len(items) != 0 {
+			t.Errorf("expected 0 scenarios after delete, got %d", len(items))
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Multiple scenarios on the same task
+// ---------------------------------------------------------------------------
+
+func TestE2EBDDScenarios_MultipleScenarios(t *testing.T) {
+	env := newE2EEnv(t)
+	seedTaskMemberUser(t, env, "bdd-multi-user", "bddmultipass")
+	client, token := taskMemberLogin(t, env, "bdd-multi-user", "bddmultipass")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+	taskID := createTaskForBDDViaAPI(t, env, client, token, projID)
+
+	titles := []string{"Scenario A", "Scenario B", "Scenario C"}
+	for _, title := range titles {
+		createBDDScenarioViaAPI(t, env, client, token, projID, taskID, map[string]any{"title": title})
+	}
+
+	req := mustRequest(env.ctx, t, http.MethodGet,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projID, taskID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	items, _ := data["items"].([]any)
+	if len(items) != 3 {
+		t.Errorf("expected 3 scenarios, got %d", len(items))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation: missing title returns 400
+// ---------------------------------------------------------------------------
+
+func TestE2EBDDScenarios_MissingTitle(t *testing.T) {
+	env := newE2EEnv(t)
+	seedTaskMemberUser(t, env, "bdd-validation-user", "bddvalidpass")
+	client, token := taskMemberLogin(t, env, "bdd-validation-user", "bddvalidpass")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+	taskID := createTaskForBDDViaAPI(t, env, client, token, projID)
+
+	body := jsonBody(t, map[string]any{
+		"given": "some context",
+		"when":  "something happens",
+		"then":  "something is true",
+		// title intentionally omitted
+	})
+	req := mustRequest(env.ctx, t, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projID, taskID), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusBadRequest)
+}
+
+// ---------------------------------------------------------------------------
+// Authorisation: tasks.read is sufficient to list; tasks.write required to mutate
+// ---------------------------------------------------------------------------
+
+func TestE2EBDDScenarios_Authorisation(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Writer — creates the project, task, and scenario.
+	seedTaskMemberUser(t, env, "bdd-writer", "bddwritepass")
+	writerClient, writerToken := taskMemberLogin(t, env, "bdd-writer", "bddwritepass")
+	projID := createProjectForTasksViaAPI(t, env, writerClient, writerToken)
+	taskID := createTaskForBDDViaAPI(t, env, writerClient, writerToken, projID)
+	scenarioID := createBDDScenarioViaAPI(t, env, writerClient, writerToken, projID, taskID, map[string]any{
+		"title": "Auth test scenario",
+	})
+
+	t.Run("get_not_found_returns_404", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, uuid.New()), nil)
+		req.Header.Set("Authorization", "Bearer "+writerToken)
+		resp := mustDo(t, writerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+		assertErrorCode(t, resp, "BDD_SCENARIO_NOT_FOUND")
+	})
+
+	t.Run("update_non_existent_returns_404", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"title": "Ghost"})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, uuid.New()), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+writerToken)
+		resp := mustDo(t, writerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+	})
+
+	t.Run("delete_non_existent_returns_404", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", env.base, projID, taskID, uuid.New()), nil)
+		req.Header.Set("Authorization", "Bearer "+writerToken)
+		resp := mustDo(t, writerClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+	})
+
+	_ = scenarioID // used indirectly by the setup above
+}
+
+// ---------------------------------------------------------------------------
+// Cascade: deleting a task removes its BDD scenarios
+// ---------------------------------------------------------------------------
+
+func TestE2EBDDScenarios_CascadeDeleteWithTask(t *testing.T) {
+	env := newE2EEnv(t)
+	seedTaskMemberUser(t, env, "bdd-cascade-user", "bddcascadepass")
+	client, token := taskMemberLogin(t, env, "bdd-cascade-user", "bddcascadepass")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+	taskID := createTaskForBDDViaAPI(t, env, client, token, projID)
+
+	// Seed a few scenarios.
+	createBDDScenarioViaAPI(t, env, client, token, projID, taskID, map[string]any{"title": "Cascade S1"})
+	createBDDScenarioViaAPI(t, env, client, token, projID, taskID, map[string]any{"title": "Cascade S2"})
+
+	// Delete the parent task.
+	delReq := mustRequest(env.ctx, t, http.MethodDelete,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s", env.base, projID, taskID), nil)
+	delReq.Header.Set("Authorization", "Bearer "+token)
+	delResp := mustDo(t, client, delReq)
+	_ = delResp.Body.Close()
+	assertStatus(t, delResp, http.StatusOK)
+
+	// The task is gone; attempting to list its BDD scenarios should return 404
+	// (task not found) rather than an empty list.
+	listReq := mustRequest(env.ctx, t, http.MethodGet,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/bdd-scenarios", env.base, projID, taskID), nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listResp := mustDo(t, client, listReq)
+	_ = listResp.Body.Close()
+	// Depending on implementation the service may return 404 (task not found)
+	// or 200 with an empty list after a soft delete.  Either is acceptable;
+	// what matters is that the scenarios are not returned as populated data.
+	if listResp.StatusCode != http.StatusOK && listResp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 200 or 404 after task deletion, got %d", listResp.StatusCode)
+	}
+}

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -36,6 +36,7 @@ type fakeTaskRepo struct {
 	statuses     map[uuid.UUID]*taskdom.TaskStatus
 	tasks        map[uuid.UUID]*taskdom.Task
 	customFields map[uuid.UUID]*taskdom.CustomFieldDefinition
+	bddScenarios map[uuid.UUID]*taskdom.BDDScenario
 	counters     map[uuid.UUID]int64
 }
 
@@ -45,6 +46,7 @@ func newFakeTaskRepoIT() *fakeTaskRepo {
 		statuses:     make(map[uuid.UUID]*taskdom.TaskStatus),
 		tasks:        make(map[uuid.UUID]*taskdom.Task),
 		customFields: make(map[uuid.UUID]*taskdom.CustomFieldDefinition),
+		bddScenarios: make(map[uuid.UUID]*taskdom.BDDScenario),
 		counters:     make(map[uuid.UUID]int64),
 	}
 }
@@ -399,6 +401,61 @@ func (r *fakeTaskRepo) DeleteCustomFieldDefinition(_ context.Context, id uuid.UU
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.customFields, id)
+	return nil
+}
+
+// -- fakeTaskRepo: BDDScenario methods --
+
+func (r *fakeTaskRepo) ListBDDScenarios(_ context.Context, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []*taskdom.BDDScenario
+	for _, s := range r.bddScenarios {
+		if s.TaskID == taskID {
+			cp := *s
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeTaskRepo) FindBDDScenarioByID(_ context.Context, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.bddScenarios[id]
+	if !ok {
+		return nil, taskdom.ErrBDDScenarioNotFound
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (r *fakeTaskRepo) CreateBDDScenario(_ context.Context, s *taskdom.BDDScenario) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := *s
+	r.bddScenarios[s.ID] = &cp
+	return nil
+}
+
+func (r *fakeTaskRepo) UpdateBDDScenario(_ context.Context, s *taskdom.BDDScenario) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.bddScenarios[s.ID]; !ok {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	cp := *s
+	r.bddScenarios[s.ID] = &cp
+	return nil
+}
+
+func (r *fakeTaskRepo) DeleteBDDScenario(_ context.Context, id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.bddScenarios[id]; !ok {
+		return taskdom.ErrBDDScenarioNotFound
+	}
+	delete(r.bddScenarios, id)
 	return nil
 }
 
@@ -2515,5 +2572,187 @@ func TestIntegrationCompleteSprint_Forbidden(t *testing.T) {
 		fmt.Sprintf("/api/v1/projects/%s/sprints/%s/complete", projectID, sprintID), tok, map[string]any{}))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BDD Scenario integration tests
+// ---------------------------------------------------------------------------
+
+func TestBDDScenarios_CreateAndList(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+
+	// Create a task first.
+	createTaskW := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks", projectID), tok,
+		map[string]any{"title": "Feature X"},
+	))
+	if createTaskW.Code != http.StatusCreated {
+		t.Fatalf("create task: expected 201, got %d: %s", createTaskW.Code, createTaskW.Body.String())
+	}
+	taskID := taskIDFrom(t, "task", createTaskW.Body.Bytes())
+
+	// Initially no BDD scenarios.
+	listW := serve(r, authedJSONReq(t.Context(), http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID), tok, nil,
+	))
+	if listW.Code != http.StatusOK {
+		t.Fatalf("initial list: expected 200, got %d", listW.Code)
+	}
+	if cnt := taskListCount(t, listW.Body.Bytes()); cnt != 0 {
+		t.Fatalf("expected 0 scenarios initially, got %d", cnt)
+	}
+
+	// Create a BDD scenario.
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID), tok,
+		map[string]any{
+			"title": "User logs in",
+			"given": "the user is on the login page",
+			"when":  "they enter valid credentials",
+			"then":  "they are redirected to dashboard",
+		},
+	))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create scenario: expected 201, got %d: %s", createW.Code, createW.Body.String())
+	}
+	scenarioID := taskIDFrom(t, "scenario", createW.Body.Bytes())
+
+	// List — should have 1 scenario.
+	listW2 := serve(r, authedJSONReq(t.Context(), http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID), tok, nil,
+	))
+	if listW2.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", listW2.Code)
+	}
+	if cnt := taskListCount(t, listW2.Body.Bytes()); cnt != 1 {
+		t.Fatalf("expected 1 scenario, got %d", cnt)
+	}
+
+	// Get by ID.
+	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID), tok, nil,
+	))
+	if getW.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d: %s", getW.Code, getW.Body.String())
+	}
+}
+
+func TestBDDScenarios_Update(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+
+	// Create task + scenario.
+	createTaskW := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks", projectID), tok,
+		map[string]any{"title": "Feature Y"},
+	))
+	taskID := taskIDFrom(t, "task", createTaskW.Body.Bytes())
+
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID), tok,
+		map[string]any{"title": "Original"},
+	))
+	scenarioID := taskIDFrom(t, "scenario", createW.Body.Bytes())
+
+	// Update.
+	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID), tok,
+		map[string]any{"title": "Updated", "given": "new given clause"},
+	))
+	if patchW.Code != http.StatusOK {
+		t.Fatalf("patch: expected 200, got %d: %s", patchW.Code, patchW.Body.String())
+	}
+
+	// Verify persisted values.
+	var env struct {
+		Data struct {
+			Title string `json:"title"`
+			Given string `json:"given"`
+		} `json:"data"`
+	}
+	json.Unmarshal(patchW.Body.Bytes(), &env)
+	if env.Data.Title != "Updated" {
+		t.Errorf("expected title 'Updated', got %q", env.Data.Title)
+	}
+	if env.Data.Given != "new given clause" {
+		t.Errorf("expected given 'new given clause', got %q", env.Data.Given)
+	}
+}
+
+func TestBDDScenarios_Delete(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+
+	// Create task + scenario.
+	createTaskW := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks", projectID), tok,
+		map[string]any{"title": "Feature Z"},
+	))
+	taskID := taskIDFrom(t, "task", createTaskW.Body.Bytes())
+
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID), tok,
+		map[string]any{"title": "Delete me"},
+	))
+	scenarioID := taskIDFrom(t, "scenario", createW.Body.Bytes())
+
+	// Delete.
+	delW := serve(r, authedJSONReq(t.Context(), http.MethodDelete,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID), tok, nil,
+	))
+	if delW.Code != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d: %s", delW.Code, delW.Body.String())
+	}
+
+	// Get after delete → 404.
+	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios/%s", projectID, taskID, scenarioID), tok, nil,
+	))
+	if getW.Code != http.StatusNotFound {
+		t.Fatalf("get after delete: expected 404, got %d", getW.Code)
+	}
+}
+
+func TestBDDScenarios_RequiresTasksWritePermission(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead}, // read only, no write
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+
+	taskID := uuid.New()
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/bdd-scenarios", projectID, taskID), tok,
+		map[string]any{"title": "Should fail"},
+	))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without tasks.write, got %d (%s)", w.Code, w.Body.String())
 	}
 }

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -2686,7 +2686,9 @@ func TestBDDScenarios_Update(t *testing.T) {
 			Given string `json:"given"`
 		} `json:"data"`
 	}
-	json.Unmarshal(patchW.Body.Bytes(), &env)
+	if err := json.Unmarshal(patchW.Body.Bytes(), &env); err != nil {
+		t.Fatalf("json.Unmarshal env: %v", err)
+	}
 	if env.Data.Title != "Updated" {
 		t.Errorf("expected title 'Updated', got %q", env.Data.Title)
 	}


### PR DESCRIPTION
## Summary
This pull request implements the BDD (Behavior-Driven Development) Scenarios feature within the task detail modal. This update allows users to define, manage, and track acceptance criteria directly within their tasks using Gherkin-style syntax. Along with the core functionality, this PR introduces a robust Playwright E2E suite to ensure all CRUD operations are verified and stable.

## Key Changes
###Core Feature Implementation
BDD Scenario Management: Enabled the ability for users to create, view, edit, and delete BDD scenarios within the project management task modal.

Gherkin Syntax Support: Integrated support for "Given/When/Then" clauses to standardize acceptance criteria.

Inline Editing & UI: Implemented a seamless inline editing experience for scenario titles and a responsive "empty state" for tasks without defined scenarios.

### Behavior Definition (Gherkin)
Added bdd-scenarios.feature, which serves as the "source of truth" for the feature's behavior. This file details:

User stories for scenario management.

Permission-based access and UI expectations.

Formal acceptance criteria for CRUD operations.

### Automated Validation (E2E)
Playwright Test Suite: Introduced bdd-scenarios.spec.ts to automate the verification of the feature.

CRUD Coverage: Full automation of creating (with/without clauses), updating, and deleting scenarios.

Test Infrastructure: * Implemented robust setup/teardown logic to ensure test isolation.

Added helper functions for dynamic project creation, authentication, and API-driven data cleanup.

Ensured all tests are idempotent, preventing data pollution across test runs.