### PR TITLE
refactor: update API base URL handling to use window.location.origin

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -132,11 +132,9 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   # Web app image
   # ─────────────────────────────────────────────────────────────────────────────
-  # The Vite bundle bakes VITE_API_BASE_URL at compile time.
-  # The pre-built image uses an empty string so all API calls are relative to
-  # the current origin — nginx proxies /api/* to the backend automatically.
-  # Self-hosters who need a custom absolute URL can rebuild with:
-  #   PACA_WEB_IMAGE=my-registry/paca-web:tag and --build in docker compose.
+  # The pre-built image uses relative URLs that work with nginx /api proxy
+  # out of the box, since the API client now derives the base URL from
+  # window.location.origin at runtime.
   web-image:
     name: Build and push Web image
     runs-on: ubuntu-latest
@@ -182,9 +180,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Empty string → relative URLs; works with nginx /api proxy out of the box.
-          build-args: |
-            VITE_API_BASE_URL=
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,14 +11,6 @@ RUN bun install --frozen-lockfile
 
 COPY . .
 
-# VITE_API_BASE_URL is injected at build time so the bundled client always
-# points at the correct gateway origin (set via docker-compose build args).
-ARG VITE_API_BASE_URL
-ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
-# VITE_REALTIME_URL points at the Socket.IO gateway path.
-# Defaults to the same origin as the web app (nginx proxies /ws/).
-ARG VITE_REALTIME_URL
-ENV VITE_REALTIME_URL=${VITE_REALTIME_URL}
 RUN bun run build
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -6,8 +6,7 @@ import axios, {
 
 import { ApiErrorCode } from "./api-error";
 
-const API_BASE_URL =
-	import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080";
+const API_BASE_URL = window.location.origin;
 
 /**
  * SPA navigation callback injected after the router is created (see router.tsx).

--- a/apps/web/src/lib/socket-client.ts
+++ b/apps/web/src/lib/socket-client.ts
@@ -14,9 +14,9 @@
 
 import { io, type Socket } from "socket.io-client";
 
-const REALTIME_URL = import.meta.env.VITE_REALTIME_URL ?? "http://localhost";
+const REALTIME_URL = window.location.origin;
 
-const SOCKET_PATH = import.meta.env.VITE_REALTIME_PATH ?? "/ws/socket.io";
+const SOCKET_PATH = "/ws/socket.io";
 
 let socket: Socket | null = null;
 

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -1,10 +1,15 @@
 # Container images. Override these when pulling from a registry in CI/CD.
-PACA_API_IMAGE=pacaai/paca-api:latest
-PACA_WEB_IMAGE=pacaai/paca-web:latest
-PACA_REALTIME_IMAGE=pacaai/paca-realtime:latest
+PACA_API_IMAGE=paca-api:latest
+PACA_WEB_IMAGE=paca-web:latest
+PACA_REALTIME_IMAGE=paca-realtime:latest
 
 # Runtime settings.
 ENVIRONMENT=production
+
+# Cloud deployments:
+# - Aurora DSQL: Set DATABASE_DRIVER=dsql, DATABASE_AWS_REGION, DATABASE_URL. Run with --scale postgres=0
+# - AWS S3: Set STORAGE_PROVIDER=s3 and real AWS credentials. Run with --scale minio=0
+# Environment variables below have defaults for self-hosted deployments and are optional when using cloud services.
 
 # Public URL for the web application and plugin callbacks.
 # This should be the full URL where your Paca instance will be accessible,
@@ -12,6 +17,8 @@ ENVIRONMENT=production
 PUBLIC_URL=http://localhost
 
 # Stateful service credentials.
+# These are optional when using Aurora DSQL (--scale postgres=0) or AWS S3 (--scale minio=0).
+# Defaults are provided for self-hosted deployments.
 POSTGRES_DB=paca
 POSTGRES_USER=paca
 POSTGRES_PASSWORD=replace-with-a-strong-postgres-password

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -117,8 +117,6 @@ services:
     environment:
       NODE_ENV: development
       DOCKER: "true"
-      # Gateway is the single public entry-point; the browser always calls it.
-      VITE_API_BASE_URL: http://localhost
     volumes:
       - ../apps/web:/workspace
       - web_node_modules:/workspace/node_modules

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -98,9 +98,6 @@ services:
     image: paca-web:e2e
     build:
       context: ../apps/web
-      args:
-        # The browser always accesses the gateway on localhost:80.
-        VITE_API_BASE_URL: http://localhost
     restart: unless-stopped
     depends_on:
       api:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -2,7 +2,7 @@
 #
 # This file is a self-hosting baseline for open-source users who want one
 # deployable stack with the application and its stateful dependencies. Teams
-# running managed PostgreSQL or Valkey can still use the same images
+# running managed PostgreSQL, Aurora DSQL, or Valkey can still use the same images
 # and environment variables as a handoff into their own platform.
 #
 # ── Pre-built images ──────────────────────────────────────────────────────────
@@ -31,6 +31,22 @@
 #   docker compose \
 #     --env-file deploy/.env.production \
 #     -f deploy/docker-compose.prod.yml up -d --scale minio=0
+#
+# ── Database ────────────────────────────────────────────────────────────────
+# PostgreSQL runs by default (self-hosted). To use Aurora DSQL instead, scale
+# postgres to zero and configure Aurora DSQL settings.
+#
+# Self-hosted with PostgreSQL (default):
+#   # Set POSTGRES_PASSWORD or use the default
+#   docker compose \
+#     --env-file deploy/.env.production \
+#     -f deploy/docker-compose.prod.yml up -d
+#
+# With Aurora DSQL (PostgreSQL container suppressed):
+#   # Set DATABASE_DRIVER=dsql, DATABASE_AWS_REGION, DATABASE_URL
+#   docker compose \
+#     --env-file deploy/.env.production \
+#     -f deploy/docker-compose.prod.yml up -d --scale postgres=0
 
 name: paca-prod
 
@@ -41,7 +57,7 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-paca}
       POSTGRES_USER: ${POSTGRES_USER:-paca}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ../services/api/migrations:/docker-entrypoint-initdb.d:ro
@@ -93,8 +109,8 @@ services:
       STORAGE_PUBLIC_URL: ${STORAGE_PUBLIC_URL:-http://localhost/storage}
       STORAGE_REGION: ${STORAGE_REGION:-us-east-1}
       STORAGE_BUCKET: ${STORAGE_BUCKET:-paca}
-      STORAGE_ACCESS_KEY_ID: ${STORAGE_ACCESS_KEY_ID:?set STORAGE_ACCESS_KEY_ID}
-      STORAGE_SECRET_ACCESS_KEY: ${STORAGE_SECRET_ACCESS_KEY:?set STORAGE_SECRET_ACCESS_KEY}
+      STORAGE_ACCESS_KEY_ID: ${STORAGE_ACCESS_KEY_ID:-minioadmin}
+      STORAGE_SECRET_ACCESS_KEY: ${STORAGE_SECRET_ACCESS_KEY:-minioadmin}
       STORAGE_USE_SSL: ${STORAGE_USE_SSL:-false}
       # Encryption key for sensitive values (plugin tokens/secrets).
       # Must be a 64-char lowercase hex string (32 bytes).
@@ -108,6 +124,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false  # skipped when --scale postgres=0 (Aurora DSQL mode)
       valkey:
         condition: service_healthy
       minio:
@@ -138,10 +155,6 @@ services:
     image: ${PACA_WEB_IMAGE:-pacaai/paca-web:latest}
     build:
       context: ../apps/web
-      args:
-        # VITE_API_BASE_URL is baked into the static bundle at build time.
-        # Set PUBLIC_URL to your public domain (e.g. https://paca.example.com).
-        VITE_API_BASE_URL: ${PUBLIC_URL:-http://localhost}
     restart: unless-stopped
     depends_on:
       - api
@@ -190,8 +203,8 @@ services:
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID:?set STORAGE_ACCESS_KEY_ID}
-      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY:?set STORAGE_SECRET_ACCESS_KEY}
+      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY:-minioadmin}
     volumes:
       - minio_data:/data
     healthcheck:


### PR DESCRIPTION
This pull request modernizes how the web client and realtime client determine their backend URLs, shifting from build-time environment variables to runtime detection. It also updates deployment and configuration files to simplify self-hosting and support cloud services like AWS Aurora DSQL and S3 more easily. The most important changes are grouped below.

**Frontend configuration simplification:**

* The web API client (`apps/web/src/lib/api-client.ts`) and realtime client (`apps/web/src/lib/socket-client.ts`) now derive their base URLs from `window.location.origin` at runtime, removing the need for `VITE_API_BASE_URL` and `VITE_REALTIME_URL` build-time environment variables. [[1]](diffhunk://#diff-50854f47986eccccb58452e3f2e5cf0057e6e54105823248fba4f78526f08005L9-R9) [[2]](diffhunk://#diff-10883a5f30e91538249923c1778edb9e7ad9d1baef265ef382422c137f937277L17-R19)
* All references to `VITE_API_BASE_URL` and `VITE_REALTIME_URL` have been removed from the Dockerfile and Docker Compose files, simplifying builds and deployments. [[1]](diffhunk://#diff-4eb403c1470ca34300aea23c38f170d0e8b3c16932a5af4c99da390622d3db4eL14-L21) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L185-L187) [[3]](diffhunk://#diff-5163dce73a55334e96161253592a73a8c050f90a5caa98172bfdb54b3e9f5221L120-L121) [[4]](diffhunk://#diff-ab0092df079b8fb5cce83a17f0831d5cc6ea2f72c60354aa53e5d16d8ace4726L101-L103) [[5]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL141-L144)

**Deployment and configuration improvements:**

* The `.env.production.example` and `docker-compose.prod.yml` files now provide clearer defaults and instructions for both self-hosted and cloud deployments, including using Aurora DSQL and AWS S3. [[1]](diffhunk://#diff-d958f49a7fa9b46f3a1e4b9ae1bf36360da0312a6d1a2b2087208bf5fcc9c4b0L2-R21) [[2]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL5-R5) [[3]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feR34-R49)
* Default credentials for PostgreSQL and MinIO are now provided for easier self-hosted setup, with instructions for overriding in production. [[1]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL44-R60) [[2]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL96-R113) [[3]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL193-R207)
* The dependency on PostgreSQL is now optional in Docker Compose, enabling Aurora DSQL mode by scaling the `postgres` service to zero.

**Documentation and comments:**

* Comments and documentation in deployment files have been updated for accuracy and to reflect the new configuration approach. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L135-R137) [[2]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL5-R5) [[3]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feR34-R49)

These changes streamline both local development and production deployments, reducing configuration complexity and making cloud migrations easier.