### PR TITLE
feat: add loading skeletons to various components for improved user e…

### DIFF
--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -25,7 +25,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-
+import { Skeleton } from "@/components/ui/skeleton";
 import {
 	allTasksQueryOptions,
 	bulkMoveViewTaskPositions,
@@ -72,6 +72,116 @@ import {
 	type TaskFieldUpdate,
 	type ViewContext,
 } from "./view-utils";
+
+// ── Loading skeletons ─────────────────────────────────────────────────────────
+
+function ListViewSkeleton() {
+	return (
+		<div className="flex flex-col overflow-hidden h-full">
+			{/* group header */}
+			<div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/30 bg-muted/20">
+				<Skeleton className="size-4 rounded" />
+				<Skeleton className="h-3.5 w-20" />
+				<Skeleton className="h-4 w-6 rounded-full ml-1" />
+			</div>
+			{/* column header row */}
+			<div className="flex items-center gap-4 px-4 py-2 border-b border-border/20 bg-muted/10">
+				<Skeleton className="h-3 w-14 shrink-0" />
+				<Skeleton className="h-3 flex-1" />
+				<Skeleton className="h-3 w-16 shrink-0" />
+				<Skeleton className="h-3 w-14 shrink-0" />
+				<Skeleton className="h-3 w-20 shrink-0" />
+				<Skeleton className="h-3 w-16 shrink-0" />
+			</div>
+			{/* task rows */}
+			{[
+				{ id: "sk-r1", w: "w-48", wp: "w-16", ws: "w-20" },
+				{ id: "sk-r2", w: "w-64", wp: "w-14", ws: "w-24" },
+				{ id: "sk-r3", w: "w-40", wp: "w-20", ws: "w-16" },
+				{ id: "sk-r4", w: "w-56", wp: "w-12", ws: "w-20" },
+				{ id: "sk-r5", w: "w-52", wp: "w-18", ws: "w-24" },
+			].map(({ id, w, wp, ws }) => (
+				<div
+					key={id}
+					className="flex items-center gap-4 px-4 py-3 border-b border-border/15 last:border-0"
+				>
+					<Skeleton className="size-5 rounded shrink-0" />
+					<Skeleton className={`h-3.5 ${w} shrink-0`} />
+					<div className="flex-1" />
+					<Skeleton className={`h-3 ${wp} shrink-0`} />
+					<Skeleton className={`h-3 ${ws} shrink-0`} />
+					<Skeleton className="size-6 rounded-full shrink-0" />
+				</div>
+			))}
+		</div>
+	);
+}
+
+function BoardViewSkeleton() {
+	const cols = [
+		{
+			id: "sk-col1",
+			w: "w-24",
+			cards: [
+				{ id: "sk-c1r1", tw: "w-32", th: "h-3.5" },
+				{ id: "sk-c1r2", tw: "w-40", th: "h-3" },
+				{ id: "sk-c1r3", tw: "w-28", th: "h-4" },
+			],
+		},
+		{
+			id: "sk-col2",
+			w: "w-20",
+			cards: [
+				{ id: "sk-c2r1", tw: "w-36", th: "h-3.5" },
+				{ id: "sk-c2r2", tw: "w-24", th: "h-3" },
+			],
+		},
+		{
+			id: "sk-col3",
+			w: "w-28",
+			cards: [
+				{ id: "sk-c3r1", tw: "w-28", th: "h-4" },
+				{ id: "sk-c3r2", tw: "w-44", th: "h-3.5" },
+				{ id: "sk-c3r3", tw: "w-32", th: "h-3" },
+				{ id: "sk-c3r4", tw: "w-20", th: "h-3.5" },
+			],
+		},
+		{
+			id: "sk-col4",
+			w: "w-16",
+			cards: [{ id: "sk-c4r1", tw: "w-40", th: "h-3" }],
+		},
+	];
+	return (
+		<div className="flex h-full gap-3 overflow-x-auto px-4 py-4">
+			{cols.map((col) => (
+				<div key={col.id} className="flex w-64 shrink-0 flex-col gap-2">
+					{/* column header */}
+					<div className="flex items-center gap-2 px-1">
+						<Skeleton className={`h-3.5 ${col.w}`} />
+						<Skeleton className="h-4 w-5 rounded-full" />
+					</div>
+					{/* cards */}
+					{col.cards.map(({ id, tw, th }) => (
+						<div
+							key={id}
+							className="rounded-xl border border-border/50 bg-card p-3.5 space-y-3"
+						>
+							<div className="flex items-center gap-2">
+								<Skeleton className="size-4 rounded shrink-0" />
+								<Skeleton className={`${th} ${tw}`} />
+							</div>
+							<div className="flex items-center justify-between">
+								<Skeleton className="h-4 w-16 rounded-full" />
+								<Skeleton className="size-5 rounded-full" />
+							</div>
+						</div>
+					))}
+				</div>
+			))}
+		</div>
+	);
+}
 
 interface InteractionLayoutProps {
 	projectId: string;
@@ -959,9 +1069,11 @@ export function InteractionLayout({
 			{/* View content */}
 			<div className="flex flex-1 flex-col overflow-hidden">
 				{tasksLoading ? (
-					<div className="flex h-full items-center justify-center">
-						<div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-					</div>
+					activeView?.layout === "Board" ? (
+						<BoardViewSkeleton />
+					) : (
+						<ListViewSkeleton />
+					)
 				) : activeView?.layout === "Board" ? (
 					<BoardView
 						projectId={projectId}

--- a/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
@@ -18,6 +18,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { Sprint, Task } from "@/lib/interaction-api";
 import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
 import { getTaskTypeIconComponent } from "../../task-types/task-type-icons";
@@ -448,9 +449,7 @@ export function PropertiesPanel({
 								);
 							})()
 						) : task.parent_task_id ? (
-							<span className="text-[12px] text-muted-foreground/60 italic">
-								Loading…
-							</span>
+							<Skeleton className="h-3.5 w-28" />
 						) : (
 							<span className="text-[12px] text-muted-foreground/50 italic">
 								No parent

--- a/apps/web/src/routes/_authenticated/profile/api-keys.tsx
+++ b/apps/web/src/routes/_authenticated/profile/api-keys.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Table,
 	TableBody,
@@ -158,9 +159,45 @@ function APIKeysPage() {
 
 				<CardContent>
 					{isLoading ? (
-						<p className="text-sm text-muted-foreground py-4 text-center">
-							Loading…
-						</p>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Name</TableHead>
+									<TableHead>Prefix</TableHead>
+									<TableHead>Created</TableHead>
+									<TableHead>Expires</TableHead>
+									<TableHead>Last used</TableHead>
+									<TableHead className="w-10" />
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{[...Array(3)].map((_, i) => (
+									<TableRow
+										// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+										key={i}
+									>
+										<TableCell>
+											<Skeleton className="h-4 w-28" />
+										</TableCell>
+										<TableCell>
+											<Skeleton className="h-4 w-24" />
+										</TableCell>
+										<TableCell>
+											<Skeleton className="h-4 w-20" />
+										</TableCell>
+										<TableCell>
+											<Skeleton className="h-4 w-20" />
+										</TableCell>
+										<TableCell>
+											<Skeleton className="h-4 w-20" />
+										</TableCell>
+										<TableCell>
+											<Skeleton className="size-8 rounded-md" />
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
 					) : keys.length === 0 ? (
 						<div className="flex flex-col items-center gap-2 py-10 text-center">
 							<Key className="size-8 text-muted-foreground/50" />

--- a/apps/web/src/routes/_authenticated/profile/index.tsx
+++ b/apps/web/src/routes/_authenticated/profile/index.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { apiClient } from "@/lib/api-client";
 import type { SuccessEnvelope } from "@/lib/api-error";
 import type { User as UserType } from "@/lib/auth-api";
@@ -80,7 +81,77 @@ function ProfilePage() {
 		},
 	});
 
-	if (!user) return null;
+	if (!user) {
+		return (
+			<div className="flex flex-col gap-6 p-6 max-w-2xl">
+				{/* Header skeleton */}
+				<div>
+					<div className="flex items-center gap-2">
+						<Skeleton className="size-5 rounded" />
+						<Skeleton className="h-5 w-24" />
+					</div>
+					<Skeleton className="mt-1.5 h-3.5 w-64" />
+				</div>
+				<Separator />
+				{/* Profile card skeleton */}
+				<Card>
+					<CardHeader>
+						<div className="flex items-center gap-4">
+							<Skeleton className="size-14 rounded-xl shrink-0" />
+							<div className="space-y-2">
+								<Skeleton className="h-5 w-36" />
+								<Skeleton className="h-3.5 w-24" />
+								<div className="flex items-center gap-2 mt-1">
+									<Skeleton className="h-5 w-16 rounded-full" />
+									<Skeleton className="h-3.5 w-28" />
+								</div>
+							</div>
+						</div>
+					</CardHeader>
+					<Separator />
+					<CardContent className="pt-5">
+						<div className="flex flex-col gap-4">
+							<div className="flex flex-col gap-1.5">
+								<Skeleton className="h-3.5 w-20" />
+								<Skeleton className="h-4 w-40 mt-1" />
+							</div>
+							<div className="flex flex-col gap-1.5">
+								<Skeleton className="h-3.5 w-20" />
+								<Skeleton className="h-4 w-32 mt-1" />
+							</div>
+						</div>
+					</CardContent>
+					<CardFooter className="border-t pt-4">
+						<Skeleton className="h-8 w-24 rounded-md" />
+					</CardFooter>
+				</Card>
+				{/* Change password card skeleton */}
+				<Card>
+					<CardHeader>
+						<Skeleton className="h-5 w-36" />
+						<Skeleton className="h-3.5 w-64 mt-1" />
+					</CardHeader>
+					<CardContent className="space-y-3">
+						<div className="flex flex-col gap-1.5">
+							<Skeleton className="h-3.5 w-28" />
+							<Skeleton className="h-9 w-full rounded-md" />
+						</div>
+						<div className="flex flex-col gap-1.5">
+							<Skeleton className="h-3.5 w-32" />
+							<Skeleton className="h-9 w-full rounded-md" />
+						</div>
+						<div className="flex flex-col gap-1.5">
+							<Skeleton className="h-3.5 w-36" />
+							<Skeleton className="h-9 w-full rounded-md" />
+						</div>
+					</CardContent>
+					<CardFooter className="border-t pt-4">
+						<Skeleton className="h-8 w-32 rounded-md" />
+					</CardFooter>
+				</Card>
+			</div>
+		);
+	}
 
 	const displayName = user.full_name || user.username;
 	const initials = getInitials(displayName);

--- a/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
@@ -336,7 +336,7 @@ function DocEditorPage() {
 						)}
 
 						{!doc && (
-							<div className="space-y-6 animate-pulse">
+							<div className="space-y-6">
 								{/* Title skeleton */}
 								<Skeleton className="h-9 w-2/3 rounded-md" />
 								{/* Content blocks skeleton */}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/projects/docs/doc-editor";
 import { DocHistoryPanel } from "@/components/projects/docs/doc-history-panel";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
 import { useProjectPermissions } from "@/hooks/use-project-permissions";
 import { currentUserQueryOptions } from "@/lib/auth-api";
@@ -195,11 +196,13 @@ function DocEditorPage() {
 							<ChevronRight className="size-3.5 text-muted-foreground/30 shrink-0" />
 						</span>
 					))}
-					{doc?.title && (
+					{doc?.title ? (
 						<span className="text-foreground/70 font-medium truncate max-w-60">
 							{doc.title}
 						</span>
-					)}
+					) : !doc ? (
+						<Skeleton className="h-3 w-28" />
+					) : null}
 				</div>
 
 				{/* Right: save status + panel toggles */}
@@ -333,10 +336,28 @@ function DocEditorPage() {
 						)}
 
 						{!doc && (
-							<div className="h-40 flex items-center justify-center">
-								<span className="text-muted-foreground/50 text-sm animate-pulse">
-									Loading…
-								</span>
+							<div className="space-y-6 animate-pulse">
+								{/* Title skeleton */}
+								<Skeleton className="h-9 w-2/3 rounded-md" />
+								{/* Content blocks skeleton */}
+								<div className="space-y-3 pt-2">
+									<Skeleton className="h-4 w-full" />
+									<Skeleton className="h-4 w-11/12" />
+									<Skeleton className="h-4 w-5/6" />
+								</div>
+								<div className="space-y-3 pt-2">
+									<Skeleton className="h-4 w-full" />
+									<Skeleton className="h-4 w-3/4" />
+								</div>
+								<div className="space-y-3 pt-2">
+									<Skeleton className="h-4 w-full" />
+									<Skeleton className="h-4 w-11/12" />
+									<Skeleton className="h-4 w-4/5" />
+									<Skeleton className="h-4 w-2/3" />
+								</div>
+								<div className="space-y-3 pt-2">
+									<Skeleton className="h-4 w-1/2" />
+								</div>
 							</div>
 						)}
 

--- a/apps/web/src/routes/_authenticated/projects/$projectId/tasks/$taskId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/tasks/$taskId.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
+import { AlertCircle, ArrowLeft } from "lucide-react";
 
 import { TaskDetailModal } from "@/components/projects/interactions/task-detail-modal";
+import { Skeleton } from "@/components/ui/skeleton";
 import { taskQueryOptions } from "@/lib/interaction-api";
 import {
 	projectMembersQueryOptions,
@@ -16,6 +17,81 @@ export const Route = createFileRoute(
 )({
 	component: TaskDetailPage,
 });
+
+function TaskDetailSkeleton() {
+	return (
+		<div className="flex h-full flex-col overflow-hidden bg-background">
+			{/* Back nav strip */}
+			<div className="shrink-0 border-b border-border/40 px-5 py-2.5 flex items-center gap-3">
+				<Skeleton className="h-4 w-28" />
+			</div>
+			{/* Task detail skeleton body */}
+			<div className="flex flex-col lg:flex-row flex-1 min-w-0 min-h-0 overflow-y-auto lg:overflow-hidden">
+				{/* Main content */}
+				<div className="lg:flex-1 lg:overflow-y-auto px-4 lg:px-8 py-5 lg:py-7 space-y-6 lg:space-y-8 max-w-3xl mx-auto w-full">
+					{/* Type + status badges */}
+					<div className="flex items-center gap-2.5 flex-wrap">
+						<Skeleton className="h-6 w-20 rounded-md" />
+						<Skeleton className="h-6 w-24 rounded-full" />
+					</div>
+					{/* Title */}
+					<Skeleton className="h-8 w-3/4 rounded-md" />
+					{/* Properties section */}
+					<div className="space-y-3">
+						<div className="flex items-center gap-2 mb-3">
+							<Skeleton className="h-3 w-20" />
+							<div className="flex-1 h-px bg-border/30" />
+						</div>
+						{[
+							{ lw: "w-20", vw: "w-32" },
+							{ lw: "w-16", vw: "w-28" },
+							{ lw: "w-24", vw: "w-20" },
+							{ lw: "w-20", vw: "w-36" },
+							{ lw: "w-24", vw: "w-24" },
+						].map(({ lw, vw }, i) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+							<div key={i} className="flex items-center gap-3 py-1.5">
+								<Skeleton className={`h-3.5 ${lw} shrink-0`} />
+								<Skeleton className={`h-5 ${vw} rounded-md`} />
+							</div>
+						))}
+					</div>
+					{/* Description section */}
+					<div className="space-y-2 pt-2">
+						<div className="flex items-center gap-2 mb-3">
+							<Skeleton className="h-3 w-24" />
+							<div className="flex-1 h-px bg-border/30" />
+						</div>
+						<Skeleton className="h-3.5 w-full" />
+						<Skeleton className="h-3.5 w-5/6" />
+						<Skeleton className="h-3.5 w-4/5" />
+						<Skeleton className="h-3.5 w-2/3" />
+					</div>
+				</div>
+				{/* Right sidebar — activity panel placeholder */}
+				<div className="hidden lg:block w-72 shrink-0 border-l border-border/30 p-4 space-y-3">
+					<Skeleton className="h-4 w-24 mb-4" />
+					{[
+						{ fw: "w-4/5" },
+						{ fw: "w-3/5" },
+						{ fw: "w-3/4" },
+						{ fw: "w-1/2" },
+						{ fw: "w-2/3" },
+					].map(({ fw }, i) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+						<div key={i} className="flex gap-2.5">
+							<Skeleton className="size-6 rounded-full shrink-0 mt-0.5" />
+							<div className="flex-1 space-y-1.5">
+								<Skeleton className={`h-3 ${fw}`} />
+								<Skeleton className="h-2.5 w-1/3" />
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
 
 function TaskDetailPage() {
 	const { projectId, taskId } = Route.useParams();
@@ -33,11 +109,7 @@ function TaskDetailPage() {
 	);
 
 	if (isLoading) {
-		return (
-			<div className="flex h-full items-center justify-center">
-				<Loader2 className="size-6 animate-spin text-muted-foreground" />
-			</div>
-		);
+		return <TaskDetailSkeleton />;
 	}
 
 	if (!task) {

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -624,11 +624,23 @@ function TeamPage() {
 				{isLoading ? (
 					<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
 						{[...Array(4)].map((_, i) => (
-							<Skeleton
+							<div
 								// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
 								key={i}
-								className="h-16 w-full rounded-xl"
-							/>
+								className="flex items-center gap-3 rounded-xl border border-border/50 bg-card px-4 py-3"
+							>
+								{/* Avatar */}
+								<Skeleton className="size-9 rounded-full shrink-0" />
+								{/* Name + username */}
+								<div className="min-w-0 flex-1 space-y-1.5">
+									<Skeleton className="h-3.5 w-32" />
+									<Skeleton className="h-3 w-20" />
+								</div>
+								{/* Role chip */}
+								<Skeleton className="h-6 w-24 rounded-full shrink-0" />
+								{/* Action button */}
+								<Skeleton className="size-7 rounded-md shrink-0" />
+							</div>
 						))}
 					</div>
 				) : !members?.length ? (


### PR DESCRIPTION
This pull request significantly improves the loading experience across several pages by replacing generic "Loading…" messages and spinners with detailed skeleton UI components. These skeletons provide a more visually consistent and informative placeholder while data is being fetched, enhancing perceived performance and user experience. The changes introduce new skeleton components for various layouts and update existing loading states to use these components.

**Enhanced loading skeletons throughout the app:**

* Added comprehensive skeleton components for list and board views in the project interaction layout, replacing the old spinner-based loading indicator. (`interaction-layout.tsx`) [[1]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL28-R28) [[2]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR76-R185) [[3]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL962-R1076)
* Introduced a detailed skeleton for the task detail page, improving the placeholder shown while task data is loading. (`$taskId.tsx`) [[1]](diffhunk://#diff-3477d94fae1ba0b2ece0d338730af9814fb6a0035c458873fcc7ae811c9e2657L3-R6) [[2]](diffhunk://#diff-3477d94fae1ba0b2ece0d338730af9814fb6a0035c458873fcc7ae811c9e2657R21-R95) [[3]](diffhunk://#diff-3477d94fae1ba0b2ece0d338730af9814fb6a0035c458873fcc7ae811c9e2657L36-R112)
* Updated the team page to use a richer, card-like skeleton for each team member instead of a simple rectangle. (`team/index.tsx`)

**Improved loading states in profile and API key pages:**

* Replaced the blank state on the profile page with a structured skeleton layout that mimics the final profile UI. (`profile/index.tsx`) [[1]](diffhunk://#diff-54ab1d2648e22eb57ddf27b1c49e6a0e8dbde216fb9952f069839dedd721cbb1R20) [[2]](diffhunk://#diff-54ab1d2648e22eb57ddf27b1c49e6a0e8dbde216fb9952f069839dedd721cbb1L83-R154)
* Updated the API keys page to show a table of skeleton rows during loading, instead of a text message. (`profile/api-keys.tsx`) [[1]](diffhunk://#diff-5a081009bf89d6a1c9cfaf0ead2c06553133da36bcb463f5db95b3bfc73cd2bdR23) [[2]](diffhunk://#diff-5a081009bf89d6a1c9cfaf0ead2c06553133da36bcb463f5db95b3bfc73cd2bdL161-R200)

**Skeletons for document editor and properties panel:**

* Added skeleton placeholders for document titles and content blocks in the doc editor, and replaced the loading message with a skeleton. (`$docId.tsx`) [[1]](diffhunk://#diff-bb6a4349bc11a4536de531a437da2e86400b8ffcb3a2debc7369938e3060fc4fR20) [[2]](diffhunk://#diff-bb6a4349bc11a4536de531a437da2e86400b8ffcb3a2debc7369938e3060fc4fL198-R205) [[3]](diffhunk://#diff-bb6a4349bc11a4536de531a437da2e86400b8ffcb3a2debc7369938e3060fc4fL336-R360)
* Updated the task properties panel to show a skeleton when loading parent task data. (`properties-panel.tsx`) [[1]](diffhunk://#diff-f963fb92badcf033b5ee6146753a2e42d52f39296a098f482c663d52bd80e668R21) [[2]](diffhunk://#diff-f963fb92badcf033b5ee6146753a2e42d52f39296a098f482c663d52bd80e668L451-R452)