### PR TITLE
chore: update README and setup guide to reflect new npm package namin…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -167,6 +167,9 @@ jobs:
     name: Publish MCP package
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
 
     defaults:
       run:
@@ -210,6 +213,4 @@ jobs:
           scope: "@paca-ai"
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -35,7 +35,7 @@ Add the following to your Claude Desktop config file:
   "mcpServers": {
     "paca": {
       "command": "npx",
-      "args": ["-y", "github:paca-ai/paca-mcp"],
+      "args": ["-y", "@paca-ai/paca-mcp"],
       "env": {
         "PACA_API_KEY": "your-api-key-here",
         "PACA_API_URL": "http://localhost:8080"
@@ -57,7 +57,7 @@ Add to your VS Code `settings.json` or `.vscode/mcp.json`:
     "servers": {
       "paca": {
         "command": "npx",
-        "args": ["-y", "github:paca-ai/paca-mcp"],
+        "args": ["-y", "@paca-ai/paca-mcp"],
         "env": {
           "PACA_API_KEY": "your-api-key-here",
           "PACA_API_URL": "http://localhost:8080"
@@ -76,7 +76,7 @@ Any MCP-compatible client can use the server with:
 {
   "name": "paca",
   "command": "npx",
-  "args": ["-y", "github:paca-ai/paca-mcp"],
+  "args": ["-y", "@paca-ai/paca-mcp"],
   "env": {
     "PACA_API_KEY": "your-api-key-here",
     "PACA_API_URL": "http://localhost:8080"

--- a/docs/guides/mcp-server-setup.md
+++ b/docs/guides/mcp-server-setup.md
@@ -16,7 +16,7 @@ The Paca MCP server is available as a GitHub package — no installation or buil
 
 ### Package Information
 
-- **Package**: `github:paca-ai/paca-mcp`
+- **Package**: `@paca-ai/paca-mcp`
 - **Repository**: [github.com/paca-ai/paca](https://github.com/paca-ai/paca) (MCP server source lives under `apps/mcp`)
 
 ### Checking the Package
@@ -24,7 +24,7 @@ The Paca MCP server is available as a GitHub package — no installation or buil
 To inspect the latest version of the MCP package:
 
 ```bash
-npx github:paca-ai/paca-mcp --version
+npx @paca-ai/paca-mcp --version
 ```
 
 ## Agent-Specific Setup
@@ -50,7 +50,7 @@ Claude Desktop provides the most seamless integration with the Paca MCP server.
       "command": "npx",
       "args": [
         "-y",
-        "github:paca-ai/paca-mcp"
+        "@paca-ai/paca-mcp"
       ],
       "env": {
         "PACA_API_KEY": "your-api-key-here",
@@ -67,7 +67,7 @@ Claude Desktop provides the most seamless integration with the Paca MCP server.
 
 4. Restart Claude Desktop
 
-**Note**: The `npx -y github:paca-ai/paca-mcp` command automatically downloads and runs the latest version of the Paca MCP server directly from GitHub.
+**Note**: The `npx -y @paca-ai/paca-mcp` command automatically downloads and runs the latest version of the Paca MCP server from npm.
 
 **Usage in Claude Desktop:**
 
@@ -85,7 +85,7 @@ The Paca MCP server follows the standard MCP protocol and can be used with any M
 
 **Required Configuration:**
 
-1. **Command**: Use `npx -y github:paca-ai/paca-mcp` to automatically download and run the latest version
+1. **Command**: Use `npx -y @paca-ai/paca-mcp` to automatically download and run the latest version
 2. **Environment Variables**:
    - `PACA_API_KEY` (required): Your Paca API key
    - `PACA_API_URL` (optional): Paca API URL (default: `http://localhost:8080`)
@@ -100,7 +100,7 @@ Most MCP clients will accept configuration in this format:
   "command": "npx",
   "args": [
     "-y",
-    "github:paca-ai/paca-mcp"
+    "@paca-ai/paca-mcp"
   ],
   "env": {
     "PACA_API_KEY": "your-api-key-here",
@@ -119,7 +119,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 
 const transport = new StdioClientTransport({
   command: "npx",
-  args: ["-y", "github:paca-ai/paca-mcp"],
+  args: ["-y", "@paca-ai/paca-mcp"],
   env: {
     PACA_API_KEY: "your-api-key-here",
     PACA_API_URL: "http://localhost:8080"
@@ -265,8 +265,8 @@ npm run inspector
 **Issue**: Claude Desktop doesn't show Paca tools
 - **Solution**: Check config file path, verify JSON syntax, and restart Claude Desktop
 
-**Issue**: "Cannot find package 'github:paca-ai/paca-mcp'" error
-- **Solution**: Ensure you have internet connectivity and access to GitHub
+**Issue**: "Cannot find package '@paca-ai/paca-mcp'" error
+- **Solution**: Ensure you have internet connectivity and npm registry access
 
 ### Debug Mode
 


### PR DESCRIPTION
This pull request updates the MCP package publishing workflow and documentation to reflect the move from a GitHub-based package (`github:paca-ai/paca-mcp`) to a scoped npm package (`@paca-ai/paca-mcp`). It also improves the npm publishing process by adding provenance and adjusting permissions.

**Documentation and usage updates:**

* Updated all documentation and example configurations in `apps/mcp/README.md` and `docs/guides/mcp-server-setup.md` to reference the npm package `@paca-ai/paca-mcp` instead of the old GitHub package. This ensures users are guided to use the published npm package for setup and integration. [[1]](diffhunk://#diff-b7fc5caeb0e7d9dfe08f09e242ecb6f490243fd5c29b2f7da660d22113d30b58L38-R38) [[2]](diffhunk://#diff-b7fc5caeb0e7d9dfe08f09e242ecb6f490243fd5c29b2f7da660d22113d30b58L60-R60) [[3]](diffhunk://#diff-b7fc5caeb0e7d9dfe08f09e242ecb6f490243fd5c29b2f7da660d22113d30b58L79-R79) [[4]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL19-R27) [[5]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL53-R53) [[6]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL70-R70) [[7]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL88-R88) [[8]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL103-R103) [[9]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL122-R122) [[10]](diffhunk://#diff-dbad0cf6b7e6b03158a72c12d115cd7f021acf245b44f9692d9264a2bad9e20dL268-R269)

**CI/CD workflow improvements:**

* Added explicit `permissions` (`contents: read`, `id-token: write`) to the `Publish MCP package` job in `.github/workflows/cd.yml`, which is required for publishing with provenance.
* Changed the npm publish step to use `npm publish --provenance --access public`, which attaches provenance metadata and ensures the package is public. Removed the now-unnecessary `NODE_AUTH_TOKEN` environment variable.…g convention