### PR TITLE
feat: add CI/CD workflow for building and publishing Docker images an…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,215 @@
+name: cd
+
+# Triggered when a GitHub Release is published (draft → published or created as
+# published).  Each job builds one artefact and pushes it to the appropriate
+# GitHub registry so that self-hosters can pull pre-built images/packages.
+#
+# Artefacts produced per release:
+#   ghcr.io/paca-ai/paca-api:<tag>       — Go API service Docker image
+#   ghcr.io/paca-ai/paca-realtime:<tag>  — Node realtime service Docker image
+#   ghcr.io/paca-ai/paca-web:<tag>       — Web app Docker image (nginx)
+#   npm.pkg.github.com @paca-ai/paca     — MCP server npm package
+
+on:
+  release:
+    types: [published]
+
+# All jobs need read on contents (checkout) and write on packages (push/publish).
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API service image
+# ─────────────────────────────────────────────────────────────────────────────
+jobs:
+  api-image:
+    name: Build and push API image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/api
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Realtime service image
+  # ─────────────────────────────────────────────────────────────────────────────
+  realtime-image:
+    name: Build and push Realtime image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-realtime
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/realtime
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Web app image
+  # ─────────────────────────────────────────────────────────────────────────────
+  # The Vite bundle bakes VITE_API_BASE_URL at compile time.
+  # The pre-built image uses an empty string so all API calls are relative to
+  # the current origin — nginx proxies /api/* to the backend automatically.
+  # Self-hosters who need a custom absolute URL can rebuild with:
+  #   PACA_WEB_IMAGE=my-registry/paca-web:tag and --build in docker compose.
+  web-image:
+    name: Build and push Web image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-web
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Empty string → relative URLs; works with nginx /api proxy out of the box.
+          build-args: |
+            VITE_API_BASE_URL=
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # MCP server npm package → GitHub Packages
+  # ─────────────────────────────────────────────────────────────────────────────
+  publish-mcp:
+    name: Publish MCP package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: apps/mcp
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.23"
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-mcp-${{ hashFiles('apps/mcp/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-mcp-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      # Strip the leading 'v' from the release tag (v1.2.3 → 1.2.3) so it
+      # matches npm's semver format, then stamp package.json without a git tag.
+      - name: Set package version
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          npm version "${VERSION#v}" --no-git-tag-version
+
+      - name: Setup Node.js with GitHub Packages registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@paca-ai"
+
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Paca centralizes the source of truth, ensuring that even in highly volatile proj
 - **AI-PO & BA Support**: Collaborate with AI to refine the backlog and break down "complex" epics into structured BDD scenarios.
 - **Unified Scrumban Board**: A real-time workspace where humans and Agents update statuses and discuss requirements together.
 - **SDD Documentation Hub**: High-level documentation that bridges the gap between code and business logic for the entire team.
+- **MCP Server Integration**: Connect your AI agents (Claude, custom agents) directly to Paca via Model Context Protocol for seamless project management automation.
 - **Server-Side Agent Orchestration**: Agents run on your infrastructure, maintaining full team context and security.
 - **Open Source**: Complete control over your project management environment and AI data.
 
@@ -83,6 +84,7 @@ But Paca is a project born from passion, not profit. We believe there is wisdom 
 - [ROADMAP.md](ROADMAP.md): project roadmap and future plans.
 - [docs/README.md](docs/README.md): documentation index.
 - [docs/architecture/overview.md](docs/architecture/overview.md): high-level system architecture.
+- [docs/guides/mcp-server-setup.md](docs/guides/mcp-server-setup.md): setup guide for integrating AI agents via MCP server.
 
 ## License
 

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "paca",
+  "name": "@paca-ai/paca",
   "version": "0.1.0",
   "description": "Paca MCP server - Complete API access for AI-powered project management",
-  "private": true,
   "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "bin": {
     "paca": "./build/index.js"
   },

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -5,6 +5,17 @@
 # running managed PostgreSQL or Valkey can still use the same images
 # and environment variables as a handoff into their own platform.
 #
+# ── Pre-built images ──────────────────────────────────────────────────────────
+# By default this file pulls the official pre-built images from GitHub Container
+# Registry (GHCR).  To pin a specific release, set the IMAGE env vars:
+#
+#   PACA_API_IMAGE=ghcr.io/paca-ai/paca-api:1.2.3
+#   PACA_WEB_IMAGE=ghcr.io/paca-ai/paca-web:1.2.3
+#   PACA_REALTIME_IMAGE=ghcr.io/paca-ai/paca-realtime:1.2.3
+#
+# To build the images locally instead of pulling (e.g. with custom patches),
+# append --build to the docker compose up command.
+#
 # ── Object storage ────────────────────────────────────────────────────────────
 # MinIO runs by default (self-hosted). To use AWS S3 instead, scale MinIO to
 # zero so it does not start, and supply real AWS credentials.
@@ -13,13 +24,13 @@
 #   cp deploy/.env.production.example deploy/.env.production
 #   docker compose \
 #     --env-file deploy/.env.production \
-#     -f deploy/docker-compose.prod.yml up -d --build
+#     -f deploy/docker-compose.prod.yml up -d
 #
 # With AWS S3 (MinIO container suppressed):
 #   # Set STORAGE_PROVIDER=s3 and real AWS credentials in .env.production
 #   docker compose \
 #     --env-file deploy/.env.production \
-#     -f deploy/docker-compose.prod.yml up -d --build --scale minio=0
+#     -f deploy/docker-compose.prod.yml up -d --scale minio=0
 
 name: paca-prod
 
@@ -53,7 +64,7 @@ services:
       retries: 10
 
   api:
-    image: ${PACA_API_IMAGE:-paca-api:latest}
+    image: ${PACA_API_IMAGE:-ghcr.io/paca-ai/paca-api:latest}
     build:
       context: ../services/api
     restart: unless-stopped
@@ -96,7 +107,7 @@ services:
         required: false  # skipped when --scale minio=0 (AWS S3 mode)
 
   web:
-    image: ${PACA_WEB_IMAGE:-paca-web:latest}
+    image: ${PACA_WEB_IMAGE:-ghcr.io/paca-ai/paca-web:latest}
     build:
       context: ../apps/web
       args:
@@ -108,7 +119,7 @@ services:
       - api
 
   realtime:
-    image: ${PACA_REALTIME_IMAGE:-paca-realtime:latest}
+    image: ${PACA_REALTIME_IMAGE:-ghcr.io/paca-ai/paca-realtime:latest}
     build:
       context: ../services/realtime
     restart: unless-stopped

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory is the main documentation home for Paca.
 - [architecture/database-schema.md](architecture/database-schema.md): database schema (DBML) and interactive diagram.
 - [architecture/interaction-views.md](architecture/interaction-views.md): how sprint, backlog, and timeline views share one model and one task-list API.
 - [guides/getting-started.md](guides/getting-started.md): what a new contributor should read first.
+- [guides/mcp-server-setup.md](guides/mcp-server-setup.md): setup guide for integrating AI agents (Claude, custom agents) with Paca via MCP server.
 - [guides/local-development.md](guides/local-development.md): local development intent and future setup direction.
 - [guides/design-system.md](guides/design-system.md): visual language, component patterns, and interaction conventions for the web UI.
 - [api/README.md](api/README.md): API and event contract documentation index.

--- a/docs/guides/mcp-server-setup.md
+++ b/docs/guides/mcp-server-setup.md
@@ -1,0 +1,307 @@
+# MCP Server Setup Guide
+
+This guide walks you through setting up the Paca MCP (Model Context Protocol) server to integrate with your AI agents, enabling them to interact with Paca projects, tasks, sprints, and documents.
+
+## Prerequisites
+
+Before setting up the MCP server, ensure you have:
+
+- A running Paca API instance (local or deployed)
+- An API key from your Paca instance (generate it in user settings)
+- Node.js 18+ installed (required by MCP clients)
+
+## Quick Start
+
+The Paca MCP server is published as an npm package `@paca-ai/paca`, so you don't need to clone the repository or build it yourself. Simply configure your MCP client to use the published package.
+
+### Package Information
+
+- **Package name**: `@paca-ai/paca`
+- **Registry**: [npmjs.com/package/@paca-ai/paca](https://www.npmjs.com/package/@paca-ai/paca)
+- **Repository**: [github.com/paca-ai/paca](https://github.com/paca-ai/paca)
+
+### Checking Available Versions
+
+To see available versions of the package:
+
+```bash
+npm view @paca-ai/paca versions
+```
+
+To view the latest version:
+
+```bash
+npm view @paca-ai/paca version
+```
+
+## Agent-Specific Setup
+
+The MCP server can be integrated with various AI agents and platforms. Below are configuration guides for popular options.
+
+### Claude Desktop (Recommended)
+
+Claude Desktop provides the most seamless integration with the Paca MCP server.
+
+**Configuration Steps:**
+
+1. Locate your Claude Desktop config file:
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+2. Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "paca": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@paca-ai/paca"
+      ],
+      "env": {
+        "PACA_API_KEY": "your-api-key-here",
+        "PACA_API_URL": "http://localhost:8080"
+      }
+    }
+  }
+}
+```
+
+3. Replace the placeholder values:
+   - `your-api-key-here` with your actual Paca API key
+   - `http://localhost:8080` with your Paca API URL if different
+
+4. Restart Claude Desktop
+
+**Note**: The `npx -y @paca-ai/paca` command automatically downloads and runs the latest version of the Paca MCP server from npm. To use a specific version, replace `@paca-ai/paca` with `@paca-ai/paca@1.0.0` (or your desired version).
+
+**Usage in Claude Desktop:**
+
+Once configured, Claude will automatically have access to all 86 Paca tools. You can ask Claude to:
+
+- "List all projects in my Paca workspace"
+- "Create a new task for user authentication"
+- "Create a sprint for the next 2 weeks"
+- "Update the task status to in progress"
+- "Add a comment to the design document"
+
+### Other MCP-Compatible Clients
+
+The Paca MCP server follows the standard MCP protocol and can be used with any MCP-compatible client.
+
+**Required Configuration:**
+
+1. **Command**: Use `npx -y @paca-ai/paca` to automatically download and run the latest version
+2. **Environment Variables**:
+   - `PACA_API_KEY` (required): Your Paca API key
+   - `PACA_API_URL` (optional): Paca API URL (default: `http://localhost:8080`)
+
+**Example Client Configuration:**
+
+Most MCP clients will accept configuration in this format:
+
+```json
+{
+  "name": "paca",
+  "command": "npx",
+  "args": [
+    "-y",
+    "@paca-ai/paca"
+  ],
+  "env": {
+    "PACA_API_KEY": "your-api-key-here",
+    "PACA_API_URL": "http://localhost:8080"
+  }
+}
+```
+
+### Custom AI Agents
+
+For custom AI agents or applications, you can use the MCP server programmatically:
+
+```javascript
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const transport = new StdioClientTransport({
+  command: "npx",
+  args: ["-y", "@paca-ai/paca"],
+  env: {
+    PACA_API_KEY: "your-api-key-here",
+    PACA_API_URL: "http://localhost:8080"
+  }
+});
+
+const client = new Client({
+  name: "my-agent",
+  version: "1.0.0"
+}, {
+  capabilities: {}
+});
+
+await client.connect(transport);
+
+// List available tools
+const tools = await client.listTools();
+console.log("Available tools:", tools.tools);
+
+// Call a tool
+const result = await client.callTool({
+  name: "list_projects",
+  arguments: {}
+});
+console.log("Projects:", result.content);
+```
+
+## Available Tools
+
+The Paca MCP server provides **86 tools** across **17 categories**:
+
+- 📁 **Project Management** (5 tools): Create, read, update, delete projects
+- ✅ **Task Management** (6 tools): Full task lifecycle management
+- 🏃 **Sprint Management** (6 tools): Complete sprint workflow
+- 📄 **Document Management** (5 tools): Document CRUD operations
+- 👥 **Project Members** (5 tools): Team and role management
+- 🎭 **Project Roles** (4 tools): Custom role definitions
+- 🏷️ **Task Types** (5 tools): Task type configurations
+- 📊 **Task Statuses** (4 tools): Workflow status management
+- 🎯 **Views** (9 tools): Sprint, backlog, and timeline views
+- 🔧 **Custom Fields** (5 tools): Custom field definitions
+- 📎 **Attachments** (3 tools): File attachment management
+- 🧪 **BDD Scenarios** (5 tools): Behavior-driven development scenarios
+- 📁 **Document Folders** (4 tools): Document organization
+- 📸 **Document Snapshots** (2 tools): Document versioning
+- 🔗 **GitHub Integration** (7 tools): Repository and PR linking
+- 💬 **Task Activities** (4 tools): Comments and activity tracking
+- 🔀 **Task GitHub** (5 tools): Branch and PR management
+
+For a complete list of all tools with detailed descriptions, see the [MCP README](../../apps/mcp/README.md).
+
+## Markdown/BlockNote Conversion
+
+The MCP server automatically handles content conversion:
+
+- **Reading**: Fetches content as BlockNote JSON and converts to Markdown for readability
+- **Writing**: Accepts Markdown input and converts to BlockNote JSON for storage
+
+This allows your AI agent to work with familiar Markdown format while Paca stores content in rich text format.
+
+## Example Agent Interactions
+
+### Example 1: Create a Complete Sprint Workflow
+
+```
+User: "Create a new sprint for next week and add these tasks: 
+1. Implement authentication 
+2. Set up database 
+3. Create user API"
+
+Agent: (uses MCP tools)
+1. create_sprint - Creates sprint "Sprint 1" with dates
+2. create_task - Creates "Implement authentication" task
+3. create_task - Creates "Set up database" task  
+4. create_task - Creates "Create user API" task
+5. bulk_move_tasks - Moves all tasks to the new sprint
+```
+
+### Example 2: Review and Update Task Status
+
+```
+User: "Review all in-progress tasks and update their status based on completion"
+
+Agent: (uses MCP tools)
+1. list_tasks - Gets all tasks with "in_progress" status
+2. get_task - Retrieves details for each task
+3. update_task - Updates status to "done" or "blocked" based on analysis
+```
+
+### Example 3: Document Management
+
+```
+User: "Create a system design document for the authentication module"
+
+Agent: (uses MCP tools)
+1. create_document - Creates "Authentication System Design" document
+2. update_document - Adds Markdown content with architecture diagrams
+3. create_doc_folder - Optionally organizes in "Architecture" folder
+```
+
+## Testing the MCP Server
+
+Once configured, you can test the MCP server directly through your MCP client:
+
+### Testing with Claude Desktop
+
+After restarting Claude Desktop, simply ask Claude:
+- "What Paca tools are available?"
+- "List all my projects"
+- "Create a test task"
+
+### Testing with Custom Clients
+
+Use the client's built-in testing tools to:
+- List available tools
+- Call sample tools
+- Verify API authentication
+
+### Development Testing
+
+For development or advanced testing, you can clone the repository and use the MCP Inspector:
+
+```bash
+git clone https://github.com/paca-ai/paca.git
+cd paca/apps/mcp
+npm install
+npm run inspector
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: "Connection refused" error
+- **Solution**: Ensure Paca API is running and `PACA_API_URL` is correct
+
+**Issue**: "Unauthorized" error
+- **Solution**: Verify `PACA_API_KEY` is valid and has proper permissions
+
+**Issue**: "npx: command not found" error
+- **Solution**: Ensure Node.js 18+ is installed and npx is in your PATH
+
+**Issue**: Claude Desktop doesn't show Paca tools
+- **Solution**: Check config file path, verify JSON syntax, and restart Claude Desktop
+
+**Issue**: "Cannot find package '@paca-ai/paca'" error
+- **Solution**: Ensure you have internet connectivity and npm registry access
+
+### Debug Mode
+
+Enable debug logging by setting:
+
+```bash
+export DEBUG="*"
+```
+
+Then run the MCP server to see detailed logs.
+
+## Security Best Practices
+
+1. **Never commit API keys** to version control
+2. **Use environment variables** for sensitive configuration
+3. **Limit API key permissions** to only what your agent needs
+4. **Rotate API keys** regularly
+5. **Use HTTPS** for production deployments
+
+## Next Steps
+
+- Explore the [complete tool documentation](../../apps/mcp/ALL_TOOLS.md)
+- Learn about the [MCP server architecture](../../apps/mcp/ARCHITECTURE.md)
+- Review [Paca API documentation](../api/README.md) for deeper integration
+- Check the [main MCP README](../../apps/mcp/README.md) for development guide
+
+## Getting Help
+
+- Report issues: [GitHub Issues](https://github.com/paca-ai/paca/issues)
+- Documentation: [docs/README.md](../README.md)
+- Contributing: [CONTRIBUTING.md](../../CONTRIBUTING.md)


### PR DESCRIPTION
This pull request introduces a continuous deployment (CD) workflow for publishing pre-built Docker images and an npm package to GitHub registries on release, and updates deployment and packaging configurations to support this new publishing flow. The changes streamline self-hosted deployments by defaulting to official pre-built images and publishing the MCP server as a scoped npm package.

**Continuous Deployment & Packaging Enhancements:**

* Added a new GitHub Actions workflow (`cd.yml`) that builds and publishes Docker images for the API, Realtime, and Web services to GitHub Container Registry (GHCR), and publishes the MCP server as an npm package to GitHub Packages on every release.
* Updated `apps/mcp/package.json` to publish the MCP server as a public, scoped package (`@paca-ai/paca`) to GitHub Packages, and removed the `private` flag to enable publishing.

**Deployment Configuration Updates:**

* Updated `deploy/docker-compose.prod.yml` to:
  - Default to pulling official pre-built images from GHCR for API, Web, and Realtime services, with environment variables for easy pinning of specific versions. [[1]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feR8-R18) [[2]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL56-R67) [[3]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL99-R110) [[4]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL111-R122)
  - Clarified documentation and usage instructions to reflect the new image defaults and to recommend building locally only for custom patches. [[1]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feR8-R18) [[2]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL16-R33)…d MCP package
