### PR TITLE
fix: update tag enabling condition for Docker images in CI/CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -96,7 +96,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -144,7 +144,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This pull request updates the logic for tagging Docker images as latest in the continuous deployment workflow. Instead of relying on the previous `is_default_branch` variable, the workflow now uses a condition that checks if the branch name does not contain a hyphen, which helps avoid tagging pre-release or feature branches as latest.

Changes to Docker tagging logic in `.github/workflows/cd.yml`:

* Updated the `latest` tag to be enabled only if the branch name does not contain a hyphen (`-`), replacing the previous `is_default_branch` check. This change is applied in three places in the workflow file to ensure only mainline branches (like `main` or `master`) are tagged as latest, and not feature or pre-release branches. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L56-R56) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L99-R99) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L147-R147)