### PR TITLE
feat: add canEdit prop to task detail components for permission-based…

### DIFF
--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1182,6 +1182,7 @@ export function InteractionLayout({
 				statuses={statuses}
 				taskTypes={taskTypes}
 				members={members}
+				canEdit={canEdit}
 			/>
 		</div>
 	);

--- a/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
@@ -22,7 +22,11 @@ interface TaskActivityPaneProps {
 	canEdit?: boolean;
 }
 
-export function TaskActivityPane({ projectId, taskId, canEdit = true }: TaskActivityPaneProps) {
+export function TaskActivityPane({
+	projectId,
+	taskId,
+	canEdit = true,
+}: TaskActivityPaneProps) {
 	const { data: membersData } = useQuery(projectMembersQueryOptions(projectId));
 	const { data: sprintsData } = useQuery(sprintsQueryOptions(projectId));
 
@@ -101,7 +105,9 @@ export function TaskActivityPane({ projectId, taskId, canEdit = true }: TaskActi
 			entityId={taskId}
 			queryKey={queryKey}
 			queryFn={() => listTaskActivities(projectId, taskId)}
-			addComment={canEdit ? (text) => addComment(projectId, taskId, text) : undefined}
+			addComment={
+				canEdit ? (text) => addComment(projectId, taskId, text) : undefined
+			}
 			describeActivity={describeActivity}
 			getCommentText={(content) => (content as { text?: string }).text ?? ""}
 		/>

--- a/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
@@ -19,9 +19,10 @@ type FieldChange = {
 interface TaskActivityPaneProps {
 	projectId: string;
 	taskId: string;
+	canEdit?: boolean;
 }
 
-export function TaskActivityPane({ projectId, taskId }: TaskActivityPaneProps) {
+export function TaskActivityPane({ projectId, taskId, canEdit = true }: TaskActivityPaneProps) {
 	const { data: membersData } = useQuery(projectMembersQueryOptions(projectId));
 	const { data: sprintsData } = useQuery(sprintsQueryOptions(projectId));
 
@@ -100,7 +101,7 @@ export function TaskActivityPane({ projectId, taskId }: TaskActivityPaneProps) {
 			entityId={taskId}
 			queryKey={queryKey}
 			queryFn={() => listTaskActivities(projectId, taskId)}
-			addComment={(text) => addComment(projectId, taskId, text)}
+			addComment={canEdit ? (text) => addComment(projectId, taskId, text) : undefined}
 			describeActivity={describeActivity}
 			getCommentText={(content) => (content as { text?: string }).text ?? ""}
 		/>

--- a/apps/web/src/components/projects/interactions/task-detail/checklists-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/checklists-section.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { ChecklistSection } from "./checklist-section";
 import type { Checklist } from "./types";
 
-export function ChecklistsSection() {
+export function ChecklistsSection({ canEdit = true }: { canEdit?: boolean }) {
 	const [checklists, setChecklists] = useState<Checklist[]>([]);
 
 	const handleCreate = () => {
@@ -24,14 +24,16 @@ export function ChecklistsSection() {
 					<span>Checklists</span>
 					<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
 				</h3>
-				<button
-					type="button"
-					onClick={handleCreate}
-					className="flex items-center gap-1.5 rounded-lg bg-muted/40 text-muted-foreground/80 hover:bg-muted/60 hover:text-foreground px-2.5 py-1.5 text-[11px] font-semibold transition-all duration-150"
-				>
-					<Plus className="size-3" />
-					Create checklist
-				</button>
+				{canEdit && (
+					<button
+						type="button"
+						onClick={handleCreate}
+						className="flex items-center gap-1.5 rounded-lg bg-muted/40 text-muted-foreground/80 hover:bg-muted/60 hover:text-foreground px-2.5 py-1.5 text-[11px] font-semibold transition-all duration-150"
+					>
+						<Plus className="size-3" />
+						Create checklist
+					</button>
+				)}
 			</div>
 
 			{checklists.length > 0 ? (

--- a/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
@@ -141,13 +141,15 @@ export function DescriptionSection({
 					<span>Description</span>
 					<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
 				</h3>
-				<button
-					type="button"
-					className="flex items-center gap-1.5 text-[11px] text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-150 font-medium"
-				>
-					<Sparkles className="size-3" />
-					Write with AI
-				</button>
+				{canEdit && (
+					<button
+						type="button"
+						className="flex items-center gap-1.5 text-[11px] text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-150 font-medium"
+					>
+						<Sparkles className="size-3" />
+						Write with AI
+					</button>
+				)}
 			</div>
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: wrapper captures blur from BlockNote rich-text editor */}

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -384,8 +384,7 @@ export function TaskDetailModal({
 						)}
 
 						{/* Checklists */}
-						<ChecklistsSection />
-
+							<ChecklistsSection canEdit={canEdit} />
 						{/* Attachments */}
 						<AttachmentsSection
 							projectId={projectId ?? ""}
@@ -420,7 +419,7 @@ export function TaskDetailModal({
 				</div>
 
 				{/* ── Right: Activity pane ── */}
-				<ActivityPane projectId={projectId ?? ""} taskId={task?.id ?? ""} />
+				<ActivityPane projectId={projectId ?? ""} taskId={task?.id ?? ""} canEdit={canEdit} />
 			</div>
 		</div>
 	) : (

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -384,7 +384,7 @@ export function TaskDetailModal({
 						)}
 
 						{/* Checklists */}
-							<ChecklistsSection canEdit={canEdit} />
+						<ChecklistsSection canEdit={canEdit} />
 						{/* Attachments */}
 						<AttachmentsSection
 							projectId={projectId ?? ""}
@@ -419,7 +419,11 @@ export function TaskDetailModal({
 				</div>
 
 				{/* ── Right: Activity pane ── */}
-				<ActivityPane projectId={projectId ?? ""} taskId={task?.id ?? ""} canEdit={canEdit} />
+				<ActivityPane
+					projectId={projectId ?? ""}
+					taskId={task?.id ?? ""}
+					canEdit={canEdit}
+				/>
 			</div>
 		</div>
 	) : (

--- a/apps/web/src/components/shared/activity-pane.tsx
+++ b/apps/web/src/components/shared/activity-pane.tsx
@@ -45,7 +45,7 @@ export interface ActivityPaneConfig<T extends ActivityEntry> {
 	entityId: string;
 	queryKey: QueryKey;
 	queryFn: () => Promise<T[]>;
-	addComment: (text: string) => Promise<unknown>;
+	addComment?: (text: string) => Promise<unknown>;
 	updateComment?: (commentId: string, text: string) => Promise<unknown>;
 	deleteComment?: (commentId: string) => Promise<void>;
 	describeActivity: (entry: T) => string;
@@ -84,7 +84,10 @@ export function ActivityPane<T extends ActivityEntry>({
 	}, [activities, sortAscending]);
 
 	const addMutation = useMutation({
-		mutationFn: (text: string) => addComment(text),
+		mutationFn: (text: string) => {
+			if (!addComment) return Promise.resolve();
+			return addComment(text);
+		},
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey });
 		},
@@ -135,76 +138,78 @@ export function ActivityPane<T extends ActivityEntry>({
 				</div>
 			</ScrollArea>
 
-			<div className="shrink-0 border-t border-border/25 p-3 space-y-1.5 bg-background/50">
-				{commentFocused && (
-					<div className="flex items-center gap-0.5 rounded-lg border border-border/25 bg-muted/25 px-2 py-1">
-						{[
-							{ icon: Bold, title: "Bold" },
-							{ icon: Italic, title: "Italic" },
-							{ icon: List, title: "List" },
-						].map(({ icon: Icon, title }) => (
-							<button
-								key={title}
-								type="button"
-								title={title}
-								className="flex size-6 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-all duration-150"
-							>
-								<Icon className="size-3" />
-							</button>
-						))}
-						<div className="mx-1 h-3.5 w-px bg-border/30" />
-						{[
-							{ icon: Smile, title: "Emoji" },
-							{ icon: Paperclip, title: "Attach" },
-							{ icon: Hash, title: "Mention" },
-						].map(({ icon: Icon, title }) => (
-							<button
-								key={title}
-								type="button"
-								title={title}
-								className="flex size-6 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-all duration-150"
-							>
-								<Icon className="size-3" />
-							</button>
-						))}
-					</div>
-				)}
-
-				<div
-					className={cn(
-						"flex items-end gap-2 rounded-xl border border-border/30 bg-card/80 px-3 py-2.5 transition-all duration-200",
-						commentFocused && "border-primary/25 shadow-sm shadow-primary/5",
+			{addComment && (
+				<div className="shrink-0 border-t border-border/25 p-3 space-y-1.5 bg-background/50">
+					{commentFocused && (
+						<div className="flex items-center gap-0.5 rounded-lg border border-border/25 bg-muted/25 px-2 py-1">
+							{[
+								{ icon: Bold, title: "Bold" },
+								{ icon: Italic, title: "Italic" },
+								{ icon: List, title: "List" },
+							].map(({ icon: Icon, title }) => (
+								<button
+									key={title}
+									type="button"
+									title={title}
+									className="flex size-6 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-all duration-150"
+								>
+									<Icon className="size-3" />
+								</button>
+							))}
+							<div className="mx-1 h-3.5 w-px bg-border/30" />
+							{[
+								{ icon: Smile, title: "Emoji" },
+								{ icon: Paperclip, title: "Attach" },
+								{ icon: Hash, title: "Mention" },
+							].map(({ icon: Icon, title }) => (
+								<button
+									key={title}
+									type="button"
+									title={title}
+									className="flex size-6 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-all duration-150"
+								>
+									<Icon className="size-3" />
+								</button>
+							))}
+						</div>
 					)}
-				>
-					<textarea
-						value={comment}
-						onChange={(e) => setComment(e.target.value)}
-						onFocus={() => setCommentFocused(true)}
-						onBlur={() => !comment && setCommentFocused(false)}
-						placeholder="Write a comment…"
-						rows={commentFocused ? 3 : 1}
-						className="flex-1 resize-none bg-transparent text-[13px] outline-none placeholder:text-muted-foreground/50 leading-relaxed"
-						onKeyDown={(e) => {
-							if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
-								handleSend();
-							}
-						}}
-					/>
-					<button
-						type="button"
-						onClick={handleSend}
-						disabled={!comment.trim() || addMutation.isPending}
-						className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground disabled:opacity-40 hover:bg-primary/90 transition-all duration-150 shadow-sm disabled:shadow-none"
+
+					<div
+						className={cn(
+							"flex items-end gap-2 rounded-xl border border-border/30 bg-card/80 px-3 py-2.5 transition-all duration-200",
+							commentFocused && "border-primary/25 shadow-sm shadow-primary/5",
+						)}
 					>
-						<Send className="size-3" />
-					</button>
+						<textarea
+							value={comment}
+							onChange={(e) => setComment(e.target.value)}
+							onFocus={() => setCommentFocused(true)}
+							onBlur={() => !comment && setCommentFocused(false)}
+							placeholder="Write a comment…"
+							rows={commentFocused ? 3 : 1}
+							className="flex-1 resize-none bg-transparent text-[13px] outline-none placeholder:text-muted-foreground/50 leading-relaxed"
+							onKeyDown={(e) => {
+								if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+									handleSend();
+								}
+							}}
+						/>
+						<button
+							type="button"
+							onClick={handleSend}
+							disabled={!comment.trim() || addMutation.isPending}
+							className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground disabled:opacity-40 hover:bg-primary/90 transition-all duration-150 shadow-sm disabled:shadow-none"
+						>
+							<Send className="size-3" />
+						</button>
+					</div>
+					{commentFocused && (
+						<p className="text-[10px] text-muted-foreground/40 text-right pr-1">
+							⌘↵ to send
+						</p>
+					)}
 				</div>
-				{commentFocused && (
-					<p className="text-[10px] text-muted-foreground/40 text-right pr-1">
-						⌘↵ to send
-					</p>
-				)}
-			</div>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectId/tasks/$taskId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/tasks/$taskId.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, ArrowLeft } from "lucide-react";
 
 import { TaskDetailModal } from "@/components/projects/interactions/task-detail-modal";
 import { Skeleton } from "@/components/ui/skeleton";
+import { usePermissions } from "@/hooks/use-permissions";
 import { taskQueryOptions } from "@/lib/interaction-api";
 import {
 	projectMembersQueryOptions,
@@ -96,6 +97,9 @@ function TaskDetailSkeleton() {
 function TaskDetailPage() {
 	const { projectId, taskId } = Route.useParams();
 
+	const { hasPermission } = usePermissions();
+	const canEdit = hasPermission("tasks.write");
+
 	const { data: project } = useQuery(projectQueryOptions(projectId));
 	const { data: taskStatuses = [] } = useQuery(
 		taskStatusesQueryOptions(projectId),
@@ -162,7 +166,7 @@ function TaskDetailPage() {
 					projectName={project?.name}
 					projectId={projectId}
 					mode="page"
-					canEdit
+					canEdit={canEdit}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
This pull request introduces a set of changes to support conditional editing permissions throughout the task detail UI. The main focus is to ensure that UI elements and actions for editing are only available to users with the appropriate permissions, improving both security and user experience. The changes propagate a `canEdit` prop through multiple components and adjust their behaviors accordingly.

**Permission-based UI and logic:**

* Introduced the `usePermissions` hook in `TaskDetailPage` to determine if the user has `"tasks.write"` permission, and passed the resulting `canEdit` boolean down to relevant components. [[1]](diffhunk://#diff-3477d94fae1ba0b2ece0d338730af9814fb6a0035c458873fcc7ae811c9e2657R7) [[2]](diffhunk://#diff-3477d94fae1ba0b2ece0d338730af9814fb6a0035c458873fcc7ae811c9e2657R100-R102) [[3]](diffhunk://#diff-3477d94fae1ba0b2ece0d338730af9814fb6a0035c458873fcc7ae811c9e2657L165-R169)
* Updated `InteractionLayout`, `TaskDetailModal`, and `ActivityPane` to accept and forward the `canEdit` prop, ensuring all child components respect the user's editing permissions. [[1]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR1185) [[2]](diffhunk://#diff-c7ddfeb42ca1bb6f8545ca81ead5cad5847faa5e5566d8e16d81b5f40a9e8be9L387-R387) [[3]](diffhunk://#diff-c7ddfeb42ca1bb6f8545ca81ead5cad5847faa5e5566d8e16d81b5f40a9e8be9L423-R422)

**Component behavior adjustments:**

* Modified `ChecklistsSection` and `DescriptionSection` to show creation and AI writing buttons only if `canEdit` is true, hiding these controls for users without edit permissions. [[1]](diffhunk://#diff-857ca520ccbb6fc7b6859f8f35925b00d9a1547d46744a8f14413bbd9de91861L6-R6) [[2]](diffhunk://#diff-857ca520ccbb6fc7b6859f8f35925b00d9a1547d46744a8f14413bbd9de91861R27) [[3]](diffhunk://#diff-857ca520ccbb6fc7b6859f8f35925b00d9a1547d46744a8f14413bbd9de91861R36) [[4]](diffhunk://#diff-6520e73191a646fd8e022eccdf1e80c0b16a47f6a1062eb4aeb091f07802b218R144-R152)
* Updated the shared `ActivityPane` to make the `addComment` function optional, only enabling comment addition UI and logic if editing is permitted. [[1]](diffhunk://#diff-019ba260c26d226f9fb2949eaa129498c385d1b676397bf47260de4049324171L48-R48) [[2]](diffhunk://#diff-019ba260c26d226f9fb2949eaa129498c385d1b676397bf47260de4049324171L87-R90) [[3]](diffhunk://#diff-019ba260c26d226f9fb2949eaa129498c385d1b676397bf47260de4049324171R141) [[4]](diffhunk://#diff-019ba260c26d226f9fb2949eaa129498c385d1b676397bf47260de4049324171R212)
* Adjusted `TaskActivityPane` to default `canEdit` to true and disable comment addition if the user lacks edit permissions. [[1]](diffhunk://#diff-07d735d4af9500a5e4aaed82e3db2ecf818b8c1b2d75700f4f27c32e98be5fb5R22-R25) [[2]](diffhunk://#diff-07d735d4af9500a5e4aaed82e3db2ecf818b8c1b2d75700f4f27c32e98be5fb5L103-R104)

These changes collectively ensure that editing capabilities are consistently gated by user permissions across the task detail interface.