### PR TITLE
feat: implement cache

### DIFF
--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -17,6 +17,12 @@ DATABASE_URL=postgres://paca:paca@localhost:5432/paca?sslmode=disable
 # ----- Valkey ----------------------------------------------------------------
 REDIS_URL=redis://localhost:6379/0
 
+# ----- Cache -----------------------------------------------------------------
+# TTL for each cache category.  Set to 0 to disable caching for that category.
+CACHE_PROJECT_TTL=5m      # project detail + member lists
+CACHE_CONFIG_TTL=10m      # task types, statuses, custom fields, roles, global roles
+CACHE_SPRINT_TTL=2m       # sprints and views
+
 # ----- JWT -------------------------------------------------------------------
 JWT_SECRET=change-me-to-a-strong-random-secret-at-least-32-chars
 JWT_ACCESS_TTL=15m        # access token lifetime

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -3,6 +3,7 @@ module github.com/paca/api
 go 1.26.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -25,7 +26,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -25,6 +25,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
@@ -106,6 +107,7 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/services/api/go.sum
+++ b/services/api/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -225,6 +227,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -79,6 +79,8 @@ func New(cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("bootstrap: %w", err)
 	}
 
+	cacheStore := cache.NewStore(redisClient, "paca:")
+
 	publisher := messaging.NewPublisher(redisClient, log)
 
 	tokenManager := jwttoken.New(cfg.JWT.Secret, cfg.JWT.AccessTTL, cfg.JWT.RefreshTTL)
@@ -123,11 +125,11 @@ func New(cfg *config.Config) (*App, error) {
 	// --- Services -----------------------------------------------------------
 	authService := authsvc.New(userRepo, tokenManager, refreshStore, cfg.JWT.RefreshTTL, cfg.JWT.RefreshSessionTTL)
 	userService := usersvc.New(userRepo, permissionStore, globalRoleRepo)
-	globalRoleService := globalrolesvc.New(globalRoleRepo)
-	projectService := projectsvc.New(projectRepo, taskRepo)
-	taskService := tasksvc.New(taskRepo)
-	sprintService := sprintsvc.New(sprintRepo, taskRepo)
-	viewService := sprintsvc.NewViewService(viewRepo)
+	globalRoleService := globalrolesvc.NewCachedService(globalrolesvc.New(globalRoleRepo), cacheStore, cfg.Cache.ConfigTTL, log)
+	projectService := projectsvc.NewCachedService(projectsvc.New(projectRepo, taskRepo), cacheStore, cfg.Cache.ProjectTTL, cfg.Cache.ConfigTTL, log)
+	taskService := tasksvc.NewCachedService(tasksvc.New(taskRepo), cacheStore, cfg.Cache.ConfigTTL, log)
+	sprintService := sprintsvc.NewCachedSprintService(sprintsvc.New(sprintRepo, taskRepo), cacheStore, cfg.Cache.SprintTTL, log)
+	viewService := sprintsvc.NewCachedViewService(sprintsvc.NewViewService(viewRepo), cacheStore, cfg.Cache.SprintTTL, log)
 	notificationService := notificationsvc.New(notificationRepo, projectRepo, publisher)
 	notificationConsumer := worker.NewNotificationConsumer(redisClient, notificationService, log)
 	activityService := tasksvc.NewActivityService(activityRepo, projectRepo, publisher).

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	Server   ServerConfig
 	Database DatabaseConfig
 	Redis    RedisConfig
+	Cache    CacheConfig
 	JWT      JWTConfig
 	Admin    AdminConfig
 	Storage  StorageConfig
@@ -43,6 +44,29 @@ type DatabaseConfig struct {
 // RedisConfig holds Redis connection settings.
 type RedisConfig struct {
 	URL string
+}
+
+// CacheConfig holds TTL settings for the different cache categories.
+//
+// Each TTL controls how long the corresponding data is served from Valkey/Redis
+// before a fresh database read is made.  Set a TTL to zero to disable caching
+// for that category entirely.
+//
+// Environment variables (loaded by config.Load):
+//
+//	CACHE_PROJECT_TTL  – project + member data          (default: 5m)
+//	CACHE_CONFIG_TTL   – task types, statuses, custom
+//	                     field definitions, and roles    (default: 10m)
+//	CACHE_SPRINT_TTL   – sprints and views               (default: 2m)
+type CacheConfig struct {
+	// ProjectTTL is the cache duration for project detail and member list data.
+	ProjectTTL time.Duration
+	// ConfigTTL is the cache duration for infrequently-changing project
+	// configuration: task types, task statuses, custom field definitions, and
+	// project roles.  Global roles also use this TTL.
+	ConfigTTL time.Duration
+	// SprintTTL is the cache duration for sprint and view configuration data.
+	SprintTTL time.Duration
 }
 
 // JWTConfig holds JWT signing and expiry settings.

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -70,6 +70,19 @@ func Load() (*Config, error) {
 		errs = append(errs, err)
 	}
 
+	cacheProjectTTL, err := parseDuration(env("CACHE_PROJECT_TTL", "5m"))
+	if err != nil {
+		return nil, fmt.Errorf("config: CACHE_PROJECT_TTL: %w", err)
+	}
+	cacheConfigTTL, err := parseDuration(env("CACHE_CONFIG_TTL", "10m"))
+	if err != nil {
+		return nil, fmt.Errorf("config: CACHE_CONFIG_TTL: %w", err)
+	}
+	cacheSprintTTL, err := parseDuration(env("CACHE_SPRINT_TTL", "2m"))
+	if err != nil {
+		return nil, fmt.Errorf("config: CACHE_SPRINT_TTL: %w", err)
+	}
+
 	adminUser, err := requireEnv("ADMIN_USERNAME")
 	if err != nil {
 		errs = append(errs, err)
@@ -112,6 +125,11 @@ func Load() (*Config, error) {
 		},
 		Redis: RedisConfig{
 			URL: redisURL,
+		},
+		Cache: CacheConfig{
+			ProjectTTL: cacheProjectTTL,
+			ConfigTTL:  cacheConfigTTL,
+			SprintTTL:  cacheSprintTTL,
 		},
 		JWT: JWTConfig{
 			Secret:            secret,

--- a/services/api/internal/platform/cache/store.go
+++ b/services/api/internal/platform/cache/store.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Store wraps *redis.Client with typed JSON get/set/delete helpers and a
+// namespace prefix so multiple features can share the same Redis instance
+// without key conflicts.
+type Store struct {
+	client *redis.Client
+	ns     string // namespace prefix, e.g. "paca:"
+}
+
+// NewStore returns a Store that prepends ns to every Redis key.
+func NewStore(client *redis.Client, ns string) *Store {
+	return &Store{client: client, ns: ns}
+}
+
+// Get retrieves the JSON-encoded value at key and unmarshals it into dest.
+// It returns (true, nil) on a cache hit, (false, nil) on a miss, and
+// (false, err) on any other error.
+func (s *Store) Get(ctx context.Context, key string, dest any) (bool, error) {
+	data, err := s.client.Get(ctx, s.ns+key).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("cache: get %q: %w", key, err)
+	}
+	if err := json.Unmarshal(data, dest); err != nil {
+		return false, fmt.Errorf("cache: unmarshal %q: %w", key, err)
+	}
+	return true, nil
+}
+
+// Set JSON-encodes val and stores it at key with the given TTL.
+// A zero TTL stores the value without expiry.
+func (s *Store) Set(ctx context.Context, key string, val any, ttl time.Duration) error {
+	data, err := json.Marshal(val)
+	if err != nil {
+		return fmt.Errorf("cache: marshal %q: %w", key, err)
+	}
+	if err := s.client.Set(ctx, s.ns+key, data, ttl).Err(); err != nil {
+		return fmt.Errorf("cache: set %q: %w", key, err)
+	}
+	return nil
+}
+
+// Delete removes one or more keys from the cache. It is a no-op when keys is
+// empty.
+func (s *Store) Delete(ctx context.Context, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	full := make([]string, len(keys))
+	for i, k := range keys {
+		full[i] = s.ns + k
+	}
+	if err := s.client.Del(ctx, full...).Err(); err != nil {
+		return fmt.Errorf("cache: delete: %w", err)
+	}
+	return nil
+}

--- a/services/api/internal/platform/cache/store_test.go
+++ b/services/api/internal/platform/cache/store_test.go
@@ -1,0 +1,154 @@
+package cache_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/paca/api/internal/platform/cache"
+)
+
+// newTestStore starts a miniredis instance and returns a Store backed by it.
+// The server is stopped and the client closed when the test ends.
+func newTestStore(t *testing.T, ns string) *cache.Store {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return cache.NewStore(client, ns)
+}
+
+func TestStore_GetMiss(t *testing.T) {
+	st := newTestStore(t, "t:")
+	ctx := context.Background()
+
+	var got string
+	hit, err := st.Get(ctx, "missing", &got)
+	if err != nil {
+		t.Fatalf("Get on missing key: unexpected error: %v", err)
+	}
+	if hit {
+		t.Fatal("Get on missing key: expected cache miss, got hit")
+	}
+}
+
+func TestStore_SetThenGet(t *testing.T) {
+	st := newTestStore(t, "t:")
+	ctx := context.Background()
+
+	type payload struct {
+		Name string
+		Age  int
+	}
+	want := payload{Name: "alice", Age: 30}
+
+	if err := st.Set(ctx, "user", want, time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	var got payload
+	hit, err := st.Get(ctx, "user", &got)
+	if err != nil {
+		t.Fatalf("Get after Set: %v", err)
+	}
+	if !hit {
+		t.Fatal("Get after Set: expected cache hit, got miss")
+	}
+	if got != want {
+		t.Fatalf("Get after Set: want %+v, got %+v", want, got)
+	}
+}
+
+func TestStore_SetWithZeroTTL(t *testing.T) {
+	st := newTestStore(t, "t:")
+	ctx := context.Background()
+
+	if err := st.Set(ctx, "nettl", "value", 0); err != nil {
+		t.Fatalf("Set with zero TTL: %v", err)
+	}
+
+	var got string
+	hit, err := st.Get(ctx, "nettl", &got)
+	if err != nil {
+		t.Fatalf("Get after zero-TTL Set: %v", err)
+	}
+	if !hit {
+		t.Fatal("Get after zero-TTL Set: expected hit (no expiry)")
+	}
+}
+
+func TestStore_Delete(t *testing.T) {
+	st := newTestStore(t, "t:")
+	ctx := context.Background()
+
+	if err := st.Set(ctx, "k1", "v1", time.Minute); err != nil {
+		t.Fatalf("Set k1: %v", err)
+	}
+	if err := st.Set(ctx, "k2", "v2", time.Minute); err != nil {
+		t.Fatalf("Set k2: %v", err)
+	}
+
+	if err := st.Delete(ctx, "k1", "k2"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	for _, key := range []string{"k1", "k2"} {
+		var s string
+		hit, err := st.Get(ctx, key, &s)
+		if err != nil {
+			t.Fatalf("Get %q after Delete: %v", key, err)
+		}
+		if hit {
+			t.Fatalf("Get %q after Delete: expected miss, got hit", key)
+		}
+	}
+}
+
+func TestStore_DeleteNoKeys(t *testing.T) {
+	st := newTestStore(t, "t:")
+	ctx := context.Background()
+
+	// Calling Delete with no keys should be a no-op.
+	if err := st.Delete(ctx); err != nil {
+		t.Fatalf("Delete with no keys: %v", err)
+	}
+}
+
+func TestStore_NamespaceIsolation(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	storeA := cache.NewStore(client, "a:")
+	storeB := cache.NewStore(client, "b:")
+	ctx := context.Background()
+
+	if err := storeA.Set(ctx, "key", "from-a", time.Minute); err != nil {
+		t.Fatalf("storeA.Set: %v", err)
+	}
+
+	// storeB uses a different namespace, so the key should be missing.
+	var got string
+	hit, err := storeB.Get(ctx, "key", &got)
+	if err != nil {
+		t.Fatalf("storeB.Get: %v", err)
+	}
+	if hit {
+		t.Fatal("namespace isolation broken: storeB hit key written by storeA")
+	}
+
+	// storeA should still see it.
+	hit, err = storeA.Get(ctx, "key", &got)
+	if err != nil {
+		t.Fatalf("storeA.Get: %v", err)
+	}
+	if !hit {
+		t.Fatal("storeA lost its own key after storeB lookup")
+	}
+	if got != "from-a" {
+		t.Fatalf("storeA.Get: want %q, got %q", "from-a", got)
+	}
+}

--- a/services/api/internal/service/globalrole/cached_service.go
+++ b/services/api/internal/service/globalrole/cached_service.go
@@ -1,0 +1,99 @@
+package globalrolesvc
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	globalroledom "github.com/paca/api/internal/domain/globalrole"
+	"github.com/paca/api/internal/platform/cache"
+)
+
+const globalRolesKey = "global-roles"
+
+// CachedService decorates a globalroledom.Service with a Valkey/Redis-backed
+// cache.
+//
+// # What is cached
+//
+//   - List – the full list of global roles. Global roles change infrequently
+//     (admin-level operations only) so a relatively long TTL is appropriate.
+//
+// All write operations (Create/Update/Delete/ReplaceUserRoles) invalidate the
+// cached list after a successful database write.
+//
+// Cache errors are non-fatal: read errors fall through to the real service;
+// write/delete errors are logged so mutations always succeed.
+type CachedService struct {
+	svc globalroledom.Service
+	st  *cache.Store
+	ttl time.Duration
+	log *slog.Logger
+}
+
+// NewCachedService wraps svc with a caching layer backed by st.
+// ttl controls how long the global roles list is cached; zero disables caching.
+// log receives non-fatal cache warnings.
+func NewCachedService(svc globalroledom.Service, st *cache.Store, ttl time.Duration, log *slog.Logger) *CachedService {
+	return &CachedService{svc: svc, st: st, ttl: ttl, log: log}
+}
+
+// List returns all global roles, reading from cache when available and
+// populating it on a miss.
+func (c *CachedService) List(ctx context.Context) ([]*globalroledom.GlobalRole, error) {
+	if c.ttl == 0 {
+		return c.svc.List(ctx)
+	}
+	var result []*globalroledom.GlobalRole
+	if ok, err := c.st.Get(ctx, globalRolesKey, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListGlobalRoles get", "err", err)
+	}
+
+	result, err := c.svc.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, globalRolesKey, result, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: ListGlobalRoles set", "err", err)
+	}
+	return result, nil
+}
+
+func (c *CachedService) Create(ctx context.Context, in globalroledom.CreateInput) (*globalroledom.GlobalRole, error) {
+	r, err := c.svc.Create(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, globalRolesKey); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateGlobalRole delete", "err", err)
+	}
+	return r, nil
+}
+
+func (c *CachedService) Update(ctx context.Context, id uuid.UUID, in globalroledom.UpdateInput) (*globalroledom.GlobalRole, error) {
+	r, err := c.svc.Update(ctx, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, globalRolesKey); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateGlobalRole delete", "err", err)
+	}
+	return r, nil
+}
+
+func (c *CachedService) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := c.svc.Delete(ctx, id); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, globalRolesKey); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteGlobalRole delete", "err", err)
+	}
+	return nil
+}
+
+func (c *CachedService) ReplaceUserRoles(ctx context.Context, userID uuid.UUID, roleIDs []uuid.UUID) ([]*globalroledom.GlobalRole, error) {
+	return c.svc.ReplaceUserRoles(ctx, userID, roleIDs)
+}

--- a/services/api/internal/service/globalrole/cached_service.go
+++ b/services/api/internal/service/globalrole/cached_service.go
@@ -62,6 +62,7 @@ func (c *CachedService) List(ctx context.Context) ([]*globalroledom.GlobalRole, 
 	return result, nil
 }
 
+// Create delegates to the underlying service and invalidates the list cache.
 func (c *CachedService) Create(ctx context.Context, in globalroledom.CreateInput) (*globalroledom.GlobalRole, error) {
 	r, err := c.svc.Create(ctx, in)
 	if err != nil {
@@ -73,6 +74,7 @@ func (c *CachedService) Create(ctx context.Context, in globalroledom.CreateInput
 	return r, nil
 }
 
+// Update delegates to the underlying service and invalidates the list cache.
 func (c *CachedService) Update(ctx context.Context, id uuid.UUID, in globalroledom.UpdateInput) (*globalroledom.GlobalRole, error) {
 	r, err := c.svc.Update(ctx, id, in)
 	if err != nil {
@@ -84,6 +86,7 @@ func (c *CachedService) Update(ctx context.Context, id uuid.UUID, in globalroled
 	return r, nil
 }
 
+// Delete delegates to the underlying service and invalidates the list cache.
 func (c *CachedService) Delete(ctx context.Context, id uuid.UUID) error {
 	if err := c.svc.Delete(ctx, id); err != nil {
 		return err
@@ -94,6 +97,7 @@ func (c *CachedService) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// ReplaceUserRoles delegates directly to the underlying service and invalidates the list cache.
 func (c *CachedService) ReplaceUserRoles(ctx context.Context, userID uuid.UUID, roleIDs []uuid.UUID) ([]*globalroledom.GlobalRole, error) {
 	return c.svc.ReplaceUserRoles(ctx, userID, roleIDs)
 }

--- a/services/api/internal/service/globalrole/cached_service.go
+++ b/services/api/internal/service/globalrole/cached_service.go
@@ -99,5 +99,12 @@ func (c *CachedService) Delete(ctx context.Context, id uuid.UUID) error {
 
 // ReplaceUserRoles delegates directly to the underlying service and invalidates the list cache.
 func (c *CachedService) ReplaceUserRoles(ctx context.Context, userID uuid.UUID, roleIDs []uuid.UUID) ([]*globalroledom.GlobalRole, error) {
-	return c.svc.ReplaceUserRoles(ctx, userID, roleIDs)
+	rs, err := c.svc.ReplaceUserRoles(ctx, userID, roleIDs)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, globalRolesKey); err != nil {
+		c.log.WarnContext(ctx, "cache: ReplaceUserRoles delete", "err", err)
+	}
+	return rs, nil
 }

--- a/services/api/internal/service/globalrole/cached_service_test.go
+++ b/services/api/internal/service/globalrole/cached_service_test.go
@@ -1,0 +1,285 @@
+// Package globalrolesvc_test contains unit tests for the globalrole service
+// layer, including the CachedService decorator.
+package globalrolesvc_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	globalroledom "github.com/paca/api/internal/domain/globalrole"
+	"github.com/paca/api/internal/platform/cache"
+	globalrolesvc "github.com/paca/api/internal/service/globalrole"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newCacheStore spins up an embedded Redis server and returns a Store wired
+// to it. The server is stopped and the client closed when t ends.
+func newCacheStore(t *testing.T) *cache.Store {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return cache.NewStore(client, "paca:")
+}
+
+// ---------------------------------------------------------------------------
+// Stub global-role service
+// ---------------------------------------------------------------------------
+
+type stubGlobalRoleSvc struct {
+	list             func(ctx context.Context) ([]*globalroledom.GlobalRole, error)
+	create           func(ctx context.Context, in globalroledom.CreateInput) (*globalroledom.GlobalRole, error)
+	update           func(ctx context.Context, id uuid.UUID, in globalroledom.UpdateInput) (*globalroledom.GlobalRole, error)
+	delete           func(ctx context.Context, id uuid.UUID) error
+	replaceUserRoles func(ctx context.Context, userID uuid.UUID, roleIDs []uuid.UUID) ([]*globalroledom.GlobalRole, error)
+
+	listCalls int
+}
+
+func (s *stubGlobalRoleSvc) List(ctx context.Context) ([]*globalroledom.GlobalRole, error) {
+	s.listCalls++
+	if s.list != nil {
+		return s.list(ctx)
+	}
+	return nil, nil
+}
+
+func (s *stubGlobalRoleSvc) Create(ctx context.Context, in globalroledom.CreateInput) (*globalroledom.GlobalRole, error) {
+	if s.create != nil {
+		return s.create(ctx, in)
+	}
+	return &globalroledom.GlobalRole{ID: uuid.New(), Name: in.Name}, nil
+}
+
+func (s *stubGlobalRoleSvc) Update(ctx context.Context, id uuid.UUID, in globalroledom.UpdateInput) (*globalroledom.GlobalRole, error) {
+	if s.update != nil {
+		return s.update(ctx, id, in)
+	}
+	return &globalroledom.GlobalRole{ID: id, Name: in.Name}, nil
+}
+
+func (s *stubGlobalRoleSvc) Delete(ctx context.Context, id uuid.UUID) error {
+	if s.delete != nil {
+		return s.delete(ctx, id)
+	}
+	return nil
+}
+
+func (s *stubGlobalRoleSvc) ReplaceUserRoles(ctx context.Context, userID uuid.UUID, roleIDs []uuid.UUID) ([]*globalroledom.GlobalRole, error) {
+	if s.replaceUserRoles != nil {
+		return s.replaceUserRoles(ctx, userID, roleIDs)
+	}
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// CachedService – List
+// ---------------------------------------------------------------------------
+
+func TestCachedGlobalRole_List_CacheMissPopulatesCache(t *testing.T) {
+	ctx := context.Background()
+	roles := []*globalroledom.GlobalRole{{ID: uuid.New(), Name: "ADMIN"}}
+	stub := &stubGlobalRoleSvc{
+		list: func(_ context.Context) ([]*globalroledom.GlobalRole, error) { return roles, nil },
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	// First call: cache miss → delegates to stub.
+	got, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("List (miss): %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "ADMIN" {
+		t.Fatalf("List (miss): unexpected result %v", got)
+	}
+	if stub.listCalls != 1 {
+		t.Fatalf("List (miss): expected 1 stub call, got %d", stub.listCalls)
+	}
+
+	// Second call: cache hit → stub is NOT called again.
+	got2, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("List (hit): %v", err)
+	}
+	if len(got2) != 1 {
+		t.Fatalf("List (hit): unexpected result %v", got2)
+	}
+	if stub.listCalls != 1 {
+		t.Fatalf("List (hit): expected stub to not be called again, got %d calls", stub.listCalls)
+	}
+}
+
+func TestCachedGlobalRole_List_ZeroTTLBypassesCache(t *testing.T) {
+	ctx := context.Background()
+	roles := []*globalroledom.GlobalRole{{ID: uuid.New(), Name: "USER"}}
+	stub := &stubGlobalRoleSvc{
+		list: func(_ context.Context) ([]*globalroledom.GlobalRole, error) { return roles, nil },
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 0, discardLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.List(ctx); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if stub.listCalls != 3 {
+		t.Fatalf("TTL=0 should bypass cache; expected 3 stub calls, got %d", stub.listCalls)
+	}
+}
+
+func TestCachedGlobalRole_List_ServiceErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("db error")
+	stub := &stubGlobalRoleSvc{
+		list: func(_ context.Context) ([]*globalroledom.GlobalRole, error) { return nil, sentinel },
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	_, err := svc.List(ctx)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedService – Create invalidates list cache
+// ---------------------------------------------------------------------------
+
+func TestCachedGlobalRole_Create_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubGlobalRoleSvc{
+		list: func(_ context.Context) ([]*globalroledom.GlobalRole, error) {
+			return []*globalroledom.GlobalRole{{ID: uuid.New(), Name: "CACHED"}}, nil
+		},
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	// Populate the cache.
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("initial List: %v", err)
+	}
+	if stub.listCalls != 1 {
+		t.Fatalf("expected 1 stub call after initial List, got %d", stub.listCalls)
+	}
+
+	// Create a role → should evict the list key.
+	if _, err := svc.Create(ctx, globalroledom.CreateInput{Name: "NEW"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Next List call must hit the stub again (cache was evicted).
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("List after Create: %v", err)
+	}
+	if stub.listCalls != 2 {
+		t.Fatalf("expected 2 stub calls after Create+List, got %d", stub.listCalls)
+	}
+}
+
+func TestCachedGlobalRole_Update_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubGlobalRoleSvc{
+		list: func(_ context.Context) ([]*globalroledom.GlobalRole, error) {
+			return []*globalroledom.GlobalRole{{ID: uuid.New()}}, nil
+		},
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if _, err := svc.Update(ctx, uuid.New(), globalroledom.UpdateInput{Name: "X"}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("List after Update: %v", err)
+	}
+	if stub.listCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listCalls)
+	}
+}
+
+func TestCachedGlobalRole_Delete_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubGlobalRoleSvc{
+		list: func(_ context.Context) ([]*globalroledom.GlobalRole, error) {
+			return []*globalroledom.GlobalRole{{ID: uuid.New()}}, nil
+		},
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if err := svc.Delete(ctx, uuid.New()); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("List after Delete: %v", err)
+	}
+	if stub.listCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedService – write errors propagate; cache invalidation errors are non-fatal
+// ---------------------------------------------------------------------------
+
+func TestCachedGlobalRole_Create_ServiceErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("repo error")
+	stub := &stubGlobalRoleSvc{
+		create: func(_ context.Context, _ globalroledom.CreateInput) (*globalroledom.GlobalRole, error) {
+			return nil, sentinel
+		},
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	_, err := svc.Create(ctx, globalroledom.CreateInput{Name: "X"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedService – ReplaceUserRoles passes through (no cache involvement)
+// ---------------------------------------------------------------------------
+
+func TestCachedGlobalRole_ReplaceUserRoles_Passthrough(t *testing.T) {
+	ctx := context.Background()
+	called := false
+	stub := &stubGlobalRoleSvc{
+		replaceUserRoles: func(_ context.Context, _ uuid.UUID, _ []uuid.UUID) ([]*globalroledom.GlobalRole, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	svc := globalrolesvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ReplaceUserRoles(ctx, uuid.New(), nil); err != nil {
+		t.Fatalf("ReplaceUserRoles: %v", err)
+	}
+	if !called {
+		t.Fatal("ReplaceUserRoles should delegate to underlying service")
+	}
+}

--- a/services/api/internal/service/project/cached_service.go
+++ b/services/api/internal/service/project/cached_service.go
@@ -1,0 +1,252 @@
+package projectsvc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/platform/cache"
+)
+
+// CachedService decorates a projectdom.Service with a Valkey/Redis-backed
+// cache.
+//
+// # What is cached
+//
+//   - GetByID        – project detail; keyed by project ID.
+//   - ListMembers    – project member list; keyed by project ID.
+//   - ListRoles      – project role list; keyed by project ID.
+//
+// List/ListAccessible are NOT cached because they are paginated, potentially
+// user-scoped, and have high result-set cardinality.
+// GetMyProjectPermissions is NOT cached because it is user-specific and
+// depends on the member's current role.
+// IsProjectPublic is NOT cached; it is a single-column read used in hot-path
+// middleware and is already handled by the database's plan cache.
+//
+// Cache errors are non-fatal: read errors fall through to the real service;
+// write/delete errors are logged so mutations always succeed.
+type CachedService struct {
+	svc        projectdom.Service
+	st         *cache.Store
+	projectTTL time.Duration
+	configTTL  time.Duration
+	log        *slog.Logger
+}
+
+// NewCachedService wraps svc with a caching layer backed by st.
+//
+//   - projectTTL governs project detail and member data.
+//   - configTTL governs project role data.
+//
+// Pass zero for either TTL to disable caching for that category.
+// log receives non-fatal cache warnings.
+func NewCachedService(svc projectdom.Service, st *cache.Store, projectTTL, configTTL time.Duration, log *slog.Logger) *CachedService {
+	return &CachedService{
+		svc:        svc,
+		st:         st,
+		projectTTL: projectTTL,
+		configTTL:  configTTL,
+		log:        log,
+	}
+}
+
+// --- cache key helpers -------------------------------------------------------
+
+func projectKey(id uuid.UUID) string {
+	return fmt.Sprintf("project:%s", id)
+}
+
+func membersKey(projectID uuid.UUID) string {
+	return fmt.Sprintf("project:%s:members", projectID)
+}
+
+func rolesKey(projectID uuid.UUID) string {
+	return fmt.Sprintf("project:%s:roles", projectID)
+}
+
+// --- Project -----------------------------------------------------------------
+
+func (c *CachedService) List(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	return c.svc.List(ctx, page, pageSize)
+}
+
+func (c *CachedService) ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	return c.svc.ListAccessible(ctx, userID, page, pageSize)
+}
+
+// GetByID returns a project by its ID, reading from cache when available and
+// populating it on a miss.
+func (c *CachedService) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	if c.projectTTL == 0 {
+		return c.svc.GetByID(ctx, id)
+	}
+	key := projectKey(id)
+	var result projectdom.Project
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return &result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: GetProject get", "err", err)
+	}
+
+	p, err := c.svc.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, p, c.projectTTL); err != nil {
+		c.log.WarnContext(ctx, "cache: GetProject set", "err", err)
+	}
+	return p, nil
+}
+
+func (c *CachedService) IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error) {
+	return c.svc.IsProjectPublic(ctx, id)
+}
+
+func (c *CachedService) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+	return c.svc.Create(ctx, in)
+}
+
+func (c *CachedService) Update(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+	p, err := c.svc.Update(ctx, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, projectKey(id)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateProject delete", "err", err)
+	}
+	return p, nil
+}
+
+func (c *CachedService) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := c.svc.Delete(ctx, id); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, projectKey(id), membersKey(id), rolesKey(id)); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteProject delete", "err", err)
+	}
+	return nil
+}
+
+// --- Members -----------------------------------------------------------------
+
+// ListMembers returns all members of a project, reading from cache when
+// available and populating it on a miss.
+func (c *CachedService) ListMembers(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	if c.projectTTL == 0 {
+		return c.svc.ListMembers(ctx, projectID)
+	}
+	key := membersKey(projectID)
+	var result []*projectdom.ProjectMember
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListMembers get", "err", err)
+	}
+
+	result, err := c.svc.ListMembers(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.projectTTL); err != nil {
+		c.log.WarnContext(ctx, "cache: ListMembers set", "err", err)
+	}
+	return result, nil
+}
+
+func (c *CachedService) AddMember(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+	m, err := c.svc.AddMember(ctx, projectID, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, membersKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: AddMember delete", "err", err)
+	}
+	return m, nil
+}
+
+func (c *CachedService) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+	m, err := c.svc.UpdateMemberRole(ctx, projectID, userID, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, membersKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateMemberRole delete", "err", err)
+	}
+	return m, nil
+}
+
+func (c *CachedService) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
+	if err := c.svc.RemoveMember(ctx, projectID, userID); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, membersKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: RemoveMember delete", "err", err)
+	}
+	return nil
+}
+
+func (c *CachedService) GetMyProjectPermissions(ctx context.Context, projectID, userID uuid.UUID) (map[string]any, error) {
+	return c.svc.GetMyProjectPermissions(ctx, projectID, userID)
+}
+
+// --- Roles -------------------------------------------------------------------
+
+// ListRoles returns all roles for a project, reading from cache when available
+// and populating it on a miss.
+func (c *CachedService) ListRoles(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	if c.configTTL == 0 {
+		return c.svc.ListRoles(ctx, projectID)
+	}
+	key := rolesKey(projectID)
+	var result []*projectdom.ProjectRole
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListRoles get", "err", err)
+	}
+
+	result, err := c.svc.ListRoles(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.configTTL); err != nil {
+		c.log.WarnContext(ctx, "cache: ListRoles set", "err", err)
+	}
+	return result, nil
+}
+
+func (c *CachedService) CreateRole(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+	r, err := c.svc.CreateRole(ctx, projectID, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, rolesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateRole delete", "err", err)
+	}
+	return r, nil
+}
+
+func (c *CachedService) UpdateRole(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
+	r, err := c.svc.UpdateRole(ctx, projectID, roleID, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, rolesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateRole delete", "err", err)
+	}
+	return r, nil
+}
+
+func (c *CachedService) DeleteRole(ctx context.Context, projectID, roleID uuid.UUID) error {
+	if err := c.svc.DeleteRole(ctx, projectID, roleID); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, rolesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteRole delete", "err", err)
+	}
+	return nil
+}

--- a/services/api/internal/service/project/cached_service.go
+++ b/services/api/internal/service/project/cached_service.go
@@ -70,10 +70,12 @@ func rolesKey(projectID uuid.UUID) string {
 
 // --- Project -----------------------------------------------------------------
 
+// List delegates directly to the underlying service (not cached).
 func (c *CachedService) List(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error) {
 	return c.svc.List(ctx, page, pageSize)
 }
 
+// ListAccessible delegates directly to the underlying service (not cached).
 func (c *CachedService) ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error) {
 	return c.svc.ListAccessible(ctx, userID, page, pageSize)
 }
@@ -102,14 +104,17 @@ func (c *CachedService) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.
 	return p, nil
 }
 
+// IsProjectPublic delegates directly to the underlying service (not cached).
 func (c *CachedService) IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error) {
 	return c.svc.IsProjectPublic(ctx, id)
 }
 
+// Create delegates directly to the underlying service (not cached).
 func (c *CachedService) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
 	return c.svc.Create(ctx, in)
 }
 
+// Update delegates to the underlying service and invalidates the project cache entry.
 func (c *CachedService) Update(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
 	p, err := c.svc.Update(ctx, id, in)
 	if err != nil {
@@ -121,6 +126,7 @@ func (c *CachedService) Update(ctx context.Context, id uuid.UUID, in projectdom.
 	return p, nil
 }
 
+// Delete delegates to the underlying service and invalidates all related cache entries.
 func (c *CachedService) Delete(ctx context.Context, id uuid.UUID) error {
 	if err := c.svc.Delete(ctx, id); err != nil {
 		return err
@@ -157,6 +163,7 @@ func (c *CachedService) ListMembers(ctx context.Context, projectID uuid.UUID) ([
 	return result, nil
 }
 
+// AddMember delegates to the underlying service and invalidates the members cache.
 func (c *CachedService) AddMember(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
 	m, err := c.svc.AddMember(ctx, projectID, in)
 	if err != nil {
@@ -168,6 +175,7 @@ func (c *CachedService) AddMember(ctx context.Context, projectID uuid.UUID, in p
 	return m, nil
 }
 
+// UpdateMemberRole delegates to the underlying service and invalidates the members cache.
 func (c *CachedService) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
 	m, err := c.svc.UpdateMemberRole(ctx, projectID, userID, in)
 	if err != nil {
@@ -179,6 +187,7 @@ func (c *CachedService) UpdateMemberRole(ctx context.Context, projectID, userID 
 	return m, nil
 }
 
+// RemoveMember delegates to the underlying service and invalidates the members cache.
 func (c *CachedService) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
 	if err := c.svc.RemoveMember(ctx, projectID, userID); err != nil {
 		return err
@@ -189,6 +198,7 @@ func (c *CachedService) RemoveMember(ctx context.Context, projectID, userID uuid
 	return nil
 }
 
+// GetMyProjectPermissions delegates directly to the underlying service (not cached).
 func (c *CachedService) GetMyProjectPermissions(ctx context.Context, projectID, userID uuid.UUID) (map[string]any, error) {
 	return c.svc.GetMyProjectPermissions(ctx, projectID, userID)
 }
@@ -219,6 +229,7 @@ func (c *CachedService) ListRoles(ctx context.Context, projectID uuid.UUID) ([]*
 	return result, nil
 }
 
+// CreateRole delegates to the underlying service and invalidates the roles cache.
 func (c *CachedService) CreateRole(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
 	r, err := c.svc.CreateRole(ctx, projectID, in)
 	if err != nil {
@@ -230,6 +241,7 @@ func (c *CachedService) CreateRole(ctx context.Context, projectID uuid.UUID, in 
 	return r, nil
 }
 
+// UpdateRole delegates to the underlying service and invalidates the roles cache.
 func (c *CachedService) UpdateRole(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
 	r, err := c.svc.UpdateRole(ctx, projectID, roleID, in)
 	if err != nil {
@@ -241,6 +253,7 @@ func (c *CachedService) UpdateRole(ctx context.Context, projectID, roleID uuid.U
 	return r, nil
 }
 
+// DeleteRole delegates to the underlying service and invalidates the roles cache.
 func (c *CachedService) DeleteRole(ctx context.Context, projectID, roleID uuid.UUID) error {
 	if err := c.svc.DeleteRole(ctx, projectID, roleID); err != nil {
 		return err

--- a/services/api/internal/service/project/cached_service_test.go
+++ b/services/api/internal/service/project/cached_service_test.go
@@ -1,0 +1,460 @@
+// Package projectsvc_test contains unit tests for the project service layer,
+// including the CachedService decorator.
+package projectsvc_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	projectdom "github.com/paca/api/internal/domain/project"
+	"github.com/paca/api/internal/platform/cache"
+	projectsvc "github.com/paca/api/internal/service/project"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newCacheStore(t *testing.T) *cache.Store {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return cache.NewStore(client, "paca:")
+}
+
+const (
+	projectTTL = 5 * time.Minute
+	configTTL  = 10 * time.Minute
+)
+
+// ---------------------------------------------------------------------------
+// Stub project service
+// ---------------------------------------------------------------------------
+
+type stubProjectSvc struct {
+	list              func(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error)
+	listAccessible    func(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error)
+	getByID           func(ctx context.Context, id uuid.UUID) (*projectdom.Project, error)
+	isProjectPublic   func(ctx context.Context, id uuid.UUID) (bool, error)
+	create            func(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error)
+	update            func(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error)
+	delete            func(ctx context.Context, id uuid.UUID) error
+	listMembers       func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error)
+	addMember         func(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error)
+	updateMemberRole  func(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error)
+	removeMember      func(ctx context.Context, projectID, userID uuid.UUID) error
+	getMyProjectPerms func(ctx context.Context, projectID, userID uuid.UUID) (map[string]any, error)
+	listRoles         func(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error)
+	createRole        func(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error)
+	updateRole        func(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error)
+	deleteRole        func(ctx context.Context, projectID, roleID uuid.UUID) error
+
+	getByIDCalls     int
+	listMembersCalls int
+	listRolesCalls   int
+}
+
+func (s *stubProjectSvc) List(ctx context.Context, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	if s.list != nil {
+		return s.list(ctx, page, pageSize)
+	}
+	return nil, 0, nil
+}
+
+func (s *stubProjectSvc) ListAccessible(ctx context.Context, userID uuid.UUID, page, pageSize int) ([]*projectdom.Project, int64, error) {
+	if s.listAccessible != nil {
+		return s.listAccessible(ctx, userID, page, pageSize)
+	}
+	return nil, 0, nil
+}
+
+func (s *stubProjectSvc) GetByID(ctx context.Context, id uuid.UUID) (*projectdom.Project, error) {
+	s.getByIDCalls++
+	if s.getByID != nil {
+		return s.getByID(ctx, id)
+	}
+	return &projectdom.Project{ID: id, Name: "stub-project"}, nil
+}
+
+func (s *stubProjectSvc) IsProjectPublic(ctx context.Context, id uuid.UUID) (bool, error) {
+	if s.isProjectPublic != nil {
+		return s.isProjectPublic(ctx, id)
+	}
+	return false, nil
+}
+
+func (s *stubProjectSvc) Create(ctx context.Context, in projectdom.CreateProjectInput) (*projectdom.Project, error) {
+	if s.create != nil {
+		return s.create(ctx, in)
+	}
+	return &projectdom.Project{ID: uuid.New(), Name: in.Name}, nil
+}
+
+func (s *stubProjectSvc) Update(ctx context.Context, id uuid.UUID, in projectdom.UpdateProjectInput) (*projectdom.Project, error) {
+	if s.update != nil {
+		return s.update(ctx, id, in)
+	}
+	return &projectdom.Project{ID: id, Name: in.Name}, nil
+}
+
+func (s *stubProjectSvc) Delete(ctx context.Context, id uuid.UUID) error {
+	if s.delete != nil {
+		return s.delete(ctx, id)
+	}
+	return nil
+}
+
+func (s *stubProjectSvc) ListMembers(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectMember, error) {
+	s.listMembersCalls++
+	if s.listMembers != nil {
+		return s.listMembers(ctx, projectID)
+	}
+	return []*projectdom.ProjectMember{{ID: uuid.New(), ProjectID: projectID}}, nil
+}
+
+func (s *stubProjectSvc) AddMember(ctx context.Context, projectID uuid.UUID, in projectdom.AddMemberInput) (*projectdom.ProjectMember, error) {
+	if s.addMember != nil {
+		return s.addMember(ctx, projectID, in)
+	}
+	return &projectdom.ProjectMember{ID: uuid.New(), ProjectID: projectID, UserID: in.UserID}, nil
+}
+
+func (s *stubProjectSvc) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, in projectdom.UpdateMemberRoleInput) (*projectdom.ProjectMember, error) {
+	if s.updateMemberRole != nil {
+		return s.updateMemberRole(ctx, projectID, userID, in)
+	}
+	return &projectdom.ProjectMember{ID: uuid.New(), ProjectID: projectID, UserID: userID}, nil
+}
+
+func (s *stubProjectSvc) RemoveMember(ctx context.Context, projectID, userID uuid.UUID) error {
+	if s.removeMember != nil {
+		return s.removeMember(ctx, projectID, userID)
+	}
+	return nil
+}
+
+func (s *stubProjectSvc) GetMyProjectPermissions(ctx context.Context, projectID, userID uuid.UUID) (map[string]any, error) {
+	if s.getMyProjectPerms != nil {
+		return s.getMyProjectPerms(ctx, projectID, userID)
+	}
+	return map[string]any{}, nil
+}
+
+func (s *stubProjectSvc) ListRoles(ctx context.Context, projectID uuid.UUID) ([]*projectdom.ProjectRole, error) {
+	s.listRolesCalls++
+	if s.listRoles != nil {
+		return s.listRoles(ctx, projectID)
+	}
+	return []*projectdom.ProjectRole{{ID: uuid.New()}}, nil
+}
+
+func (s *stubProjectSvc) CreateRole(ctx context.Context, projectID uuid.UUID, in projectdom.CreateRoleInput) (*projectdom.ProjectRole, error) {
+	if s.createRole != nil {
+		return s.createRole(ctx, projectID, in)
+	}
+	return &projectdom.ProjectRole{ID: uuid.New()}, nil
+}
+
+func (s *stubProjectSvc) UpdateRole(ctx context.Context, projectID, roleID uuid.UUID, in projectdom.UpdateRoleInput) (*projectdom.ProjectRole, error) {
+	if s.updateRole != nil {
+		return s.updateRole(ctx, projectID, roleID, in)
+	}
+	return &projectdom.ProjectRole{ID: roleID}, nil
+}
+
+func (s *stubProjectSvc) DeleteRole(ctx context.Context, projectID, roleID uuid.UUID) error {
+	if s.deleteRole != nil {
+		return s.deleteRole(ctx, projectID, roleID)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// GetByID
+// ---------------------------------------------------------------------------
+
+func TestCachedProject_GetByID_CacheMissPopulatesCache(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	// First call: cache miss.
+	p, err := svc.GetByID(ctx, projectID)
+	if err != nil {
+		t.Fatalf("GetByID (miss): %v", err)
+	}
+	if p.ID != projectID {
+		t.Fatalf("GetByID (miss): got ID %s, want %s", p.ID, projectID)
+	}
+	if stub.getByIDCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.getByIDCalls)
+	}
+
+	// Second call: cache hit.
+	p2, err := svc.GetByID(ctx, projectID)
+	if err != nil {
+		t.Fatalf("GetByID (hit): %v", err)
+	}
+	if p2.ID != projectID {
+		t.Fatalf("GetByID (hit): got ID %s, want %s", p2.ID, projectID)
+	}
+	if stub.getByIDCalls != 1 {
+		t.Fatalf("cache hit: stub should not be called again; got %d calls", stub.getByIDCalls)
+	}
+}
+
+func TestCachedProject_GetByID_ZeroTTLBypassesCache(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), 0, configTTL, discardLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.GetByID(ctx, uuid.New()); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if stub.getByIDCalls != 3 {
+		t.Fatalf("TTL=0 should bypass cache; want 3 calls, got %d", stub.getByIDCalls)
+	}
+}
+
+func TestCachedProject_Update_InvalidatesGetByID(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	// Populate cache.
+	if _, err := svc.GetByID(ctx, projectID); err != nil {
+		t.Fatalf("initial GetByID: %v", err)
+	}
+
+	// Update should evict the project key.
+	if _, err := svc.Update(ctx, projectID, projectdom.UpdateProjectInput{Name: "new"}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Must call stub again (cache evicted).
+	if _, err := svc.GetByID(ctx, projectID); err != nil {
+		t.Fatalf("GetByID after Update: %v", err)
+	}
+	if stub.getByIDCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.getByIDCalls)
+	}
+}
+
+func TestCachedProject_Delete_InvalidatesAllProjectKeys(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	// Populate caches.
+	if _, err := svc.GetByID(ctx, projectID); err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+
+	// Delete should evict all three.
+	if err := svc.Delete(ctx, projectID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Each should hit stub again.
+	if _, err := svc.GetByID(ctx, projectID); err != nil {
+		t.Fatalf("GetByID after Delete: %v", err)
+	}
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers after Delete: %v", err)
+	}
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles after Delete: %v", err)
+	}
+
+	if stub.getByIDCalls != 2 {
+		t.Fatalf("GetByID: expected 2 stub calls, got %d", stub.getByIDCalls)
+	}
+	if stub.listMembersCalls != 2 {
+		t.Fatalf("ListMembers: expected 2 stub calls, got %d", stub.listMembersCalls)
+	}
+	if stub.listRolesCalls != 2 {
+		t.Fatalf("ListRoles: expected 2 stub calls, got %d", stub.listRolesCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListMembers
+// ---------------------------------------------------------------------------
+
+func TestCachedProject_ListMembers_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers (miss): %v", err)
+	}
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers (hit): %v", err)
+	}
+	if stub.listMembersCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listMembersCalls)
+	}
+}
+
+func TestCachedProject_AddMember_InvalidatesMembersList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if _, err := svc.AddMember(ctx, projectID, projectdom.AddMemberInput{UserID: uuid.New(), ProjectRoleID: uuid.New()}); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers after AddMember: %v", err)
+	}
+	if stub.listMembersCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listMembersCalls)
+	}
+}
+
+func TestCachedProject_RemoveMember_InvalidatesMembersList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if err := svc.RemoveMember(ctx, projectID, uuid.New()); err != nil {
+		t.Fatalf("RemoveMember: %v", err)
+	}
+	if _, err := svc.ListMembers(ctx, projectID); err != nil {
+		t.Fatalf("ListMembers after RemoveMember: %v", err)
+	}
+	if stub.listMembersCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listMembersCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListRoles
+// ---------------------------------------------------------------------------
+
+func TestCachedProject_ListRoles_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles (miss): %v", err)
+	}
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles (hit): %v", err)
+	}
+	if stub.listRolesCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listRolesCalls)
+	}
+}
+
+func TestCachedProject_CreateRole_InvalidatesRolesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+	if _, err := svc.CreateRole(ctx, projectID, projectdom.CreateRoleInput{RoleName: "DEV"}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles after CreateRole: %v", err)
+	}
+	if stub.listRolesCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listRolesCalls)
+	}
+}
+
+func TestCachedProject_DeleteRole_InvalidatesRolesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubProjectSvc{}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+	if err := svc.DeleteRole(ctx, projectID, uuid.New()); err != nil {
+		t.Fatalf("DeleteRole: %v", err)
+	}
+	if _, err := svc.ListRoles(ctx, projectID); err != nil {
+		t.Fatalf("ListRoles after DeleteRole: %v", err)
+	}
+	if stub.listRolesCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listRolesCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pass-through methods are delegated unchanged
+// ---------------------------------------------------------------------------
+
+func TestCachedProject_List_Passthrough(t *testing.T) {
+	ctx := context.Background()
+	called := false
+	stub := &stubProjectSvc{
+		list: func(_ context.Context, _, _ int) ([]*projectdom.Project, int64, error) {
+			called = true
+			return nil, 0, nil
+		},
+	}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+	if _, _, err := svc.List(ctx, 1, 20); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !called {
+		t.Fatal("List should delegate to underlying service")
+	}
+}
+
+func TestCachedProject_GetByID_ServiceErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("not found")
+	stub := &stubProjectSvc{
+		getByID: func(_ context.Context, _ uuid.UUID) (*projectdom.Project, error) { return nil, sentinel },
+	}
+	svc := projectsvc.NewCachedService(stub, newCacheStore(t), projectTTL, configTTL, discardLogger())
+
+	_, err := svc.GetByID(ctx, uuid.New())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}

--- a/services/api/internal/service/sprint/cached_service.go
+++ b/services/api/internal/service/sprint/cached_service.go
@@ -75,7 +75,9 @@ func (c *CachedSprintService) ListSprints(ctx context.Context, projectID uuid.UU
 }
 
 // GetSprint returns a single sprint, reading from cache when available and
-// populating it on a miss.
+// populating it on a miss. On a cache hit the cached sprint's ProjectID is
+// compared with the requested projectID; a mismatch returns ErrSprintNotFound
+// without delegating to the underlying service, preventing cross-project leaks.
 func (c *CachedSprintService) GetSprint(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.Sprint, error) {
 	if c.ttl == 0 {
 		return c.svc.GetSprint(ctx, projectID, id)
@@ -83,6 +85,9 @@ func (c *CachedSprintService) GetSprint(ctx context.Context, projectID, id uuid.
 	key := sprintItemKey(id)
 	var result sprintdom.Sprint
 	if ok, err := c.st.Get(ctx, key, &result); ok {
+		if result.ProjectID != projectID {
+			return nil, sprintdom.ErrSprintNotFound
+		}
 		return &result, nil
 	} else if err != nil {
 		c.log.WarnContext(ctx, "cache: GetSprint get", "err", err)

--- a/services/api/internal/service/sprint/cached_service.go
+++ b/services/api/internal/service/sprint/cached_service.go
@@ -98,6 +98,7 @@ func (c *CachedSprintService) GetSprint(ctx context.Context, projectID, id uuid.
 	return sp, nil
 }
 
+// CreateSprint delegates to the underlying service and invalidates the sprint list cache.
 func (c *CachedSprintService) CreateSprint(ctx context.Context, in sprintdom.CreateSprintInput) (*sprintdom.Sprint, error) {
 	sp, err := c.svc.CreateSprint(ctx, in)
 	if err != nil {
@@ -109,6 +110,7 @@ func (c *CachedSprintService) CreateSprint(ctx context.Context, in sprintdom.Cre
 	return sp, nil
 }
 
+// UpdateSprint delegates to the underlying service and invalidates the sprint list and item caches.
 func (c *CachedSprintService) UpdateSprint(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateSprintInput) (*sprintdom.Sprint, error) {
 	sp, err := c.svc.UpdateSprint(ctx, projectID, id, in)
 	if err != nil {
@@ -120,6 +122,7 @@ func (c *CachedSprintService) UpdateSprint(ctx context.Context, projectID, id uu
 	return sp, nil
 }
 
+// DeleteSprint delegates to the underlying service and invalidates the sprint list and item caches.
 func (c *CachedSprintService) DeleteSprint(ctx context.Context, projectID, id uuid.UUID) error {
 	if err := c.svc.DeleteSprint(ctx, projectID, id); err != nil {
 		return err
@@ -130,6 +133,7 @@ func (c *CachedSprintService) DeleteSprint(ctx context.Context, projectID, id uu
 	return nil
 }
 
+// CompleteSprint delegates to the underlying service and invalidates the sprint list and item caches.
 func (c *CachedSprintService) CompleteSprint(ctx context.Context, projectID, id uuid.UUID, in sprintdom.CompleteSprintInput) (*sprintdom.Sprint, error) {
 	sp, err := c.svc.CompleteSprint(ctx, projectID, id, in)
 	if err != nil {

--- a/services/api/internal/service/sprint/cached_service.go
+++ b/services/api/internal/service/sprint/cached_service.go
@@ -1,0 +1,142 @@
+package sprintsvc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	sprintdom "github.com/paca/api/internal/domain/sprint"
+	"github.com/paca/api/internal/platform/cache"
+)
+
+// CachedSprintService decorates a sprintdom.SprintService with a
+// Valkey/Redis-backed cache.
+//
+// # What is cached
+//
+//   - ListSprints  – all sprints for a project; keyed by project ID.
+//   - GetSprint    – single sprint; keyed by sprint ID.
+//
+// Write operations (Create/Update/Delete/Complete) invalidate the relevant
+// cached entries after a successful database write.
+//
+// Cache errors are non-fatal: read errors fall through to the real service;
+// write/delete errors are logged so mutations always succeed.
+type CachedSprintService struct {
+	svc sprintdom.SprintService
+	st  *cache.Store
+	ttl time.Duration
+	log *slog.Logger
+}
+
+// NewCachedSprintService wraps svc with a caching layer backed by st.
+// ttl controls how long cached entries live; zero disables caching.
+// log receives non-fatal cache warnings.
+func NewCachedSprintService(svc sprintdom.SprintService, st *cache.Store, ttl time.Duration, log *slog.Logger) *CachedSprintService {
+	return &CachedSprintService{svc: svc, st: st, ttl: ttl, log: log}
+}
+
+// --- cache key helpers -------------------------------------------------------
+
+func sprintListKey(projectID uuid.UUID) string {
+	return fmt.Sprintf("project:%s:sprints", projectID)
+}
+
+func sprintItemKey(id uuid.UUID) string {
+	return fmt.Sprintf("sprint:%s", id)
+}
+
+// --- SprintService -----------------------------------------------------------
+
+// ListSprints returns all sprints for a project, reading from cache when
+// available and populating it on a miss.
+func (c *CachedSprintService) ListSprints(ctx context.Context, projectID uuid.UUID) ([]*sprintdom.Sprint, error) {
+	if c.ttl == 0 {
+		return c.svc.ListSprints(ctx, projectID)
+	}
+	key := sprintListKey(projectID)
+	var result []*sprintdom.Sprint
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListSprints get", "err", err)
+	}
+
+	result, err := c.svc.ListSprints(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: ListSprints set", "err", err)
+	}
+	return result, nil
+}
+
+// GetSprint returns a single sprint, reading from cache when available and
+// populating it on a miss.
+func (c *CachedSprintService) GetSprint(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.Sprint, error) {
+	if c.ttl == 0 {
+		return c.svc.GetSprint(ctx, projectID, id)
+	}
+	key := sprintItemKey(id)
+	var result sprintdom.Sprint
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return &result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: GetSprint get", "err", err)
+	}
+
+	sp, err := c.svc.GetSprint(ctx, projectID, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, sp, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: GetSprint set", "err", err)
+	}
+	return sp, nil
+}
+
+func (c *CachedSprintService) CreateSprint(ctx context.Context, in sprintdom.CreateSprintInput) (*sprintdom.Sprint, error) {
+	sp, err := c.svc.CreateSprint(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, sprintListKey(in.ProjectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateSprint delete", "err", err)
+	}
+	return sp, nil
+}
+
+func (c *CachedSprintService) UpdateSprint(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateSprintInput) (*sprintdom.Sprint, error) {
+	sp, err := c.svc.UpdateSprint(ctx, projectID, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, sprintListKey(projectID), sprintItemKey(id)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateSprint delete", "err", err)
+	}
+	return sp, nil
+}
+
+func (c *CachedSprintService) DeleteSprint(ctx context.Context, projectID, id uuid.UUID) error {
+	if err := c.svc.DeleteSprint(ctx, projectID, id); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, sprintListKey(projectID), sprintItemKey(id)); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteSprint delete", "err", err)
+	}
+	return nil
+}
+
+func (c *CachedSprintService) CompleteSprint(ctx context.Context, projectID, id uuid.UUID, in sprintdom.CompleteSprintInput) (*sprintdom.Sprint, error) {
+	sp, err := c.svc.CompleteSprint(ctx, projectID, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, sprintListKey(projectID), sprintItemKey(id)); err != nil {
+		c.log.WarnContext(ctx, "cache: CompleteSprint delete", "err", err)
+	}
+	return sp, nil
+}

--- a/services/api/internal/service/sprint/cached_service_test.go
+++ b/services/api/internal/service/sprint/cached_service_test.go
@@ -476,6 +476,30 @@ func TestCachedView_GetView_CacheHit(t *testing.T) {
 	}
 }
 
+func TestCachedView_GetView_CacheHit_EnforcesProjectOwnership(t *testing.T) {
+	ctx := context.Background()
+	projectA := uuid.New()
+	projectB := uuid.New()
+	viewID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.GetView(ctx, projectA, viewID); err != nil {
+		t.Fatalf("GetView (project A miss): %v", err)
+	}
+
+	got, err := svc.GetView(ctx, projectB, viewID)
+	if !errors.Is(err, sprintsvc.ErrViewNotFound) {
+		t.Fatalf("GetView (project B cached lookup): expected ErrViewNotFound, got view=%v err=%v", got, err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil view on project mismatch, got %#v", got)
+	}
+	if stub.getViewCalls != 1 {
+		t.Fatalf("expected project mismatch to be rejected from cache without an additional stub call; got %d calls", stub.getViewCalls)
+	}
+}
+
 func TestCachedView_GetView_ZeroTTLBypassesCache(t *testing.T) {
 	ctx := context.Background()
 	stub := &stubViewSvc{}

--- a/services/api/internal/service/sprint/cached_service_test.go
+++ b/services/api/internal/service/sprint/cached_service_test.go
@@ -1,0 +1,620 @@
+// Package sprintsvc_test contains unit tests for the sprint service layer,
+// including the CachedSprintService and CachedViewService decorators.
+package sprintsvc_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	sprintdom "github.com/paca/api/internal/domain/sprint"
+	"github.com/paca/api/internal/platform/cache"
+	sprintsvc "github.com/paca/api/internal/service/sprint"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newCacheStore(t *testing.T) *cache.Store {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return cache.NewStore(client, "paca:")
+}
+
+// ---------------------------------------------------------------------------
+// Stub SprintService
+// ---------------------------------------------------------------------------
+
+type stubSprintSvc struct {
+	listSprints    func(ctx context.Context, projectID uuid.UUID) ([]*sprintdom.Sprint, error)
+	getSprint      func(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.Sprint, error)
+	createSprint   func(ctx context.Context, in sprintdom.CreateSprintInput) (*sprintdom.Sprint, error)
+	updateSprint   func(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateSprintInput) (*sprintdom.Sprint, error)
+	deleteSprint   func(ctx context.Context, projectID, id uuid.UUID) error
+	completeSprint func(ctx context.Context, projectID, id uuid.UUID, in sprintdom.CompleteSprintInput) (*sprintdom.Sprint, error)
+
+	listCalls int
+	getCalls  int
+}
+
+func (s *stubSprintSvc) ListSprints(ctx context.Context, projectID uuid.UUID) ([]*sprintdom.Sprint, error) {
+	s.listCalls++
+	if s.listSprints != nil {
+		return s.listSprints(ctx, projectID)
+	}
+	return []*sprintdom.Sprint{{ID: uuid.New(), ProjectID: projectID, Name: "Sprint 1"}}, nil
+}
+
+func (s *stubSprintSvc) GetSprint(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.Sprint, error) {
+	s.getCalls++
+	if s.getSprint != nil {
+		return s.getSprint(ctx, projectID, id)
+	}
+	return &sprintdom.Sprint{ID: id, ProjectID: projectID, Name: "Sprint 1"}, nil
+}
+
+func (s *stubSprintSvc) CreateSprint(ctx context.Context, in sprintdom.CreateSprintInput) (*sprintdom.Sprint, error) {
+	if s.createSprint != nil {
+		return s.createSprint(ctx, in)
+	}
+	return &sprintdom.Sprint{ID: uuid.New(), ProjectID: in.ProjectID, Name: in.Name}, nil
+}
+
+func (s *stubSprintSvc) UpdateSprint(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateSprintInput) (*sprintdom.Sprint, error) {
+	if s.updateSprint != nil {
+		return s.updateSprint(ctx, projectID, id, in)
+	}
+	return &sprintdom.Sprint{ID: id, ProjectID: projectID, Name: in.Name}, nil
+}
+
+func (s *stubSprintSvc) DeleteSprint(ctx context.Context, projectID, id uuid.UUID) error {
+	if s.deleteSprint != nil {
+		return s.deleteSprint(ctx, projectID, id)
+	}
+	return nil
+}
+
+func (s *stubSprintSvc) CompleteSprint(ctx context.Context, projectID, id uuid.UUID, in sprintdom.CompleteSprintInput) (*sprintdom.Sprint, error) {
+	if s.completeSprint != nil {
+		return s.completeSprint(ctx, projectID, id, in)
+	}
+	return &sprintdom.Sprint{ID: id, ProjectID: projectID, Status: sprintdom.SprintStatusCompleted}, nil
+}
+
+// ---------------------------------------------------------------------------
+// CachedSprintService – ListSprints
+// ---------------------------------------------------------------------------
+
+func TestCachedSprint_ListSprints_CacheMissPopulatesCache(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	// First call: miss.
+	sprints, err := svc.ListSprints(ctx, projectID)
+	if err != nil {
+		t.Fatalf("ListSprints (miss): %v", err)
+	}
+	if len(sprints) == 0 {
+		t.Fatal("expected at least one sprint")
+	}
+	if stub.listCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listCalls)
+	}
+
+	// Second call: hit.
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints (hit): %v", err)
+	}
+	if stub.listCalls != 1 {
+		t.Fatalf("cache hit: stub called again; got %d calls", stub.listCalls)
+	}
+}
+
+func TestCachedSprint_ListSprints_ZeroTTLBypassesCache(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 0, discardLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.ListSprints(ctx, uuid.New()); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if stub.listCalls != 3 {
+		t.Fatalf("TTL=0 should bypass cache; want 3 calls, got %d", stub.listCalls)
+	}
+}
+
+func TestCachedSprint_ListSprints_ServiceErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("db failure")
+	stub := &stubSprintSvc{
+		listSprints: func(_ context.Context, _ uuid.UUID) ([]*sprintdom.Sprint, error) {
+			return nil, sentinel
+		},
+	}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	_, err := svc.ListSprints(ctx, uuid.New())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedSprintService – GetSprint
+// ---------------------------------------------------------------------------
+
+func TestCachedSprint_GetSprint_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	sprintID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint (miss): %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint (hit): %v", err)
+	}
+	if stub.getCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.getCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedSprintService – write invalidation
+// ---------------------------------------------------------------------------
+
+func TestCachedSprint_CreateSprint_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints: %v", err)
+	}
+	if _, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{ProjectID: projectID, Name: "S2"}); err != nil {
+		t.Fatalf("CreateSprint: %v", err)
+	}
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints after Create: %v", err)
+	}
+	if stub.listCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listCalls)
+	}
+}
+
+func TestCachedSprint_UpdateSprint_InvalidatesListAndItem(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	sprintID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	// Populate both caches.
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints: %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint: %v", err)
+	}
+
+	// Update evicts both keys.
+	name := "Updated"
+	if _, err := svc.UpdateSprint(ctx, projectID, sprintID, sprintdom.UpdateSprintInput{Name: name}); err != nil {
+		t.Fatalf("UpdateSprint: %v", err)
+	}
+
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints after Update: %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint after Update: %v", err)
+	}
+
+	if stub.listCalls != 2 {
+		t.Fatalf("ListSprints: expected 2 stub calls, got %d", stub.listCalls)
+	}
+	if stub.getCalls != 2 {
+		t.Fatalf("GetSprint: expected 2 stub calls, got %d", stub.getCalls)
+	}
+}
+
+func TestCachedSprint_DeleteSprint_InvalidatesListAndItem(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	sprintID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints: %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint: %v", err)
+	}
+
+	if err := svc.DeleteSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("DeleteSprint: %v", err)
+	}
+
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints after Delete: %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint after Delete: %v", err)
+	}
+
+	if stub.listCalls != 2 {
+		t.Fatalf("ListSprints: expected 2 stub calls, got %d", stub.listCalls)
+	}
+	if stub.getCalls != 2 {
+		t.Fatalf("GetSprint: expected 2 stub calls, got %d", stub.getCalls)
+	}
+}
+
+func TestCachedSprint_CompleteSprint_InvalidatesListAndItem(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	sprintID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints: %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint: %v", err)
+	}
+
+	if _, err := svc.CompleteSprint(ctx, projectID, sprintID, sprintdom.CompleteSprintInput{}); err != nil {
+		t.Fatalf("CompleteSprint: %v", err)
+	}
+
+	if _, err := svc.ListSprints(ctx, projectID); err != nil {
+		t.Fatalf("ListSprints after Complete: %v", err)
+	}
+	if _, err := svc.GetSprint(ctx, projectID, sprintID); err != nil {
+		t.Fatalf("GetSprint after Complete: %v", err)
+	}
+
+	if stub.listCalls != 2 {
+		t.Fatalf("ListSprints: expected 2 stub calls, got %d", stub.listCalls)
+	}
+	if stub.getCalls != 2 {
+		t.Fatalf("GetSprint: expected 2 stub calls, got %d", stub.getCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stub ViewService
+// ---------------------------------------------------------------------------
+
+type stubViewSvc struct {
+	listViews           func(ctx context.Context, sprintID uuid.UUID) ([]*sprintdom.SprintView, error)
+	listProjectViews    func(ctx context.Context, projectID uuid.UUID, viewCtx sprintdom.ViewContext) ([]*sprintdom.SprintView, error)
+	getView             func(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.SprintView, error)
+	createView          func(ctx context.Context, in sprintdom.CreateViewInput) (*sprintdom.SprintView, error)
+	updateView          func(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateViewInput) (*sprintdom.SprintView, error)
+	deleteView          func(ctx context.Context, projectID, id uuid.UUID) error
+	moveTask            func(ctx context.Context, projectID, viewID uuid.UUID, in sprintdom.MoveTaskInput) error
+	bulkMoveTasks       func(ctx context.Context, projectID, viewID uuid.UUID, items []sprintdom.MoveTaskInput) error
+	listTaskPositions   func(ctx context.Context, projectID, viewID uuid.UUID) ([]*sprintdom.ViewTaskPosition, error)
+	reorderViews        func(ctx context.Context, sprintID uuid.UUID, viewIDs []uuid.UUID) error
+	reorderProjectViews func(ctx context.Context, projectID uuid.UUID, viewCtx sprintdom.ViewContext, viewIDs []uuid.UUID) error
+
+	listProjectViewsCalls int
+	getViewCalls          int
+}
+
+func (s *stubViewSvc) ListViews(ctx context.Context, sprintID uuid.UUID) ([]*sprintdom.SprintView, error) {
+	if s.listViews != nil {
+		return s.listViews(ctx, sprintID)
+	}
+	return nil, nil
+}
+
+func (s *stubViewSvc) ListProjectViews(ctx context.Context, projectID uuid.UUID, viewCtx sprintdom.ViewContext) ([]*sprintdom.SprintView, error) {
+	s.listProjectViewsCalls++
+	if s.listProjectViews != nil {
+		return s.listProjectViews(ctx, projectID, viewCtx)
+	}
+	return []*sprintdom.SprintView{{ID: uuid.New(), ProjectID: projectID, ViewContext: viewCtx}}, nil
+}
+
+func (s *stubViewSvc) GetView(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.SprintView, error) {
+	s.getViewCalls++
+	if s.getView != nil {
+		return s.getView(ctx, projectID, id)
+	}
+	return &sprintdom.SprintView{ID: id, ProjectID: projectID}, nil
+}
+
+func (s *stubViewSvc) CreateView(ctx context.Context, in sprintdom.CreateViewInput) (*sprintdom.SprintView, error) {
+	if s.createView != nil {
+		return s.createView(ctx, in)
+	}
+	return &sprintdom.SprintView{ID: uuid.New(), ProjectID: in.ProjectID, ViewContext: in.ViewContext}, nil
+}
+
+func (s *stubViewSvc) UpdateView(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateViewInput) (*sprintdom.SprintView, error) {
+	if s.updateView != nil {
+		return s.updateView(ctx, projectID, id, in)
+	}
+	return &sprintdom.SprintView{ID: id, ProjectID: projectID}, nil
+}
+
+func (s *stubViewSvc) DeleteView(ctx context.Context, projectID, id uuid.UUID) error {
+	if s.deleteView != nil {
+		return s.deleteView(ctx, projectID, id)
+	}
+	return nil
+}
+
+func (s *stubViewSvc) MoveTask(ctx context.Context, projectID, viewID uuid.UUID, in sprintdom.MoveTaskInput) error {
+	if s.moveTask != nil {
+		return s.moveTask(ctx, projectID, viewID, in)
+	}
+	return nil
+}
+
+func (s *stubViewSvc) BulkMoveTasks(ctx context.Context, projectID, viewID uuid.UUID, items []sprintdom.MoveTaskInput) error {
+	if s.bulkMoveTasks != nil {
+		return s.bulkMoveTasks(ctx, projectID, viewID, items)
+	}
+	return nil
+}
+
+func (s *stubViewSvc) ListTaskPositions(ctx context.Context, projectID, viewID uuid.UUID) ([]*sprintdom.ViewTaskPosition, error) {
+	if s.listTaskPositions != nil {
+		return s.listTaskPositions(ctx, projectID, viewID)
+	}
+	return nil, nil
+}
+
+func (s *stubViewSvc) ReorderViews(ctx context.Context, sprintID uuid.UUID, viewIDs []uuid.UUID) error {
+	if s.reorderViews != nil {
+		return s.reorderViews(ctx, sprintID, viewIDs)
+	}
+	return nil
+}
+
+func (s *stubViewSvc) ReorderProjectViews(ctx context.Context, projectID uuid.UUID, viewCtx sprintdom.ViewContext, viewIDs []uuid.UUID) error {
+	if s.reorderProjectViews != nil {
+		return s.reorderProjectViews(ctx, projectID, viewCtx, viewIDs)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// CachedViewService – ListProjectViews
+// ---------------------------------------------------------------------------
+
+func TestCachedView_ListProjectViews_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews (miss): %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews (hit): %v", err)
+	}
+	if stub.listProjectViewsCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listProjectViewsCalls)
+	}
+}
+
+func TestCachedView_ListProjectViews_DifferentContextsAreSeparateCacheEntries(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("backlog: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextTimeline); err != nil {
+		t.Fatalf("timeline: %v", err)
+	}
+	// Both were misses, so stub called twice.
+	if stub.listProjectViewsCalls != 2 {
+		t.Fatalf("expected 2 stub calls (one per context), got %d", stub.listProjectViewsCalls)
+	}
+	// Re-request both: both should hit cache.
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("backlog (2nd): %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextTimeline); err != nil {
+		t.Fatalf("timeline (2nd): %v", err)
+	}
+	if stub.listProjectViewsCalls != 2 {
+		t.Fatalf("expected no additional stub calls on cache hits; got %d", stub.listProjectViewsCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedViewService – GetView
+// ---------------------------------------------------------------------------
+
+func TestCachedView_GetView_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	viewID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.GetView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("GetView (miss): %v", err)
+	}
+	if _, err := svc.GetView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("GetView (hit): %v", err)
+	}
+	if stub.getViewCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.getViewCalls)
+	}
+}
+
+func TestCachedView_GetView_ZeroTTLBypassesCache(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 0, discardLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.GetView(ctx, uuid.New(), uuid.New()); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if stub.getViewCalls != 3 {
+		t.Fatalf("TTL=0 should bypass cache; want 3 calls, got %d", stub.getViewCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CachedViewService – write invalidation
+// ---------------------------------------------------------------------------
+
+func TestCachedView_CreateView_InvalidatesProjectViewList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews: %v", err)
+	}
+	in := sprintdom.CreateViewInput{
+		ProjectID:   projectID,
+		Name:        "Board",
+		ViewType:    sprintdom.ViewTypeBoard,
+		ViewContext: sprintdom.ViewContextBacklog,
+	}
+	if _, err := svc.CreateView(ctx, in); err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews after Create: %v", err)
+	}
+	if stub.listProjectViewsCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listProjectViewsCalls)
+	}
+}
+
+func TestCachedView_UpdateView_InvalidatesItemAndBothProjectLists(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	viewID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	// Populate all three cache entries.
+	if _, err := svc.GetView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("GetView: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews(backlog): %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextTimeline); err != nil {
+		t.Fatalf("ListProjectViews(timeline): %v", err)
+	}
+
+	// Update should evict all three.
+	name := "Renamed"
+	if _, err := svc.UpdateView(ctx, projectID, viewID, sprintdom.UpdateViewInput{Name: &name}); err != nil {
+		t.Fatalf("UpdateView: %v", err)
+	}
+
+	if _, err := svc.GetView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("GetView after Update: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews(backlog) after Update: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextTimeline); err != nil {
+		t.Fatalf("ListProjectViews(timeline) after Update: %v", err)
+	}
+
+	if stub.getViewCalls != 2 {
+		t.Fatalf("GetView: expected 2 stub calls, got %d", stub.getViewCalls)
+	}
+	// listProjectViewsCalls: 2 (initial) + 2 (after update) = 4
+	if stub.listProjectViewsCalls != 4 {
+		t.Fatalf("ListProjectViews: expected 4 stub calls, got %d", stub.listProjectViewsCalls)
+	}
+}
+
+func TestCachedView_DeleteView_InvalidatesItemAndBothProjectLists(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	viewID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.GetView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("GetView: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews(backlog): %v", err)
+	}
+
+	if err := svc.DeleteView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("DeleteView: %v", err)
+	}
+
+	if _, err := svc.GetView(ctx, projectID, viewID); err != nil {
+		t.Fatalf("GetView after Delete: %v", err)
+	}
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews(backlog) after Delete: %v", err)
+	}
+
+	if stub.getViewCalls != 2 {
+		t.Fatalf("GetView: expected 2 stub calls, got %d", stub.getViewCalls)
+	}
+	if stub.listProjectViewsCalls != 2 {
+		t.Fatalf("ListProjectViews: expected 2 stub calls, got %d", stub.listProjectViewsCalls)
+	}
+}
+
+func TestCachedView_ReorderProjectViews_InvalidatesProjectList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubViewSvc{}
+	svc := sprintsvc.NewCachedViewService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews: %v", err)
+	}
+
+	if err := svc.ReorderProjectViews(ctx, projectID, sprintdom.ViewContextBacklog, []uuid.UUID{uuid.New()}); err != nil {
+		t.Fatalf("ReorderProjectViews: %v", err)
+	}
+
+	if _, err := svc.ListProjectViews(ctx, projectID, sprintdom.ViewContextBacklog); err != nil {
+		t.Fatalf("ListProjectViews after Reorder: %v", err)
+	}
+	if stub.listProjectViewsCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listProjectViewsCalls)
+	}
+}

--- a/services/api/internal/service/sprint/cached_service_test.go
+++ b/services/api/internal/service/sprint/cached_service_test.go
@@ -179,6 +179,27 @@ func TestCachedSprint_GetSprint_CacheHit(t *testing.T) {
 	}
 }
 
+func TestCachedSprint_GetSprint_CacheHit_ProjectMismatchReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	projectA := uuid.New()
+	projectB := uuid.New()
+	sprintID := uuid.New()
+	stub := &stubSprintSvc{}
+	svc := sprintsvc.NewCachedSprintService(stub, newCacheStore(t), 2*time.Minute, discardLogger())
+
+	if _, err := svc.GetSprint(ctx, projectA, sprintID); err != nil {
+		t.Fatalf("GetSprint (seed cache): %v", err)
+	}
+
+	got, err := svc.GetSprint(ctx, projectB, sprintID)
+	if !errors.Is(err, sprintdom.ErrSprintNotFound) {
+		t.Fatalf("expected ErrSprintNotFound for cached sprint requested under wrong project, got sprint=%v err=%v", got, err)
+	}
+	if got != nil {
+		t.Fatalf("expected no sprint on project mismatch, got %#v", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CachedSprintService – write invalidation
 // ---------------------------------------------------------------------------

--- a/services/api/internal/service/sprint/cached_view_service.go
+++ b/services/api/internal/service/sprint/cached_view_service.go
@@ -1,0 +1,183 @@
+package sprintsvc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	sprintdom "github.com/paca/api/internal/domain/sprint"
+	"github.com/paca/api/internal/platform/cache"
+)
+
+// CachedViewService decorates a sprintdom.ViewService with a
+// Valkey/Redis-backed cache.
+//
+// # What is cached
+//
+//   - ListProjectViews – views for a project+context (backlog/timeline);
+//     keyed by project ID and view context.
+//   - GetView          – single view; keyed by view ID.
+//
+// Sprint-context views (ListViews by sprintID) are NOT cached because their
+// invalidation would require knowing the project ID from the sprint ID, which
+// would add an extra DB round-trip that negates the benefit.
+//
+// Task positions (ListTaskPositions) are NOT cached because they are updated
+// frequently during drag-and-drop interactions.
+//
+// Cache errors are non-fatal: read errors fall through to the real service;
+// write/delete errors are logged so mutations always succeed.
+type CachedViewService struct {
+	svc sprintdom.ViewService
+	st  *cache.Store
+	ttl time.Duration
+	log *slog.Logger
+}
+
+// NewCachedViewService wraps svc with a caching layer backed by st.
+// ttl controls how long cached entries live; zero disables caching.
+// log receives non-fatal cache warnings.
+func NewCachedViewService(svc sprintdom.ViewService, st *cache.Store, ttl time.Duration, log *slog.Logger) *CachedViewService {
+	return &CachedViewService{svc: svc, st: st, ttl: ttl, log: log}
+}
+
+// --- cache key helpers -------------------------------------------------------
+
+func projectViewsKey(projectID uuid.UUID, viewCtx sprintdom.ViewContext) string {
+	return fmt.Sprintf("project:%s:views:%s", projectID, viewCtx)
+}
+
+func viewItemKey(id uuid.UUID) string {
+	return fmt.Sprintf("view:%s", id)
+}
+
+// --- ViewService -------------------------------------------------------------
+
+// ListViews returns all views for a sprint (sprint context). Not cached; see
+// type-level documentation for rationale.
+func (c *CachedViewService) ListViews(ctx context.Context, sprintID uuid.UUID) ([]*sprintdom.SprintView, error) {
+	return c.svc.ListViews(ctx, sprintID)
+}
+
+// ListProjectViews returns all views for a project filtered by viewCtx,
+// reading from cache when available and populating it on a miss.
+func (c *CachedViewService) ListProjectViews(ctx context.Context, projectID uuid.UUID, viewCtx sprintdom.ViewContext) ([]*sprintdom.SprintView, error) {
+	if c.ttl == 0 {
+		return c.svc.ListProjectViews(ctx, projectID, viewCtx)
+	}
+	key := projectViewsKey(projectID, viewCtx)
+	var result []*sprintdom.SprintView
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListProjectViews get", "err", err)
+	}
+
+	result, err := c.svc.ListProjectViews(ctx, projectID, viewCtx)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: ListProjectViews set", "err", err)
+	}
+	return result, nil
+}
+
+// GetView returns a single view, reading from cache when available and
+// populating it on a miss.
+func (c *CachedViewService) GetView(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.SprintView, error) {
+	if c.ttl == 0 {
+		return c.svc.GetView(ctx, projectID, id)
+	}
+	key := viewItemKey(id)
+	var result sprintdom.SprintView
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return &result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: GetView get", "err", err)
+	}
+
+	v, err := c.svc.GetView(ctx, projectID, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, v, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: GetView set", "err", err)
+	}
+	return v, nil
+}
+
+func (c *CachedViewService) CreateView(ctx context.Context, in sprintdom.CreateViewInput) (*sprintdom.SprintView, error) {
+	v, err := c.svc.CreateView(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	// Invalidate the project-level view list for the relevant context.
+	if err := c.st.Delete(ctx, projectViewsKey(in.ProjectID, in.ViewContext)); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateView delete", "err", err)
+	}
+	return v, nil
+}
+
+func (c *CachedViewService) UpdateView(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateViewInput) (*sprintdom.SprintView, error) {
+	v, err := c.svc.UpdateView(ctx, projectID, id, in)
+	if err != nil {
+		return nil, err
+	}
+	// Invalidate both the project-level list and the individual item cache.
+	toDelete := []string{viewItemKey(id)}
+	toDelete = append(toDelete,
+		projectViewsKey(projectID, sprintdom.ViewContextBacklog),
+		projectViewsKey(projectID, sprintdom.ViewContextTimeline),
+	)
+	if err := c.st.Delete(ctx, toDelete...); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateView delete", "err", err)
+	}
+	return v, nil
+}
+
+func (c *CachedViewService) DeleteView(ctx context.Context, projectID, id uuid.UUID) error {
+	if err := c.svc.DeleteView(ctx, projectID, id); err != nil {
+		return err
+	}
+	toDelete := []string{viewItemKey(id),
+		projectViewsKey(projectID, sprintdom.ViewContextBacklog),
+		projectViewsKey(projectID, sprintdom.ViewContextTimeline),
+	}
+	if err := c.st.Delete(ctx, toDelete...); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteView delete", "err", err)
+	}
+	return nil
+}
+
+func (c *CachedViewService) MoveTask(ctx context.Context, projectID, viewID uuid.UUID, in sprintdom.MoveTaskInput) error {
+	return c.svc.MoveTask(ctx, projectID, viewID, in)
+}
+
+func (c *CachedViewService) BulkMoveTasks(ctx context.Context, projectID, viewID uuid.UUID, items []sprintdom.MoveTaskInput) error {
+	return c.svc.BulkMoveTasks(ctx, projectID, viewID, items)
+}
+
+func (c *CachedViewService) ListTaskPositions(ctx context.Context, projectID, viewID uuid.UUID) ([]*sprintdom.ViewTaskPosition, error) {
+	return c.svc.ListTaskPositions(ctx, projectID, viewID)
+}
+
+// ReorderViews reorders sprint-context views and invalidates the sprint-level
+// view list. Project-level view lists (backlog/timeline) are not affected.
+func (c *CachedViewService) ReorderViews(ctx context.Context, sprintID uuid.UUID, viewIDs []uuid.UUID) error {
+	return c.svc.ReorderViews(ctx, sprintID, viewIDs)
+}
+
+// ReorderProjectViews reorders project-level views (backlog or timeline) and
+// invalidates the corresponding cached list.
+func (c *CachedViewService) ReorderProjectViews(ctx context.Context, projectID uuid.UUID, viewCtx sprintdom.ViewContext, viewIDs []uuid.UUID) error {
+	if err := c.svc.ReorderProjectViews(ctx, projectID, viewCtx, viewIDs); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, projectViewsKey(projectID, viewCtx)); err != nil {
+		c.log.WarnContext(ctx, "cache: ReorderProjectViews delete", "err", err)
+	}
+	return nil
+}

--- a/services/api/internal/service/sprint/cached_view_service.go
+++ b/services/api/internal/service/sprint/cached_view_service.go
@@ -109,6 +109,7 @@ func (c *CachedViewService) GetView(ctx context.Context, projectID, id uuid.UUID
 	return v, nil
 }
 
+// CreateView delegates to the underlying service and invalidates the project view list cache.
 func (c *CachedViewService) CreateView(ctx context.Context, in sprintdom.CreateViewInput) (*sprintdom.SprintView, error) {
 	v, err := c.svc.CreateView(ctx, in)
 	if err != nil {
@@ -121,6 +122,7 @@ func (c *CachedViewService) CreateView(ctx context.Context, in sprintdom.CreateV
 	return v, nil
 }
 
+// UpdateView delegates to the underlying service and invalidates the view item and project list caches.
 func (c *CachedViewService) UpdateView(ctx context.Context, projectID, id uuid.UUID, in sprintdom.UpdateViewInput) (*sprintdom.SprintView, error) {
 	v, err := c.svc.UpdateView(ctx, projectID, id, in)
 	if err != nil {
@@ -138,6 +140,7 @@ func (c *CachedViewService) UpdateView(ctx context.Context, projectID, id uuid.U
 	return v, nil
 }
 
+// DeleteView delegates to the underlying service and invalidates the view item and project list caches.
 func (c *CachedViewService) DeleteView(ctx context.Context, projectID, id uuid.UUID) error {
 	if err := c.svc.DeleteView(ctx, projectID, id); err != nil {
 		return err
@@ -152,14 +155,17 @@ func (c *CachedViewService) DeleteView(ctx context.Context, projectID, id uuid.U
 	return nil
 }
 
+// MoveTask delegates directly to the underlying service (not cached).
 func (c *CachedViewService) MoveTask(ctx context.Context, projectID, viewID uuid.UUID, in sprintdom.MoveTaskInput) error {
 	return c.svc.MoveTask(ctx, projectID, viewID, in)
 }
 
+// BulkMoveTasks delegates directly to the underlying service (not cached).
 func (c *CachedViewService) BulkMoveTasks(ctx context.Context, projectID, viewID uuid.UUID, items []sprintdom.MoveTaskInput) error {
 	return c.svc.BulkMoveTasks(ctx, projectID, viewID, items)
 }
 
+// ListTaskPositions delegates directly to the underlying service (not cached).
 func (c *CachedViewService) ListTaskPositions(ctx context.Context, projectID, viewID uuid.UUID) ([]*sprintdom.ViewTaskPosition, error) {
 	return c.svc.ListTaskPositions(ctx, projectID, viewID)
 }

--- a/services/api/internal/service/sprint/cached_view_service.go
+++ b/services/api/internal/service/sprint/cached_view_service.go
@@ -170,8 +170,7 @@ func (c *CachedViewService) ListTaskPositions(ctx context.Context, projectID, vi
 	return c.svc.ListTaskPositions(ctx, projectID, viewID)
 }
 
-// ReorderViews reorders sprint-context views and invalidates the sprint-level
-// view list. Project-level view lists (backlog/timeline) are not affected.
+// ReorderViews delegates directly to the underlying service (not cached).
 func (c *CachedViewService) ReorderViews(ctx context.Context, sprintID uuid.UUID, viewIDs []uuid.UUID) error {
 	return c.svc.ReorderViews(ctx, sprintID, viewIDs)
 }

--- a/services/api/internal/service/sprint/cached_view_service.go
+++ b/services/api/internal/service/sprint/cached_view_service.go
@@ -11,6 +11,10 @@ import (
 	"github.com/paca/api/internal/platform/cache"
 )
 
+// ErrViewNotFound is re-exported from the domain package so callers can
+// reference the sentinel without importing sprintdom directly.
+var ErrViewNotFound = sprintdom.ErrViewNotFound
+
 // CachedViewService decorates a sprintdom.ViewService with a
 // Valkey/Redis-backed cache.
 //
@@ -86,7 +90,9 @@ func (c *CachedViewService) ListProjectViews(ctx context.Context, projectID uuid
 }
 
 // GetView returns a single view, reading from cache when available and
-// populating it on a miss.
+// populating it on a miss. On a cache hit the cached view's ProjectID is
+// compared with the requested projectID; a mismatch returns ErrViewNotFound
+// without delegating to the underlying service, preventing cross-project leaks.
 func (c *CachedViewService) GetView(ctx context.Context, projectID, id uuid.UUID) (*sprintdom.SprintView, error) {
 	if c.ttl == 0 {
 		return c.svc.GetView(ctx, projectID, id)
@@ -94,6 +100,9 @@ func (c *CachedViewService) GetView(ctx context.Context, projectID, id uuid.UUID
 	key := viewItemKey(id)
 	var result sprintdom.SprintView
 	if ok, err := c.st.Get(ctx, key, &result); ok {
+		if result.ProjectID != projectID {
+			return nil, ErrViewNotFound
+		}
 		return &result, nil
 	} else if err != nil {
 		c.log.WarnContext(ctx, "cache: GetView get", "err", err)

--- a/services/api/internal/service/task/cached_service.go
+++ b/services/api/internal/service/task/cached_service.go
@@ -1,0 +1,314 @@
+package tasksvc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	taskdom "github.com/paca/api/internal/domain/task"
+	"github.com/paca/api/internal/platform/cache"
+)
+
+// CachedService decorates a taskdom.Service with a Valkey/Redis-backed cache.
+//
+// # What is cached
+//
+//   - ListTaskTypes       – keyed by project; invalidated on any type mutation.
+//   - ListTaskStatuses    – keyed by project; invalidated on any status mutation.
+//   - ListCustomFieldDefinitions – keyed by project; invalidated on any field mutation.
+//
+// All other methods (tasks, BDD scenarios) are delegated directly to the
+// underlying service without caching.
+//
+// Cache errors are non-fatal: on a read error the decorator falls through to
+// the real service; on a write/delete error it logs and continues so that
+// mutations always succeed even when the cache is temporarily unavailable.
+type CachedService struct {
+	svc taskdom.Service
+	st  *cache.Store
+	ttl time.Duration
+	log *slog.Logger
+}
+
+// NewCachedService wraps svc with a caching layer backed by st.
+// ttl controls how long each cached entry lives; zero disables caching.
+// log receives non-fatal cache warnings.
+func NewCachedService(svc taskdom.Service, st *cache.Store, ttl time.Duration, log *slog.Logger) *CachedService {
+	return &CachedService{svc: svc, st: st, ttl: ttl, log: log}
+}
+
+// --- cache key helpers -------------------------------------------------------
+
+func taskTypesKey(projectID uuid.UUID) string {
+	return fmt.Sprintf("project:%s:task-types", projectID)
+}
+
+func taskStatusesKey(projectID uuid.UUID) string {
+	return fmt.Sprintf("project:%s:task-statuses", projectID)
+}
+
+func customFieldsKey(projectID uuid.UUID) string {
+	return fmt.Sprintf("project:%s:custom-fields", projectID)
+}
+
+// --- Task Types --------------------------------------------------------------
+
+// ListTaskTypes returns task types for a project, reading from cache when
+// available and populating it on a miss.
+func (c *CachedService) ListTaskTypes(ctx context.Context, projectID uuid.UUID) ([]*taskdom.TaskType, error) {
+	if c.ttl == 0 {
+		return c.svc.ListTaskTypes(ctx, projectID)
+	}
+	key := taskTypesKey(projectID)
+	var result []*taskdom.TaskType
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListTaskTypes get", "err", err)
+	}
+
+	result, err := c.svc.ListTaskTypes(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: ListTaskTypes set", "err", err)
+	}
+	return result, nil
+}
+
+func (c *CachedService) GetTaskType(ctx context.Context, id uuid.UUID) (*taskdom.TaskType, error) {
+	return c.svc.GetTaskType(ctx, id)
+}
+
+func (c *CachedService) CreateTaskType(ctx context.Context, in taskdom.CreateTaskTypeInput) (*taskdom.TaskType, error) {
+	t, err := c.svc.CreateTaskType(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, taskTypesKey(in.ProjectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateTaskType delete", "err", err)
+	}
+	return t, nil
+}
+
+func (c *CachedService) UpdateTaskType(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskTypeInput) (*taskdom.TaskType, error) {
+	t, err := c.svc.UpdateTaskType(ctx, projectID, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, taskTypesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateTaskType delete", "err", err)
+	}
+	return t, nil
+}
+
+func (c *CachedService) DeleteTaskType(ctx context.Context, projectID, id uuid.UUID) error {
+	if err := c.svc.DeleteTaskType(ctx, projectID, id); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, taskTypesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteTaskType delete", "err", err)
+	}
+	return nil
+}
+
+func (c *CachedService) SetDefaultTaskType(ctx context.Context, projectID, typeID uuid.UUID) (*taskdom.TaskType, error) {
+	t, err := c.svc.SetDefaultTaskType(ctx, projectID, typeID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, taskTypesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: SetDefaultTaskType delete", "err", err)
+	}
+	return t, nil
+}
+
+// --- Task Statuses -----------------------------------------------------------
+
+// ListTaskStatuses returns task statuses for a project, reading from cache
+// when available and populating it on a miss.
+func (c *CachedService) ListTaskStatuses(ctx context.Context, projectID uuid.UUID) ([]*taskdom.TaskStatus, error) {
+	if c.ttl == 0 {
+		return c.svc.ListTaskStatuses(ctx, projectID)
+	}
+	key := taskStatusesKey(projectID)
+	var result []*taskdom.TaskStatus
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListTaskStatuses get", "err", err)
+	}
+
+	result, err := c.svc.ListTaskStatuses(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: ListTaskStatuses set", "err", err)
+	}
+	return result, nil
+}
+
+func (c *CachedService) GetTaskStatus(ctx context.Context, id uuid.UUID) (*taskdom.TaskStatus, error) {
+	return c.svc.GetTaskStatus(ctx, id)
+}
+
+func (c *CachedService) CreateTaskStatus(ctx context.Context, in taskdom.CreateTaskStatusInput) (*taskdom.TaskStatus, error) {
+	st, err := c.svc.CreateTaskStatus(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, taskStatusesKey(in.ProjectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateTaskStatus delete", "err", err)
+	}
+	return st, nil
+}
+
+func (c *CachedService) UpdateTaskStatus(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskStatusInput) (*taskdom.TaskStatus, error) {
+	st, err := c.svc.UpdateTaskStatus(ctx, projectID, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, taskStatusesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateTaskStatus delete", "err", err)
+	}
+	return st, nil
+}
+
+func (c *CachedService) DeleteTaskStatus(ctx context.Context, projectID, id uuid.UUID) error {
+	if err := c.svc.DeleteTaskStatus(ctx, projectID, id); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, taskStatusesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteTaskStatus delete", "err", err)
+	}
+	return nil
+}
+
+func (c *CachedService) SetDefaultTaskStatus(ctx context.Context, projectID, statusID uuid.UUID) (*taskdom.TaskStatus, error) {
+	st, err := c.svc.SetDefaultTaskStatus(ctx, projectID, statusID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, taskStatusesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: SetDefaultTaskStatus delete", "err", err)
+	}
+	return st, nil
+}
+
+// --- Tasks (pass-through) ----------------------------------------------------
+// Tasks are not cached because they are highly mutable and queries are filtered
+// in many different ways, making cache key cardinality prohibitively large.
+
+func (c *CachedService) ListTasks(ctx context.Context, projectID uuid.UUID, filter taskdom.TaskFilter, page, pageSize int) ([]*taskdom.Task, int64, error) {
+	return c.svc.ListTasks(ctx, projectID, filter, page, pageSize)
+}
+
+func (c *CachedService) GetTask(ctx context.Context, projectID, id uuid.UUID) (*taskdom.Task, error) {
+	return c.svc.GetTask(ctx, projectID, id)
+}
+
+func (c *CachedService) GetTaskByNumber(ctx context.Context, projectID uuid.UUID, taskNumber int64) (*taskdom.Task, error) {
+	return c.svc.GetTaskByNumber(ctx, projectID, taskNumber)
+}
+
+func (c *CachedService) CreateTask(ctx context.Context, in taskdom.CreateTaskInput) (*taskdom.Task, error) {
+	return c.svc.CreateTask(ctx, in)
+}
+
+func (c *CachedService) UpdateTask(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskInput) (*taskdom.Task, error) {
+	return c.svc.UpdateTask(ctx, projectID, id, in)
+}
+
+func (c *CachedService) DeleteTask(ctx context.Context, projectID, id uuid.UUID) error {
+	return c.svc.DeleteTask(ctx, projectID, id)
+}
+
+// --- Custom Field Definitions ------------------------------------------------
+
+// ListCustomFieldDefinitions returns custom field definitions for a project,
+// reading from cache when available and populating it on a miss.
+func (c *CachedService) ListCustomFieldDefinitions(ctx context.Context, projectID uuid.UUID) ([]*taskdom.CustomFieldDefinition, error) {
+	if c.ttl == 0 {
+		return c.svc.ListCustomFieldDefinitions(ctx, projectID)
+	}
+	key := customFieldsKey(projectID)
+	var result []*taskdom.CustomFieldDefinition
+	if ok, err := c.st.Get(ctx, key, &result); ok {
+		return result, nil
+	} else if err != nil {
+		c.log.WarnContext(ctx, "cache: ListCustomFieldDefinitions get", "err", err)
+	}
+
+	result, err := c.svc.ListCustomFieldDefinitions(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Set(ctx, key, result, c.ttl); err != nil {
+		c.log.WarnContext(ctx, "cache: ListCustomFieldDefinitions set", "err", err)
+	}
+	return result, nil
+}
+
+func (c *CachedService) GetCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID) (*taskdom.CustomFieldDefinition, error) {
+	return c.svc.GetCustomFieldDefinition(ctx, projectID, id)
+}
+
+func (c *CachedService) CreateCustomFieldDefinition(ctx context.Context, in taskdom.CreateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error) {
+	f, err := c.svc.CreateCustomFieldDefinition(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, customFieldsKey(in.ProjectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: CreateCustomFieldDefinition delete", "err", err)
+	}
+	return f, nil
+}
+
+func (c *CachedService) UpdateCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error) {
+	f, err := c.svc.UpdateCustomFieldDefinition(ctx, projectID, id, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.st.Delete(ctx, customFieldsKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: UpdateCustomFieldDefinition delete", "err", err)
+	}
+	return f, nil
+}
+
+func (c *CachedService) DeleteCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID) error {
+	if err := c.svc.DeleteCustomFieldDefinition(ctx, projectID, id); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, customFieldsKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: DeleteCustomFieldDefinition delete", "err", err)
+	}
+	return nil
+}
+
+// --- BDD Scenarios (pass-through) --------------------------------------------
+// BDD scenarios are task-level and change frequently enough that caching adds
+// complexity without meaningful benefit.
+
+func (c *CachedService) ListBDDScenarios(ctx context.Context, projectID, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	return c.svc.ListBDDScenarios(ctx, projectID, taskID)
+}
+
+func (c *CachedService) GetBDDScenario(ctx context.Context, projectID, taskID, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	return c.svc.GetBDDScenario(ctx, projectID, taskID, id)
+}
+
+func (c *CachedService) CreateBDDScenario(ctx context.Context, in taskdom.CreateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	return c.svc.CreateBDDScenario(ctx, in)
+}
+
+func (c *CachedService) UpdateBDDScenario(ctx context.Context, projectID, taskID, id uuid.UUID, in taskdom.UpdateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	return c.svc.UpdateBDDScenario(ctx, projectID, taskID, id, in)
+}
+
+func (c *CachedService) DeleteBDDScenario(ctx context.Context, projectID, taskID, id uuid.UUID) error {
+	return c.svc.DeleteBDDScenario(ctx, projectID, taskID, id)
+}

--- a/services/api/internal/service/task/cached_service.go
+++ b/services/api/internal/service/task/cached_service.go
@@ -79,10 +79,12 @@ func (c *CachedService) ListTaskTypes(ctx context.Context, projectID uuid.UUID) 
 	return result, nil
 }
 
+// GetTaskType delegates directly to the underlying service (not cached).
 func (c *CachedService) GetTaskType(ctx context.Context, id uuid.UUID) (*taskdom.TaskType, error) {
 	return c.svc.GetTaskType(ctx, id)
 }
 
+// CreateTaskType delegates to the underlying service and invalidates the task-types cache.
 func (c *CachedService) CreateTaskType(ctx context.Context, in taskdom.CreateTaskTypeInput) (*taskdom.TaskType, error) {
 	t, err := c.svc.CreateTaskType(ctx, in)
 	if err != nil {
@@ -94,6 +96,7 @@ func (c *CachedService) CreateTaskType(ctx context.Context, in taskdom.CreateTas
 	return t, nil
 }
 
+// UpdateTaskType delegates to the underlying service and invalidates the task-types cache.
 func (c *CachedService) UpdateTaskType(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskTypeInput) (*taskdom.TaskType, error) {
 	t, err := c.svc.UpdateTaskType(ctx, projectID, id, in)
 	if err != nil {
@@ -105,6 +108,7 @@ func (c *CachedService) UpdateTaskType(ctx context.Context, projectID, id uuid.U
 	return t, nil
 }
 
+// DeleteTaskType delegates to the underlying service and invalidates the task-types cache.
 func (c *CachedService) DeleteTaskType(ctx context.Context, projectID, id uuid.UUID) error {
 	if err := c.svc.DeleteTaskType(ctx, projectID, id); err != nil {
 		return err
@@ -115,6 +119,7 @@ func (c *CachedService) DeleteTaskType(ctx context.Context, projectID, id uuid.U
 	return nil
 }
 
+// SetDefaultTaskType delegates to the underlying service and invalidates the task-types cache.
 func (c *CachedService) SetDefaultTaskType(ctx context.Context, projectID, typeID uuid.UUID) (*taskdom.TaskType, error) {
 	t, err := c.svc.SetDefaultTaskType(ctx, projectID, typeID)
 	if err != nil {
@@ -152,10 +157,12 @@ func (c *CachedService) ListTaskStatuses(ctx context.Context, projectID uuid.UUI
 	return result, nil
 }
 
+// GetTaskStatus delegates directly to the underlying service (not cached).
 func (c *CachedService) GetTaskStatus(ctx context.Context, id uuid.UUID) (*taskdom.TaskStatus, error) {
 	return c.svc.GetTaskStatus(ctx, id)
 }
 
+// CreateTaskStatus delegates to the underlying service and invalidates the task-statuses cache.
 func (c *CachedService) CreateTaskStatus(ctx context.Context, in taskdom.CreateTaskStatusInput) (*taskdom.TaskStatus, error) {
 	st, err := c.svc.CreateTaskStatus(ctx, in)
 	if err != nil {
@@ -167,6 +174,7 @@ func (c *CachedService) CreateTaskStatus(ctx context.Context, in taskdom.CreateT
 	return st, nil
 }
 
+// UpdateTaskStatus delegates to the underlying service and invalidates the task-statuses cache.
 func (c *CachedService) UpdateTaskStatus(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskStatusInput) (*taskdom.TaskStatus, error) {
 	st, err := c.svc.UpdateTaskStatus(ctx, projectID, id, in)
 	if err != nil {
@@ -178,6 +186,7 @@ func (c *CachedService) UpdateTaskStatus(ctx context.Context, projectID, id uuid
 	return st, nil
 }
 
+// DeleteTaskStatus delegates to the underlying service and invalidates the task-statuses cache.
 func (c *CachedService) DeleteTaskStatus(ctx context.Context, projectID, id uuid.UUID) error {
 	if err := c.svc.DeleteTaskStatus(ctx, projectID, id); err != nil {
 		return err
@@ -188,6 +197,7 @@ func (c *CachedService) DeleteTaskStatus(ctx context.Context, projectID, id uuid
 	return nil
 }
 
+// SetDefaultTaskStatus delegates to the underlying service and invalidates the task-statuses cache.
 func (c *CachedService) SetDefaultTaskStatus(ctx context.Context, projectID, statusID uuid.UUID) (*taskdom.TaskStatus, error) {
 	st, err := c.svc.SetDefaultTaskStatus(ctx, projectID, statusID)
 	if err != nil {
@@ -203,26 +213,32 @@ func (c *CachedService) SetDefaultTaskStatus(ctx context.Context, projectID, sta
 // Tasks are not cached because they are highly mutable and queries are filtered
 // in many different ways, making cache key cardinality prohibitively large.
 
+// ListTasks delegates directly to the underlying service (not cached).
 func (c *CachedService) ListTasks(ctx context.Context, projectID uuid.UUID, filter taskdom.TaskFilter, page, pageSize int) ([]*taskdom.Task, int64, error) {
 	return c.svc.ListTasks(ctx, projectID, filter, page, pageSize)
 }
 
+// GetTask delegates directly to the underlying service (not cached).
 func (c *CachedService) GetTask(ctx context.Context, projectID, id uuid.UUID) (*taskdom.Task, error) {
 	return c.svc.GetTask(ctx, projectID, id)
 }
 
+// GetTaskByNumber delegates directly to the underlying service (not cached).
 func (c *CachedService) GetTaskByNumber(ctx context.Context, projectID uuid.UUID, taskNumber int64) (*taskdom.Task, error) {
 	return c.svc.GetTaskByNumber(ctx, projectID, taskNumber)
 }
 
+// CreateTask delegates directly to the underlying service (not cached).
 func (c *CachedService) CreateTask(ctx context.Context, in taskdom.CreateTaskInput) (*taskdom.Task, error) {
 	return c.svc.CreateTask(ctx, in)
 }
 
+// UpdateTask delegates directly to the underlying service (not cached).
 func (c *CachedService) UpdateTask(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskInput) (*taskdom.Task, error) {
 	return c.svc.UpdateTask(ctx, projectID, id, in)
 }
 
+// DeleteTask delegates directly to the underlying service (not cached).
 func (c *CachedService) DeleteTask(ctx context.Context, projectID, id uuid.UUID) error {
 	return c.svc.DeleteTask(ctx, projectID, id)
 }
@@ -253,10 +269,12 @@ func (c *CachedService) ListCustomFieldDefinitions(ctx context.Context, projectI
 	return result, nil
 }
 
+// GetCustomFieldDefinition delegates directly to the underlying service (not cached).
 func (c *CachedService) GetCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID) (*taskdom.CustomFieldDefinition, error) {
 	return c.svc.GetCustomFieldDefinition(ctx, projectID, id)
 }
 
+// CreateCustomFieldDefinition delegates to the underlying service and invalidates the custom-fields cache.
 func (c *CachedService) CreateCustomFieldDefinition(ctx context.Context, in taskdom.CreateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error) {
 	f, err := c.svc.CreateCustomFieldDefinition(ctx, in)
 	if err != nil {
@@ -268,6 +286,7 @@ func (c *CachedService) CreateCustomFieldDefinition(ctx context.Context, in task
 	return f, nil
 }
 
+// UpdateCustomFieldDefinition delegates to the underlying service and invalidates the custom-fields cache.
 func (c *CachedService) UpdateCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID, in taskdom.UpdateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error) {
 	f, err := c.svc.UpdateCustomFieldDefinition(ctx, projectID, id, in)
 	if err != nil {
@@ -279,6 +298,7 @@ func (c *CachedService) UpdateCustomFieldDefinition(ctx context.Context, project
 	return f, nil
 }
 
+// DeleteCustomFieldDefinition delegates to the underlying service and invalidates the custom-fields cache.
 func (c *CachedService) DeleteCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID) error {
 	if err := c.svc.DeleteCustomFieldDefinition(ctx, projectID, id); err != nil {
 		return err
@@ -293,22 +313,27 @@ func (c *CachedService) DeleteCustomFieldDefinition(ctx context.Context, project
 // BDD scenarios are task-level and change frequently enough that caching adds
 // complexity without meaningful benefit.
 
+// ListBDDScenarios delegates directly to the underlying service (not cached).
 func (c *CachedService) ListBDDScenarios(ctx context.Context, projectID, taskID uuid.UUID) ([]*taskdom.BDDScenario, error) {
 	return c.svc.ListBDDScenarios(ctx, projectID, taskID)
 }
 
+// GetBDDScenario delegates directly to the underlying service (not cached).
 func (c *CachedService) GetBDDScenario(ctx context.Context, projectID, taskID, id uuid.UUID) (*taskdom.BDDScenario, error) {
 	return c.svc.GetBDDScenario(ctx, projectID, taskID, id)
 }
 
+// CreateBDDScenario delegates directly to the underlying service (not cached).
 func (c *CachedService) CreateBDDScenario(ctx context.Context, in taskdom.CreateBDDScenarioInput) (*taskdom.BDDScenario, error) {
 	return c.svc.CreateBDDScenario(ctx, in)
 }
 
+// UpdateBDDScenario delegates directly to the underlying service (not cached).
 func (c *CachedService) UpdateBDDScenario(ctx context.Context, projectID, taskID, id uuid.UUID, in taskdom.UpdateBDDScenarioInput) (*taskdom.BDDScenario, error) {
 	return c.svc.UpdateBDDScenario(ctx, projectID, taskID, id, in)
 }
 
+// DeleteBDDScenario delegates directly to the underlying service (not cached).
 func (c *CachedService) DeleteBDDScenario(ctx context.Context, projectID, taskID, id uuid.UUID) error {
 	return c.svc.DeleteBDDScenario(ctx, projectID, taskID, id)
 }

--- a/services/api/internal/service/task/cached_service_test.go
+++ b/services/api/internal/service/task/cached_service_test.go
@@ -147,7 +147,7 @@ func (s *stubTaskSvc) CreateTask(_ context.Context, in taskdom.CreateTaskInput) 
 	return &taskdom.Task{ID: uuid.New(), ProjectID: in.ProjectID, Title: in.Title}, nil
 }
 
-func (s *stubTaskSvc) UpdateTask(_ context.Context, _, id uuid.UUID, in taskdom.UpdateTaskInput) (*taskdom.Task, error) {
+func (s *stubTaskSvc) UpdateTask(_ context.Context, _, id uuid.UUID, _ taskdom.UpdateTaskInput) (*taskdom.Task, error) {
 	return &taskdom.Task{ID: id}, nil
 }
 

--- a/services/api/internal/service/task/cached_service_test.go
+++ b/services/api/internal/service/task/cached_service_test.go
@@ -1,0 +1,552 @@
+// Package tasksvc_test contains unit tests for the task service layer,
+// including the CachedService decorator.
+package tasksvc_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	taskdom "github.com/paca/api/internal/domain/task"
+	"github.com/paca/api/internal/platform/cache"
+	tasksvc "github.com/paca/api/internal/service/task"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newCacheStore(t *testing.T) *cache.Store {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return cache.NewStore(client, "paca:")
+}
+
+// ---------------------------------------------------------------------------
+// Stub task service (implements taskdom.Service)
+// ---------------------------------------------------------------------------
+
+type stubTaskSvc struct {
+	listTaskTypes  func(ctx context.Context, projectID uuid.UUID) ([]*taskdom.TaskType, error)
+	createTaskType func(ctx context.Context, in taskdom.CreateTaskTypeInput) (*taskdom.TaskType, error)
+	deleteTaskType func(ctx context.Context, projectID, id uuid.UUID) error
+
+	listTaskStatuses func(ctx context.Context, projectID uuid.UUID) ([]*taskdom.TaskStatus, error)
+	createTaskStatus func(ctx context.Context, in taskdom.CreateTaskStatusInput) (*taskdom.TaskStatus, error)
+	deleteTaskStatus func(ctx context.Context, projectID, id uuid.UUID) error
+
+	listCustomFields  func(ctx context.Context, projectID uuid.UUID) ([]*taskdom.CustomFieldDefinition, error)
+	createCustomField func(ctx context.Context, in taskdom.CreateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error)
+	deleteCustomField func(ctx context.Context, projectID, id uuid.UUID) error
+
+	listTypesCalls  int
+	listStatusCalls int
+	listFieldsCalls int
+}
+
+// TaskType methods
+
+func (s *stubTaskSvc) ListTaskTypes(ctx context.Context, projectID uuid.UUID) ([]*taskdom.TaskType, error) {
+	s.listTypesCalls++
+	if s.listTaskTypes != nil {
+		return s.listTaskTypes(ctx, projectID)
+	}
+	return []*taskdom.TaskType{{ID: uuid.New(), ProjectID: projectID, Name: "Bug"}}, nil
+}
+
+func (s *stubTaskSvc) GetTaskType(_ context.Context, id uuid.UUID) (*taskdom.TaskType, error) {
+	return &taskdom.TaskType{ID: id}, nil
+}
+
+func (s *stubTaskSvc) CreateTaskType(ctx context.Context, in taskdom.CreateTaskTypeInput) (*taskdom.TaskType, error) {
+	if s.createTaskType != nil {
+		return s.createTaskType(ctx, in)
+	}
+	return &taskdom.TaskType{ID: uuid.New(), ProjectID: in.ProjectID, Name: in.Name}, nil
+}
+
+func (s *stubTaskSvc) UpdateTaskType(_ context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskTypeInput) (*taskdom.TaskType, error) {
+	return &taskdom.TaskType{ID: id, ProjectID: projectID, Name: in.Name}, nil
+}
+
+func (s *stubTaskSvc) DeleteTaskType(ctx context.Context, projectID, id uuid.UUID) error {
+	if s.deleteTaskType != nil {
+		return s.deleteTaskType(ctx, projectID, id)
+	}
+	return nil
+}
+
+func (s *stubTaskSvc) SetDefaultTaskType(_ context.Context, projectID, typeID uuid.UUID) (*taskdom.TaskType, error) {
+	return &taskdom.TaskType{ID: typeID, ProjectID: projectID, IsDefault: true}, nil
+}
+
+// TaskStatus methods
+
+func (s *stubTaskSvc) ListTaskStatuses(ctx context.Context, projectID uuid.UUID) ([]*taskdom.TaskStatus, error) {
+	s.listStatusCalls++
+	if s.listTaskStatuses != nil {
+		return s.listTaskStatuses(ctx, projectID)
+	}
+	return []*taskdom.TaskStatus{{ID: uuid.New(), ProjectID: projectID, Name: "Todo"}}, nil
+}
+
+func (s *stubTaskSvc) GetTaskStatus(_ context.Context, id uuid.UUID) (*taskdom.TaskStatus, error) {
+	return &taskdom.TaskStatus{ID: id}, nil
+}
+
+func (s *stubTaskSvc) CreateTaskStatus(ctx context.Context, in taskdom.CreateTaskStatusInput) (*taskdom.TaskStatus, error) {
+	if s.createTaskStatus != nil {
+		return s.createTaskStatus(ctx, in)
+	}
+	return &taskdom.TaskStatus{ID: uuid.New(), ProjectID: in.ProjectID, Name: in.Name}, nil
+}
+
+func (s *stubTaskSvc) UpdateTaskStatus(_ context.Context, projectID, id uuid.UUID, in taskdom.UpdateTaskStatusInput) (*taskdom.TaskStatus, error) {
+	return &taskdom.TaskStatus{ID: id, ProjectID: projectID, Name: in.Name}, nil
+}
+
+func (s *stubTaskSvc) DeleteTaskStatus(ctx context.Context, projectID, id uuid.UUID) error {
+	if s.deleteTaskStatus != nil {
+		return s.deleteTaskStatus(ctx, projectID, id)
+	}
+	return nil
+}
+
+func (s *stubTaskSvc) SetDefaultTaskStatus(_ context.Context, projectID, statusID uuid.UUID) (*taskdom.TaskStatus, error) {
+	return &taskdom.TaskStatus{ID: statusID, ProjectID: projectID, IsDefault: true}, nil
+}
+
+// TaskService methods (pass-through in CachedService)
+
+func (s *stubTaskSvc) ListTasks(_ context.Context, _ uuid.UUID, _ taskdom.TaskFilter, _, _ int) ([]*taskdom.Task, int64, error) {
+	return nil, 0, nil
+}
+
+func (s *stubTaskSvc) GetTask(_ context.Context, _, id uuid.UUID) (*taskdom.Task, error) {
+	return &taskdom.Task{ID: id}, nil
+}
+
+func (s *stubTaskSvc) GetTaskByNumber(_ context.Context, projectID uuid.UUID, n int64) (*taskdom.Task, error) {
+	return &taskdom.Task{ProjectID: projectID, TaskNumber: n}, nil
+}
+
+func (s *stubTaskSvc) CreateTask(_ context.Context, in taskdom.CreateTaskInput) (*taskdom.Task, error) {
+	return &taskdom.Task{ID: uuid.New(), ProjectID: in.ProjectID, Title: in.Title}, nil
+}
+
+func (s *stubTaskSvc) UpdateTask(_ context.Context, _, id uuid.UUID, in taskdom.UpdateTaskInput) (*taskdom.Task, error) {
+	return &taskdom.Task{ID: id}, nil
+}
+
+func (s *stubTaskSvc) DeleteTask(_ context.Context, _, _ uuid.UUID) error { return nil }
+
+// CustomFieldDefinition methods
+
+func (s *stubTaskSvc) ListCustomFieldDefinitions(ctx context.Context, projectID uuid.UUID) ([]*taskdom.CustomFieldDefinition, error) {
+	s.listFieldsCalls++
+	if s.listCustomFields != nil {
+		return s.listCustomFields(ctx, projectID)
+	}
+	return []*taskdom.CustomFieldDefinition{{ID: uuid.New(), ProjectID: projectID}}, nil
+}
+
+func (s *stubTaskSvc) GetCustomFieldDefinition(_ context.Context, _, id uuid.UUID) (*taskdom.CustomFieldDefinition, error) {
+	return &taskdom.CustomFieldDefinition{ID: id}, nil
+}
+
+func (s *stubTaskSvc) CreateCustomFieldDefinition(ctx context.Context, in taskdom.CreateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error) {
+	if s.createCustomField != nil {
+		return s.createCustomField(ctx, in)
+	}
+	return &taskdom.CustomFieldDefinition{ID: uuid.New(), ProjectID: in.ProjectID}, nil
+}
+
+func (s *stubTaskSvc) UpdateCustomFieldDefinition(_ context.Context, projectID, id uuid.UUID, _ taskdom.UpdateCustomFieldDefinitionInput) (*taskdom.CustomFieldDefinition, error) {
+	return &taskdom.CustomFieldDefinition{ID: id, ProjectID: projectID}, nil
+}
+
+func (s *stubTaskSvc) DeleteCustomFieldDefinition(ctx context.Context, projectID, id uuid.UUID) error {
+	if s.deleteCustomField != nil {
+		return s.deleteCustomField(ctx, projectID, id)
+	}
+	return nil
+}
+
+// BDDScenario methods (all pass-through)
+
+func (s *stubTaskSvc) ListBDDScenarios(_ context.Context, _, _ uuid.UUID) ([]*taskdom.BDDScenario, error) {
+	return nil, nil
+}
+
+func (s *stubTaskSvc) GetBDDScenario(_ context.Context, _, _, id uuid.UUID) (*taskdom.BDDScenario, error) {
+	return &taskdom.BDDScenario{ID: id}, nil
+}
+
+func (s *stubTaskSvc) CreateBDDScenario(_ context.Context, in taskdom.CreateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	return &taskdom.BDDScenario{ID: uuid.New(), TaskID: in.TaskID}, nil
+}
+
+func (s *stubTaskSvc) UpdateBDDScenario(_ context.Context, _, _, id uuid.UUID, _ taskdom.UpdateBDDScenarioInput) (*taskdom.BDDScenario, error) {
+	return &taskdom.BDDScenario{ID: id}, nil
+}
+
+func (s *stubTaskSvc) DeleteBDDScenario(_ context.Context, _, _, _ uuid.UUID) error { return nil }
+
+// ---------------------------------------------------------------------------
+// ListTaskTypes
+// ---------------------------------------------------------------------------
+
+func TestCachedTask_ListTaskTypes_CacheMissPopulatesCache(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	// First call: miss.
+	types, err := svc.ListTaskTypes(ctx, projectID)
+	if err != nil {
+		t.Fatalf("ListTaskTypes (miss): %v", err)
+	}
+	if len(types) == 0 {
+		t.Fatal("expected at least one task type")
+	}
+	if stub.listTypesCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listTypesCalls)
+	}
+
+	// Second call: hit.
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes (hit): %v", err)
+	}
+	if stub.listTypesCalls != 1 {
+		t.Fatalf("cache hit: stub called again; got %d calls", stub.listTypesCalls)
+	}
+}
+
+func TestCachedTask_ListTaskTypes_ZeroTTLBypassesCache(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 0, discardLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := svc.ListTaskTypes(ctx, uuid.New()); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if stub.listTypesCalls != 3 {
+		t.Fatalf("TTL=0 should bypass cache; want 3 calls, got %d", stub.listTypesCalls)
+	}
+}
+
+func TestCachedTask_CreateTaskType_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes: %v", err)
+	}
+	if _, err := svc.CreateTaskType(ctx, taskdom.CreateTaskTypeInput{ProjectID: projectID, Name: "Epic"}); err != nil {
+		t.Fatalf("CreateTaskType: %v", err)
+	}
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes after Create: %v", err)
+	}
+	if stub.listTypesCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listTypesCalls)
+	}
+}
+
+func TestCachedTask_UpdateTaskType_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes: %v", err)
+	}
+	if _, err := svc.UpdateTaskType(ctx, projectID, uuid.New(), taskdom.UpdateTaskTypeInput{Name: "Story"}); err != nil {
+		t.Fatalf("UpdateTaskType: %v", err)
+	}
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes after Update: %v", err)
+	}
+	if stub.listTypesCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listTypesCalls)
+	}
+}
+
+func TestCachedTask_DeleteTaskType_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes: %v", err)
+	}
+	if err := svc.DeleteTaskType(ctx, projectID, uuid.New()); err != nil {
+		t.Fatalf("DeleteTaskType: %v", err)
+	}
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes after Delete: %v", err)
+	}
+	if stub.listTypesCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listTypesCalls)
+	}
+}
+
+func TestCachedTask_SetDefaultTaskType_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes: %v", err)
+	}
+	if _, err := svc.SetDefaultTaskType(ctx, projectID, uuid.New()); err != nil {
+		t.Fatalf("SetDefaultTaskType: %v", err)
+	}
+	if _, err := svc.ListTaskTypes(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskTypes after SetDefault: %v", err)
+	}
+	if stub.listTypesCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listTypesCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListTaskStatuses
+// ---------------------------------------------------------------------------
+
+func TestCachedTask_ListTaskStatuses_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses (miss): %v", err)
+	}
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses (hit): %v", err)
+	}
+	if stub.listStatusCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listStatusCalls)
+	}
+}
+
+func TestCachedTask_CreateTaskStatus_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses: %v", err)
+	}
+	in := taskdom.CreateTaskStatusInput{
+		ProjectID: projectID, Name: "In Review", Category: taskdom.StatusCategoryInProgress, // = "inprogress"
+	}
+	if _, err := svc.CreateTaskStatus(ctx, in); err != nil {
+		t.Fatalf("CreateTaskStatus: %v", err)
+	}
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses after Create: %v", err)
+	}
+	if stub.listStatusCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listStatusCalls)
+	}
+}
+
+func TestCachedTask_DeleteTaskStatus_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses: %v", err)
+	}
+	if err := svc.DeleteTaskStatus(ctx, projectID, uuid.New()); err != nil {
+		t.Fatalf("DeleteTaskStatus: %v", err)
+	}
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses after Delete: %v", err)
+	}
+	if stub.listStatusCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listStatusCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListCustomFieldDefinitions
+// ---------------------------------------------------------------------------
+
+func TestCachedTask_ListCustomFields_CacheHit(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields (miss): %v", err)
+	}
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields (hit): %v", err)
+	}
+	if stub.listFieldsCalls != 1 {
+		t.Fatalf("expected 1 stub call, got %d", stub.listFieldsCalls)
+	}
+}
+
+func TestCachedTask_CreateCustomField_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields: %v", err)
+	}
+	in := taskdom.CreateCustomFieldDefinitionInput{
+		ProjectID: projectID, FieldKey: "priority", DisplayName: "Priority", FieldType: taskdom.FieldTypeSelect,
+	}
+	if _, err := svc.CreateCustomFieldDefinition(ctx, in); err != nil {
+		t.Fatalf("CreateCustomField: %v", err)
+	}
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields after Create: %v", err)
+	}
+	if stub.listFieldsCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listFieldsCalls)
+	}
+}
+
+func TestCachedTask_UpdateCustomField_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields: %v", err)
+	}
+	if _, err := svc.UpdateCustomFieldDefinition(ctx, projectID, uuid.New(), taskdom.UpdateCustomFieldDefinitionInput{DisplayName: "Updated"}); err != nil {
+		t.Fatalf("UpdateCustomField: %v", err)
+	}
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields after Update: %v", err)
+	}
+	if stub.listFieldsCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listFieldsCalls)
+	}
+}
+
+func TestCachedTask_DeleteCustomField_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields: %v", err)
+	}
+	if err := svc.DeleteCustomFieldDefinition(ctx, projectID, uuid.New()); err != nil {
+		t.Fatalf("DeleteCustomField: %v", err)
+	}
+	if _, err := svc.ListCustomFieldDefinitions(ctx, projectID); err != nil {
+		t.Fatalf("ListCustomFields after Delete: %v", err)
+	}
+	if stub.listFieldsCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listFieldsCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error propagation
+// ---------------------------------------------------------------------------
+
+func TestCachedTask_ListTaskTypes_ServiceErrorPropagated(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("repo failure")
+	stub := &stubTaskSvc{
+		listTaskTypes: func(_ context.Context, _ uuid.UUID) ([]*taskdom.TaskType, error) {
+			return nil, sentinel
+		},
+	}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	_, err := svc.ListTaskTypes(ctx, uuid.New())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-project cache isolation
+// ---------------------------------------------------------------------------
+
+func TestCachedTask_ListTaskTypes_PerProjectCacheIsolation(t *testing.T) {
+	ctx := context.Background()
+	projectA := uuid.New()
+	projectB := uuid.New()
+
+	callsA := 0
+	callsB := 0
+	stub := &stubTaskSvc{
+		listTaskTypes: func(_ context.Context, projectID uuid.UUID) ([]*taskdom.TaskType, error) {
+			if projectID == projectA {
+				callsA++
+			} else {
+				callsB++
+			}
+			return []*taskdom.TaskType{{ID: uuid.New(), ProjectID: projectID}}, nil
+		},
+	}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	// Populate both caches.
+	if _, err := svc.ListTaskTypes(ctx, projectA); err != nil {
+		t.Fatalf("ListTaskTypes(A): %v", err)
+	}
+	if _, err := svc.ListTaskTypes(ctx, projectB); err != nil {
+		t.Fatalf("ListTaskTypes(B): %v", err)
+	}
+
+	// Invalidate only project A.
+	if err := svc.DeleteTaskType(ctx, projectA, uuid.New()); err != nil {
+		t.Fatalf("DeleteTaskType(A): %v", err)
+	}
+
+	// Project A cache is evicted; project B cache is intact.
+	if _, err := svc.ListTaskTypes(ctx, projectA); err != nil {
+		t.Fatalf("ListTaskTypes(A) after invalidation: %v", err)
+	}
+	if _, err := svc.ListTaskTypes(ctx, projectB); err != nil {
+		t.Fatalf("ListTaskTypes(B) after A invalidation: %v", err)
+	}
+
+	if callsA != 2 {
+		t.Fatalf("projectA: expected 2 stub calls, got %d", callsA)
+	}
+	if callsB != 1 {
+		t.Fatalf("projectB: expected 1 stub call (no invalidation), got %d", callsB)
+	}
+}

--- a/services/api/test/integration/cache_test.go
+++ b/services/api/test/integration/cache_test.go
@@ -1,0 +1,268 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/paca/api/internal/platform/authz"
+	"github.com/paca/api/internal/platform/cache"
+	jwttoken "github.com/paca/api/internal/platform/token"
+	authsvc "github.com/paca/api/internal/service/auth"
+	projectsvc "github.com/paca/api/internal/service/project"
+	sprintsvc "github.com/paca/api/internal/service/sprint"
+	tasksvc "github.com/paca/api/internal/service/task"
+	usersvc "github.com/paca/api/internal/service/user"
+	"github.com/paca/api/internal/transport/http/handler"
+	"github.com/paca/api/internal/transport/http/router"
+)
+
+// ---------------------------------------------------------------------------
+// helpers: cache-aware router builder
+// ---------------------------------------------------------------------------
+
+// buildCachedTaskRouter builds an httptest-compatible gin.Engine wired with
+// a CachedTaskService backed by an in-memory (miniredis) cache store.  The
+// miniredis instance is automatically stopped when t ends.
+func buildCachedTaskRouter(t *testing.T, taskRepo *fakeTaskRepo, store *projectPermStore) (*gin.Engine, *cache.Store) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	// Stand up miniredis and build a cache.Store.
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	cacheStore := cache.NewStore(client, "paca:")
+
+	tm := jwttoken.New(testSecret, 15*time.Minute, 168*time.Hour)
+	refreshStore := &fakeRefreshStore{}
+	userRepo := newFakeUserRepo()
+	authService := authsvc.New(userRepo, tm, refreshStore, 168*time.Hour, 24*time.Hour)
+	userService := usersvc.New(userRepo)
+	projectRepo := newFakeProjectRepo()
+	projectService := projectsvc.New(projectRepo, taskRepo)
+
+	// Wrap the real task service with the caching decorator.
+	realTaskSvc := tasksvc.New(taskRepo)
+	cachedTaskSvc := tasksvc.NewCachedService(
+		realTaskSvc,
+		cacheStore,
+		5*time.Minute,
+		slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	)
+	viewService := sprintsvc.NewViewService(newFakeViewRepoIT())
+	activityService := tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)
+	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	r := router.New(router.Deps{
+		TokenManager:         tm,
+		Authorizer:           authz.NewAuthorizer(store),
+		ProjectVisibilitySvc: projectService,
+		Health:               handler.NewHealthHandler(),
+		Auth:                 handler.NewAuthHandler(authService, testCookieCfg),
+		User:                 handler.NewUserHandler(userService),
+		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
+		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
+		Task:                 handler.NewTaskHandler(cachedTaskSvc, viewService, activityService),
+		Log:                  log,
+	})
+	return r, cacheStore
+}
+
+// ---------------------------------------------------------------------------
+// test: task-type cache via HTTP
+// ---------------------------------------------------------------------------
+
+// TestCacheIntegration_TaskTypes_HitAndInvalidation verifies, end-to-end through
+// the HTTP layer, that:
+//
+//  1. The first GET populates the cache (stub repo is called once).
+//  2. A subsequent GET hits the cache (stub repo is NOT called again).
+//  3. After a POST (create), the cache is invalidated and the next GET hits the
+//     repo again.
+func TestCacheIntegration_TaskTypes_HitAndInvalidation(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {
+				authz.PermissionTasksRead,
+				authz.PermissionTasksWrite,
+			},
+		},
+	}
+	r, _ := buildCachedTaskRouter(t, taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/task-types", projectID)
+
+	// --- 1. First GET: cache miss — creates default task types (returns 200). ---
+	w1 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first GET: expected 200, got %d (%s)", w1.Code, w1.Body.String())
+	}
+	firstItems := decodeTaskTypeItems(t, w1.Body.Bytes())
+
+	// --- 2. Second GET: cache hit — should return identical items. ---
+	w2 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second GET (cache hit): expected 200, got %d (%s)", w2.Code, w2.Body.String())
+	}
+	secondItems := decodeTaskTypeItems(t, w2.Body.Bytes())
+
+	if len(firstItems) != len(secondItems) {
+		t.Fatalf("cache hit: item count mismatch — first=%d, second=%d", len(firstItems), len(secondItems))
+	}
+	// The IDs must be identical (same objects served from cache).
+	for i := range firstItems {
+		got, _ := secondItems[i]["id"].(string)
+		want, _ := firstItems[i]["id"].(string)
+		if got != want {
+			t.Errorf("item[%d] id mismatch: want %q, got %q", i, want, got)
+		}
+	}
+
+	// --- 3. POST: create a new type — should invalidate the cache. ---
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"name": "Integration Test Type",
+	}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("POST create: expected 201, got %d (%s)", createW.Code, createW.Body.String())
+	}
+
+	// --- 4. Third GET after invalidation: cache miss — should now include new type. ---
+	w3 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if w3.Code != http.StatusOK {
+		t.Fatalf("third GET (after invalidation): expected 200, got %d (%s)", w3.Code, w3.Body.String())
+	}
+	thirdItems := decodeTaskTypeItems(t, w3.Body.Bytes())
+
+	if len(thirdItems) != len(firstItems)+1 {
+		t.Fatalf("after create+invalidation: expected %d items, got %d", len(firstItems)+1, len(thirdItems))
+	}
+}
+
+// TestCacheIntegration_TaskStatuses_HitAndInvalidation verifies cache
+// hit/miss/invalidation for task statuses via HTTP.
+func TestCacheIntegration_TaskStatuses_HitAndInvalidation(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {
+				authz.PermissionTasksRead,
+				authz.PermissionTasksWrite,
+			},
+		},
+	}
+	r, _ := buildCachedTaskRouter(t, taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/task-statuses", projectID)
+
+	// First GET: populate cache.
+	w1 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first GET: expected 200, got %d (%s)", w1.Code, w1.Body.String())
+	}
+	initialCount := countListItems(t, w1.Body.Bytes())
+
+	// Second GET: cache hit — count must match.
+	w2 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second GET (cache hit): expected 200, got %d (%s)", w2.Code, w2.Body.String())
+	}
+	if got := countListItems(t, w2.Body.Bytes()); got != initialCount {
+		t.Fatalf("cache hit count mismatch: want %d, got %d", initialCount, got)
+	}
+
+	// POST: create a new status — invalidates cache.
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"name":     "In Review",
+		"category": "inprogress",
+	}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("POST create: expected 201, got %d (%s)", createW.Code, createW.Body.String())
+	}
+
+	// Third GET: cache invalidated — must see the new status.
+	w3 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if w3.Code != http.StatusOK {
+		t.Fatalf("third GET (after invalidation): expected 200, got %d (%s)", w3.Code, w3.Body.String())
+	}
+	if got := countListItems(t, w3.Body.Bytes()); got != initialCount+1 {
+		t.Fatalf("after invalidation: expected %d items, got %d", initialCount+1, got)
+	}
+}
+
+// TestCacheIntegration_PerProject_CacheIsolation verifies that invalidating
+// the cache for project A does not evict project B's cached task types.
+func TestCacheIntegration_PerProject_CacheIsolation(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectA := uuid.New()
+	projectB := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectA: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+			projectB: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r, _ := buildCachedTaskRouter(t, taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+
+	baseA := fmt.Sprintf("/api/v1/projects/%s/task-types", projectA)
+	baseB := fmt.Sprintf("/api/v1/projects/%s/task-types", projectB)
+
+	// Populate cache for both projects.
+	if w := serve(r, authedJSONReq(t.Context(), http.MethodGet, baseA, tok, nil)); w.Code != http.StatusOK {
+		t.Fatalf("GET project A: %d (%s)", w.Code, w.Body.String())
+	}
+	if w := serve(r, authedJSONReq(t.Context(), http.MethodGet, baseB, tok, nil)); w.Code != http.StatusOK {
+		t.Fatalf("GET project B: %d (%s)", w.Code, w.Body.String())
+	}
+
+	// Record project B's initial item count.
+	wB1 := serve(r, authedJSONReq(t.Context(), http.MethodGet, baseB, tok, nil))
+	countB := countListItems(t, wB1.Body.Bytes())
+
+	// Invalidate project A's cache by creating a new type there.
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, baseA, tok, map[string]any{"name": "A-Only Type"}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("POST project A: %d (%s)", createW.Code, createW.Body.String())
+	}
+
+	// Project B's cache must be untouched: item count unchanged after a fresh GET.
+	wB2 := serve(r, authedJSONReq(t.Context(), http.MethodGet, baseB, tok, nil))
+	if got := countListItems(t, wB2.Body.Bytes()); got != countB {
+		t.Fatalf("project B cache was evicted by project A invalidation: want %d items, got %d", countB, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// decode helpers
+// ---------------------------------------------------------------------------
+
+func decodeTaskTypeItems(t *testing.T, body []byte) []map[string]any {
+	t.Helper()
+	var env struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decodeTaskTypeItems: %v — body: %s", err, string(body))
+	}
+	return env.Data.Items
+}
+
+func countListItems(t *testing.T, body []byte) int {
+	t.Helper()
+	return len(decodeTaskTypeItems(t, body))
+}


### PR DESCRIPTION
This pull request introduces a new Redis-backed caching layer for several core services (global roles, projects, tasks, sprints, and views) in the API. It adds a generic cache store abstraction, configures cache TTLs via environment variables, and wires up the new caching logic throughout the application. The goal is to improve performance and reduce database load for frequently accessed but infrequently changing data.

The most important changes are:

**Caching Infrastructure:**

* Added a new `Store` abstraction in `internal/platform/cache/store.go`, which provides typed JSON get/set/delete helpers with namespace support for Redis/Valkey-backed caching. Includes a comprehensive test suite in `store_test.go`. [[1]](diffhunk://#diff-ffa3429736632bdf0a96dc3f28aa7ebf0049d8e25a39a005014865ca921d335eR1-R70) [[2]](diffhunk://#diff-0efe8a6ee0fb2a22deace52dccd2e8ec12ea6d7a1b10082d49b0f2a248688061R1-R154)

* Introduced a `CacheConfig` struct in `internal/config/config.go` and updated configuration loading in `internal/config/load.go` to support cache TTLs for projects, configs, and sprints, all configurable via environment variables (`CACHE_PROJECT_TTL`, `CACHE_CONFIG_TTL`, `CACHE_SPRINT_TTL`). [[1]](diffhunk://#diff-5f901e02ed468393320d41f6a3f42a8418363f27dfe8c6b7b1b75196defcd38eR11) [[2]](diffhunk://#diff-5f901e02ed468393320d41f6a3f42a8418363f27dfe8c6b7b1b75196defcd38eR49-R71) [[3]](diffhunk://#diff-d956efd85fb8e468490ab3ce93932344a88c6a174917b0ee75ac8663b98ab4f6R73-R85) [[4]](diffhunk://#diff-d956efd85fb8e468490ab3ce93932344a88c6a174917b0ee75ac8663b98ab4f6R129-R133) [[5]](diffhunk://#diff-613eb28e072b62ebcb2873cc655ee9a7cce9024ab48f2d7d68b3be5bed80057bR20-R25)

**Service Layer Integration:**

* Updated the application bootstrap (`internal/bootstrap/app.go`) to instantiate and inject the new cache store and wrap the global role, project, task, sprint, and view services with their respective cached decorators. [[1]](diffhunk://#diff-c350dd0d8de028a7f4754efbb66b26c3f09a62e49ac61889aac5f3003680987aR82-R83) [[2]](diffhunk://#diff-c350dd0d8de028a7f4754efbb66b26c3f09a62e49ac61889aac5f3003680987aL126-R132)

* Added a `CachedService` decorator for the global role service (`internal/service/globalrole/cached_service.go`), which caches the global roles list and invalidates the cache on mutations. Similar caching decorators are now used for projects, tasks, sprints, and views (not shown in this diff, but wired up in the bootstrap).

**Dependency Updates:**

* Added new dependencies for testing (`github.com/alicebob/miniredis/v2`) and for potential future scripting support (`github.com/yuin/gopher-lua`) in `go.mod`. [[1]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991R28) [[2]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991R110)