### PR TITLE
refactor: upgrade npm to latest version in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -212,5 +212,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@paca-ai"
 
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
This pull request makes a minor update to the continuous deployment workflow by ensuring that the latest version of npm is used before publishing to npm.

- CI/CD workflow improvement:
  * [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R215-R217): Added a step to upgrade npm to the latest version before running the publish step to ensure compatibility and access to the latest npm features.