### PR TITLE
feat: setup docker cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,11 +6,11 @@ name: cd
 #
 # Artefacts produced per release:
 #   ghcr.io/paca-ai/paca-api:<tag>       — Go API service Docker image
-#   docker.io/<dockerhub-username>/paca-api:<tag>     — Go API service Docker image
+#   <dockerhub-username>/paca-api:<tag>  — Go API service Docker image
 #   ghcr.io/paca-ai/paca-realtime:<tag>  — Node realtime service Docker image
-#   docker.io/<dockerhub-username>/paca-realtime:<tag> — Node realtime service Docker image
+#   <dockerhub-username>/paca-realtime:<tag> — Node realtime service Docker image
 #   ghcr.io/paca-ai/paca-web:<tag>       — Web app Docker image (nginx)
-#   docker.io/<dockerhub-username>/paca-web:<tag>     — Web app Docker image (nginx)
+#   <dockerhub-username>/paca-web:<tag>  — Web app Docker image (nginx)
 #   registry.npmjs.org @paca-ai/paca-mcp — MCP server npm package
 
 on:
@@ -24,7 +24,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  DOCKERHUB_REGISTRY: docker.io
 
 # ─────────────────────────────────────────────────────────────────────────────
 # API service image
@@ -52,7 +51,6 @@ jobs:
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -62,7 +60,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-api
-            ${{ env.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/paca-api
+            ${{ secrets.DOCKERHUB_USERNAME }}/paca-api
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -104,7 +102,6 @@ jobs:
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -114,7 +111,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-realtime
-            ${{ env.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/paca-realtime
+            ${{ secrets.DOCKERHUB_USERNAME }}/paca-realtime
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -161,7 +158,6 @@ jobs:
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -171,7 +167,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-web
-            ${{ env.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/paca-web
+            ${{ secrets.DOCKERHUB_USERNAME }}/paca-web
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,12 +2,15 @@ name: cd
 
 # Triggered when a GitHub Release is published (draft → published or created as
 # published).  Each job builds one artefact and pushes it to the appropriate
-# GitHub registry so that self-hosters can pull pre-built images/packages.
+# GitHub registry and DockerHub so that self-hosters can pull pre-built images/packages.
 #
 # Artefacts produced per release:
 #   ghcr.io/paca-ai/paca-api:<tag>       — Go API service Docker image
+#   docker.io/<dockerhub-username>/paca-api:<tag>     — Go API service Docker image
 #   ghcr.io/paca-ai/paca-realtime:<tag>  — Node realtime service Docker image
+#   docker.io/<dockerhub-username>/paca-realtime:<tag> — Node realtime service Docker image
 #   ghcr.io/paca-ai/paca-web:<tag>       — Web app Docker image (nginx)
+#   docker.io/<dockerhub-username>/paca-web:<tag>     — Web app Docker image (nginx)
 #   registry.npmjs.org @paca-ai/paca-mcp — MCP server npm package
 
 on:
@@ -21,6 +24,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
 
 # ─────────────────────────────────────────────────────────────────────────────
 # API service image
@@ -45,11 +49,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-api
+          images: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-api
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/paca-api
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -88,11 +101,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-realtime
+          images: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-realtime
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/paca-realtime
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -136,11 +158,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-web
+          images: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/paca-web
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/paca-web
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -6,12 +6,12 @@
 # and environment variables as a handoff into their own platform.
 #
 # ── Pre-built images ──────────────────────────────────────────────────────────
-# By default this file pulls the official pre-built images from GitHub Container
-# Registry (GHCR).  To pin a specific release, set the IMAGE env vars:
+# By default this file pulls the official pre-built images from DockerHub.
+# To pin a specific release, set the IMAGE env vars:
 #
-#   PACA_API_IMAGE=ghcr.io/paca-ai/paca-api:1.2.3
-#   PACA_WEB_IMAGE=ghcr.io/paca-ai/paca-web:1.2.3
-#   PACA_REALTIME_IMAGE=ghcr.io/paca-ai/paca-realtime:1.2.3
+#   PACA_API_IMAGE=pacaai/paca-api:1.2.3
+#   PACA_WEB_IMAGE=pacaai/paca-web:1.2.3
+#   PACA_REALTIME_IMAGE=pacaai/paca-realtime:1.2.3
 #
 # To build the images locally instead of pulling (e.g. with custom patches),
 # append --build to the docker compose up command.
@@ -64,7 +64,7 @@ services:
       retries: 10
 
   api:
-    image: ${PACA_API_IMAGE:-ghcr.io/paca-ai/paca-api:latest}
+    image: ${PACA_API_IMAGE:-pacaai/paca-api:latest}
     build:
       context: ../services/api
     restart: unless-stopped
@@ -107,7 +107,7 @@ services:
         required: false  # skipped when --scale minio=0 (AWS S3 mode)
 
   web:
-    image: ${PACA_WEB_IMAGE:-ghcr.io/paca-ai/paca-web:latest}
+    image: ${PACA_WEB_IMAGE:-pacaai/paca-web:latest}
     build:
       context: ../apps/web
       args:
@@ -119,7 +119,7 @@ services:
       - api
 
   realtime:
-    image: ${PACA_REALTIME_IMAGE:-ghcr.io/paca-ai/paca-realtime:latest}
+    image: ${PACA_REALTIME_IMAGE:-pacaai/paca-realtime:latest}
     build:
       context: ../services/realtime
     restart: unless-stopped


### PR DESCRIPTION
This pull request updates the continuous deployment workflow to also publish Docker images to DockerHub, in addition to the existing GitHub Container Registry (GHCR) targets. This allows self-hosters to pull pre-built images from either registry, increasing flexibility and availability.

**Docker image publishing enhancements:**

* Updated documentation and image lists in `.github/workflows/cd.yml` to reflect that Docker images will now be published to both GHCR and DockerHub for all major services (`paca-api`, `paca-realtime`, `paca-web`).
* Added `DOCKERHUB_REGISTRY` environment variable to support DockerHub publishing.

**Workflow authentication and metadata:**

* Added a step to log in to DockerHub using secrets for all relevant jobs, enabling image pushes to DockerHub. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R52-R65) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R104-R117) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R161-R174)
* Modified the Docker metadata extraction step to include both GHCR and DockerHub image targets for each service, ensuring proper tagging and publishing to both registries. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R52-R65) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R104-R117) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R161-R174)