### PR TITLE
feat: add is_public flag to projects for anonymous access

### DIFF
--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -68,6 +68,7 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { useProjectPermissions } from "@/hooks/use-project-permissions";
 import type { ThemeMode } from "@/hooks/use-theme-mode";
 import { useThemeMode } from "@/hooks/use-theme-mode";
+import { currentUserOptionalQueryOptions } from "@/lib/auth-api";
 import {
 	createDocument,
 	createFolder,
@@ -711,6 +712,19 @@ function ProjectSwitcher({
 		? currentProject.name.slice(0, 2).toUpperCase()
 		: null;
 
+	const { data: user } = useQuery(currentUserOptionalQueryOptions);
+
+	if (!user) {
+		return (
+			<div className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm font-medium text-sidebar-foreground/80 select-none">
+				<div className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/15 text-primary text-[10px] font-bold">
+					{initials ?? <FolderKanban className="size-3" />}
+				</div>
+				<span className="flex-1 truncate text-left">{label}</span>
+			</div>
+		);
+	}
+
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger
@@ -852,7 +866,15 @@ function ProjectNav() {
 	);
 }
 
-function ProjectNavItems({ projectId }: { projectId: string }) {
+const ANON_HIDDEN_SEGMENTS = new Set(["team", "settings"]);
+
+function ProjectNavItems({
+	projectId,
+	isAnonymous,
+}: {
+	projectId: string;
+	isAnonymous?: boolean;
+}) {
 	const location = useRouterState({ select: (s) => s.location.pathname });
 
 	const [collapsed, setCollapsed] = useState(() => {
@@ -899,7 +921,9 @@ function ProjectNavItems({ projectId }: { projectId: string }) {
 			{!collapsed && (
 				<SidebarGroupContent>
 					<SidebarMenu>
-						{PROJECT_NAV_ITEMS.map(({ segment, icon: Icon, label }) => {
+						{PROJECT_NAV_ITEMS.filter(
+							(item) => !isAnonymous || !ANON_HIDDEN_SEGMENTS.has(item.segment),
+						).map(({ segment, icon: Icon, label }) => {
 							const href = segment
 								? `/projects/${projectId}/${segment}`
 								: `/projects/${projectId}`;
@@ -933,7 +957,13 @@ function ProjectNavItems({ projectId }: { projectId: string }) {
 }
 
 // ── Project Interactions Section ───────────────────────────────────────────────
-function ProjectInteractionsSection({ projectId }: { projectId: string }) {
+function ProjectInteractionsSection({
+	projectId,
+	isAnonymous,
+}: {
+	projectId: string;
+	isAnonymous?: boolean;
+}) {
 	const location = useRouterState({ select: (s) => s.location.pathname });
 	const { hasPermission } = usePermissions();
 	const qc = useQueryClient();
@@ -991,7 +1021,7 @@ function ProjectInteractionsSection({ projectId }: { projectId: string }) {
 		e: React.DragEvent,
 		interactionId: string,
 	) => {
-		if (!canEditTasks) return;
+		if (!canEditTasks || isAnonymous) return;
 		if (!e.dataTransfer.types.includes("application/x-paca-task-id")) return;
 		e.preventDefault();
 		e.dataTransfer.dropEffect = "move";
@@ -1029,7 +1059,8 @@ function ProjectInteractionsSection({ projectId }: { projectId: string }) {
 	});
 
 	// Hide entire section if user lacks the "View Sprints" permission
-	if (!canViewSprints) return null;
+	// (anonymous visitors on public projects can always view interactions)
+	if (!canViewSprints && !isAnonymous) return null;
 
 	const openSprints = sprints
 		.filter((s) => s.status === "active")
@@ -1211,6 +1242,7 @@ export function AppSidebar() {
 	const { hasPermission } = usePermissions();
 	const { resolvedMode } = useThemeMode();
 	const { projectId } = useParams({ strict: false });
+	const { data: user } = useQuery(currentUserOptionalQueryOptions);
 
 	const canAccessGlobalRoles =
 		hasPermission("global_roles.read") || hasPermission("global_roles.write");
@@ -1222,13 +1254,26 @@ export function AppSidebar() {
 
 	const showAdminSection = canAccessGlobalRoles || canAccessUsers;
 	const isProjectContext = !!projectId;
+	const isAnonymous = !user;
 
 	return (
 		<Sidebar collapsible="icon">
 			{/* Brand */}
 			<SidebarHeader className="gap-2 pb-2">
 				<div className="flex items-center gap-2.5 px-2 pt-1">
-					<Link to="/home">
+					{user ? (
+						<Link to="/home">
+							<img
+								src={
+									resolvedMode === "dark"
+										? "/paca-logo-dark.svg"
+										: "/paca-logo.svg"
+								}
+								alt="Paca Logo"
+								className="size-8 shrink-0"
+							/>
+						</Link>
+					) : (
 						<img
 							src={
 								resolvedMode === "dark"
@@ -1238,7 +1283,7 @@ export function AppSidebar() {
 							alt="Paca Logo"
 							className="size-8 shrink-0"
 						/>
-					</Link>
+					)}
 					<span className="font-[Syne] font-bold text-[15px] tracking-tight text-sidebar-foreground group-data-[collapsible=icon]:hidden">
 						paca
 					</span>
@@ -1257,23 +1302,28 @@ export function AppSidebar() {
 			<SidebarContent>
 				{isProjectContext ? (
 					<>
-						<ProjectNav />
-						<SidebarSeparator />
-						<ProjectInteractionsSection projectId={projectId} />
+						{user && <ProjectNav />}
+						{user && <SidebarSeparator />}
+						<ProjectInteractionsSection
+							projectId={projectId}
+							isAnonymous={isAnonymous}
+						/>
 						<SidebarSeparator />
 						<DocsSidebarSection projectId={projectId} />
 						<SidebarSeparator />
-						<ProjectNavItems projectId={projectId} />
+						<ProjectNavItems projectId={projectId} isAnonymous={isAnonymous} />
 					</>
 				) : (
 					<>
-						<SidebarGroup>
-							<SidebarGroupContent>
-								<SidebarMenu>
-									<NavItem to="/home" icon={Home} label="Home" />
-								</SidebarMenu>
-							</SidebarGroupContent>
-						</SidebarGroup>
+						{user && (
+							<SidebarGroup>
+								<SidebarGroupContent>
+									<SidebarMenu>
+										<NavItem to="/home" icon={Home} label="Home" />
+									</SidebarMenu>
+								</SidebarGroupContent>
+							</SidebarGroup>
+						)}
 
 						{/* Admin section */}
 						{showAdminSection ? (

--- a/apps/web/src/components/app-shell/user-menu.tsx
+++ b/apps/web/src/components/app-shell/user-menu.tsx
@@ -18,7 +18,11 @@ import {
 	SidebarMenuButton,
 	SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { currentUserQueryOptions, logout } from "@/lib/auth-api";
+import {
+	currentUserOptionalQueryOptions,
+	currentUserQueryOptions,
+	logout,
+} from "@/lib/auth-api";
 
 function getInitials(name: string): string {
 	return name
@@ -33,10 +37,27 @@ function getInitials(name: string): string {
 export function UserMenu() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
-	const { data: user } = useQuery(currentUserQueryOptions);
+	const { data: user } = useQuery(currentUserOptionalQueryOptions);
 	const [isLoggingOut, setIsLoggingOut] = useState(false);
 
-	if (!user) return null;
+	if (!user) {
+		return (
+			<SidebarMenu>
+				<SidebarMenuItem>
+					<SidebarMenuButton
+						tooltip="Sign in"
+						onClick={() => {
+							window.location.href = "/";
+						}}
+						className="text-muted-foreground hover:text-foreground hover:bg-sidebar-accent/60 transition-all"
+					>
+						<User className="size-4" />
+						<span>Sign in</span>
+					</SidebarMenuButton>
+				</SidebarMenuItem>
+			</SidebarMenu>
+		);
+	}
 
 	const displayName = user.full_name || user.username;
 	const initials = getInitials(displayName);

--- a/apps/web/src/components/projects/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/projects/settings/GeneralSettings.tsx
@@ -1,9 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { Globe, Loader2, Lock } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import { projectQueryOptions, updateProject } from "@/lib/project-api";
@@ -21,6 +22,7 @@ export function GeneralSettings({
 	const [name, setName] = useState(project?.name ?? "");
 	const [description, setDescription] = useState(project?.description ?? "");
 	const [prefix, setPrefix] = useState(project?.task_id_prefix ?? "");
+	const [isPublic, setIsPublic] = useState(project?.is_public ?? false);
 	const [nameError, setNameError] = useState<string | null>(null);
 	const [prefixError, setPrefixError] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
@@ -32,6 +34,7 @@ export function GeneralSettings({
 				name: name.trim(),
 				description: description.trim(),
 				task_id_prefix: prefix.trim() || undefined,
+				is_public: isPublic,
 			}),
 		onSuccess: async (updated) => {
 			await queryClient.invalidateQueries({
@@ -42,6 +45,7 @@ export function GeneralSettings({
 			setName(updated.name);
 			setDescription(updated.description);
 			setPrefix(updated.task_id_prefix);
+			setIsPublic(updated.is_public);
 			setError(null);
 			setNameError(null);
 			setPrefixError(null);
@@ -71,7 +75,8 @@ export function GeneralSettings({
 	const isDirty =
 		name.trim() !== (project?.name ?? "") ||
 		description.trim() !== (project?.description ?? "") ||
-		prefix.trim() !== (project?.task_id_prefix ?? "");
+		prefix.trim() !== (project?.task_id_prefix ?? "") ||
+		isPublic !== (project?.is_public ?? false);
 
 	return (
 		<div className="rounded-xl border border-border/60 bg-card p-6">
@@ -138,6 +143,34 @@ export function GeneralSettings({
 						rows={3}
 						disabled={!canEdit}
 						className="resize-none"
+					/>
+				</div>
+
+				<div className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+					<div className="flex items-start gap-3">
+						<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-primary/15">
+							{isPublic ? (
+								<Globe className="size-4 text-primary" />
+							) : (
+								<Lock className="size-4 text-primary" />
+							)}
+						</div>
+						<div>
+							<Label htmlFor="is-public" className="font-medium cursor-pointer">
+								Public project
+							</Label>
+							<p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+								{isPublic
+									? "Anyone with the link can view this project. Anonymous users have read-only access."
+									: "Only team members can access this project."}
+							</p>
+						</div>
+					</div>
+					<Switch
+						id="is-public"
+						checked={isPublic}
+						onCheckedChange={setIsPublic}
+						disabled={!canEdit}
 					/>
 				</div>
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -46,6 +46,7 @@ export class ApiClient {
 			async (error) => {
 				const originalRequest = error.config as InternalAxiosRequestConfig & {
 					_retry?: boolean;
+					_skipAuthRefresh?: boolean;
 				};
 
 				// Redirect to the forced password-change page on this specific 403.
@@ -63,6 +64,12 @@ export class ApiClient {
 				}
 
 				if (error.response?.status !== 401 || originalRequest._retry) {
+					return Promise.reject(error);
+				}
+
+				// Skip refresh for requests marked as public access (e.g. optional
+				// /users/me calls on public project pages).
+				if (originalRequest._skipAuthRefresh) {
 					return Promise.reject(error);
 				}
 

--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -45,9 +45,28 @@ export async function getMe(): Promise<User> {
 	return data.data;
 }
 
+export async function getMeOptional(): Promise<User | null> {
+	try {
+		const { data } = await apiClient.instance.get<SuccessEnvelope<User>>(
+			"/users/me",
+			{ _skipAuthRefresh: true } as Record<string, unknown>,
+		);
+		return data.data;
+	} catch {
+		return null;
+	}
+}
+
 export const currentUserQueryOptions = queryOptions({
 	queryKey: ["auth", "me"],
 	queryFn: getMe,
+	retry: false,
+	staleTime: 5 * 60 * 1000,
+});
+
+export const currentUserOptionalQueryOptions = queryOptions({
+	queryKey: ["auth", "me-optional"],
+	queryFn: getMeOptional,
 	retry: false,
 	staleTime: 5 * 60 * 1000,
 });

--- a/apps/web/src/lib/project-api.test.ts
+++ b/apps/web/src/lib/project-api.test.ts
@@ -60,6 +60,7 @@ const mockProject: Project = {
 	id: "p1",
 	name: "Alpha",
 	description: "First project",
+	is_public: false,
 	task_id_prefix: "ALPH",
 	settings: {},
 	created_by: "u1",
@@ -165,6 +166,17 @@ describe("project-api", () => {
 		});
 	});
 
+	it("createProject forwards is_public when provided", async () => {
+		const publicProject = { ...mockProject, is_public: true };
+		mockPost.mockResolvedValue(ok(publicProject));
+
+		await createProject({ name: "Public", is_public: true });
+		expect(mockPost).toHaveBeenCalledWith("/projects", {
+			name: "Public",
+			is_public: true,
+		});
+	});
+
 	it("updateProject patches by id and unwraps the updated project", async () => {
 		const updated = { ...mockProject, name: "Alpha v2" };
 		mockPatch.mockResolvedValue(ok(updated));
@@ -175,6 +187,16 @@ describe("project-api", () => {
 		expect(mockPatch).toHaveBeenCalledWith("/projects/p1", {
 			name: "Alpha v2",
 		});
+	});
+
+	it("updateProject forwards is_public when toggling visibility", async () => {
+		const publicProject = { ...mockProject, is_public: true };
+		mockPatch.mockResolvedValue(ok(publicProject));
+
+		await expect(updateProject("p1", { is_public: true })).resolves.toEqual(
+			publicProject,
+		);
+		expect(mockPatch).toHaveBeenCalledWith("/projects/p1", { is_public: true });
 	});
 
 	it("deleteProject sends DELETE to correct URL and returns undefined", async () => {

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -9,6 +9,7 @@ export interface Project {
 	id: string;
 	name: string;
 	description: string;
+	is_public: boolean;
 	task_id_prefix: string;
 	settings: Record<string, unknown>;
 	created_by?: string;
@@ -64,6 +65,7 @@ export async function createProject(payload: {
 	name: string;
 	description?: string;
 	task_id_prefix?: string;
+	is_public?: boolean;
 }): Promise<Project> {
 	const { data } = await apiClient.instance.post<SuccessEnvelope<Project>>(
 		"/projects",
@@ -74,7 +76,12 @@ export async function createProject(payload: {
 
 export async function updateProject(
 	projectId: string,
-	payload: { name?: string; description?: string; task_id_prefix?: string },
+	payload: {
+		name?: string;
+		description?: string;
+		task_id_prefix?: string;
+		is_public?: boolean;
+	},
 ): Promise<Project> {
 	const { data } = await apiClient.instance.patch<SuccessEnvelope<Project>>(
 		`/projects/${projectId}`,

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,6 +1,7 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { useEffect } from "react";
+
 import { AppSidebar } from "@/components/app-shell/app-sidebar";
 import { NotificationBell } from "@/components/app-shell/notification-bell";
 import {
@@ -9,24 +10,38 @@ import {
 	SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { isPasswordChangeRequired } from "@/lib/api-error";
-import { currentUserQueryOptions } from "@/lib/auth-api";
+import {
+	currentUserOptionalQueryOptions,
+	currentUserQueryOptions,
+} from "@/lib/auth-api";
 import { connectSocket, disconnectSocket } from "@/lib/socket-client";
 
-/**
- * Pathless layout route that guards every route nested under it.
- *
- * Any route placed inside `routes/_authenticated/` automatically requires the
- * user to be signed in.  Unauthenticated visitors are redirected to the login
- * page (`/`).  The check reuses the cached React Query result so it only hits
- * the network when the cache is stale.
- */
+const PROJECT_ROUTE_RE = /^\/projects\/[^/]+/;
+
 export const Route = createFileRoute("/_authenticated")({
-	beforeLoad: async ({ context: { queryClient } }) => {
+	beforeLoad: async ({ context: { queryClient }, location }) => {
+		const isProjectRoute = PROJECT_ROUTE_RE.test(location.pathname);
+
+		if (isProjectRoute) {
+			const user = await queryClient
+				.fetchQuery(currentUserOptionalQueryOptions)
+				.catch((err: unknown) => {
+					if (isPasswordChangeRequired(err)) {
+						throw redirect({ to: "/change-password" });
+					}
+					return null;
+				});
+
+			if (user?.must_change_password) {
+				throw redirect({ to: "/change-password" });
+			}
+
+			return { user };
+		}
+
 		const user = await queryClient
 			.fetchQuery(currentUserQueryOptions)
 			.catch((err: unknown) => {
-				// 403 AUTH_PASSWORD_CHANGE_REQUIRED means the user IS authenticated
-				// but the backend blocks all endpoints. Send them to the dedicated page.
 				if (isPasswordChangeRequired(err)) {
 					throw redirect({ to: "/change-password" });
 				}
@@ -40,19 +55,21 @@ export const Route = createFileRoute("/_authenticated")({
 		if (user.must_change_password) {
 			throw redirect({ to: "/change-password" });
 		}
+
+		return { user };
 	},
 	component: AuthenticatedLayout,
 });
 
 function AuthenticatedLayout() {
-	// Open the Socket.IO connection as soon as the user is authenticated and
-	// close it when they log out (component unmounts).
 	const queryClient = useQueryClient();
+	const { data: user } = useQuery(currentUserOptionalQueryOptions);
 
 	useEffect(() => {
+		if (!user) return;
+
 		const socket = connectSocket();
 
-		// Listen for notification events delivered to the user's personal room.
 		const handleNotification = ({ type }: { type: string }) => {
 			if (type === "notification.created") {
 				queryClient.invalidateQueries({ queryKey: ["notifications"] });
@@ -64,7 +81,7 @@ function AuthenticatedLayout() {
 			socket.off("notification", handleNotification);
 			disconnectSocket();
 		};
-	}, [queryClient]);
+	}, [queryClient, user]);
 
 	return (
 		<SidebarProvider className="h-svh">
@@ -74,9 +91,11 @@ function AuthenticatedLayout() {
 					<div className="absolute inset-x-0 bottom-0 h-px bg-border/40" />
 					<SidebarTrigger className="-ml-1 text-muted-foreground hover:text-foreground transition-colors" />
 					<div className="w-px h-4 bg-border/60" />
-					<div className="ml-auto">
-						<NotificationBell />
-					</div>
+					{user && (
+						<div className="ml-auto">
+							<NotificationBell />
+						</div>
+					)}
 				</header>
 				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
 					<Outlet />

--- a/apps/web/src/routes/_authenticated/home/index.tsx
+++ b/apps/web/src/routes/_authenticated/home/index.tsx
@@ -6,8 +6,10 @@ import {
 	Calendar,
 	FolderKanban,
 	GitMerge,
+	Globe,
 	Layers,
 	Loader2,
+	Lock,
 	Plus,
 	Users,
 	Zap,
@@ -29,6 +31,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { usePermissions } from "@/hooks/use-permissions";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
@@ -74,6 +77,7 @@ function CreateProjectDialog({
 	const [name, setName] = useState("");
 	const [description, setDescription] = useState("");
 	const [prefix, setPrefix] = useState("");
+	const [isPublic, setIsPublic] = useState(false);
 	const [prefixTouched, setPrefixTouched] = useState(false);
 	const [nameError, setNameError] = useState<string | null>(null);
 	const [prefixError, setPrefixError] = useState<string | null>(null);
@@ -83,6 +87,7 @@ function CreateProjectDialog({
 		setName("");
 		setDescription("");
 		setPrefix("");
+		setIsPublic(false);
 		setPrefixTouched(false);
 		setNameError(null);
 		setPrefixError(null);
@@ -96,6 +101,7 @@ function CreateProjectDialog({
 				name: name.trim(),
 				description: description.trim() || undefined,
 				task_id_prefix: prefix.trim() || undefined,
+				is_public: isPublic,
 			});
 		},
 		onSuccess: async () => {
@@ -242,6 +248,35 @@ function CreateProjectDialog({
 							className="resize-none"
 						/>
 					</div>
+					<div className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+						<div className="flex items-start gap-3">
+							<div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-primary/15">
+								{isPublic ? (
+									<Globe className="size-4 text-primary" />
+								) : (
+									<Lock className="size-4 text-primary" />
+								)}
+							</div>
+							<div>
+								<Label
+									htmlFor="is-public"
+									className="font-medium cursor-pointer"
+								>
+									Public project
+								</Label>
+								<p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+									{isPublic
+										? "Anyone with the link can view this project. Anonymous users have read-only access."
+										: "Only team members can access this project."}
+								</p>
+							</div>
+						</div>
+						<Switch
+							id="is-public"
+							checked={isPublic}
+							onCheckedChange={setIsPublic}
+						/>
+					</div>
 					{error ? (
 						<p className="text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
 							{error}
@@ -306,9 +341,20 @@ function ProjectCard({ project }: { project: Project }) {
 					{initials || <FolderKanban className="size-4" />}
 				</div>
 				<div className="min-w-0 flex-1">
-					<p className="font-[Syne] text-sm font-bold truncate leading-snug">
-						{project.name}
-					</p>
+					<div className="flex items-center gap-2 mb-0.5">
+						<p className="font-[Syne] text-sm font-bold truncate leading-snug">
+							{project.name}
+						</p>
+						{project.is_public && (
+							<Badge
+								variant="secondary"
+								className="gap-1 px-1.5 py-0 text-[10px] font-medium border border-border/60 shrink-0"
+							>
+								<Globe className="size-3" />
+								Public
+							</Badge>
+						)}
+					</div>
 					{project.description ? (
 						<p className="mt-0.5 text-xs text-muted-foreground line-clamp-2 leading-relaxed">
 							{project.description}

--- a/apps/web/src/routes/_authenticated/projects/$projectId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId.tsx
@@ -7,10 +7,11 @@ import { projectQueryOptions } from "@/lib/project-api";
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId")({
 	loader: async ({ context: { queryClient }, params: { projectId } }) => {
+		const user = queryClient.getQueryData(["auth", "me-optional"]);
 		await queryClient
 			.ensureQueryData(projectQueryOptions(projectId))
 			.catch(() => {
-				throw redirect({ to: "/home" });
+				throw redirect({ to: user ? "/home" : "/" });
 			});
 	},
 	component: ProjectLayout,

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -184,14 +184,15 @@ func New(cfg *config.Config) (*App, error) {
 	}
 
 	deps := router.Deps{
-		TokenManager: tokenManager,
-		APIKeyAuth:   apiKeyService,
-		Authorizer:   authorizer,
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, cookieCfg),
-		User:         handler.NewUserHandler(userService, authService),
-		GlobalRole:   handler.NewGlobalRoleHandler(globalRoleService),
-		Project:      handler.NewProjectHandler(projectService, authorizer, handler.WithProjectDefaultViews(viewService, taskService)),
+		TokenManager:         tokenManager,
+		APIKeyAuth:           apiKeyService,
+		Authorizer:           authorizer,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, cookieCfg),
+		User:                 handler.NewUserHandler(userService, authService),
+		GlobalRole:           handler.NewGlobalRoleHandler(globalRoleService),
+		ProjectVisibilitySvc: projectService,
+		Project:              handler.NewProjectHandler(projectService, authorizer, handler.WithProjectDefaultViews(viewService, taskService)),
 		Task: handler.NewTaskHandler(taskService, viewService, activityService,
 			handler.WithTaskPublisher(publisher)),
 		Sprint:       handler.NewSprintHandler(sprintService, viewService, handler.WithSprintDefaultTaskTypes(taskService)),

--- a/services/api/internal/domain/project/entity.go
+++ b/services/api/internal/domain/project/entity.go
@@ -13,6 +13,7 @@ type Project struct {
 	Name         string
 	Description  string
 	TaskIDPrefix string
+	IsPublic     bool
 	Settings     map[string]any
 	CreatedBy    *uuid.UUID
 	CreatedAt    time.Time

--- a/services/api/internal/domain/project/service.go
+++ b/services/api/internal/domain/project/service.go
@@ -11,6 +11,7 @@ type CreateProjectInput struct {
 	Name         string
 	Description  string
 	TaskIDPrefix string
+	IsPublic     bool
 	Settings     map[string]any
 	CreatedBy    *uuid.UUID
 }
@@ -20,6 +21,7 @@ type UpdateProjectInput struct {
 	Name         string
 	Description  string
 	TaskIDPrefix string
+	IsPublic     *bool
 	Settings     map[string]any
 }
 
@@ -37,6 +39,8 @@ type ProjectService interface {
 	// ListAccessible returns only the projects the given user is a member of.
 	ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*Project, int64, error)
 	GetByID(ctx context.Context, id uuid.UUID) (*Project, error)
+	// IsProjectPublic returns true when the project exists and is_public is set.
+	IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error)
 	Create(ctx context.Context, in CreateProjectInput) (*Project, error)
 	Update(ctx context.Context, id uuid.UUID, in UpdateProjectInput) (*Project, error)
 	Delete(ctx context.Context, id uuid.UUID) error

--- a/services/api/internal/repository/postgres/project_repository.go
+++ b/services/api/internal/repository/postgres/project_repository.go
@@ -19,6 +19,7 @@ type projectRecord struct {
 	Name         string `gorm:"not null"`
 	Description  string
 	TaskIDPrefix string  `gorm:"column:task_id_prefix;not null;default:''"`
+	IsPublic     bool    `gorm:"column:is_public;not null;default:false"`
 	Settings     []byte  `gorm:"type:jsonb;not null"`
 	CreatedBy    *string `gorm:"type:uuid"`
 	CreatedAt    time.Time
@@ -200,6 +201,7 @@ func (r *ProjectRepository) Update(ctx context.Context, p *projectdom.Project) e
 			"name":           p.Name,
 			"description":    p.Description,
 			"task_id_prefix": p.TaskIDPrefix,
+			"is_public":      p.IsPublic,
 			"settings":       settings,
 			"created_by":     createdBy,
 		})
@@ -504,6 +506,7 @@ func toProjectEntity(rec *projectRecord) (*projectdom.Project, error) {
 		Name:         rec.Name,
 		Description:  rec.Description,
 		TaskIDPrefix: rec.TaskIDPrefix,
+		IsPublic:     rec.IsPublic,
 		Settings:     settings,
 		CreatedBy:    createdBy,
 		CreatedAt:    rec.CreatedAt,
@@ -525,6 +528,7 @@ func fromProjectEntity(p *projectdom.Project) (*projectRecord, error) {
 		Name:         p.Name,
 		Description:  p.Description,
 		TaskIDPrefix: p.TaskIDPrefix,
+		IsPublic:     p.IsPublic,
 		Settings:     settings,
 		CreatedBy:    createdBy,
 		CreatedAt:    p.CreatedAt,

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -144,6 +144,7 @@ func (s *Service) Create(ctx context.Context, in projectdom.CreateProjectInput) 
 		Name:         name,
 		Description:  strings.TrimSpace(in.Description),
 		TaskIDPrefix: prefix,
+		IsPublic:     in.IsPublic,
 		Settings:     cloneSettings(in.Settings),
 		CreatedBy:    in.CreatedBy,
 		CreatedAt:    now,
@@ -297,6 +298,9 @@ func (s *Service) Update(ctx context.Context, id uuid.UUID, in projectdom.Update
 		}
 		p.TaskIDPrefix = rawPrefix
 	}
+	if in.IsPublic != nil {
+		p.IsPublic = *in.IsPublic
+	}
 	if in.Settings != nil {
 		p.Settings = cloneSettings(in.Settings)
 	}
@@ -305,6 +309,15 @@ func (s *Service) Update(ctx context.Context, id uuid.UUID, in projectdom.Update
 		return nil, err
 	}
 	return p, nil
+}
+
+// IsProjectPublic returns true when the project exists and has is_public set.
+func (s *Service) IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error) {
+	p, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return p.IsPublic, nil
 }
 
 // Delete removes a project and all cascading records defined in the DB schema.

--- a/services/api/internal/transport/http/dto/project_dto.go
+++ b/services/api/internal/transport/http/dto/project_dto.go
@@ -14,6 +14,7 @@ type CreateProjectRequest struct {
 	Name         string         `json:"name" binding:"required"`
 	Description  string         `json:"description"`
 	TaskIDPrefix string         `json:"task_id_prefix"`
+	IsPublic     bool           `json:"is_public"`
 	Settings     map[string]any `json:"settings"`
 }
 
@@ -22,6 +23,7 @@ type UpdateProjectRequest struct {
 	Name         string         `json:"name"`
 	Description  string         `json:"description"`
 	TaskIDPrefix string         `json:"task_id_prefix"`
+	IsPublic     *bool          `json:"is_public"`
 	Settings     map[string]any `json:"settings"`
 }
 
@@ -31,6 +33,7 @@ type ProjectResponse struct {
 	Name         string         `json:"name"`
 	Description  string         `json:"description"`
 	TaskIDPrefix string         `json:"task_id_prefix"`
+	IsPublic     bool           `json:"is_public"`
 	Settings     map[string]any `json:"settings"`
 	CreatedBy    *uuid.UUID     `json:"created_by,omitempty"`
 	CreatedAt    time.Time      `json:"created_at"`
@@ -47,6 +50,7 @@ func ProjectFromEntity(p *projectdom.Project) ProjectResponse {
 		Name:         p.Name,
 		Description:  p.Description,
 		TaskIDPrefix: p.TaskIDPrefix,
+		IsPublic:     p.IsPublic,
 		Settings:     settings,
 		CreatedBy:    p.CreatedBy,
 		CreatedAt:    p.CreatedAt,

--- a/services/api/internal/transport/http/handler/project_handler.go
+++ b/services/api/internal/transport/http/handler/project_handler.go
@@ -122,6 +122,7 @@ func (h *ProjectHandler) CreateProject(c *gin.Context) {
 		Name:         req.Name,
 		Description:  req.Description,
 		TaskIDPrefix: req.TaskIDPrefix,
+		IsPublic:     req.IsPublic,
 		Settings:     req.Settings,
 		CreatedBy:    createdBy,
 	})
@@ -162,6 +163,7 @@ func (h *ProjectHandler) UpdateProject(c *gin.Context) {
 		Name:         req.Name,
 		Description:  req.Description,
 		TaskIDPrefix: req.TaskIDPrefix,
+		IsPublic:     req.IsPublic,
 		Settings:     req.Settings,
 	})
 	if err != nil {

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -31,6 +31,7 @@ type mockProjectSvc struct {
 	list                    func(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error)
 	listAccessible          func(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error)
 	getByID                 func(ctx context.Context, id uuid.UUID) (*projectdom.Project, error)
+	isProjectPublic         func(ctx context.Context, id uuid.UUID) (bool, error)
 	create                  func(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error)
 	update                  func(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error)
 	delete                  func(ctx context.Context, id uuid.UUID) error
@@ -64,6 +65,13 @@ func (m *mockProjectSvc) GetByID(ctx context.Context, id uuid.UUID) (*projectdom
 		return m.getByID(ctx, id)
 	}
 	return nil, projectdom.ErrNotFound
+}
+
+func (m *mockProjectSvc) IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error) {
+	if m.isProjectPublic != nil {
+		return m.isProjectPublic(ctx, id)
+	}
+	return false, nil
 }
 
 func (m *mockProjectSvc) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {

--- a/services/api/internal/transport/http/middleware/authn.go
+++ b/services/api/internal/transport/http/middleware/authn.go
@@ -140,6 +140,86 @@ func Authn(tm *jwttoken.Manager, apiKeyAuth ...APIKeyAuthenticator) gin.HandlerF
 	}
 }
 
+// OptionalAuthn tries to authenticate the request using the same credential
+// sources as Authn (cookie → Bearer → API key), but does NOT abort if no
+// credentials are present.  Downstream handlers must check ClaimsFrom for nil
+// to determine whether the caller is authenticated.
+func OptionalAuthn(tm *jwttoken.Manager, apiKeyAuth ...APIKeyAuthenticator) gin.HandlerFunc {
+	var apiKeyAuthenticator APIKeyAuthenticator
+	if len(apiKeyAuth) > 0 {
+		apiKeyAuthenticator = apiKeyAuth[0]
+	}
+	return func(c *gin.Context) {
+		tokenStr := ""
+		isAPIKey := false
+
+		if cookie, err := c.Cookie("access_token"); err == nil && cookie != "" {
+			tokenStr = cookie
+		}
+		if tokenStr == "" {
+			header := c.GetHeader("Authorization")
+			if header != "" {
+				parts := strings.SplitN(header, " ", 2)
+				if len(parts) == 2 {
+					switch strings.ToLower(parts[0]) {
+					case "bearer":
+						tokenStr = parts[1]
+					case "apikey":
+						tokenStr = parts[1]
+						isAPIKey = true
+					}
+				}
+			}
+		}
+		if tokenStr == "" {
+			if v := c.GetHeader("X-API-Key"); v != "" {
+				tokenStr = v
+				isAPIKey = true
+			}
+		}
+
+		// No credentials at all — allow the request through as anonymous.
+		if tokenStr == "" {
+			c.Next()
+			return
+		}
+
+		if isAPIKey {
+			if apiKeyAuthenticator != nil {
+				key, err := apiKeyAuthenticator.Authenticate(c.Request.Context(), tokenStr)
+				if err == nil {
+					syntheticClaims := &domainauth.Claims{
+						RegisteredClaims: jwt.RegisteredClaims{
+							Subject: key.UserID.String(),
+						},
+						Kind: "access",
+					}
+					c.Set(claimsKey, syntheticClaims)
+					c.Set(authMethodKey, "apikey")
+					ctx := context.WithValue(c.Request.Context(), actorContextKey{}, key.UserID)
+					c.Request = c.Request.WithContext(ctx)
+				}
+			}
+			c.Next()
+			return
+		}
+
+		claims, err := tm.Verify(tokenStr)
+		if err != nil || claims.Kind != "access" {
+			// Invalid token provided — reject rather than silently downgrade.
+			presenter.Error(c, apierr.New(apierr.CodeTokenInvalid, "invalid or expired token"))
+			return
+		}
+
+		c.Set(claimsKey, claims)
+		if actorID, parseErr := uuid.Parse(claims.Subject); parseErr == nil {
+			ctx := context.WithValue(c.Request.Context(), actorContextKey{}, actorID)
+			c.Request = c.Request.WithContext(ctx)
+		}
+		c.Next()
+	}
+}
+
 // ClaimsFrom retrieves the authenticated claims from the Gin context.
 // It returns nil if no claims are present (e.g. on unauthenticated routes).
 func ClaimsFrom(c *gin.Context) *domainauth.Claims {

--- a/services/api/internal/transport/http/middleware/authz.go
+++ b/services/api/internal/transport/http/middleware/authz.go
@@ -1,9 +1,13 @@
 package middleware
 
 import (
+	"context"
+	"errors"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/paca/api/internal/apierr"
+	"github.com/paca/api/internal/domain/project"
 	"github.com/paca/api/internal/platform/authz"
 	"github.com/paca/api/internal/transport/http/presenter"
 )
@@ -147,5 +151,91 @@ func RequireAnyPermissions(authorizer *authz.Authorizer, groups ...PermissionGro
 			return
 		}
 		presenter.Error(c, apierr.New(apierr.CodeForbidden, "insufficient permissions"))
+	}
+}
+
+// ProjectVisibilityChecker is the minimal interface the public-project
+// middleware requires.  It is satisfied by *projectsvc.Service.
+type ProjectVisibilityChecker interface {
+	IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error)
+}
+
+// RequirePublicProjectOrPermissions grants access when at least one of the
+// following conditions is true:
+//
+//   - The request is authenticated and the caller satisfies any of the
+//     provided PermissionGroups (same logic as RequireAnyPermissions).
+//   - The project identified by the "projectId" route parameter has
+//     is_public = true, regardless of authentication status.
+//
+// Use this instead of RequireAnyPermissions on read-only project-scoped routes
+// that should be accessible to anonymous users when the project is public.
+func RequirePublicProjectOrPermissions(checker ProjectVisibilityChecker, authorizer *authz.Authorizer, groups ...PermissionGroup) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claims := ClaimsFrom(c)
+
+		// Authenticated path: run normal permission check.
+		if claims != nil {
+			userID, err := uuid.Parse(claims.Subject)
+			if err != nil {
+				presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid subject claim"))
+				return
+			}
+			var firstScopeErr error
+			for _, group := range groups {
+				resolver := group.Scope
+				if resolver == nil {
+					resolver = GlobalScope()
+				}
+				projectID, err := resolver(c)
+				if err != nil {
+					if firstScopeErr == nil {
+						firstScopeErr = err
+					}
+					continue
+				}
+				allowed, err := authorizer.HasPermissions(c.Request.Context(), userID, projectID, claims.Role, group.Permissions...)
+				if err != nil {
+					presenter.Error(c, err)
+					return
+				}
+				if allowed {
+					c.Next()
+					return
+				}
+			}
+			if firstScopeErr != nil {
+				presenter.Error(c, firstScopeErr)
+				return
+			}
+			presenter.Error(c, apierr.New(apierr.CodeForbidden, "insufficient permissions"))
+			return
+		}
+
+		// Unauthenticated path: allow only when the project is public.
+		projectIDStr := c.Param("projectId")
+		if projectIDStr == "" {
+			presenter.Error(c, apierr.New(apierr.CodeUnauthenticated, "unauthenticated"))
+			return
+		}
+		projectID, err := uuid.Parse(projectIDStr)
+		if err != nil {
+			presenter.Error(c, apierr.New(apierr.CodeBadRequest, "invalid project id"))
+			return
+		}
+		isPublic, err := checker.IsProjectPublic(c.Request.Context(), projectID)
+		if err != nil {
+			if errors.Is(err, projectdom.ErrNotFound) {
+				presenter.Error(c, apierr.New(apierr.CodeUnauthenticated, "unauthenticated"))
+				return
+			}
+			presenter.Error(c, err)
+			return
+		}
+		if !isPublic {
+			presenter.Error(c, apierr.New(apierr.CodeUnauthenticated, "unauthenticated"))
+			return
+		}
+		c.Next()
 	}
 }

--- a/services/api/internal/transport/http/middleware/authz.go
+++ b/services/api/internal/transport/http/middleware/authz.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/paca/api/internal/apierr"
-	"github.com/paca/api/internal/domain/project"
+	projectdom "github.com/paca/api/internal/domain/project"
 	"github.com/paca/api/internal/platform/authz"
 	"github.com/paca/api/internal/transport/http/presenter"
 )

--- a/services/api/internal/transport/http/middleware/authz_test.go
+++ b/services/api/internal/transport/http/middleware/authz_test.go
@@ -262,3 +262,120 @@ func TestRequireAnyPermissions_InvalidProjectID_GlobalGroupSucceeds(t *testing.T
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// RequirePublicProjectOrPermissions
+// ---------------------------------------------------------------------------
+
+type mockVisibilityChecker struct {
+	isPublic bool
+	err      error
+}
+
+func (m *mockVisibilityChecker) IsProjectPublic(_ context.Context, _ uuid.UUID) (bool, error) {
+	return m.isPublic, m.err
+}
+
+func TestRequirePublicProjectOrPermissions_AnonymousPublicProject_Allows(t *testing.T) {
+	// No claims (anonymous), checker says project is public → 200.
+	checker := &mockVisibilityChecker{isPublic: true}
+	r := gin.New()
+	r.GET("/projects/:projectId/tasks",
+		RequirePublicProjectOrPermissions(checker, authz.NewAuthorizer(nil),
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/tasks", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequirePublicProjectOrPermissions_AnonymousPrivateProject_Returns401(t *testing.T) {
+	// No claims, checker says project is private → 401.
+	checker := &mockVisibilityChecker{isPublic: false}
+	r := gin.New()
+	r.GET("/projects/:projectId/tasks",
+		RequirePublicProjectOrPermissions(checker, authz.NewAuthorizer(nil),
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/tasks", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRequirePublicProjectOrPermissions_AnonymousInvalidProjectID_Returns400(t *testing.T) {
+	// No claims, invalid project UUID → 400.
+	checker := &mockVisibilityChecker{isPublic: false}
+	r := gin.New()
+	r.GET("/projects/:projectId/tasks",
+		RequirePublicProjectOrPermissions(checker, authz.NewAuthorizer(nil),
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/not-a-uuid/tasks", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestRequirePublicProjectOrPermissions_AuthenticatedWithPermission_Allows(t *testing.T) {
+	// Authenticated user with sufficient permission → 200.
+	store := &mockPermissionStore{projectPerms: []authz.Permission{authz.PermissionTasksRead}}
+	checker := &mockVisibilityChecker{isPublic: false}
+	r := gin.New()
+	r.GET("/projects/:projectId/tasks",
+		withClaims("USER"),
+		RequirePublicProjectOrPermissions(checker, authz.NewAuthorizer(store),
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/tasks", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequirePublicProjectOrPermissions_AuthenticatedWithoutPermission_Returns403(t *testing.T) {
+	// Authenticated user without permission, private project → 403.
+	store := &mockPermissionStore{}
+	checker := &mockVisibilityChecker{isPublic: false}
+	r := gin.New()
+	r.GET("/projects/:projectId/tasks",
+		withClaims("USER"),
+		RequirePublicProjectOrPermissions(checker, authz.NewAuthorizer(store),
+			PermissionGroup{Scope: ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+		),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/projects/"+uuid.NewString()+"/tasks", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -17,24 +17,25 @@ import (
 
 // Deps holds all handler and middleware dependencies.
 type Deps struct {
-	TokenManager *jwttoken.Manager
-	APIKeyAuth   httpmw.APIKeyAuthenticator
-	Authorizer   *authz.Authorizer
-	Health       *handler.HealthHandler
-	Auth         *handler.AuthHandler
-	User         *handler.UserHandler
-	GlobalRole   *handler.GlobalRoleHandler
-	Project      *handler.ProjectHandler
-	Task         *handler.TaskHandler
-	Sprint       *handler.SprintHandler
-	View         *handler.ViewHandler
-	Attachment   *handler.AttachmentHandler
-	Document     *handler.DocumentHandler
-	DocFile      *handler.DocFileHandler
-	Notification *handler.NotificationHandler
-	GitHub       *handler.GitHubHandler
-	APIKey       *handler.APIKeyHandler
-	Log          *slog.Logger
+	TokenManager         *jwttoken.Manager
+	APIKeyAuth           httpmw.APIKeyAuthenticator
+	Authorizer           *authz.Authorizer
+	ProjectVisibilitySvc httpmw.ProjectVisibilityChecker
+	Health               *handler.HealthHandler
+	Auth                 *handler.AuthHandler
+	User                 *handler.UserHandler
+	GlobalRole           *handler.GlobalRoleHandler
+	Project              *handler.ProjectHandler
+	Task                 *handler.TaskHandler
+	Sprint               *handler.SprintHandler
+	View                 *handler.ViewHandler
+	Attachment           *handler.AttachmentHandler
+	Document             *handler.DocumentHandler
+	DocFile              *handler.DocFileHandler
+	Notification         *handler.NotificationHandler
+	GitHub               *handler.GitHubHandler
+	APIKey               *handler.APIKeyHandler
+	Log                  *slog.Logger
 }
 
 // New builds and returns a configured *gin.Engine.
@@ -151,6 +152,8 @@ func New(deps Deps) *gin.Engine {
 
 		// Project routes — list/create are collection-level; all other actions are
 		// project-scoped and accessible to members with appropriate roles.
+		// Collection routes require authentication; per-project read routes also
+		// allow anonymous access when the project has is_public = true.
 		projects := v1.Group("/projects")
 		projects.Use(httpmw.Authn(deps.TokenManager, deps.APIKeyAuth))
 		projects.Use(httpmw.RequireFreshPassword())
@@ -163,514 +166,514 @@ func New(deps Deps) *gin.Engine {
 				httpmw.RequirePermissions(deps.Authorizer, httpmw.GlobalScope(), authz.PermissionProjectsCreate),
 				deps.Project.CreateProject,
 			)
+		}
 
-			// Single-project routes
-			project := projects.Group("/:projectId")
+		// Single-project routes — use optional auth so anonymous users can access
+		// public projects (is_public = true) without credentials.
+		project := v1.Group("/projects/:projectId")
+		project.Use(httpmw.OptionalAuthn(deps.TokenManager, deps.APIKeyAuth))
+		project.Use(httpmw.RequireFreshPassword())
+		{
+			project.GET("",
+				// Allow: global projects.read OR project-scoped projects.read OR public project.
+				httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+					httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+					httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+				),
+				deps.Project.GetProject,
+			)
+			project.PATCH("",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsWrite),
+				deps.Project.UpdateProject,
+			)
+			project.DELETE("",
+				httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsDelete),
+				deps.Project.DeleteProject,
+			)
+
+			members := project.Group("/members")
 			{
-				project.GET("",
-					// Allow: global projects.read OR project-scoped projects.read
-					// (any project member role with projects.read can view the project).
-					httpmw.RequireAnyPermissions(deps.Authorizer,
+				members.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
 					),
-					deps.Project.GetProject,
+					deps.Project.ListMembers,
 				)
-				project.PATCH("",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsWrite),
-					deps.Project.UpdateProject,
+				members.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+					deps.Project.AddMember,
 				)
-				project.DELETE("",
-					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsDelete),
-					deps.Project.DeleteProject,
+				// Static sub-path must come before /:userId to avoid the param swallowing it.
+				members.GET("/me/permissions", deps.Project.GetMyProjectPermissions)
+				members.PATCH("/:userId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+					deps.Project.UpdateMemberRole,
+				)
+				members.DELETE("/:userId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
+					deps.Project.RemoveMember,
+				)
+			}
+
+			roles := project.Group("/roles")
+			{
+				roles.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectRolesRead}},
+					),
+					deps.Project.ListRoles,
+				)
+				roles.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+					deps.Project.CreateRole,
+				)
+				roles.PATCH("/:roleId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+					deps.Project.UpdateRole,
+				)
+				roles.DELETE("/:roleId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
+					deps.Project.DeleteRole,
+				)
+			}
+
+			// Task types — project-scoped configuration
+			taskTypes := project.Group("/task-types")
+			{
+				taskTypes.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.ListTaskTypes,
+				)
+				taskTypes.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.CreateTaskType,
+				)
+				taskTypes.PATCH("/:typeId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.UpdateTaskType,
+				)
+				taskTypes.DELETE("/:typeId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.DeleteTaskType,
+				)
+				taskTypes.PUT("/:typeId/set-default",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.SetDefaultTaskType,
+				)
+			}
+
+			// Task statuses — project-scoped workflow configuration
+			taskStatuses := project.Group("/task-statuses")
+			{
+				taskStatuses.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.ListTaskStatuses,
+				)
+				taskStatuses.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.CreateTaskStatus,
+				)
+				taskStatuses.PATCH("/:statusId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.UpdateTaskStatus,
+				)
+				taskStatuses.DELETE("/:statusId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.DeleteTaskStatus,
+				)
+				taskStatuses.PUT("/:statusId/set-default",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.SetDefaultTaskStatus,
+				)
+			}
+
+			// Sprints
+			sprints := project.Group("/sprints")
+			{
+				sprints.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
+					),
+					deps.Sprint.ListSprints,
+				)
+				sprints.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.Sprint.CreateSprint,
+				)
+				sprints.GET("/:sprintId",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
+					),
+					deps.Sprint.GetSprint,
+				)
+				sprints.PATCH("/:sprintId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.Sprint.UpdateSprint,
+				)
+				sprints.DELETE("/:sprintId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.Sprint.DeleteSprint,
+				)
+				sprints.POST("/:sprintId/complete",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.Sprint.CompleteSprint,
+				)
+			}
+
+			// Views — unified endpoint for sprint, backlog, and timeline views.
+			// Use ?context=sprint|backlog|timeline; sprint context also requires ?sprint_id=<uuid>.
+			views := project.Group("/views")
+			{
+				views.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
+					),
+					deps.View.ListViews,
+				)
+				views.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.View.CreateView,
+				)
+				// Static /positions must be registered before /:viewId.
+				views.PUT("/positions",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.View.ReorderViews,
+				)
+				views.GET("/:viewId",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
+					),
+					deps.View.GetView,
+				)
+				views.PATCH("/:viewId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.View.UpdateView,
+				)
+				views.DELETE("/:viewId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
+					deps.View.DeleteView,
+				)
+				views.GET("/:viewId/task-positions",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.View.ListTaskPositions,
+				)
+				views.PUT("/:viewId/task-positions",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.View.BulkMoveTasks,
+				)
+				views.PUT("/:viewId/task-positions/:taskId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.View.MoveTask,
+				)
+			}
+
+			// Tasks — core work items
+			tasks := project.Group("/tasks")
+			{
+				tasks.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.ListTasks,
+				)
+				tasks.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.CreateTask,
+				)
+				tasks.GET("/by-number/:taskNumber",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.GetTaskByNumber,
+				)
+				tasks.GET("/:taskId",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.GetTask,
+				)
+				tasks.PATCH("/:taskId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.UpdateTask,
+				)
+				tasks.DELETE("/:taskId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.DeleteTask,
 				)
 
-				members := project.Group("/members")
+				// BDD scenarios — task-level acceptance criteria
+				bddScenarios := tasks.Group("/:taskId/bdd-scenarios")
 				{
-					members.GET("",
-						// Allow: global projects.read (view-all grant) OR project-scoped members.read.
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectMembersRead}},
-						),
-						deps.Project.ListMembers,
-					)
-					members.POST("",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
-						deps.Project.AddMember,
-					)
-					// Static sub-path must come before /:userId to avoid the param swallowing it.
-					members.GET("/me/permissions", deps.Project.GetMyProjectPermissions)
-					members.PATCH("/:userId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
-						deps.Project.UpdateMemberRole,
-					)
-					members.DELETE("/:userId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectMembersWrite),
-						deps.Project.RemoveMember,
-					)
-				}
-
-				roles := project.Group("/roles")
-				{
-					roles.GET("",
-						// Allow: global projects.read (view-all grant) OR project-scoped roles.read.
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionProjectRolesRead}},
-						),
-						deps.Project.ListRoles,
-					)
-					roles.POST("",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
-						deps.Project.CreateRole,
-					)
-					roles.PATCH("/:roleId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
-						deps.Project.UpdateRole,
-					)
-					roles.DELETE("/:roleId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectRolesWrite),
-						deps.Project.DeleteRole,
-					)
-				}
-
-				// Task types — project-scoped configuration
-				taskTypes := project.Group("/task-types")
-				{
-					taskTypes.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
+					bddScenarios.GET("",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
 						),
-						deps.Task.ListTaskTypes,
+						deps.Task.ListBDDScenarios,
 					)
-					taskTypes.POST("",
+					bddScenarios.POST("",
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.CreateTaskType,
+						deps.Task.CreateBDDScenario,
 					)
-					taskTypes.PATCH("/:typeId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.UpdateTaskType,
+					bddScenarios.GET("/:scenarioId",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+						),
+						deps.Task.GetBDDScenario,
 					)
-					taskTypes.DELETE("/:typeId",
+					bddScenarios.PATCH("/:scenarioId",
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.DeleteTaskType,
+						deps.Task.UpdateBDDScenario,
 					)
-					taskTypes.PUT("/:typeId/set-default",
+					bddScenarios.DELETE("/:scenarioId",
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.SetDefaultTaskType,
+						deps.Task.DeleteBDDScenario,
 					)
 				}
 
-				// Task statuses — project-scoped workflow configuration
-				taskStatuses := project.Group("/task-statuses")
+				// Activities — task activity log and user comments
+				activities := tasks.Group("/:taskId/activities")
 				{
-					taskStatuses.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
+					activities.GET("",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
 						),
-						deps.Task.ListTaskStatuses,
+						deps.Task.ListTaskActivities,
 					)
-					taskStatuses.POST("",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.CreateTaskStatus,
-					)
-					taskStatuses.PATCH("/:statusId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.UpdateTaskStatus,
-					)
-					taskStatuses.DELETE("/:statusId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.DeleteTaskStatus,
-					)
-					taskStatuses.PUT("/:statusId/set-default",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.SetDefaultTaskStatus,
-					)
-				}
-
-				// Sprints
-				sprints := project.Group("/sprints")
-				{
-					sprints.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
-						),
-						deps.Sprint.ListSprints,
-					)
-					sprints.POST("",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.Sprint.CreateSprint,
-					)
-					sprints.GET("/:sprintId",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
-						),
-						deps.Sprint.GetSprint,
-					)
-					sprints.PATCH("/:sprintId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.Sprint.UpdateSprint,
-					)
-					sprints.DELETE("/:sprintId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.Sprint.DeleteSprint,
-					)
-					sprints.POST("/:sprintId/complete",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.Sprint.CompleteSprint,
-					)
-				}
-
-				// Views — unified endpoint for sprint, backlog, and timeline views.
-				// Use ?context=sprint|backlog|timeline; sprint context also requires ?sprint_id=<uuid>.
-				views := project.Group("/views")
-				{
-					views.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
-						),
-						deps.View.ListViews,
-					)
-					views.POST("",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.View.CreateView,
-					)
-					// Static /positions must be registered before /:viewId.
-					views.PUT("/positions",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.View.ReorderViews,
-					)
-					views.GET("/:viewId",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionSprintsRead}},
-						),
-						deps.View.GetView,
-					)
-					views.PATCH("/:viewId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.View.UpdateView,
-					)
-					views.DELETE("/:viewId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionSprintsWrite),
-						deps.View.DeleteView,
-					)
-					views.GET("/:viewId/task-positions",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-						),
-						deps.View.ListTaskPositions,
-					)
-					views.PUT("/:viewId/task-positions",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.View.BulkMoveTasks,
-					)
-					views.PUT("/:viewId/task-positions/:taskId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.View.MoveTask,
-					)
-				}
-
-				// Tasks — core work items
-				tasks := project.Group("/tasks")
-				{
-					tasks.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-						),
-						deps.Task.ListTasks,
-					)
-					tasks.POST("",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.CreateTask,
-					)
-					tasks.GET("/by-number/:taskNumber",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-						),
-						deps.Task.GetTaskByNumber,
-					)
-					tasks.GET("/:taskId",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
-							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-						),
-						deps.Task.GetTask,
-					)
-					tasks.PATCH("/:taskId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.UpdateTask,
-					)
-					tasks.DELETE("/:taskId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.DeleteTask,
-					)
-
-					// BDD scenarios — task-level acceptance criteria
-					bddScenarios := tasks.Group("/:taskId/bdd-scenarios")
+					// Comments are a sub-resource of activities
+					comments := activities.Group("/comments")
 					{
-						bddScenarios.GET("",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
-								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-							),
-							deps.Task.ListBDDScenarios,
-						)
-						bddScenarios.POST("",
+						comments.POST("",
 							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-							deps.Task.CreateBDDScenario,
+							deps.Task.AddComment,
 						)
-						bddScenarios.GET("/:scenarioId",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
-								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-							),
-							deps.Task.GetBDDScenario,
-						)
-						bddScenarios.PATCH("/:scenarioId",
+						comments.PATCH("/:commentId",
 							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-							deps.Task.UpdateBDDScenario,
+							deps.Task.UpdateComment,
 						)
-						bddScenarios.DELETE("/:scenarioId",
+						comments.DELETE("/:commentId",
 							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-							deps.Task.DeleteBDDScenario,
+							deps.Task.DeleteComment,
 						)
-					}
-
-					// Activities — task activity log and user comments
-					activities := tasks.Group("/:taskId/activities")
-					{
-						activities.GET("",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
-								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-							),
-							deps.Task.ListTaskActivities,
-						)
-						// Comments are a sub-resource of activities
-						comments := activities.Group("/comments")
-						{
-							comments.POST("",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-								deps.Task.AddComment,
-							)
-							comments.PATCH("/:commentId",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-								deps.Task.UpdateComment,
-							)
-							comments.DELETE("/:commentId",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-								deps.Task.DeleteComment,
-							)
-						}
-					}
-
-					// Attachments — files uploaded and linked to a task
-					attachments := tasks.Group("/:taskId/attachments")
-					{
-						attachments.GET("",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
-								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-							),
-							deps.Attachment.ListTaskAttachments,
-						)
-						attachments.POST("/initiate-upload",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-							deps.Attachment.InitiateUpload,
-						)
-						attachments.POST("/complete-upload",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-							deps.Attachment.CompleteUpload,
-						)
-						attachments.GET("/:attachmentId/download-url",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
-								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-							),
-							deps.Attachment.GetDownloadURL,
-						)
-						attachments.DELETE("/:attachmentId",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-							deps.Attachment.DeleteTaskAttachment,
-						)
-					}
-
-					// GitHub — pull requests linked to a task and branch creation
-					if deps.GitHub != nil {
-						githubTask := tasks.Group("/:taskId/github")
-						{
-							githubTask.GET("/pull-requests",
-								httpmw.RequireAnyPermissions(deps.Authorizer,
-									httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-									httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-								),
-								deps.GitHub.ListTaskPRs,
-							)
-							githubTask.POST("/pull-requests",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-								deps.GitHub.LinkPRToTask,
-							)
-							githubTask.DELETE("/pull-requests/:prId",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-								deps.GitHub.UnlinkPRFromTask,
-							)
-							githubTask.POST("/branches",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-								deps.GitHub.CreateBranch,
-							)
-							githubTask.GET("/branches",
-								httpmw.RequireAnyPermissions(deps.Authorizer,
-									httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-									httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
-								),
-								deps.GitHub.ListTaskBranches,
-							)
-						}
 					}
 				}
 
-				// Custom field definitions — project-level schema
-				customFields := project.Group("/custom-fields")
+				// Attachments — files uploaded and linked to a task
+				attachments := tasks.Group("/:taskId/attachments")
 				{
-					customFields.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
+					attachments.GET("",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
 						),
-						deps.Task.ListCustomFieldDefinitions,
+						deps.Attachment.ListTaskAttachments,
 					)
-					customFields.POST("",
+					attachments.POST("/initiate-upload",
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.CreateCustomFieldDefinition,
+						deps.Attachment.InitiateUpload,
 					)
-					customFields.GET("/:fieldId",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
+					attachments.POST("/complete-upload",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+						deps.Attachment.CompleteUpload,
+					)
+					attachments.GET("/:attachmentId/download-url",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
 						),
-						deps.Task.GetCustomFieldDefinition,
+						deps.Attachment.GetDownloadURL,
 					)
-					customFields.PATCH("/:fieldId",
+					attachments.DELETE("/:attachmentId",
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.UpdateCustomFieldDefinition,
-					)
-					customFields.DELETE("/:fieldId",
-						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
-						deps.Task.DeleteCustomFieldDefinition,
+						deps.Attachment.DeleteTaskAttachment,
 					)
 				}
 
-				// Documentation — project documents with folder hierarchy, snapshots, and activity
-				docs := project.Group("/docs")
-				{
-					// Folders
-					folders := docs.Group("/folders")
+				// GitHub — pull requests linked to a task and branch creation
+				if deps.GitHub != nil {
+					githubTask := tasks.Group("/:taskId/github")
 					{
-						folders.GET("",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
+						githubTask.GET("/pull-requests",
+							httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
+								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
 							),
-							deps.Document.ListFolders,
+							deps.GitHub.ListTaskPRs,
 						)
-						folders.POST("",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-							deps.Document.CreateFolder,
+						githubTask.POST("/pull-requests",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+							deps.GitHub.LinkPRToTask,
 						)
-						folders.PATCH("/:folderId",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-							deps.Document.UpdateFolder,
+						githubTask.DELETE("/pull-requests/:prId",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+							deps.GitHub.UnlinkPRFromTask,
 						)
-						folders.DELETE("/:folderId",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-							deps.Document.DeleteFolder,
+						githubTask.POST("/branches",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+							deps.GitHub.CreateBranch,
+						)
+						githubTask.GET("/branches",
+							httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+							),
+							deps.GitHub.ListTaskBranches,
 						)
 					}
+				}
+			}
 
-					// Documents — collection
-					docs.GET("",
-						httpmw.RequireAnyPermissions(deps.Authorizer,
+			// Custom field definitions — project-level schema
+			customFields := project.Group("/custom-fields")
+			{
+				customFields.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.ListCustomFieldDefinitions,
+				)
+				customFields.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.CreateCustomFieldDefinition,
+				)
+				customFields.GET("/:fieldId",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+					),
+					deps.Task.GetCustomFieldDefinition,
+				)
+				customFields.PATCH("/:fieldId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.UpdateCustomFieldDefinition,
+				)
+				customFields.DELETE("/:fieldId",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite),
+					deps.Task.DeleteCustomFieldDefinition,
+				)
+			}
+
+			// Documentation — project documents with folder hierarchy, snapshots, and activity
+			docs := project.Group("/docs")
+			{
+				// Folders
+				folders := docs.Group("/folders")
+				{
+					folders.GET("",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
 						),
-						deps.Document.ListDocuments,
+						deps.Document.ListFolders,
 					)
-					docs.POST("",
+					folders.POST("",
 						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-						deps.Document.CreateDocument,
+						deps.Document.CreateFolder,
+					)
+					folders.PATCH("/:folderId",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+						deps.Document.UpdateFolder,
+					)
+					folders.DELETE("/:folderId",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+						deps.Document.DeleteFolder,
+					)
+				}
+
+				// Documents — collection
+				docs.GET("",
+					httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+						httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+						httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
+					),
+					deps.Document.ListDocuments,
+				)
+				docs.POST("",
+					httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+					deps.Document.CreateDocument,
+				)
+
+				// Documents — single item
+				doc := docs.Group("/:docId")
+				{
+					doc.GET("",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
+						),
+						deps.Document.GetDocument,
+					)
+					doc.PATCH("",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+						deps.Document.UpdateDocument,
+					)
+					doc.DELETE("",
+						httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+						deps.Document.DeleteDocument,
 					)
 
-					// Documents — single item
-					doc := docs.Group("/:docId")
+					// Snapshots — version history
+					snapshots := doc.Group("/snapshots")
 					{
-						doc.GET("",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
+						snapshots.GET("",
+							httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
 							),
-							deps.Document.GetDocument,
+							deps.Document.ListSnapshots,
 						)
-						doc.PATCH("",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-							deps.Document.UpdateDocument,
-						)
-						doc.DELETE("",
-							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-							deps.Document.DeleteDocument,
-						)
-
-						// Snapshots — version history
-						snapshots := doc.Group("/snapshots")
-						{
-							snapshots.GET("",
-								httpmw.RequireAnyPermissions(deps.Authorizer,
-									httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-									httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
-								),
-								deps.Document.ListSnapshots,
-							)
-							snapshots.GET("/:snapshotId",
-								httpmw.RequireAnyPermissions(deps.Authorizer,
-									httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
-									httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
-								),
-								deps.Document.GetSnapshot,
-							)
-						}
-
-						// Activity log and comments
-						doc.GET("/activities",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
+						snapshots.GET("/:snapshotId",
+							httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
 							),
-							deps.Document.ListActivities,
+							deps.Document.GetSnapshot,
 						)
-						comments := doc.Group("/comments")
-						{
-							comments.POST("",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-								deps.Document.AddComment,
-							)
-							comments.PATCH("/:commentId",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-								deps.Document.UpdateComment,
-							)
-							comments.DELETE("/:commentId",
-								httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
-								deps.Document.DeleteComment,
-							)
-						}
+					}
+
+					// Activity log and comments
+					doc.GET("/activities",
+						httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
+						),
+						deps.Document.ListActivities,
+					)
+					comments := doc.Group("/comments")
+					{
+						comments.POST("",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+							deps.Document.AddComment,
+						)
+						comments.PATCH("/:commentId",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+							deps.Document.UpdateComment,
+						)
+						comments.DELETE("/:commentId",
+							httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionDocsWrite),
+							deps.Document.DeleteComment,
+						)
 					}
 
 					// Doc file uploads — stored directly in the files table (no join table)
@@ -685,7 +688,7 @@ func New(deps Deps) *gin.Engine {
 							deps.DocFile.CompleteDocUpload,
 						)
 						docFiles.GET("/:fileId/download-url",
-							httpmw.RequireAnyPermissions(deps.Authorizer,
+							httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
 								httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 								httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionDocsRead}},
 							),
@@ -697,20 +700,20 @@ func New(deps Deps) *gin.Engine {
 						)
 					}
 				}
+			}
 
-				// GitHub integration — project-level PAT and repository linking
-				if deps.GitHub != nil {
-					githubIntegration := project.Group("/github")
-					githubIntegration.Use(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsWrite))
-					{
-						githubIntegration.GET("", deps.GitHub.GetIntegration)
-						githubIntegration.PUT("/token", deps.GitHub.SetToken)
-						githubIntegration.DELETE("/token", deps.GitHub.DeleteToken)
-						githubIntegration.GET("/repositories", deps.GitHub.ListRepositories)
-						githubIntegration.GET("/linked-repositories", deps.GitHub.ListLinkedRepositories)
-						githubIntegration.POST("/linked-repositories", deps.GitHub.LinkRepository)
-						githubIntegration.DELETE("/linked-repositories/:repoId", deps.GitHub.UnlinkRepository)
-					}
+			// GitHub integration — project-level PAT and repository linking
+			if deps.GitHub != nil {
+				githubIntegration := project.Group("/github")
+				githubIntegration.Use(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionProjectsWrite))
+				{
+					githubIntegration.GET("", deps.GitHub.GetIntegration)
+					githubIntegration.PUT("/token", deps.GitHub.SetToken)
+					githubIntegration.DELETE("/token", deps.GitHub.DeleteToken)
+					githubIntegration.GET("/repositories", deps.GitHub.ListRepositories)
+					githubIntegration.GET("/linked-repositories", deps.GitHub.ListLinkedRepositories)
+					githubIntegration.POST("/linked-repositories", deps.GitHub.LinkRepository)
+					githubIntegration.DELETE("/linked-repositories/:repoId", deps.GitHub.UnlinkRepository)
 				}
 			}
 		}

--- a/services/api/migrations/000003_add_project_is_public.sql
+++ b/services/api/migrations/000003_add_project_is_public.sql
@@ -1,0 +1,12 @@
+-- 000003_add_project_is_public.sql
+-- Adds the is_public flag to projects, enabling anonymous read access
+-- to project data when the flag is set to true.
+
+BEGIN;
+
+ALTER TABLE projects
+    ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_projects_is_public ON projects (is_public) WHERE is_public = true;
+
+COMMIT;

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -214,21 +214,22 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 		RefreshSessionTTL: e2eRefreshSessionTTL,
 	}
 	engine := router.New(router.Deps{
-		TokenManager: tm,
-		APIKeyAuth:   apiKeyService,
-		Authorizer:   authz.NewAuthorizer(authzStore),
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, cookieCfg),
-		User:         handler.NewUserHandler(userService),
-		GlobalRole:   handler.NewGlobalRoleHandler(globalRoleService),
-		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(authzStore)),
-		Task:         handler.NewTaskHandler(taskService, viewService, activityService),
-		Sprint:       handler.NewSprintHandler(sprintService, viewService),
-		View:         handler.NewViewHandler(viewService),
-		Attachment:   handler.NewAttachmentHandler(attachmentService),
-		APIKey:       handler.NewAPIKeyHandler(apiKeyService),
-		GitHub:       nil, // GitHub handler is wired per-test in github_test.go
-		Log:          log,
+		TokenManager:         tm,
+		APIKeyAuth:           apiKeyService,
+		Authorizer:           authz.NewAuthorizer(authzStore),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, cookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(globalRoleService),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(authzStore)),
+		Task:                 handler.NewTaskHandler(taskService, viewService, activityService),
+		Sprint:               handler.NewSprintHandler(sprintService, viewService),
+		View:                 handler.NewViewHandler(viewService),
+		Attachment:           handler.NewAttachmentHandler(attachmentService),
+		APIKey:               handler.NewAPIKeyHandler(apiKeyService),
+		GitHub:               nil, // GitHub handler is wired per-test in github_test.go
+		Log:                  log,
 	})
 
 	srv := httptest.NewServer(engine)

--- a/services/api/test/e2e/project_management_test.go
+++ b/services/api/test/e2e/project_management_test.go
@@ -1214,3 +1214,98 @@ func TestE2EGetMyProjectPermissions_Unauthenticated(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	assertStatus(t, resp, http.StatusUnauthorized)
 }
+
+// ---------------------------------------------------------------------------
+// Public project e2e tests
+// ---------------------------------------------------------------------------
+
+func TestE2EProject_PublicProjectAnonymousAccess(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "pub-anon-admin", "pubpass1")
+	adminClient, adminToken := projectAdminLogin(t, env, "pub-anon-admin", "pubpass1")
+
+	// Create a public project.
+	body := jsonBody(t, map[string]any{
+		"name":      "public-project-" + uuid.NewString(),
+		"is_public": true,
+	})
+	req := mustRequest(env.ctx, t, http.MethodPost, env.base+"/api/v1/projects", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp := mustDo(t, adminClient, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	projID, _ := data["id"].(string)
+	if isPublic, _ := data["is_public"].(bool); !isPublic {
+		t.Fatalf("expected is_public=true in create response")
+	}
+
+	// Anonymous GET (no auth) should succeed.
+	getURL := fmt.Sprintf("%s/api/v1/projects/%s", env.base, projID)
+	anonReq := mustRequest(env.ctx, t, http.MethodGet, getURL, nil)
+	anonResp := mustDo(t, env.client, anonReq)
+	defer func() { _ = anonResp.Body.Close() }()
+	assertStatus(t, anonResp, http.StatusOK)
+	var getEnv envelope
+	decodeJSON(t, anonResp, &getEnv)
+	getData := assertDataMap(t, getEnv)
+	if isPublic, _ := getData["is_public"].(bool); !isPublic {
+		t.Fatalf("expected is_public=true in anonymous get response")
+	}
+}
+
+func TestE2EProject_PrivateProjectAnonymousAccessDenied(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "priv-anon-admin", "privpass1")
+	adminClient, adminToken := projectAdminLogin(t, env, "priv-anon-admin", "privpass1")
+
+	// Create a private project (default is_public: false).
+	projID := createProjectViaAPI(t, env, adminClient, adminToken, "private-project-"+uuid.NewString(), "")
+
+	// Anonymous GET should return 401.
+	getURL := fmt.Sprintf("%s/api/v1/projects/%s", env.base, projID)
+	anonReq := mustRequest(env.ctx, t, http.MethodGet, getURL, nil)
+	anonResp := mustDo(t, env.client, anonReq)
+	defer func() { _ = anonResp.Body.Close() }()
+	assertStatus(t, anonResp, http.StatusUnauthorized)
+}
+
+func TestE2EProject_UpdateProjectVisibility(t *testing.T) {
+	env := newE2EEnv(t)
+	seedProjectAdminUser(t, env, "vis-admin", "vispass1")
+	adminClient, adminToken := projectAdminLogin(t, env, "vis-admin", "vispass1")
+
+	// Create a private project.
+	projID := createProjectViaAPI(t, env, adminClient, adminToken, "vis-project-"+uuid.NewString(), "")
+
+	// Anonymous access should fail.
+	getURL := fmt.Sprintf("%s/api/v1/projects/%s", env.base, projID)
+	anonReq := mustRequest(env.ctx, t, http.MethodGet, getURL, nil)
+	anonResp := mustDo(t, env.client, anonReq)
+	defer func() { _ = anonResp.Body.Close() }()
+	assertStatus(t, anonResp, http.StatusUnauthorized)
+
+	// PATCH to make it public.
+	patchBody := jsonBody(t, map[string]any{"is_public": true})
+	patchReq := mustRequest(env.ctx, t, http.MethodPatch, getURL, patchBody)
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchReq.Header.Set("Authorization", "Bearer "+adminToken)
+	patchResp := mustDo(t, adminClient, patchReq)
+	defer func() { _ = patchResp.Body.Close() }()
+	assertStatus(t, patchResp, http.StatusOK)
+	var patchEnv envelope
+	decodeJSON(t, patchResp, &patchEnv)
+	patchData := assertDataMap(t, patchEnv)
+	if isPublic, _ := patchData["is_public"].(bool); !isPublic {
+		t.Fatalf("expected is_public=true after PATCH")
+	}
+
+	// Anonymous GET should now succeed.
+	anonReq2 := mustRequest(env.ctx, t, http.MethodGet, getURL, nil)
+	anonResp2 := mustDo(t, env.client, anonReq2)
+	defer func() { _ = anonResp2.Body.Close() }()
+	assertStatus(t, anonResp2, http.StatusOK)
+}

--- a/services/api/test/integration/attachment_test.go
+++ b/services/api/test/integration/attachment_test.go
@@ -241,18 +241,19 @@ func buildAttachmentTestRouter(attachRepo *fakeAttachmentRepo, store *fakeStorag
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	return router.New(router.Deps{
-		TokenManager: tm,
-		Authorizer:   authz.NewAuthorizer(permStore),
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
-		User:         handler.NewUserHandler(userService),
-		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
-		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(permStore)),
-		Task:         handler.NewTaskHandler(taskService, viewService, active),
-		Sprint:       handler.NewSprintHandler(sprintService, viewService),
-		View:         handler.NewViewHandler(viewService),
-		Attachment:   handler.NewAttachmentHandler(attachmentService),
-		Log:          log,
+		TokenManager:         tm,
+		Authorizer:           authz.NewAuthorizer(permStore),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, testCookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(permStore)),
+		Task:                 handler.NewTaskHandler(taskService, viewService, active),
+		Sprint:               handler.NewSprintHandler(sprintService, viewService),
+		View:                 handler.NewViewHandler(viewService),
+		Attachment:           handler.NewAttachmentHandler(attachmentService),
+		Log:                  log,
 	})
 }
 

--- a/services/api/test/integration/document_test.go
+++ b/services/api/test/integration/document_test.go
@@ -317,18 +317,19 @@ func buildDocTestRouter(docRepo *fakeDocRepoIT, store *projectPermStore) *gin.En
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	return router.New(router.Deps{
-		TokenManager: tm,
-		Authorizer:   authz.NewAuthorizer(store),
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
-		User:         handler.NewUserHandler(userService),
-		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
-		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
-		Task:         handler.NewTaskHandler(taskService, viewService, activityService),
-		Sprint:       handler.NewSprintHandler(sprintService, viewService),
-		View:         handler.NewViewHandler(viewService),
-		Document:     handler.NewDocumentHandler(docService, docActivityService),
-		Log:          log,
+		TokenManager:         tm,
+		Authorizer:           authz.NewAuthorizer(store),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, testCookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
+		Task:                 handler.NewTaskHandler(taskService, viewService, activityService),
+		Sprint:               handler.NewSprintHandler(sprintService, viewService),
+		View:                 handler.NewViewHandler(viewService),
+		Document:             handler.NewDocumentHandler(docService, docActivityService),
+		Log:                  log,
 	})
 }
 

--- a/services/api/test/integration/project_test.go
+++ b/services/api/test/integration/project_test.go
@@ -381,15 +381,16 @@ func buildProjectTestRouterWithTaskRepo(repo *fakeProjectRepo, store *projectPer
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	return router.New(router.Deps{
-		TokenManager: tm,
-		Authorizer:   authz.NewAuthorizer(store),
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
-		User:         handler.NewUserHandler(userService),
-		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
-		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
-		Task:         handler.NewTaskHandler(tasksvc.New(taskRepo), sprintsvc.NewViewService(newFakeViewRepoIT()), tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)),
-		Log:          log,
+		TokenManager:         tm,
+		Authorizer:           authz.NewAuthorizer(store),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, testCookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
+		Task:                 handler.NewTaskHandler(tasksvc.New(taskRepo), sprintsvc.NewViewService(newFakeViewRepoIT()), tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)),
+		Log:                  log,
 	}), taskRepo
 }
 
@@ -875,5 +876,93 @@ func TestIntegrationGetMyProjectPermissions_ProjectNotFound(t *testing.T) {
 	}
 	if code := decodeErrorCode(t, w); code != "PROJECT_MEMBER_NOT_FOUND" {
 		t.Fatalf("expected PROJECT_MEMBER_NOT_FOUND, got %q", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public project integration tests
+// ---------------------------------------------------------------------------
+
+func TestIntegrationProject_IsPublicField(t *testing.T) {
+	repo := newFakeProjectRepo()
+	store := &projectPermStore{
+		globalPerms: []authz.Permission{
+			authz.PermissionProjectsRead,
+			authz.PermissionProjectsCreate,
+		},
+	}
+	r := buildProjectTestRouter(repo, store)
+	tok := issueProjectToken(t, uuid.NewString())
+
+	// Create a project with is_public: true.
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, "/api/v1/projects", tok, map[string]any{
+		"name":      "Public Project",
+		"is_public": true,
+	}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d (%s)", createW.Code, createW.Body.String())
+	}
+	var createEnv struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(createW.Body).Decode(&createEnv); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if isPublic, _ := createEnv.Data["is_public"].(bool); !isPublic {
+		t.Fatalf("expected is_public=true in create response, got %v", createEnv.Data["is_public"])
+	}
+	projectID, _ := createEnv.Data["id"].(string)
+
+	// GET the project and verify is_public persists.
+	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet, "/api/v1/projects/"+projectID, tok, nil))
+	if getW.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d (%s)", getW.Code, getW.Body.String())
+	}
+	var getEnv struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(getW.Body).Decode(&getEnv); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if isPublic, _ := getEnv.Data["is_public"].(bool); !isPublic {
+		t.Fatalf("expected is_public=true in get response, got %v", getEnv.Data["is_public"])
+	}
+}
+
+func TestIntegrationProject_AnonymousAccess_PublicProject(t *testing.T) {
+	repo := newFakeProjectRepo()
+	projectID := uuid.New()
+	repo.projects[projectID] = &projectdom.Project{
+		ID:       projectID,
+		Name:     "Public Project",
+		IsPublic: true,
+	}
+	store := &projectPermStore{}
+	r := buildProjectTestRouter(repo, store)
+
+	// Anonymous GET (no Authorization header) on a public project should succeed.
+	url := "/api/v1/projects/" + projectID.String()
+	w := serve(r, httptest.NewRequestWithContext(t.Context(), http.MethodGet, url, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestIntegrationProject_AnonymousAccess_PrivateProject_Returns401(t *testing.T) {
+	repo := newFakeProjectRepo()
+	projectID := uuid.New()
+	repo.projects[projectID] = &projectdom.Project{
+		ID:       projectID,
+		Name:     "Private Project",
+		IsPublic: false,
+	}
+	store := &projectPermStore{}
+	r := buildProjectTestRouter(repo, store)
+
+	// Anonymous GET on a private project should return 401.
+	url := "/api/v1/projects/" + projectID.String()
+	w := serve(r, httptest.NewRequestWithContext(t.Context(), http.MethodGet, url, nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d (%s)", w.Code, w.Body.String())
 	}
 }

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -607,17 +607,18 @@ func buildTaskTestRouterWithSprints(taskRepo *fakeTaskRepo, sprintRepo *fakeSpri
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	return router.New(router.Deps{
-		TokenManager: tm,
-		Authorizer:   authz.NewAuthorizer(store),
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
-		User:         handler.NewUserHandler(userService),
-		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
-		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
-		Task:         handler.NewTaskHandler(taskService, viewService, activityService),
-		Sprint:       handler.NewSprintHandler(sprintService, viewService),
-		View:         handler.NewViewHandler(viewService),
-		Log:          log,
+		TokenManager:         tm,
+		Authorizer:           authz.NewAuthorizer(store),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, testCookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
+		Task:                 handler.NewTaskHandler(taskService, viewService, activityService),
+		Sprint:               handler.NewSprintHandler(sprintService, viewService),
+		View:                 handler.NewViewHandler(viewService),
+		Log:                  log,
 	})
 }
 

--- a/services/api/test/integration/view_test.go
+++ b/services/api/test/integration/view_test.go
@@ -199,17 +199,18 @@ func buildViewTestRouter(viewRepo *fakeViewRepoIT, sprintRepo *fakeSprintRepoIT,
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	return router.New(router.Deps{
-		TokenManager: tm,
-		Authorizer:   authz.NewAuthorizer(store),
-		Health:       handler.NewHealthHandler(),
-		Auth:         handler.NewAuthHandler(authService, testCookieCfg),
-		User:         handler.NewUserHandler(userService),
-		GlobalRole:   handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
-		Project:      handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
-		Task:         handler.NewTaskHandler(taskService, viewService, activityService),
-		Sprint:       handler.NewSprintHandler(sprintService, viewService),
-		View:         handler.NewViewHandler(viewService),
-		Log:          log,
+		TokenManager:         tm,
+		Authorizer:           authz.NewAuthorizer(store),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, testCookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
+		Task:                 handler.NewTaskHandler(taskService, viewService, activityService),
+		Sprint:               handler.NewSprintHandler(sprintService, viewService),
+		View:                 handler.NewViewHandler(viewService),
+		Log:                  log,
 	})
 }
 


### PR DESCRIPTION
This pull request introduces support for public (read-only) project access for anonymous users, along with UI and API changes to toggle project visibility and handle anonymous access gracefully. It also adds tests and refactors authentication checks to allow for optional user context in the sidebar and project settings.

**Public Project Support and API Changes:**

* Added `is_public` property to the `Project` model and API, allowing projects to be marked as public or private. The `createProject` and `updateProject` API functions now accept and forward the `is_public` field. [[1]](diffhunk://#diff-feb2aef112b653a9c3ca95ceb0b2be032c8297d9b3eb0f556981e09b505b4383R12) [[2]](diffhunk://#diff-feb2aef112b653a9c3ca95ceb0b2be032c8297d9b3eb0f556981e09b505b4383R68) [[3]](diffhunk://#diff-feb2aef112b653a9c3ca95ceb0b2be032c8297d9b3eb0f556981e09b505b4383L77-R84)
* Updated project tests to verify that `is_public` is correctly handled when creating or updating projects. [[1]](diffhunk://#diff-58606a71190c75b123102b948dba4b26a56d5ec7d75c0b4b54dd91531e7c658aR63) [[2]](diffhunk://#diff-58606a71190c75b123102b948dba4b26a56d5ec7d75c0b4b54dd91531e7c658aR169-R179) [[3]](diffhunk://#diff-58606a71190c75b123102b948dba4b26a56d5ec7d75c0b4b54dd91531e7c658aR192-R201)

**UI Changes for Project Visibility:**

* Added a toggle in `GeneralSettings.tsx` to set project visibility (public/private), including UI elements and state management for the `is_public` field. The toggle is disabled for users without edit permissions. [[1]](diffhunk://#diff-344d2e98ae92614e496fb32f7e42769ad767d79a098ef453d6e513d22feeb06eL2-R7) [[2]](diffhunk://#diff-344d2e98ae92614e496fb32f7e42769ad767d79a098ef453d6e513d22feeb06eR25) [[3]](diffhunk://#diff-344d2e98ae92614e496fb32f7e42769ad767d79a098ef453d6e513d22feeb06eR37) [[4]](diffhunk://#diff-344d2e98ae92614e496fb32f7e42769ad767d79a098ef453d6e513d22feeb06eR48) [[5]](diffhunk://#diff-344d2e98ae92614e496fb32f7e42769ad767d79a098ef453d6e513d22feeb06eL74-R79) [[6]](diffhunk://#diff-344d2e98ae92614e496fb32f7e42769ad767d79a098ef453d6e513d22feeb06eR149-R176)

**Anonymous User Handling in Sidebar and Navigation:**

* Refactored the sidebar and navigation components to detect anonymous users using a new `currentUserOptionalQueryOptions`, and to adjust available navigation items and UI accordingly (e.g., hiding team/settings for anonymous users, showing a sign-in button, and updating branding). [[1]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfR71) [[2]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfR715-R727) [[3]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfL855-R877) [[4]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfL902-R926) [[5]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfL936-R966) [[6]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfL994-R1024) [[7]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfL1032-R1063) [[8]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfR1245) [[9]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfR1257-R1264) [[10]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfR1276-R1286) [[11]](diffhunk://#diff-34948ddc01e62404974afc2f0644757b889e72c87314280e84b6e169a1c7bdcfL1260-R1326) [[12]](diffhunk://#diff-023751dabf583ba56d5340b5d6b330bd865b9f54becf02841e4ff835d6d3ecd7L21-R25) [[13]](diffhunk://#diff-023751dabf583ba56d5340b5d6b330bd865b9f54becf02841e4ff835d6d3ecd7L36-R60)

**Authentication and API Client Improvements:**

* Added `getMeOptional` and `currentUserOptionalQueryOptions` to allow fetching the current user without triggering authentication errors, and updated the API client to skip auth refresh for optional requests. [[1]](diffhunk://#diff-4a3b66105b29f78e5dadbee84dc7af3f954eca12ea61e915a3539ee461bbe839R48-R72) [[2]](diffhunk://#diff-50854f47986eccccb58452e3f2e5cf0057e6e54105823248fba4f78526f08005R49) [[3]](diffhunk://#diff-50854f47986eccccb58452e3f2e5cf0057e6e54105823248fba4f78526f08005R70-R75)

**Miscellaneous:**

* Minor import and test adjustments to support the new functionality.

These changes together enable anonymous, read-only access to public projects and provide a clear, user-friendly way for project owners to manage project visibility.