### PR TITLE
feat: enhance database configuration to support Amazon Aurora DSQL wi…

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -55,6 +55,9 @@ services:
       ENV: development
       PORT: "8080"
       DATABASE_URL: postgres://paca:paca@postgres:5432/paca?sslmode=disable
+      # Aurora DSQL — set DATABASE_DRIVER=dsql and DATABASE_AWS_REGION to enable IAM auth.
+      DATABASE_DRIVER: postgres
+      DATABASE_AWS_REGION: ""
       REDIS_URL: redis://valkey:6379/0
       JWT_SECRET: dev-change-in-production
       JWT_ACCESS_TTL: 15m

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -72,6 +72,9 @@ services:
       ENV: ${ENVIRONMENT:-production}
       PORT: 8080
       DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-paca}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-paca}?sslmode=disable}
+      # Aurora DSQL — set DATABASE_DRIVER=dsql and DATABASE_AWS_REGION to enable IAM auth.
+      DATABASE_DRIVER: ${DATABASE_DRIVER:-postgres}
+      DATABASE_AWS_REGION: ${DATABASE_AWS_REGION:-}
       REDIS_URL: ${REDIS_URL:-redis://valkey:6379/0}
       JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET}
       JWT_ACCESS_TTL: ${JWT_ACCESS_TTL:-15m}

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -5,6 +5,15 @@ ENV=development           # development | production
 # ----- PostgreSQL ------------------------------------------------------------
 DATABASE_URL=postgres://paca:paca@localhost:5432/paca?sslmode=disable
 
+# ----- Amazon Aurora DSQL (optional) -----------------------------------------
+# Set DATABASE_DRIVER=dsql to connect to Aurora DSQL using IAM authentication.
+# AWS credentials are resolved from the standard credential chain
+# (environment variables, ~/.aws/credentials, EC2/ECS instance role, etc.).
+#
+# DATABASE_DRIVER=dsql
+# DATABASE_URL=postgres://admin@<cluster-id>.dsql.<region>.on.aws/postgres?sslmode=require
+# DATABASE_AWS_REGION=us-east-1
+
 # ----- Valkey ----------------------------------------------------------------
 REDIS_URL=redis://localhost:6379/0
 

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.9.1
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -24,7 +26,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
@@ -69,7 +70,6 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.9.1 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -3,7 +3,7 @@ module github.com/paca/api
 go 1.26.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
@@ -24,6 +24,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
@@ -37,7 +38,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.25.0 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect

--- a/services/api/go.sum
+++ b/services/api/go.sum
@@ -8,12 +8,16 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
+github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23 h1:t/FLVaD5EbHBPfCvvSI+I1jfOFno6VT4SpAyTPbe+U0=
+github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23/go.mod h1:f6NUif0lusPQ6Tcfa0qavcKcW4lpjH76nBEklwFj+gs=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
@@ -44,6 +48,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBU
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
 github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
 github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/services/api/go.sum
+++ b/services/api/go.sum
@@ -6,8 +6,6 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
-github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -46,8 +44,6 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6f
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19/go.mod h1:YO8TrYtFdl5w/4vmjL8zaBSsiNp3w0L1FfKVKenZT7w=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
-github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
-github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
 github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -65,7 +65,11 @@ func New(cfg *config.Config) (*App, error) {
 	}
 
 	// --- Platform -----------------------------------------------------------
-	db, err := database.Open(cfg.Database.DSN, log)
+	db, err := database.Open(database.Config{
+		DSN:       cfg.Database.DSN,
+		Driver:    cfg.Database.Driver,
+		AWSRegion: cfg.Database.AWSRegion,
+	}, log)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: %w", err)
 	}

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -30,6 +30,14 @@ type AdminConfig struct {
 // DatabaseConfig holds the primary database connection settings.
 type DatabaseConfig struct {
 	DSN string
+
+	// Driver selects the database backend: "postgres" (default) or "dsql"
+	// (Amazon Aurora DSQL with IAM authentication).
+	Driver string
+
+	// AWSRegion is the AWS region used when Driver is "dsql".
+	// It must match the region where the Aurora DSQL cluster is deployed.
+	AWSRegion string
 }
 
 // RedisConfig holds Redis connection settings.

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -53,6 +53,13 @@ func Load() (*Config, error) {
 	}
 
 	dbDriver := env("DATABASE_DRIVER", "postgres")
+	switch dbDriver {
+	case "postgres", "dsql":
+		// valid values
+	default:
+		errs = append(errs, fmt.Errorf("config: DATABASE_DRIVER must be one of: postgres, dsql"))
+	}
+
 	dbAWSRegion := env("DATABASE_AWS_REGION", "")
 	if dbDriver == "dsql" && dbAWSRegion == "" {
 		errs = append(errs, fmt.Errorf("config: DATABASE_AWS_REGION must be set when DATABASE_DRIVER=dsql"))

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -52,6 +52,12 @@ func Load() (*Config, error) {
 		errs = append(errs, err)
 	}
 
+	dbDriver := env("DATABASE_DRIVER", "postgres")
+	dbAWSRegion := env("DATABASE_AWS_REGION", "")
+	if dbDriver == "dsql" && dbAWSRegion == "" {
+		errs = append(errs, fmt.Errorf("config: DATABASE_AWS_REGION must be set when DATABASE_DRIVER=dsql"))
+	}
+
 	redisURL, err := requireEnv("REDIS_URL")
 	if err != nil {
 		errs = append(errs, err)
@@ -93,7 +99,9 @@ func Load() (*Config, error) {
 			CookieSecure: cookieSecure,
 		},
 		Database: DatabaseConfig{
-			DSN: dsn,
+			DSN:       dsn,
+			Driver:    dbDriver,
+			AWSRegion: dbAWSRegion,
 		},
 		Redis: RedisConfig{
 			URL: redisURL,

--- a/services/api/internal/config/load_test.go
+++ b/services/api/internal/config/load_test.go
@@ -55,6 +55,8 @@ func TestLoad_Success(t *testing.T) {
 	t.Setenv("JWT_REFRESH_TTL", "48h")
 	t.Setenv("JWT_REFRESH_SESSION_TTL", "12h")
 	t.Setenv("DATABASE_URL", "postgres://test")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("ADMIN_USERNAME", "admin")
 	t.Setenv("ADMIN_PASSWORD", "password")
@@ -83,11 +85,16 @@ func TestLoad_Success(t *testing.T) {
 	if cfg.JWT.RefreshSessionTTL != 12*time.Hour {
 		t.Fatalf("unexpected RefreshSessionTTL: %v", cfg.JWT.RefreshSessionTTL)
 	}
+	if cfg.Database.Driver != "postgres" {
+		t.Fatalf("expected driver postgres, got %q", cfg.Database.Driver)
+	}
 }
 
 func TestLoad_MissingRequired(t *testing.T) {
 	t.Setenv("JWT_SECRET", "")
 	t.Setenv("DATABASE_URL", "")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "")
 	t.Setenv("ADMIN_USERNAME", "")
 	t.Setenv("ADMIN_PASSWORD", "")
@@ -107,6 +114,8 @@ func TestLoad_MissingRequired(t *testing.T) {
 func TestLoad_InvalidBoolOrDuration(t *testing.T) {
 	t.Setenv("JWT_SECRET", "secret")
 	t.Setenv("DATABASE_URL", "postgres://test")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("ADMIN_USERNAME", "admin")
 	t.Setenv("ADMIN_PASSWORD", "password")
@@ -120,5 +129,83 @@ func TestLoad_InvalidBoolOrDuration(t *testing.T) {
 	t.Setenv("JWT_ACCESS_TTL", "invalid")
 	if _, err := Load(); err == nil {
 		t.Fatal("expected duration parse error")
+	}
+}
+
+// setLoadDefaults is a helper that seeds the minimum valid env vars so that
+// individual driver tests only need to set the vars they are exercising.
+func setLoadDefaults(t *testing.T) {
+	t.Helper()
+	t.Setenv("ENV", "test")
+	t.Setenv("PORT", "8080")
+	t.Setenv("COOKIE_SECURE", "false")
+	t.Setenv("JWT_SECRET", "secret")
+	t.Setenv("JWT_ACCESS_TTL", "15m")
+	t.Setenv("JWT_REFRESH_TTL", "168h")
+	t.Setenv("JWT_REFRESH_SESSION_TTL", "24h")
+	t.Setenv("DATABASE_URL", "postgres://test")
+	t.Setenv("DATABASE_DRIVER", "postgres")
+	t.Setenv("DATABASE_AWS_REGION", "")
+	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
+	t.Setenv("ADMIN_USERNAME", "admin")
+	t.Setenv("ADMIN_PASSWORD", "password")
+	t.Setenv("STORAGE_ACCESS_KEY_ID", "access-key")
+	t.Setenv("STORAGE_SECRET_ACCESS_KEY", "secret-key")
+}
+
+func TestLoad_DatabaseDriverDefault(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("DATABASE_DRIVER", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Database.Driver != "postgres" {
+		t.Fatalf("expected default driver postgres, got %q", cfg.Database.Driver)
+	}
+}
+
+func TestLoad_DatabaseDriverDSQL(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("DATABASE_DRIVER", "dsql")
+	t.Setenv("DATABASE_AWS_REGION", "us-east-1")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Database.Driver != "dsql" {
+		t.Fatalf("expected driver dsql, got %q", cfg.Database.Driver)
+	}
+	if cfg.Database.AWSRegion != "us-east-1" {
+		t.Fatalf("expected AWSRegion us-east-1, got %q", cfg.Database.AWSRegion)
+	}
+}
+
+func TestLoad_DatabaseDriverInvalid(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("DATABASE_DRIVER", "dsq1") // typo
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid DATABASE_DRIVER")
+	}
+	if !strings.Contains(err.Error(), "DATABASE_DRIVER") {
+		t.Fatalf("expected error to mention DATABASE_DRIVER, got %q", err.Error())
+	}
+}
+
+func TestLoad_DatabaseDriverDSQLMissingRegion(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("DATABASE_DRIVER", "dsql")
+	t.Setenv("DATABASE_AWS_REGION", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when DATABASE_DRIVER=dsql and DATABASE_AWS_REGION is empty")
+	}
+	if !strings.Contains(err.Error(), "DATABASE_AWS_REGION") {
+		t.Fatalf("expected error to mention DATABASE_AWS_REGION, got %q", err.Error())
 	}
 }

--- a/services/api/internal/platform/database/postgres.go
+++ b/services/api/internal/platform/database/postgres.go
@@ -1,18 +1,51 @@
 // Package database provides PostgreSQL connectivity via GORM.
+// It supports two drivers:
+//   - "postgres" (default): standard PostgreSQL via pgx.
+//   - "dsql": Amazon Aurora DSQL using short-lived IAM auth tokens, refreshed
+//     automatically on every new connection via pgxpool.BeforeConnect.
 package database
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
 
+	dsqlauth "github.com/aws/aws-sdk-go-v2/feature/dsql/auth"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 )
 
-// Open establishes a GORM database connection with sensible pool settings.
-func Open(dsn string, log *slog.Logger) (*gorm.DB, error) {
+// Config holds the settings required to open a database connection.
+type Config struct {
+	// DSN is the PostgreSQL connection string.
+	// For the "dsql" driver the DSN should omit the password; an IAM auth
+	// token is injected automatically before each new connection.
+	DSN string
+
+	// Driver selects the backend: "postgres" (default) or "dsql".
+	Driver string
+
+	// AWSRegion is required when Driver is "dsql".
+	AWSRegion string
+}
+
+// Open establishes a GORM connection using the driver specified in cfg.
+func Open(cfg Config, log *slog.Logger) (*gorm.DB, error) {
+	if cfg.Driver == "dsql" {
+		return openDSQL(cfg, log)
+	}
+	return openPostgres(cfg.DSN, log)
+}
+
+// openPostgres opens a standard PostgreSQL connection via gorm+pgx.
+func openPostgres(dsn string, log *slog.Logger) (*gorm.DB, error) {
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Warn),
 	})
@@ -34,5 +67,73 @@ func Open(dsn string, log *slog.Logger) (*gorm.DB, error) {
 	}
 
 	log.Info("database connected")
+	return db, nil
+}
+
+// openDSQL opens an Aurora DSQL connection.
+//
+// IAM auth tokens are valid for 15 minutes.  A pgxpool with BeforeConnect
+// regenerates the token for every new physical connection, so the pool never
+// holds a connection whose token has already expired.  MaxConnLifetime is set
+// to 13 minutes as an extra safeguard.
+func openDSQL(cfg Config, log *slog.Logger) (*gorm.DB, error) {
+	ctx := context.Background()
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(cfg.AWSRegion))
+	if err != nil {
+		return nil, fmt.Errorf("database: dsql: load aws config: %w", err)
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(cfg.DSN)
+	if err != nil {
+		return nil, fmt.Errorf("database: dsql: parse dsn: %w", err)
+	}
+
+	endpoint := poolCfg.ConnConfig.Host
+	isAdmin := poolCfg.ConnConfig.User == "admin"
+
+	poolCfg.MaxConns = 25
+	poolCfg.MinConns = 0
+	poolCfg.MaxConnLifetime = 13 * time.Minute
+
+	poolCfg.BeforeConnect = func(ctx context.Context, connCfg *pgx.ConnConfig) error {
+		var token string
+		var tokenErr error
+		if isAdmin {
+			token, tokenErr = dsqlauth.GenerateDBConnectAdminAuthToken(
+				ctx, endpoint, cfg.AWSRegion, awsCfg.Credentials,
+			)
+		} else {
+			token, tokenErr = dsqlauth.GenerateDbConnectAuthToken(
+				ctx, endpoint, cfg.AWSRegion, awsCfg.Credentials,
+			)
+		}
+		if tokenErr != nil {
+			return fmt.Errorf("database: dsql: generate auth token: %w", tokenErr)
+		}
+		connCfg.Password = token
+		return nil
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return nil, fmt.Errorf("database: dsql: create pool: %w", err)
+	}
+
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("database: dsql: ping: %w", err)
+	}
+
+	sqlDB := stdlib.OpenDBFromPool(pool)
+
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Warn),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("database: dsql: open gorm: %w", err)
+	}
+
+	log.Info("database connected", "driver", "dsql", "endpoint", endpoint)
 	return db, nil
 }

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -103,7 +103,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	seq := testDBSeq.Add(1)
 	testDBName := fmt.Sprintf("e2e_%04d", seq)
 	adminLog := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	adminGORM, adminErr := database.Open(sharedPGDSN, adminLog)
+	adminGORM, adminErr := database.Open(database.Config{DSN: sharedPGDSN}, adminLog)
 	if adminErr != nil {
 		t.Fatalf("open admin db for test isolation: %v", adminErr)
 	}
@@ -127,7 +127,8 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	db, err := database.Open(pgDSN, log)
+	dbCfg := database.Config{DSN: pgDSN}
+	db, err := database.Open(dbCfg, log)
 	if err != nil {
 		// Postgres in fresh containers can briefly accept TCP before it is fully ready.
 		deadline := time.Now().Add(15 * time.Second)
@@ -139,7 +140,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 			}
 
 			time.Sleep(300 * time.Millisecond)
-			db, err = database.Open(pgDSN, log)
+			db, err = database.Open(dbCfg, log)
 			if err == nil {
 				break
 			}


### PR DESCRIPTION
This pull request adds support for connecting to Amazon Aurora DSQL (PostgreSQL-compatible) with IAM authentication as an alternative to standard PostgreSQL. It introduces new configuration options for selecting the database driver and region, updates the database connection logic to handle Aurora DSQL, and refreshes relevant dependencies.

**Aurora DSQL support and configuration:**

* Added new configuration fields (`Driver` and `AWSRegion`) to `DatabaseConfig` and corresponding environment variables (`DATABASE_DRIVER`, `DATABASE_AWS_REGION`) to allow selecting between standard PostgreSQL and Aurora DSQL with IAM authentication (`services/api/internal/config/config.go`, `services/api/.env.example`, `services/api/internal/config/load.go`) [[1]](diffhunk://#diff-5f901e02ed468393320d41f6a3f42a8418363f27dfe8c6b7b1b75196defcd38eR33-R40) [[2]](diffhunk://#diff-613eb28e072b62ebcb2873cc655ee9a7cce9024ab48f2d7d68b3be5bed80057bR8-R16) [[3]](diffhunk://#diff-d956efd85fb8e468490ab3ce93932344a88c6a174917b0ee75ac8663b98ab4f6R55-R60) [[4]](diffhunk://#diff-d956efd85fb8e468490ab3ce93932344a88c6a174917b0ee75ac8663b98ab4f6R103-R104).
* Updated the application bootstrap to pass the new database configuration struct to the database layer, enabling driver selection (`services/api/internal/bootstrap/app.go`).

**Database connection logic:**

* Refactored the `database` package to support both standard PostgreSQL and Aurora DSQL connections, including automatic IAM token generation and rotation for DSQL, and safe pool settings (`services/api/internal/platform/database/postgres.go`) [[1]](diffhunk://#diff-0978dd6b86f77a21091e999b51c6e510641a606fb73d72e64b3cce36949ac855R2-R48) [[2]](diffhunk://#diff-0978dd6b86f77a21091e999b51c6e510641a606fb73d72e64b3cce36949ac855R72-R139).

**Dependency updates:**

* Added `github.com/aws/aws-sdk-go-v2/feature/dsql/auth` and updated `github.com/aws/aws-sdk-go-v2` and `github.com/aws/smithy-go` to latest minor versions in `go.mod` to support Aurora DSQL (`services/api/go.mod`) [[1]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991L6-R6) [[2]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991R27) [[3]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991L40-R41).…th IAM authentication
