### PR TITLE
feat: update MCP project-related descriptions to clarify UUID usage

### DIFF
--- a/apps/mcp/src/tools/attachment-tools.ts
+++ b/apps/mcp/src/tools/attachment-tools.ts
@@ -74,11 +74,11 @@ export function getAttachmentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],
@@ -92,15 +92,15 @@ export function getAttachmentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					attachmentId: {
 						type: "string",
-						description: "The ID of the attachment",
+						description: "The technical UUID of the attachment (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_attachments to get the attachment ID.",
 					},
 				},
 				required: ["projectId", "taskId", "attachmentId"],
@@ -114,15 +114,15 @@ export function getAttachmentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					attachmentId: {
 						type: "string",
-						description: "The ID of the attachment",
+						description: "The technical UUID of the attachment (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_attachments to get the attachment ID.",
 					},
 				},
 				required: ["projectId", "taskId", "attachmentId"],
@@ -144,11 +144,11 @@ export function getBDDScenarioTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],
@@ -162,11 +162,11 @@ export function getBDDScenarioTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					title: {
 						type: "string",
@@ -197,15 +197,15 @@ export function getBDDScenarioTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					scenarioId: {
 						type: "string",
-						description: "The ID of the scenario",
+						description: "The technical UUID of the BDD scenario (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_bdd_scenarios to get the scenario ID.",
 					},
 				},
 				required: ["projectId", "taskId", "scenarioId"],
@@ -219,15 +219,15 @@ export function getBDDScenarioTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					scenarioId: {
 						type: "string",
-						description: "The ID of the scenario",
+						description: "The technical UUID of the BDD scenario (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_bdd_scenarios to get the scenario ID.",
 					},
 					title: {
 						type: "string",
@@ -258,15 +258,15 @@ export function getBDDScenarioTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					scenarioId: {
 						type: "string",
-						description: "The ID of the scenario",
+						description: "The technical UUID of the BDD scenario (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_bdd_scenarios to get the scenario ID.",
 					},
 				},
 				required: ["projectId", "taskId", "scenarioId"],

--- a/apps/mcp/src/tools/doc-github-tools.ts
+++ b/apps/mcp/src/tools/doc-github-tools.ts
@@ -82,7 +82,7 @@ export function getDocTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -96,7 +96,7 @@ export function getDocTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					name: {
 						type: "string",
@@ -118,11 +118,11 @@ export function getDocTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					folderId: {
 						type: "string",
-						description: "The ID of the folder",
+						description: "The technical UUID of the folder (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_doc_folders to get the folder ID.",
 					},
 					name: {
 						type: "string",
@@ -148,11 +148,11 @@ export function getDocTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					folderId: {
 						type: "string",
-						description: "The ID of the folder",
+						description: "The technical UUID of the folder (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_doc_folders to get the folder ID.",
 					},
 				},
 				required: ["projectId", "folderId"],
@@ -166,11 +166,11 @@ export function getDocTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					docId: {
 						type: "string",
-						description: "The ID of the document",
+						description: "The technical UUID of the document (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_documents to get the document ID.",
 					},
 				},
 				required: ["projectId", "docId"],
@@ -184,15 +184,15 @@ export function getDocTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					docId: {
 						type: "string",
-						description: "The ID of the document",
+						description: "The technical UUID of the document (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_documents to get the document ID.",
 					},
 					snapshotId: {
 						type: "string",
-						description: "The ID of the snapshot",
+						description: "The technical UUID of the snapshot (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_doc_snapshots to get the snapshot ID.",
 					},
 				},
 				required: ["projectId", "docId", "snapshotId"],
@@ -214,7 +214,7 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -228,7 +228,7 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					token: {
 						type: "string",
@@ -246,7 +246,7 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -260,7 +260,7 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -274,7 +274,7 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -288,11 +288,11 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					owner: {
 						type: "string",
-						description: "The repository owner",
+						description: "The repository owner (GitHub username)",
 					},
 					repo: {
 						type: "string",
@@ -310,11 +310,11 @@ export function getGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					repoId: {
 						type: "number",
-						description: "The repository ID",
+						description: "The numeric ID of the linked repository (e.g., 123456789). Use list_linked_github_repos to get the repository ID.",
 					},
 				},
 				required: ["projectId", "repoId"],

--- a/apps/mcp/src/tools/document-tools.ts
+++ b/apps/mcp/src/tools/document-tools.ts
@@ -46,7 +46,7 @@ export function getDocumentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -60,11 +60,11 @@ export function getDocumentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					docId: {
 						type: "string",
-						description: "The ID of the document",
+						description: "The technical UUID of the document (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_documents to get the document ID.",
 					},
 				},
 				required: ["projectId", "docId"],
@@ -78,7 +78,7 @@ export function getDocumentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					title: {
 						type: "string",
@@ -91,7 +91,7 @@ export function getDocumentTools(): Tool[] {
 					},
 					folderId: {
 						type: "string",
-						description: "The ID of the folder",
+						description: "The technical UUID of the folder (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_doc_folders to get the folder ID.",
 					},
 				},
 				required: ["projectId", "title"],
@@ -105,11 +105,11 @@ export function getDocumentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					docId: {
 						type: "string",
-						description: "The ID of the document",
+						description: "The technical UUID of the document (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_documents to get the document ID.",
 					},
 					title: {
 						type: "string",
@@ -122,7 +122,7 @@ export function getDocumentTools(): Tool[] {
 					},
 					folderId: {
 						type: "string",
-						description: "The ID of the folder",
+						description: "The technical UUID of the folder (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_doc_folders to get the folder ID.",
 					},
 				},
 				required: ["projectId", "docId"],
@@ -136,11 +136,11 @@ export function getDocumentTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					docId: {
 						type: "string",
-						description: "The ID of the document",
+						description: "The technical UUID of the document (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_documents to get the document ID.",
 					},
 				},
 				required: ["projectId", "docId"],

--- a/apps/mcp/src/tools/member-tools.ts
+++ b/apps/mcp/src/tools/member-tools.ts
@@ -65,7 +65,7 @@ export function getProjectMemberTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -79,15 +79,15 @@ export function getProjectMemberTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					userId: {
 						type: "string",
-						description: "The ID of the user to add",
+						description: "The technical UUID of the user to add (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_members to see existing member user IDs.",
 					},
 					roleId: {
 						type: "string",
-						description: "The ID of the role to assign",
+						description: "The technical UUID of the role to assign (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_roles to get the role ID.",
 					},
 				},
 				required: ["projectId", "userId", "roleId"],
@@ -101,7 +101,7 @@ export function getProjectMemberTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -115,15 +115,15 @@ export function getProjectMemberTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					userId: {
 						type: "string",
-						description: "The ID of the user",
+						description: "The technical UUID of the user (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_members to get user IDs.",
 					},
 					roleId: {
 						type: "string",
-						description: "The ID of the new role",
+						description: "The technical UUID of the new role (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_roles to get the role ID.",
 					},
 				},
 				required: ["projectId", "userId", "roleId"],
@@ -137,11 +137,11 @@ export function getProjectMemberTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					userId: {
 						type: "string",
-						description: "The ID of the user to remove",
+						description: "The technical UUID of the user to remove (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_members to get user IDs.",
 					},
 				},
 				required: ["projectId", "userId"],
@@ -163,7 +163,7 @@ export function getProjectRoleTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -177,7 +177,7 @@ export function getProjectRoleTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					name: {
 						type: "string",
@@ -204,11 +204,11 @@ export function getProjectRoleTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					roleId: {
 						type: "string",
-						description: "The ID of the role",
+						description: "The technical UUID of the role (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_roles to get the role ID.",
 					},
 					name: {
 						type: "string",
@@ -235,11 +235,11 @@ export function getProjectRoleTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					roleId: {
 						type: "string",
-						description: "The ID of the role",
+						description: "The technical UUID of the role (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_roles to get the role ID.",
 					},
 				},
 				required: ["projectId", "roleId"],

--- a/apps/mcp/src/tools/project-tools.ts
+++ b/apps/mcp/src/tools/project-tools.ts
@@ -44,7 +44,7 @@ export function getProjectTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -76,7 +76,7 @@ export function getProjectTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					name: {
 						type: "string",
@@ -98,7 +98,7 @@ export function getProjectTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],

--- a/apps/mcp/src/tools/sprint-tools.ts
+++ b/apps/mcp/src/tools/sprint-tools.ts
@@ -51,7 +51,7 @@ export function getSprintTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -65,11 +65,11 @@ export function getSprintTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					sprintId: {
 						type: "string",
-						description: "The ID of the sprint",
+						description: "The technical UUID of the sprint (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_sprints to get the sprint ID.",
 					},
 				},
 				required: ["projectId", "sprintId"],
@@ -83,7 +83,7 @@ export function getSprintTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					name: {
 						type: "string",
@@ -109,11 +109,11 @@ export function getSprintTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					sprintId: {
 						type: "string",
-						description: "The ID of the sprint",
+						description: "The technical UUID of the sprint (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_sprints to get the sprint ID.",
 					},
 					name: {
 						type: "string",
@@ -139,11 +139,11 @@ export function getSprintTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					sprintId: {
 						type: "string",
-						description: "The ID of the sprint",
+						description: "The technical UUID of the sprint (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_sprints to get the sprint ID.",
 					},
 				},
 				required: ["projectId", "sprintId"],
@@ -157,11 +157,11 @@ export function getSprintTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					sprintId: {
 						type: "string",
-						description: "The ID of the sprint",
+						description: "The technical UUID of the sprint (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_sprints to get the sprint ID.",
 					},
 				},
 				required: ["projectId", "sprintId"],

--- a/apps/mcp/src/tools/task-activity-tools.ts
+++ b/apps/mcp/src/tools/task-activity-tools.ts
@@ -70,11 +70,11 @@ export function getTaskActivityTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],
@@ -88,11 +88,11 @@ export function getTaskActivityTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					content: {
 						type: "string",
@@ -110,15 +110,15 @@ export function getTaskActivityTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					commentId: {
 						type: "string",
-						description: "The ID of the comment",
+						description: "The technical UUID of the comment (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_activities to find comment IDs in the activity list.",
 					},
 					content: {
 						type: "string",
@@ -136,15 +136,15 @@ export function getTaskActivityTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					commentId: {
 						type: "string",
-						description: "The ID of the comment",
+						description: "The technical UUID of the comment (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_activities to find comment IDs in the activity list.",
 					},
 				},
 				required: ["projectId", "taskId", "commentId"],
@@ -166,11 +166,11 @@ export function getTaskGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],
@@ -184,19 +184,19 @@ export function getTaskGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					prId: {
 						type: "number",
-						description: "The pull request number",
+						description: "The GitHub pull request number (e.g., 123)",
 					},
 					repoId: {
 						type: "string",
-						description: "The ID of the repository",
+						description: "The technical UUID of the repository (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_linked_github_repos to get the repo ID.",
 					},
 				},
 				required: ["projectId", "taskId", "prId", "repoId"],
@@ -210,15 +210,15 @@ export function getTaskGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					prId: {
 						type: "string",
-						description: "The ID of the pull request (UUID)",
+						description: "The technical UUID of the linked pull request (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_prs to get the PR ID.",
 					},
 				},
 				required: ["projectId", "taskId", "prId"],
@@ -232,15 +232,15 @@ export function getTaskGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					repoId: {
 						type: "string",
-						description: "The ID of the repository",
+						description: "The technical UUID of the repository (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_linked_github_repos to get the repo ID.",
 					},
 					branchName: {
 						type: "string",
@@ -262,11 +262,11 @@ export function getTaskGitHubTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],

--- a/apps/mcp/src/tools/task-tools.ts
+++ b/apps/mcp/src/tools/task-tools.ts
@@ -65,7 +65,7 @@ export function getTaskTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -79,11 +79,11 @@ export function getTaskTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],
@@ -97,7 +97,7 @@ export function getTaskTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskNumber: {
 						type: "number",
@@ -115,7 +115,7 @@ export function getTaskTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					title: {
 						type: "string",
@@ -128,19 +128,19 @@ export function getTaskTools(): Tool[] {
 					},
 					statusId: {
 						type: "string",
-						description: "The ID of the status",
+						description: "The technical UUID of the task status (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_statuses to get the status ID.",
 					},
 					typeId: {
 						type: "string",
-						description: "The ID of the task type",
+						description: "The technical UUID of the task type (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_types to get the type ID.",
 					},
 					sprintId: {
 						type: "string",
-						description: "The ID of the sprint",
+						description: "The technical UUID of the sprint (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_sprints to get the sprint ID.",
 					},
 					assigneeId: {
 						type: "string",
-						description: "The ID of the assignee",
+						description: "The technical UUID of the user to assign the task to (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_members to get user IDs.",
 					},
 					importance: {
 						type: "number",
@@ -171,11 +171,11 @@ export function getTaskTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 					title: {
 						type: "string",
@@ -188,19 +188,19 @@ export function getTaskTools(): Tool[] {
 					},
 					statusId: {
 						type: "string",
-						description: "The ID of the status",
+						description: "The technical UUID of the task status (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_statuses to get the status ID.",
 					},
 					typeId: {
 						type: "string",
-						description: "The ID of the task type",
+						description: "The technical UUID of the task type (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_types to get the type ID.",
 					},
 					sprintId: {
 						type: "string",
-						description: "The ID of the sprint",
+						description: "The technical UUID of the sprint (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_sprints to get the sprint ID.",
 					},
 					assigneeId: {
 						type: "string",
-						description: "The ID of the assignee",
+						description: "The technical UUID of the user to assign the task to (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_project_members to get user IDs.",
 					},
 					importance: {
 						type: "number",
@@ -231,11 +231,11 @@ export function getTaskTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					taskId: {
 						type: "string",
-						description: "The ID of the task",
+						description: "The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
 					},
 				},
 				required: ["projectId", "taskId"],

--- a/apps/mcp/src/tools/task-type-tools.ts
+++ b/apps/mcp/src/tools/task-type-tools.ts
@@ -77,7 +77,7 @@ export function getTaskTypeTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -91,7 +91,7 @@ export function getTaskTypeTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					name: {
 						type: "string",
@@ -121,11 +121,11 @@ export function getTaskTypeTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					typeId: {
 						type: "string",
-						description: "The ID of the task type",
+						description: "The technical UUID of the task type (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_types to get the type ID.",
 					},
 					name: {
 						type: "string",
@@ -155,11 +155,11 @@ export function getTaskTypeTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					typeId: {
 						type: "string",
-						description: "The ID of the task type",
+						description: "The technical UUID of the task type (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_types to get the type ID.",
 					},
 				},
 				required: ["projectId", "typeId"],
@@ -173,11 +173,11 @@ export function getTaskTypeTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					typeId: {
 						type: "string",
-						description: "The ID of the task type to set as default",
+						description: "The technical UUID of the task type (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_types to get the type ID.",
 					},
 				},
 				required: ["projectId", "typeId"],
@@ -196,7 +196,7 @@ export function getTaskStatusTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 				},
 				required: ["projectId"],
@@ -210,7 +210,7 @@ export function getTaskStatusTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					name: {
 						type: "string",
@@ -237,11 +237,11 @@ export function getTaskStatusTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					statusId: {
 						type: "string",
-						description: "The ID of the status",
+						description: "The technical UUID of the task status (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_statuses to get the status ID.",
 					},
 					name: {
 						type: "string",
@@ -271,11 +271,11 @@ export function getTaskStatusTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					statusId: {
 						type: "string",
-						description: "The ID of the status",
+						description: "The technical UUID of the task status (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_statuses to get the status ID.",
 					},
 				},
 				required: ["projectId", "statusId"],
@@ -289,11 +289,11 @@ export function getTaskStatusTools(): Tool[] {
 				properties: {
 					projectId: {
 						type: "string",
-						description: "The ID of the project",
+						description: "The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
 					},
 					statusId: {
 						type: "string",
-						description: "The ID of the task status to set as default",
+						description: "The technical UUID of the task status (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_statuses to get the status ID.",
 					},
 				},
 				required: ["projectId", "statusId"],


### PR DESCRIPTION
- Changed descriptions for projectId fields across multiple tools to specify that they should use the technical UUID format (e.g., '550e8400-e29b-41d4-a716-446655440000') instead of project names.
- Updated folderId, docId, snapshotId, userId, roleId, taskId, and other related fields to reflect the same UUID format and provide guidance on how to retrieve these IDs using respective list functions.