### PR TITLE
feat: add dark-mode theme variables for BlockNote aligned with deep-n…

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -420,3 +420,37 @@ a {
 		@apply border-border outline-ring/50;
 	}
 }
+
+/* BlockNote dark-mode theme — aligned with the app's deep-navy dark palette */
+.dark .bn-root[data-color-scheme=dark] {
+	/* Editor canvas — transparent so the card container background shows through */
+	--bn-colors-editor-text: #dde4ff;
+	--bn-colors-editor-background: transparent;
+
+	/* Floating menus / slash menu / side menu dropdowns */
+	--bn-colors-menu-text: #dde4ff;
+	--bn-colors-menu-background: #0c1428;
+
+	/* Tooltips */
+	--bn-colors-tooltip-text: #c8d0f0;
+	--bn-colors-tooltip-background: #141e38;
+
+	/* Hover state (e.g. menu items on hover) */
+	--bn-colors-hovered-text: #dde4ff;
+	--bn-colors-hovered-background: #1a2845;
+
+	/* Selected state (e.g. active menu item, selected text highlight) */
+	--bn-colors-selected-text: #070c18;
+	--bn-colors-selected-background: #567ac2;
+
+	/* Disabled state */
+	--bn-colors-disabled-text: #4a5880;
+	--bn-colors-disabled-background: #101e38;
+
+	/* Shadows and borders */
+	--bn-colors-shadow: rgba(0, 0, 0, 0.5);
+	--bn-colors-border: #1a2845;
+
+	/* Side-menu drag handle / block decorations */
+	--bn-colors-side-menu: #7a8db3;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -422,7 +422,7 @@ a {
 }
 
 /* BlockNote dark-mode theme — aligned with the app's deep-navy dark palette */
-.dark .bn-root[data-color-scheme=dark] {
+.dark .bn-root[data-color-scheme="dark"] {
 	/* Editor canvas — transparent so the card container background shows through */
 	--bn-colors-editor-text: #dde4ff;
 	--bn-colors-editor-background: transparent;


### PR DESCRIPTION
This pull request introduces a custom dark mode theme for the BlockNote editor to better match the application's deep-navy dark palette. The changes focus on aligning the editor's appearance with the rest of the app when dark mode is active.

BlockNote dark mode theming:

* Added a set of CSS custom properties under `.dark .bn-root[data-color-scheme=dark]` in `index.css` to define colors for editor text, backgrounds, menus, tooltips, hover/selected/disabled states, shadows, borders, and side-menu elements, ensuring visual consistency with the app's dark theme.