### PR TITLE
Feature/enhance plugin view

### DIFF
--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -1315,11 +1315,12 @@ export function AppSidebar() {
 						<SidebarSeparator />
 						<DocsSidebarSection projectId={projectId} />
 						<SidebarSeparator />
-						<ProjectNavItems projectId={projectId} isAnonymous={isAnonymous} />
 						<ExtensionPoint
 							point="sidebar.project.section"
 							componentProps={{ projectId }}
 						/>
+						<SidebarSeparator />
+						<ProjectNavItems projectId={projectId} isAnonymous={isAnonymous} />
 					</>
 				) : (
 					<>

--- a/apps/web/src/components/plugins/PluginPreferencesPanel.tsx
+++ b/apps/web/src/components/plugins/PluginPreferencesPanel.tsx
@@ -63,9 +63,9 @@ function DraggableItem({
 		>
 			<GripVertical className="size-4 text-muted-foreground/40 shrink-0 cursor-grab active:cursor-grabbing" />
 			<div className="flex-1 min-w-0">
-				<p className="text-sm font-medium truncate">{reg.pluginName}</p>
+				<p className="text-sm font-medium truncate">{reg.label}</p>
 				<p className="text-xs text-muted-foreground truncate">
-					{EXTENSION_POINT_LABELS[point]}
+					{reg.pluginName} · {EXTENSION_POINT_LABELS[point]}
 				</p>
 			</div>
 			<button

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -409,7 +409,7 @@ export function InteractionLayout({
 		activeView?.layout === "Plugin"
 			? (pluginViewRegistrations.find(
 					(r) =>
-						r.pluginId === activeView.config?.plugin_id &&
+						r.pluginId === activeView.config?.plugin_manifest_id &&
 						r.component === activeView.config?.plugin_component,
 				) ?? null)
 			: null;
@@ -804,7 +804,7 @@ export function InteractionLayout({
 			const config =
 				payload.layout === "Plugin" && payload.pluginRegistration
 					? {
-							plugin_id: payload.pluginRegistration.pluginId,
+							plugin_manifest_id: payload.pluginRegistration.pluginId,
 							plugin_component: payload.pluginRegistration.component,
 						}
 					: buildDefaultViewConfig(payload.layout);

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -12,6 +12,7 @@ import {
 	List,
 	Map as MapIcon,
 	Plus,
+	Puzzle,
 	Search,
 	X,
 } from "lucide-react";
@@ -52,6 +53,7 @@ import {
 	viewTaskPositionsQueryOptions,
 } from "@/lib/interaction-api";
 import { RemoteComponent } from "@/lib/plugins/loader";
+import type { PluginRegistration } from "@/lib/plugin-api";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 import {
 	customFieldsQueryOptions,
@@ -355,6 +357,7 @@ export function InteractionLayout({
 		if (!viewsQuery.isSuccess || defaultPageTaskTypeIds.length === 0) return;
 		const uninitializedViews = serverViews.filter(
 			(view) =>
+				view.layout !== "Plugin" &&
 				!initializedFiltersRef.current.has(view.id) &&
 				view.config?.filters === undefined,
 		);
@@ -395,17 +398,21 @@ export function InteractionLayout({
 	const activeView = views.find((v) => v.id === preferredViewId) ?? views[0];
 	const activeViewId = activeView?.id ?? "";
 
-	// Plugin views (from the `view` extension point)
+	// Plugin view registrations (for the "Add view" popover layout options)
 	const { getRegistrations } = usePluginRegistry();
-	const pluginViews = getRegistrations("view").filter((r) => !r.hidden);
-	const [activePluginViewId, setActivePluginViewId] = useState<string | null>(
-		null,
+	const pluginViewRegistrations = getRegistrations("view").filter(
+		(r) => !r.hidden,
 	);
-	// Resolve the active plugin view registration using composite key
+
+	// If the active view is a plugin view, resolve its registration from config
 	const activePluginView =
-		pluginViews.find(
-			(r) => `${r.pluginId}:${r.component}` === activePluginViewId,
-		) ?? null;
+		activeView?.layout === "Plugin"
+			? (pluginViewRegistrations.find(
+					(r) =>
+						r.pluginId === activeView.config?.plugin_id &&
+						r.component === activeView.config?.plugin_component,
+				) ?? null)
+			: null;
 
 	useEffect(() => {
 		if (!activeViewId) return;
@@ -788,9 +795,19 @@ export function InteractionLayout({
 	);
 
 	const createViewMutation = useMutation({
-		mutationFn: (payload: { name: string; layout: ViewLayout }) => {
+		mutationFn: (payload: {
+			name: string;
+			layout: ViewLayout;
+			pluginRegistration?: PluginRegistration;
+		}) => {
 			const view_type = layoutToViewType(payload.layout);
-			const config = buildDefaultViewConfig(payload.layout);
+			const config =
+				payload.layout === "Plugin" && payload.pluginRegistration
+					? {
+							plugin_id: payload.pluginRegistration.pluginId,
+							plugin_component: payload.pluginRegistration.component,
+						}
+					: buildDefaultViewConfig(payload.layout);
 			return createViewByContext(
 				projectId,
 				context,
@@ -964,7 +981,6 @@ export function InteractionLayout({
 									type="button"
 									onClick={() => {
 										setPreferredViewId(view.id);
-										setActivePluginViewId(null);
 									}}
 									className={cn(
 										"flex items-center gap-1.5 px-2.5 py-2.5 text-[12px] font-medium transition-all duration-150",
@@ -977,6 +993,8 @@ export function InteractionLayout({
 										<KanbanSquare className="size-3.5" />
 									) : view.layout === "Roadmap" ? (
 										<MapIcon className="size-3.5" />
+									) : view.layout === "Plugin" ? (
+										<Puzzle className="size-3.5" />
 									) : (
 										<List className="size-3.5" />
 									)}
@@ -1021,33 +1039,13 @@ export function InteractionLayout({
 
 					{canManageViews && (
 						<NewViewPopover
-							onSubmit={(name, layout) =>
-								createViewMutation.mutateAsync({ name, layout })
+							onSubmit={(name, layout, pluginRegistration) =>
+								createViewMutation.mutateAsync({ name, layout, pluginRegistration })
 							}
 							isPending={createViewMutation.isPending}
+							pluginRegistrations={pluginViewRegistrations}
 						/>
 					)}
-					{/* Plugin view tabs */}
-					{pluginViews.map((reg) => {
-						const viewKey = `${reg.pluginId}:${reg.component}`;
-						return (
-							<button
-								key={viewKey}
-								type="button"
-								onClick={() => {
-									setActivePluginViewId(viewKey);
-									setPreferredViewId("");
-								}}
-								className={`flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium transition-all duration-150 ${
-									activePluginViewId === viewKey
-										? "bg-accent text-foreground"
-										: "text-muted-foreground hover:text-foreground hover:bg-muted/60"
-								}`}
-							>
-								{reg.pluginName}
-							</button>
-						);
-					})}
 				</div>
 
 				<div className="flex shrink-0 items-center gap-1 pl-3 border-l border-border/25 ml-2">
@@ -1088,7 +1086,7 @@ export function InteractionLayout({
 						</button>
 					)}
 
-					{activeView && (
+					{activeView && activeView.layout !== "Plugin" && (
 						<ViewSettingsPanel
 							projectId={projectId}
 							view={activeView}
@@ -1121,6 +1119,10 @@ export function InteractionLayout({
 							onTaskClick: handleTaskClick,
 						}}
 					/>
+				) : activeView?.layout === "Plugin" ? (
+					<div className="flex flex-1 items-center justify-center text-muted-foreground text-sm">
+						Plugin not available
+					</div>
 				) : tasksLoading ? (
 					activeView?.layout === "Board" ? (
 						<BoardViewSkeleton />

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -52,8 +52,8 @@ import {
 	viewsByContextQueryOptions,
 	viewTaskPositionsQueryOptions,
 } from "@/lib/interaction-api";
-import { RemoteComponent } from "@/lib/plugins/loader";
 import type { PluginRegistration } from "@/lib/plugin-api";
+import { RemoteComponent } from "@/lib/plugins/loader";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 import {
 	customFieldsQueryOptions,
@@ -1040,7 +1040,11 @@ export function InteractionLayout({
 					{canManageViews && (
 						<NewViewPopover
 							onSubmit={(name, layout, pluginRegistration) =>
-								createViewMutation.mutateAsync({ name, layout, pluginRegistration })
+								createViewMutation.mutateAsync({
+									name,
+									layout,
+									pluginRegistration,
+								})
 							}
 							isPending={createViewMutation.isPending}
 							pluginRegistrations={pluginViewRegistrations}

--- a/apps/web/src/components/projects/interactions/new-view-popover.tsx
+++ b/apps/web/src/components/projects/interactions/new-view-popover.tsx
@@ -1,4 +1,4 @@
-import { KanbanSquare, List, Map as MapIcon, Plus } from "lucide-react";
+import { KanbanSquare, List, Map as MapIcon, Plus, Puzzle } from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -6,13 +6,25 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import type { PluginRegistration } from "@/lib/plugin-api";
 import type { ViewLayout } from "@/lib/interaction-api";
 import { cn } from "@/lib/utils";
 
 interface NewViewPopoverProps {
-	onSubmit: (name: string, layout: ViewLayout) => Promise<unknown>;
+	onSubmit: (
+		name: string,
+		layout: ViewLayout,
+		pluginRegistration?: PluginRegistration,
+	) => Promise<unknown>;
 	isPending?: boolean;
+	pluginRegistrations?: PluginRegistration[];
 }
+
+type LayoutOption =
+	| { type: "builtin"; layout: ViewLayout }
+	| { type: "plugin"; registration: PluginRegistration };
+
+const builtinLayouts: ViewLayout[] = ["Board", "Table", "Roadmap"];
 
 const layoutIcon = (l: ViewLayout) => {
 	if (l === "Board") return <KanbanSquare className="size-3.5" />;
@@ -20,13 +32,33 @@ const layoutIcon = (l: ViewLayout) => {
 	return <List className="size-3.5" />;
 };
 
-export function NewViewPopover({ onSubmit, isPending }: NewViewPopoverProps) {
+export function NewViewPopover({
+	onSubmit,
+	isPending,
+	pluginRegistrations = [],
+}: NewViewPopoverProps) {
 	const [open, setOpen] = useState(false);
 	const [name, setName] = useState("");
-	const [layout, setLayout] = useState<ViewLayout>("Board");
+	const [selected, setSelected] = useState<LayoutOption>({
+		type: "builtin",
+		layout: "Board",
+	});
+
+	const activeLabel =
+		selected.type === "builtin"
+			? selected.layout
+			: selected.registration.pluginName;
 
 	const submit = async () => {
-		await onSubmit(name || `New ${layout}`, layout);
+		if (selected.type === "builtin") {
+			await onSubmit(name || `New ${selected.layout}`, selected.layout);
+		} else {
+			await onSubmit(
+				name || `New ${selected.registration.pluginName}`,
+				"Plugin",
+				selected.registration,
+			);
+		}
 		setName("");
 		setOpen(false);
 	};
@@ -48,7 +80,7 @@ export function NewViewPopover({ onSubmit, isPending }: NewViewPopoverProps) {
 			<PopoverContent
 				side="bottom"
 				align="end"
-				className="w-64 p-0 gap-0 rounded-xl border border-border/40 shadow-lg"
+				className="w-72 p-0 gap-0 rounded-xl border border-border/40 shadow-lg"
 				sideOffset={6}
 			>
 				<div className="px-3 py-2.5 border-b border-border/30">
@@ -69,7 +101,7 @@ export function NewViewPopover({ onSubmit, isPending }: NewViewPopoverProps) {
 							value={name}
 							onChange={(e) => setName(e.target.value)}
 							onKeyDown={(e) => e.key === "Enter" && submit()}
-							placeholder={`New ${layout}`}
+							placeholder={`New ${activeLabel}`}
 							className="w-full rounded-lg border border-border/30 bg-muted/15 px-3 py-2 text-[13px] font-medium outline-none focus:border-primary/40 focus:ring-2 focus:ring-primary/15 placeholder:text-muted-foreground/50 transition-all duration-150"
 						/>
 					</div>
@@ -77,23 +109,52 @@ export function NewViewPopover({ onSubmit, isPending }: NewViewPopoverProps) {
 						<p className="text-[12px] font-medium text-muted-foreground">
 							Layout
 						</p>
-						<div className="flex gap-2">
-							{(["Board", "Table", "Roadmap"] as ViewLayout[]).map((l) => (
-								<button
-									key={l}
-									type="button"
-									onClick={() => setLayout(l)}
-									className={cn(
-										"flex flex-1 items-center justify-center gap-1.5 rounded-lg border py-2 text-[12px] font-medium transition-all duration-150",
-										layout === l
-											? "border-primary/40 bg-primary/8 text-primary"
-											: "border-border/25 text-muted-foreground/70 hover:text-foreground hover:border-border/40",
-									)}
-								>
-									{layoutIcon(l)}
-									{l}
-								</button>
-							))}
+						<div className="flex flex-wrap gap-2">
+							{builtinLayouts.map((l) => {
+								const isActive =
+									selected.type === "builtin" && selected.layout === l;
+								return (
+									<button
+										key={l}
+										type="button"
+										onClick={() => setSelected({ type: "builtin", layout: l })}
+										className={cn(
+											"flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-[12px] font-medium transition-all duration-150",
+											isActive
+												? "border-primary/40 bg-primary/8 text-primary"
+												: "border-border/25 text-muted-foreground/70 hover:text-foreground hover:border-border/40",
+										)}
+									>
+										{layoutIcon(l)}
+										{l}
+									</button>
+								);
+							})}
+							{pluginRegistrations.map((reg) => {
+								const key = `${reg.pluginId}:${reg.component}`;
+								const isActive =
+									selected.type === "plugin" &&
+									`${selected.registration.pluginId}:${selected.registration.component}` ===
+										key;
+								return (
+									<button
+										key={key}
+										type="button"
+										onClick={() =>
+											setSelected({ type: "plugin", registration: reg })
+										}
+										className={cn(
+											"flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-[12px] font-medium transition-all duration-150",
+											isActive
+												? "border-primary/40 bg-primary/8 text-primary"
+												: "border-border/25 text-muted-foreground/70 hover:text-foreground hover:border-border/40",
+										)}
+									>
+										<Puzzle className="size-3.5" />
+										{reg.pluginName}
+									</button>
+								);
+							})}
 						</div>
 					</div>
 					<button

--- a/apps/web/src/components/projects/interactions/new-view-popover.tsx
+++ b/apps/web/src/components/projects/interactions/new-view-popover.tsx
@@ -45,9 +45,7 @@ export function NewViewPopover({
 	});
 
 	const activeLabel =
-		selected.type === "builtin"
-			? selected.layout
-			: selected.registration.label;
+		selected.type === "builtin" ? selected.layout : selected.registration.label;
 
 	const submit = async () => {
 		if (selected.type === "builtin") {

--- a/apps/web/src/components/projects/interactions/new-view-popover.tsx
+++ b/apps/web/src/components/projects/interactions/new-view-popover.tsx
@@ -47,14 +47,14 @@ export function NewViewPopover({
 	const activeLabel =
 		selected.type === "builtin"
 			? selected.layout
-			: selected.registration.pluginName;
+			: selected.registration.label;
 
 	const submit = async () => {
 		if (selected.type === "builtin") {
 			await onSubmit(name || `New ${selected.layout}`, selected.layout);
 		} else {
 			await onSubmit(
-				name || `New ${selected.registration.pluginName}`,
+				name || `New ${selected.registration.label}`,
 				"Plugin",
 				selected.registration,
 			);
@@ -151,7 +151,7 @@ export function NewViewPopover({
 										)}
 									>
 										<Puzzle className="size-3.5" />
-										{reg.pluginName}
+										{reg.label}
 									</button>
 								);
 							})}

--- a/apps/web/src/components/projects/interactions/new-view-popover.tsx
+++ b/apps/web/src/components/projects/interactions/new-view-popover.tsx
@@ -6,8 +6,8 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
-import type { PluginRegistration } from "@/lib/plugin-api";
 import type { ViewLayout } from "@/lib/interaction-api";
+import type { PluginRegistration } from "@/lib/plugin-api";
 import { cn } from "@/lib/utils";
 
 interface NewViewPopoverProps {

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -381,14 +381,6 @@ export function TaskDetailModal({
 							/>
 						)}
 
-						{/* Checklists are now provided by the com.paca.checklist plugin */}
-						{/* Attachments */}
-						<AttachmentsSection
-							projectId={projectId ?? ""}
-							taskId={task.id}
-							canEdit={canEdit}
-						/>
-
 						{/* Branches */}
 						{projectId && hasLinkedRepo && (
 							<BranchesSection
@@ -417,6 +409,13 @@ export function TaskDetailModal({
 								componentProps={{ projectId, taskId: task.id, canEdit }}
 							/>
 						)}
+
+						{/* Attachments */}
+						<AttachmentsSection
+							projectId={projectId ?? ""}
+							taskId={task.id}
+							canEdit={canEdit}
+						/>
 
 						{/* Bottom breathing room */}
 						<div className="h-8" />

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -66,7 +66,7 @@ interface TaskPositionListResult {
 }
 
 // ── View types ─────────────────────────────────────────────────────────────────
-export type ViewType = "table" | "board" | "roadmap";
+export type ViewType = "table" | "board" | "roadmap" | "plugin";
 
 /**
  * A single entry in a FilterConfig's `items` map.
@@ -112,9 +112,12 @@ export interface ViewConfig {
 	field_sum?: string;
 	slice_by?: string;
 	filters?: ViewFilters;
+	/** Populated only for plugin views (view_type = "plugin") */
+	plugin_id?: string;
+	plugin_component?: string;
 }
 
-export type ViewLayout = "Board" | "Table" | "Roadmap";
+export type ViewLayout = "Board" | "Table" | "Roadmap" | "Plugin";
 
 // ── Filter resolver helpers ───────────────────────────────────────────────────
 
@@ -190,12 +193,14 @@ export interface InteractionView {
 function viewTypeToLayout(vt: ViewType): ViewLayout {
 	if (vt === "board") return "Board";
 	if (vt === "roadmap") return "Roadmap";
+	if (vt === "plugin") return "Plugin";
 	return "Table";
 }
 
 export function layoutToViewType(l: ViewLayout): ViewType {
 	if (l === "Board") return "board";
 	if (l === "Roadmap") return "roadmap";
+	if (l === "Plugin") return "plugin";
 	return "table";
 }
 

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -113,7 +113,7 @@ export interface ViewConfig {
 	slice_by?: string;
 	filters?: ViewFilters;
 	/** Populated only for plugin views (view_type = "plugin") */
-	plugin_id?: string;
+	plugin_manifest_id?: string;
 	plugin_component?: string;
 }
 

--- a/apps/web/src/lib/plugin-api.ts
+++ b/apps/web/src/lib/plugin-api.ts
@@ -17,6 +17,7 @@ export interface BackendManifest {
 export interface ExtensionPointRegistration {
 	point: string;
 	component: string;
+	label?: string;
 	order?: number;
 }
 
@@ -98,6 +99,8 @@ export interface PluginRegistration {
 	pluginUUID: string; // The database UUID for API calls
 	pluginId: string; // The reverse-DNS identifier (e.g., "com.paca.checklist")
 	pluginName: string;
+	/** Per-registration display label from the manifest; falls back to component name. */
+	label: string;
 	remoteEntryUrl: string;
 	component: string;
 	order: number;
@@ -123,6 +126,7 @@ export function buildRegistryMap(
 				pluginUUID: plugin.id, // UUID for API calls
 				pluginId: plugin.manifest.id, // reverse-DNS for display/keys
 				pluginName: plugin.manifest.displayName,
+				label: reg.label ?? reg.component,
 				remoteEntryUrl,
 				component: reg.component,
 				order: reg.order ?? 0,

--- a/deploy/nginx/gateway.conf
+++ b/deploy/nginx/gateway.conf
@@ -227,11 +227,7 @@ server {
         }
 
         # Fingerprinted assets can be cached immutably for a long time.
-        # This applies to all files except remoteEntry.js (handled above).
         add_header Cache-Control "public, max-age=900, immutable" always;
-        # Fingerprinted assets may be served from a CDN later; keep CORS open
-        # for remoteEntry.js loaded by the host shell across origins.
-        add_header Access-Control-Allow-Origin "*" always;
     }
 
     # -- Web application (SPA) ------------------------------------------------

--- a/deploy/nginx/gateway.conf
+++ b/deploy/nginx/gateway.conf
@@ -226,17 +226,9 @@ server {
             font/woff2              woff2;
         }
 
-        # remoteEntry.js must update promptly when plugins are upgraded.
-        # Use short TTL without immutable for this non-fingerprinted entrypoint.
-        location ~ /remoteEntry\.js$ {
-            alias /var/www/plugins/;
-            add_header Cache-Control "public, max-age=300" always;  # 5 minutes
-            add_header Access-Control-Allow-Origin "*" always;
-        }
-
         # Fingerprinted assets can be cached immutably for a long time.
         # This applies to all files except remoteEntry.js (handled above).
-        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        add_header Cache-Control "public, max-age=900, immutable" always;
         # Fingerprinted assets may be served from a CDN later; keep CORS open
         # for remoteEntry.js loaded by the host shell across origins.
         add_header Access-Control-Allow-Origin "*" always;

--- a/deploy/nginx/gateway.conf
+++ b/deploy/nginx/gateway.conf
@@ -226,9 +226,17 @@ server {
             font/woff2              woff2;
         }
 
+        # remoteEntry.js must update promptly when plugins are upgraded.
+        # Use short TTL without immutable for this non-fingerprinted entrypoint.
+        location ~ /remoteEntry\.js$ {
+            alias /var/www/plugins/;
+            add_header Cache-Control "public, max-age=300" always;  # 5 minutes
+            add_header Access-Control-Allow-Origin "*" always;
+        }
+
         # Fingerprinted assets can be cached immutably for a long time.
         # This applies to all files except remoteEntry.js (handled above).
-        add_header Cache-Control "public, max-age=900, immutable" always;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
         # Fingerprinted assets may be served from a CDN later; keep CORS open
         # for remoteEntry.js loaded by the host shell across origins.
         add_header Access-Control-Allow-Origin "*" always;

--- a/deploy/nginx/gateway.conf
+++ b/deploy/nginx/gateway.conf
@@ -226,17 +226,9 @@ server {
             font/woff2              woff2;
         }
 
-        # remoteEntry.js must update promptly when plugins are upgraded.
-        # Use short TTL for non-fingerprinted entrypoints.
-        location ~ /remoteEntry\.js$ {
-            alias /var/www/plugins/;
-            add_header Cache-Control "public, max-age=300" always;  # 5 minutes
-            add_header Access-Control-Allow-Origin "*" always;
-        }
-
         # Fingerprinted assets can be cached immutably for a long time.
         # This applies to all files except remoteEntry.js (handled above).
-        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        add_header Cache-Control "public, max-age=900, immutable" always;
         # Fingerprinted assets may be served from a CDN later; keep CORS open
         # for remoteEntry.js loaded by the host shell across origins.
         add_header Access-Control-Allow-Origin "*" always;

--- a/docs/api/http-design.md
+++ b/docs/api/http-design.md
@@ -644,6 +644,15 @@ Error codes:
 
 ## Sprint View Contracts
 
+Plugin view config identifier note:
+
+- In view `config`, `plugin_manifest_id` is the canonical plugin identifier for
+  `view_type = "plugin"`; it uses the manifest reverse-DNS format (for example
+  `com.paca.checklist`).
+- `plugin_component` identifies the frontend component export to render.
+- This is distinct from plugin-extension-settings APIs where `plugin_id` means
+  the plugin UUID.
+
 ### `GET /api/v1/projects/:projectId/sprints/:sprintId/views`
 
 Function:

--- a/docs/architecture/interaction-views.md
+++ b/docs/architecture/interaction-views.md
@@ -87,6 +87,17 @@ Each view stores both presentation settings and reusable filters.
 }
 ```
 
+For plugin views (`view_type = "plugin"`), config also includes:
+
+```json
+{
+  "plugin_manifest_id": "com.paca.checklist",
+  "plugin_component": "KanbanByPriority"
+}
+```
+
+`plugin_manifest_id` is the plugin manifest reverse-DNS identifier.
+
 ### Rule of thumb
 
 - **Presentation** belongs in top-level config keys such as `column_by`, `sort_by`, and `slice_by`

--- a/services/api/internal/domain/sprint/entity.go
+++ b/services/api/internal/domain/sprint/entity.go
@@ -66,6 +66,7 @@ const (
 	ViewTypeTable   ViewType = "table"
 	ViewTypeBoard   ViewType = "board"
 	ViewTypeRoadmap ViewType = "roadmap"
+	ViewTypePlugin  ViewType = "plugin"
 )
 
 // ValidViewTypes is the set of allowed view_type values.
@@ -73,6 +74,7 @@ var ValidViewTypes = map[ViewType]bool{
 	ViewTypeTable:   true,
 	ViewTypeBoard:   true,
 	ViewTypeRoadmap: true,
+	ViewTypePlugin:  true,
 }
 
 // FilterEntry is a discriminated union stored inside a FilterConfig's Items
@@ -168,6 +170,9 @@ type ViewConfig struct {
 	FieldSum  string       `json:"field_sum,omitempty"`
 	SliceBy   string       `json:"slice_by,omitempty"`
 	Filters   *ViewFilters `json:"filters,omitempty"`
+	// Plugin view fields (only set when view_type = "plugin")
+	PluginID        string `json:"plugin_id,omitempty"`
+	PluginComponent string `json:"plugin_component,omitempty"`
 }
 
 // SprintView is a named, persisted view configuration for a sprint,

--- a/services/api/internal/domain/sprint/entity.go
+++ b/services/api/internal/domain/sprint/entity.go
@@ -171,6 +171,8 @@ type ViewConfig struct {
 	SliceBy   string       `json:"slice_by,omitempty"`
 	Filters   *ViewFilters `json:"filters,omitempty"`
 	// Plugin view fields (only set when view_type = "plugin")
+	// PluginID stores the plugin manifest identifier (reverse-DNS), not the
+	// plugin UUID used by plugin-extension-settings APIs.
 	PluginID        string `json:"plugin_id,omitempty"`
 	PluginComponent string `json:"plugin_component,omitempty"`
 }

--- a/services/api/internal/transport/http/dto/view_dto.go
+++ b/services/api/internal/transport/http/dto/view_dto.go
@@ -32,15 +32,17 @@ type ViewFiltersDTO = sprintdom.ViewFilters
 
 // ViewConfigDTO is the JSON representation of sprintdom.ViewConfig.
 type ViewConfigDTO struct {
-	Fields          []string        `json:"fields,omitempty"`
-	ColumnBy        string          `json:"column_by,omitempty"`
-	Swimlanes       string          `json:"swimlanes,omitempty"`
-	SortBy          string          `json:"sort_by,omitempty"`
-	FieldSum        string          `json:"field_sum,omitempty"`
-	SliceBy         string          `json:"slice_by,omitempty"`
-	Filters         *ViewFiltersDTO `json:"filters,omitempty"`
-	PluginID        string          `json:"plugin_id,omitempty"`
-	PluginComponent string          `json:"plugin_component,omitempty"`
+	Fields    []string        `json:"fields,omitempty"`
+	ColumnBy  string          `json:"column_by,omitempty"`
+	Swimlanes string          `json:"swimlanes,omitempty"`
+	SortBy    string          `json:"sort_by,omitempty"`
+	FieldSum  string          `json:"field_sum,omitempty"`
+	SliceBy   string          `json:"slice_by,omitempty"`
+	Filters   *ViewFiltersDTO `json:"filters,omitempty"`
+	// PluginManifestID is the reverse-DNS plugin manifest identifier
+	// (for example "com.paca.checklist").
+	PluginManifestID string `json:"plugin_manifest_id,omitempty"`
+	PluginComponent  string `json:"plugin_component,omitempty"`
 }
 
 // ViewResponse is the public representation of a sprint view.
@@ -65,15 +67,15 @@ func ViewFromEntity(v *sprintdom.SprintView) ViewResponse {
 		Name:      v.Name,
 		ViewType:  v.ViewType,
 		Config: ViewConfigDTO{
-			Fields:          v.Config.Fields,
-			ColumnBy:        v.Config.ColumnBy,
-			Swimlanes:       v.Config.Swimlanes,
-			SortBy:          v.Config.SortBy,
-			FieldSum:        v.Config.FieldSum,
-			SliceBy:         v.Config.SliceBy,
-			Filters:         v.Config.Filters,
-			PluginID:        v.Config.PluginID,
-			PluginComponent: v.Config.PluginComponent,
+			Fields:           v.Config.Fields,
+			ColumnBy:         v.Config.ColumnBy,
+			Swimlanes:        v.Config.Swimlanes,
+			SortBy:           v.Config.SortBy,
+			FieldSum:         v.Config.FieldSum,
+			SliceBy:          v.Config.SliceBy,
+			Filters:          v.Config.Filters,
+			PluginManifestID: v.Config.PluginID,
+			PluginComponent:  v.Config.PluginComponent,
 		},
 		Position:  v.Position,
 		CreatedAt: v.CreatedAt,
@@ -94,7 +96,7 @@ func toViewConfig(d *ViewConfigDTO) sprintdom.ViewConfig {
 		FieldSum:        d.FieldSum,
 		SliceBy:         d.SliceBy,
 		Filters:         d.Filters,
-		PluginID:        d.PluginID,
+		PluginID:        d.PluginManifestID,
 		PluginComponent: d.PluginComponent,
 	}
 }

--- a/services/api/internal/transport/http/dto/view_dto.go
+++ b/services/api/internal/transport/http/dto/view_dto.go
@@ -32,13 +32,15 @@ type ViewFiltersDTO = sprintdom.ViewFilters
 
 // ViewConfigDTO is the JSON representation of sprintdom.ViewConfig.
 type ViewConfigDTO struct {
-	Fields    []string        `json:"fields,omitempty"`
-	ColumnBy  string          `json:"column_by,omitempty"`
-	Swimlanes string          `json:"swimlanes,omitempty"`
-	SortBy    string          `json:"sort_by,omitempty"`
-	FieldSum  string          `json:"field_sum,omitempty"`
-	SliceBy   string          `json:"slice_by,omitempty"`
-	Filters   *ViewFiltersDTO `json:"filters,omitempty"`
+	Fields          []string        `json:"fields,omitempty"`
+	ColumnBy        string          `json:"column_by,omitempty"`
+	Swimlanes       string          `json:"swimlanes,omitempty"`
+	SortBy          string          `json:"sort_by,omitempty"`
+	FieldSum        string          `json:"field_sum,omitempty"`
+	SliceBy         string          `json:"slice_by,omitempty"`
+	Filters         *ViewFiltersDTO `json:"filters,omitempty"`
+	PluginID        string          `json:"plugin_id,omitempty"`
+	PluginComponent string          `json:"plugin_component,omitempty"`
 }
 
 // ViewResponse is the public representation of a sprint view.
@@ -63,13 +65,15 @@ func ViewFromEntity(v *sprintdom.SprintView) ViewResponse {
 		Name:      v.Name,
 		ViewType:  v.ViewType,
 		Config: ViewConfigDTO{
-			Fields:    v.Config.Fields,
-			ColumnBy:  v.Config.ColumnBy,
-			Swimlanes: v.Config.Swimlanes,
-			SortBy:    v.Config.SortBy,
-			FieldSum:  v.Config.FieldSum,
-			SliceBy:   v.Config.SliceBy,
-			Filters:   v.Config.Filters,
+			Fields:          v.Config.Fields,
+			ColumnBy:        v.Config.ColumnBy,
+			Swimlanes:       v.Config.Swimlanes,
+			SortBy:          v.Config.SortBy,
+			FieldSum:        v.Config.FieldSum,
+			SliceBy:         v.Config.SliceBy,
+			Filters:         v.Config.Filters,
+			PluginID:        v.Config.PluginID,
+			PluginComponent: v.Config.PluginComponent,
 		},
 		Position:  v.Position,
 		CreatedAt: v.CreatedAt,
@@ -83,13 +87,15 @@ func toViewConfig(d *ViewConfigDTO) sprintdom.ViewConfig {
 		return sprintdom.ViewConfig{}
 	}
 	return sprintdom.ViewConfig{
-		Fields:    d.Fields,
-		ColumnBy:  d.ColumnBy,
-		Swimlanes: d.Swimlanes,
-		SortBy:    d.SortBy,
-		FieldSum:  d.FieldSum,
-		SliceBy:   d.SliceBy,
-		Filters:   d.Filters,
+		Fields:          d.Fields,
+		ColumnBy:        d.ColumnBy,
+		Swimlanes:       d.Swimlanes,
+		SortBy:          d.SortBy,
+		FieldSum:        d.FieldSum,
+		SliceBy:         d.SliceBy,
+		Filters:         d.Filters,
+		PluginID:        d.PluginID,
+		PluginComponent: d.PluginComponent,
 	}
 }
 

--- a/services/api/internal/transport/http/dto/view_dto_test.go
+++ b/services/api/internal/transport/http/dto/view_dto_test.go
@@ -134,8 +134,8 @@ func TestViewFromEntity_PluginConfigRoundtrip(t *testing.T) {
 
 	resp := dto.ViewFromEntity(entity)
 
-	if resp.Config.PluginID != entity.Config.PluginID {
-		t.Errorf("PluginID: want %q, got %q", entity.Config.PluginID, resp.Config.PluginID)
+	if resp.Config.PluginManifestID != entity.Config.PluginID {
+		t.Errorf("PluginManifestID: want %q, got %q", entity.Config.PluginID, resp.Config.PluginManifestID)
 	}
 	if resp.Config.PluginComponent != entity.Config.PluginComponent {
 		t.Errorf("PluginComponent: want %q, got %q", entity.Config.PluginComponent, resp.Config.PluginComponent)
@@ -216,8 +216,8 @@ func TestCreateViewRequest_ToCreateInput_PluginConfigRoundtrip(t *testing.T) {
 		Name:     "Plugin View",
 		ViewType: sprintdom.ViewTypePlugin,
 		Config: &dto.ViewConfigDTO{
-			PluginID:        pluginID,
-			PluginComponent: "KanbanByPriority",
+			PluginManifestID: pluginID,
+			PluginComponent:  "KanbanByPriority",
 		},
 	}
 

--- a/services/api/internal/transport/http/dto/view_dto_test.go
+++ b/services/api/internal/transport/http/dto/view_dto_test.go
@@ -118,6 +118,30 @@ func TestViewFromEntity_NilFilters(t *testing.T) {
 	}
 }
 
+// TestViewFromEntity_PluginConfigRoundtrip verifies plugin fields are copied
+// from domain config to DTO config.
+func TestViewFromEntity_PluginConfigRoundtrip(t *testing.T) {
+	entity := &sprintdom.SprintView{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+		Name:      "Plugin View",
+		ViewType:  sprintdom.ViewTypePlugin,
+		Config: sprintdom.ViewConfig{
+			PluginID:        uuid.NewString(),
+			PluginComponent: "KanbanByPriority",
+		},
+	}
+
+	resp := dto.ViewFromEntity(entity)
+
+	if resp.Config.PluginID != entity.Config.PluginID {
+		t.Errorf("PluginID: want %q, got %q", entity.Config.PluginID, resp.Config.PluginID)
+	}
+	if resp.Config.PluginComponent != entity.Config.PluginComponent {
+		t.Errorf("PluginComponent: want %q, got %q", entity.Config.PluginComponent, resp.Config.PluginComponent)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // toViewConfig (via CreateViewRequest / UpdateViewRequest) roundtrip
 // ---------------------------------------------------------------------------
@@ -178,6 +202,32 @@ func TestCreateViewRequest_ToCreateInput_FiltersRoundtrip(t *testing.T) {
 	sprintEntry, ok := f.Sprints.Items[sprintID.String()]
 	if !ok || !sprintEntry.Flag() {
 		t.Errorf("expected sprint entry to be included, got %+v", sprintEntry)
+	}
+}
+
+// TestCreateViewRequest_ToCreateInput_PluginConfigRoundtrip verifies plugin
+// fields are copied from DTO config to domain config through toViewConfig.
+func TestCreateViewRequest_ToCreateInput_PluginConfigRoundtrip(t *testing.T) {
+	sprintID := uuid.New()
+	projectID := uuid.New()
+	pluginID := uuid.NewString()
+
+	req := dto.CreateViewRequest{
+		Name:     "Plugin View",
+		ViewType: sprintdom.ViewTypePlugin,
+		Config: &dto.ViewConfigDTO{
+			PluginID:        pluginID,
+			PluginComponent: "KanbanByPriority",
+		},
+	}
+
+	input := req.ToCreateInput(sprintID, projectID)
+
+	if input.Config.PluginID != pluginID {
+		t.Errorf("PluginID: want %q, got %q", pluginID, input.Config.PluginID)
+	}
+	if input.Config.PluginComponent != "KanbanByPriority" {
+		t.Errorf("PluginComponent: want %q, got %q", "KanbanByPriority", input.Config.PluginComponent)
 	}
 }
 

--- a/services/api/internal/transport/http/handler/sprint_handler_test.go
+++ b/services/api/internal/transport/http/handler/sprint_handler_test.go
@@ -188,8 +188,8 @@ func TestCreateSprint_SeedsDefaultViews(t *testing.T) {
 			boardView = v
 		case sprintdom.ViewTypeTable:
 			tableView = v
-		case sprintdom.ViewTypeRoadmap:
-			// roadmap views are not seeded for sprint defaults
+		case sprintdom.ViewTypeRoadmap, sprintdom.ViewTypePlugin:
+			// roadmap and plugin views are not seeded for sprint defaults
 		}
 	}
 	if boardView == nil || tableView == nil {

--- a/services/api/migrations/000006_add_plugin_view_type.sql
+++ b/services/api/migrations/000006_add_plugin_view_type.sql
@@ -1,0 +1,14 @@
+-- 000006_add_plugin_view_type.sql
+-- Extends the sprint_views.view_type CHECK constraint to allow 'plugin' as a valid view type.
+-- Plugin views store their plugin_id and plugin_component inside the config JSONB column.
+
+BEGIN;
+
+ALTER TABLE sprint_views
+    DROP CONSTRAINT IF EXISTS sprint_views_view_type_check;
+
+ALTER TABLE sprint_views
+    ADD CONSTRAINT sprint_views_view_type_check
+    CHECK (view_type IN ('table', 'board', 'roadmap', 'plugin'));
+
+COMMIT;


### PR DESCRIPTION
This pull request introduces support for plugin-based views ("Plugin" views) in the project interactions UI and backend. It extends the view model and creation flow to allow users to add views powered by registered plugins, updates the frontend to handle these new view types, and ensures the backend and database accept and persist them. Additionally, it improves the new view popover to display both built-in and plugin-provided layouts. Some minor UI and caching changes are also included.

**Plugin View Support**

* Added "plugin" as a valid `ViewType` and `ViewLayout` in both frontend (`interaction-api.ts`) and backend (`entity.go`, `view_dto.go`), including support for storing `plugin_id` and `plugin_component` in view configs. [[1]](diffhunk://#diff-ff2cd37de44153a50032bdd6649c29fa6af291f110f72b04b7e89bcde5c1b7c9L69-R69) [[2]](diffhunk://#diff-ff2cd37de44153a50032bdd6649c29fa6af291f110f72b04b7e89bcde5c1b7c9R115-R120) [[3]](diffhunk://#diff-4b3b0a67852f1f65ada79a016a076339687ed37810c664cdb5432a8009197c27R69-R77) [[4]](diffhunk://#diff-4b3b0a67852f1f65ada79a016a076339687ed37810c664cdb5432a8009197c27R173-R175) [[5]](diffhunk://#diff-49be0a7b6ff331188f66dcfa1cbe9a204a7daf0d59d1977ce7778c617865671eR42-R43) [[6]](diffhunk://#diff-49be0a7b6ff331188f66dcfa1cbe9a204a7daf0d59d1977ce7778c617865671eR75-R76) [[7]](diffhunk://#diff-49be0a7b6ff331188f66dcfa1cbe9a204a7daf0d59d1977ce7778c617865671eR97-R98)
* Added a database migration to allow "plugin" as a valid `view_type` in the `sprint_views` table.

**Frontend UI Enhancements**

* Updated the "Add View" popover (`new-view-popover.tsx`) to show plugin view options alongside built-in layouts, and to support selecting and creating plugin views. [[1]](diffhunk://#diff-a7a057d188061bf92a6c32497eeb6d10947da2bcf3f6868c71f093af368f46b2L1-R61) [[2]](diffhunk://#diff-a7a057d188061bf92a6c32497eeb6d10947da2bcf3f6868c71f093af368f46b2L51-R83) [[3]](diffhunk://#diff-a7a057d188061bf92a6c32497eeb6d10947da2bcf3f6868c71f093af368f46b2L72-R157)
* Modified the main interaction layout (`interaction-layout.tsx`) to recognize, display, and create plugin views, including showing a puzzle icon for plugin views and handling cases where a plugin is unavailable. [[1]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR15) [[2]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR56) [[3]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR360) [[4]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL398-R415) [[5]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL791-R810) [[6]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL967) [[7]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR996-R997) [[8]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL1024-L1050) [[9]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fL1091-R1089) [[10]](diffhunk://#diff-11b7f8be38436fd22aafa3006a46e44391032c3c160ad99cc0248728de8b033fR1122-R1125)

**Miscellaneous UI and Backend Adjustments**

* Restored the attachments section in the task detail modal and removed a deprecated comment. [[1]](diffhunk://#diff-c7ddfeb42ca1bb6f8545ca81ead5cad5847faa5e5566d8e16d81b5f40a9e8be9L384-L391) [[2]](diffhunk://#diff-c7ddfeb42ca1bb6f8545ca81ead5cad5847faa5e5566d8e16d81b5f40a9e8be9R413-R419)
* Adjusted the sidebar to add a separator before project navigation items for improved layout consistency.
* Reduced the default cache time for plugin assets in the nginx gateway configuration for faster plugin updates.