### PR TITLE
refactor: remove support for Aurora DSQL and related configurations

### DIFF
--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -7,7 +7,6 @@ PACA_REALTIME_IMAGE=paca-realtime:latest
 ENVIRONMENT=production
 
 # Cloud deployments:
-# - Aurora DSQL: Set DATABASE_DRIVER=dsql, DATABASE_AWS_REGION, DATABASE_URL. Run with --scale postgres=0
 # - AWS S3: Set STORAGE_PROVIDER=s3 and real AWS credentials. Run with --scale minio=0
 # Environment variables below have defaults for self-hosted deployments and are optional when using cloud services.
 
@@ -17,7 +16,7 @@ ENVIRONMENT=production
 PUBLIC_URL=http://localhost
 
 # Stateful service credentials.
-# These are optional when using Aurora DSQL (--scale postgres=0) or AWS S3 (--scale minio=0).
+# These are optional when using AWS S3 (--scale minio=0).
 # Defaults are provided for self-hosted deployments.
 POSTGRES_DB=paca
 POSTGRES_USER=paca
@@ -26,10 +25,6 @@ POSTGRES_PASSWORD=replace-with-a-strong-postgres-password
 # Database settings.
 # Default: postgres://paca:POSTGRES_PASSWORD@postgres:5432/paca?sslmode=disable
 DATABASE_URL=
-# Aurora DSQL — set DATABASE_DRIVER=dsql and DATABASE_AWS_REGION to enable IAM auth.
-# DATABASE_DRIVER=dsql
-DATABASE_DRIVER=postgres
-DATABASE_AWS_REGION=
 
 # Redis/Valkey settings.
 # Default: redis://valkey:6379/0

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -55,9 +55,6 @@ services:
       ENV: development
       PORT: "8080"
       DATABASE_URL: postgres://paca:paca@postgres:5432/paca?sslmode=disable
-      # Aurora DSQL — set DATABASE_DRIVER=dsql and DATABASE_AWS_REGION to enable IAM auth.
-      DATABASE_DRIVER: postgres
-      DATABASE_AWS_REGION: ""
       REDIS_URL: redis://valkey:6379/0
       JWT_SECRET: dev-change-in-production
       JWT_ACCESS_TTL: 15m

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -125,6 +125,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false  # skipped when --scale postgres=0 (managed PostgreSQL mode)
       valkey:
         condition: service_healthy
       minio:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -40,17 +40,12 @@
 #   docker compose \
 #     --env-file deploy/.env.production \
 #     -f deploy/docker-compose.prod.yml up -d
-# Self-hosted with PostgreSQL:
-#   # Set POSTGRES_PASSWORD or use the default
-#   docker compose \
-#     --env-file deploy/.env.production \
-#     -f deploy/docker-compose.prod.yml up -d
 #
-# Self-hosted with PostgreSQL (default):
-#   # Set POSTGRES_PASSWORD or use the default
+# With managed/external PostgreSQL (postgres container suppressed):
+#   # Set DATABASE_URL to your managed PostgreSQL connection string in .env.production
 #   docker compose \
 #     --env-file deploy/.env.production \
-#     -f deploy/docker-compose.prod.yml up -d
+#     -f deploy/docker-compose.prod.yml up -d --scale postgres=0
 
 name: paca-prod
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -2,7 +2,7 @@
 #
 # This file is a self-hosting baseline for open-source users who want one
 # deployable stack with the application and its stateful dependencies. Teams
-# running managed PostgreSQL, Aurora DSQL, or Valkey can still use the same images
+# running managed PostgreSQL or Valkey can still use the same images
 # and environment variables as a handoff into their own platform.
 #
 # ── Pre-built images ──────────────────────────────────────────────────────────
@@ -33,20 +33,24 @@
 #     -f deploy/docker-compose.prod.yml up -d --scale minio=0
 #
 # ── Database ────────────────────────────────────────────────────────────────
-# PostgreSQL runs by default (self-hosted). To use Aurora DSQL instead, scale
-# postgres to zero and configure Aurora DSQL settings.
+# PostgreSQL runs by default (self-hosted).
 #
 # Self-hosted with PostgreSQL (default):
 #   # Set POSTGRES_PASSWORD or use the default
 #   docker compose \
 #     --env-file deploy/.env.production \
 #     -f deploy/docker-compose.prod.yml up -d
-#
-# With Aurora DSQL (PostgreSQL container suppressed):
-#   # Set DATABASE_DRIVER=dsql, DATABASE_AWS_REGION, DATABASE_URL
+# Self-hosted with PostgreSQL:
+#   # Set POSTGRES_PASSWORD or use the default
 #   docker compose \
 #     --env-file deploy/.env.production \
-#     -f deploy/docker-compose.prod.yml up -d --scale postgres=0
+#     -f deploy/docker-compose.prod.yml up -d
+#
+# Self-hosted with PostgreSQL (default):
+#   # Set POSTGRES_PASSWORD or use the default
+#   docker compose \
+#     --env-file deploy/.env.production \
+#     -f deploy/docker-compose.prod.yml up -d
 
 name: paca-prod
 
@@ -88,9 +92,6 @@ services:
       ENV: ${ENVIRONMENT:-production}
       PORT: 8080
       DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-paca}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-paca}?sslmode=disable}
-      # Aurora DSQL — set DATABASE_DRIVER=dsql and DATABASE_AWS_REGION to enable IAM auth.
-      DATABASE_DRIVER: ${DATABASE_DRIVER:-postgres}
-      DATABASE_AWS_REGION: ${DATABASE_AWS_REGION:-}
       REDIS_URL: ${REDIS_URL:-redis://valkey:6379/0}
       JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET}
       JWT_ACCESS_TTL: ${JWT_ACCESS_TTL:-15m}
@@ -124,7 +125,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-        required: false  # skipped when --scale postgres=0 (Aurora DSQL mode)
       valkey:
         condition: service_healthy
       minio:

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -5,15 +5,6 @@ ENV=development           # development | production
 # ----- PostgreSQL ------------------------------------------------------------
 DATABASE_URL=postgres://paca:paca@localhost:5432/paca?sslmode=disable
 
-# ----- Amazon Aurora DSQL (optional) -----------------------------------------
-# Set DATABASE_DRIVER=dsql to connect to Aurora DSQL using IAM authentication.
-# AWS credentials are resolved from the standard credential chain
-# (environment variables, ~/.aws/credentials, EC2/ECS instance role, etc.).
-#
-# DATABASE_DRIVER=dsql
-# DATABASE_URL=postgres://admin@<cluster-id>.dsql.<region>.on.aws/postgres?sslmode=require
-# DATABASE_AWS_REGION=us-east-1
-
 # ----- Valkey ----------------------------------------------------------------
 REDIS_URL=redis://localhost:6379/0
 

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -7,12 +7,10 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
-	github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.1
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -72,6 +70,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.9.1 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/services/api/go.sum
+++ b/services/api/go.sum
@@ -16,8 +16,6 @@ github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCC
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
-github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23 h1:t/FLVaD5EbHBPfCvvSI+I1jfOFno6VT4SpAyTPbe+U0=
-github.com/aws/aws-sdk-go-v2/feature/dsql/auth v1.1.23/go.mod h1:f6NUif0lusPQ6Tcfa0qavcKcW4lpjH76nBEklwFj+gs=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -65,9 +65,7 @@ func New(cfg *config.Config) (*App, error) {
 
 	// --- Platform -----------------------------------------------------------
 	db, err := database.Open(database.Config{
-		DSN:       cfg.Database.DSN,
-		Driver:    cfg.Database.Driver,
-		AWSRegion: cfg.Database.AWSRegion,
+		DSN: cfg.Database.DSN,
 	}, log)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap: %w", err)

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -33,14 +33,6 @@ type AdminConfig struct {
 // DatabaseConfig holds the primary database connection settings.
 type DatabaseConfig struct {
 	DSN string
-
-	// Driver selects the database backend: "postgres" (default) or "dsql"
-	// (Amazon Aurora DSQL with IAM authentication).
-	Driver string
-
-	// AWSRegion is the AWS region used when Driver is "dsql".
-	// It must match the region where the Aurora DSQL cluster is deployed.
-	AWSRegion string
 }
 
 // RedisConfig holds Redis connection settings.

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -51,19 +51,6 @@ func Load() (*Config, error) {
 		errs = append(errs, err)
 	}
 
-	dbDriver := env("DATABASE_DRIVER", "postgres")
-	switch dbDriver {
-	case "postgres", "dsql":
-		// valid values
-	default:
-		errs = append(errs, fmt.Errorf("config: DATABASE_DRIVER must be one of: postgres, dsql"))
-	}
-
-	dbAWSRegion := env("DATABASE_AWS_REGION", "")
-	if dbDriver == "dsql" && dbAWSRegion == "" {
-		errs = append(errs, fmt.Errorf("config: DATABASE_AWS_REGION must be set when DATABASE_DRIVER=dsql"))
-	}
-
 	redisURL, err := requireEnv("REDIS_URL")
 	if err != nil {
 		errs = append(errs, err)
@@ -124,9 +111,7 @@ func Load() (*Config, error) {
 			PublicURL:    env("PUBLIC_URL", ""),
 		},
 		Database: DatabaseConfig{
-			DSN:       dsn,
-			Driver:    dbDriver,
-			AWSRegion: dbAWSRegion,
+			DSN: dsn,
 		},
 		Redis: RedisConfig{
 			URL: redisURL,

--- a/services/api/internal/config/load_test.go
+++ b/services/api/internal/config/load_test.go
@@ -55,8 +55,6 @@ func TestLoad_Success(t *testing.T) {
 	t.Setenv("JWT_REFRESH_TTL", "48h")
 	t.Setenv("JWT_REFRESH_SESSION_TTL", "12h")
 	t.Setenv("DATABASE_URL", "postgres://test")
-	t.Setenv("DATABASE_DRIVER", "postgres")
-	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("ADMIN_USERNAME", "admin")
 	t.Setenv("ADMIN_PASSWORD", "password")
@@ -85,16 +83,11 @@ func TestLoad_Success(t *testing.T) {
 	if cfg.JWT.RefreshSessionTTL != 12*time.Hour {
 		t.Fatalf("unexpected RefreshSessionTTL: %v", cfg.JWT.RefreshSessionTTL)
 	}
-	if cfg.Database.Driver != "postgres" {
-		t.Fatalf("expected driver postgres, got %q", cfg.Database.Driver)
-	}
 }
 
 func TestLoad_MissingRequired(t *testing.T) {
 	t.Setenv("JWT_SECRET", "")
 	t.Setenv("DATABASE_URL", "")
-	t.Setenv("DATABASE_DRIVER", "postgres")
-	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "")
 	t.Setenv("ADMIN_USERNAME", "")
 	t.Setenv("ADMIN_PASSWORD", "")
@@ -114,8 +107,6 @@ func TestLoad_MissingRequired(t *testing.T) {
 func TestLoad_InvalidBoolOrDuration(t *testing.T) {
 	t.Setenv("JWT_SECRET", "secret")
 	t.Setenv("DATABASE_URL", "postgres://test")
-	t.Setenv("DATABASE_DRIVER", "postgres")
-	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("ADMIN_USERNAME", "admin")
 	t.Setenv("ADMIN_PASSWORD", "password")
@@ -144,68 +135,9 @@ func setLoadDefaults(t *testing.T) {
 	t.Setenv("JWT_REFRESH_TTL", "168h")
 	t.Setenv("JWT_REFRESH_SESSION_TTL", "24h")
 	t.Setenv("DATABASE_URL", "postgres://test")
-	t.Setenv("DATABASE_DRIVER", "postgres")
-	t.Setenv("DATABASE_AWS_REGION", "")
 	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
 	t.Setenv("ADMIN_USERNAME", "admin")
 	t.Setenv("ADMIN_PASSWORD", "password")
 	t.Setenv("STORAGE_ACCESS_KEY_ID", "access-key")
 	t.Setenv("STORAGE_SECRET_ACCESS_KEY", "secret-key")
-}
-
-func TestLoad_DatabaseDriverDefault(t *testing.T) {
-	setLoadDefaults(t)
-	t.Setenv("DATABASE_DRIVER", "")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Database.Driver != "postgres" {
-		t.Fatalf("expected default driver postgres, got %q", cfg.Database.Driver)
-	}
-}
-
-func TestLoad_DatabaseDriverDSQL(t *testing.T) {
-	setLoadDefaults(t)
-	t.Setenv("DATABASE_DRIVER", "dsql")
-	t.Setenv("DATABASE_AWS_REGION", "us-east-1")
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Database.Driver != "dsql" {
-		t.Fatalf("expected driver dsql, got %q", cfg.Database.Driver)
-	}
-	if cfg.Database.AWSRegion != "us-east-1" {
-		t.Fatalf("expected AWSRegion us-east-1, got %q", cfg.Database.AWSRegion)
-	}
-}
-
-func TestLoad_DatabaseDriverInvalid(t *testing.T) {
-	setLoadDefaults(t)
-	t.Setenv("DATABASE_DRIVER", "dsq1") // typo
-
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for invalid DATABASE_DRIVER")
-	}
-	if !strings.Contains(err.Error(), "DATABASE_DRIVER") {
-		t.Fatalf("expected error to mention DATABASE_DRIVER, got %q", err.Error())
-	}
-}
-
-func TestLoad_DatabaseDriverDSQLMissingRegion(t *testing.T) {
-	setLoadDefaults(t)
-	t.Setenv("DATABASE_DRIVER", "dsql")
-	t.Setenv("DATABASE_AWS_REGION", "")
-
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error when DATABASE_DRIVER=dsql and DATABASE_AWS_REGION is empty")
-	}
-	if !strings.Contains(err.Error(), "DATABASE_AWS_REGION") {
-		t.Fatalf("expected error to mention DATABASE_AWS_REGION, got %q", err.Error())
-	}
 }

--- a/services/api/internal/platform/database/postgres.go
+++ b/services/api/internal/platform/database/postgres.go
@@ -17,7 +17,7 @@ type Config struct {
 	DSN string
 }
 
-// Open establishes a GORM connection using the driver specified in cfg.
+// Open establishes a GORM PostgreSQL connection using the settings in cfg.
 func Open(cfg Config, log *slog.Logger) (*gorm.DB, error) {
 	return openPostgres(cfg.DSN, log)
 }

--- a/services/api/internal/platform/database/postgres.go
+++ b/services/api/internal/platform/database/postgres.go
@@ -1,22 +1,11 @@
 // Package database provides PostgreSQL connectivity via GORM.
-// It supports two drivers:
-//   - "postgres" (default): standard PostgreSQL via pgx.
-//   - "dsql": Amazon Aurora DSQL using short-lived IAM auth tokens, refreshed
-//     automatically on every new connection via pgxpool.BeforeConnect.
 package database
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"time"
 
-	dsqlauth "github.com/aws/aws-sdk-go-v2/feature/dsql/auth"
-
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jackc/pgx/v5/stdlib"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -25,22 +14,11 @@ import (
 // Config holds the settings required to open a database connection.
 type Config struct {
 	// DSN is the PostgreSQL connection string.
-	// For the "dsql" driver the DSN should omit the password; an IAM auth
-	// token is injected automatically before each new connection.
 	DSN string
-
-	// Driver selects the backend: "postgres" (default) or "dsql".
-	Driver string
-
-	// AWSRegion is required when Driver is "dsql".
-	AWSRegion string
 }
 
 // Open establishes a GORM connection using the driver specified in cfg.
 func Open(cfg Config, log *slog.Logger) (*gorm.DB, error) {
-	if cfg.Driver == "dsql" {
-		return openDSQL(cfg, log)
-	}
 	return openPostgres(cfg.DSN, log)
 }
 
@@ -67,73 +45,5 @@ func openPostgres(dsn string, log *slog.Logger) (*gorm.DB, error) {
 	}
 
 	log.Info("database connected")
-	return db, nil
-}
-
-// openDSQL opens an Aurora DSQL connection.
-//
-// IAM auth tokens are valid for 15 minutes.  A pgxpool with BeforeConnect
-// regenerates the token for every new physical connection, so the pool never
-// holds a connection whose token has already expired.  MaxConnLifetime is set
-// to 13 minutes as an extra safeguard.
-func openDSQL(cfg Config, log *slog.Logger) (*gorm.DB, error) {
-	ctx := context.Background()
-
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(cfg.AWSRegion))
-	if err != nil {
-		return nil, fmt.Errorf("database: dsql: load aws config: %w", err)
-	}
-
-	poolCfg, err := pgxpool.ParseConfig(cfg.DSN)
-	if err != nil {
-		return nil, fmt.Errorf("database: dsql: parse dsn: %w", err)
-	}
-
-	endpoint := poolCfg.ConnConfig.Host
-	isAdmin := poolCfg.ConnConfig.User == "admin"
-
-	poolCfg.MaxConns = 25
-	poolCfg.MinConns = 0
-	poolCfg.MaxConnLifetime = 13 * time.Minute
-
-	poolCfg.BeforeConnect = func(ctx context.Context, connCfg *pgx.ConnConfig) error {
-		var token string
-		var tokenErr error
-		if isAdmin {
-			token, tokenErr = dsqlauth.GenerateDBConnectAdminAuthToken(
-				ctx, endpoint, cfg.AWSRegion, awsCfg.Credentials,
-			)
-		} else {
-			token, tokenErr = dsqlauth.GenerateDbConnectAuthToken(
-				ctx, endpoint, cfg.AWSRegion, awsCfg.Credentials,
-			)
-		}
-		if tokenErr != nil {
-			return fmt.Errorf("database: dsql: generate auth token: %w", tokenErr)
-		}
-		connCfg.Password = token
-		return nil
-	}
-
-	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
-	if err != nil {
-		return nil, fmt.Errorf("database: dsql: create pool: %w", err)
-	}
-
-	if err := pool.Ping(ctx); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("database: dsql: ping: %w", err)
-	}
-
-	sqlDB := stdlib.OpenDBFromPool(pool)
-
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
-		Logger: gormlogger.Default.LogMode(gormlogger.Warn),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("database: dsql: open gorm: %w", err)
-	}
-
-	log.Info("database connected", "driver", "dsql", "endpoint", endpoint)
 	return db, nil
 }


### PR DESCRIPTION
This pull request removes all support for Amazon Aurora DSQL (IAM-authenticated PostgreSQL) from the codebase, configuration, and documentation. The application now only supports standard PostgreSQL as its database backend. The most important changes are grouped below.

**Configuration and Documentation Cleanup:**

* Removed all references to Aurora DSQL and related environment variables (`DATABASE_DRIVER`, `DATABASE_AWS_REGION`) from environment example files (`deploy/.env.production.example`, `services/api/.env.example`). [[1]](diffhunk://#diff-d958f49a7fa9b46f3a1e4b9ae1bf36360da0312a6d1a2b2087208bf5fcc9c4b0L10) [[2]](diffhunk://#diff-d958f49a7fa9b46f3a1e4b9ae1bf36360da0312a6d1a2b2087208bf5fcc9c4b0L20-R19) [[3]](diffhunk://#diff-d958f49a7fa9b46f3a1e4b9ae1bf36360da0312a6d1a2b2087208bf5fcc9c4b0L29-L32) [[4]](diffhunk://#diff-613eb28e072b62ebcb2873cc655ee9a7cce9024ab48f2d7d68b3be5bed80057bL8-L16)
* Updated Docker Compose files and comments to remove Aurora DSQL instructions and variables, simplifying the deployment process to only use standard PostgreSQL. [[1]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL5-R5) [[2]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL36-R53) [[3]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL91-L93) [[4]](diffhunk://#diff-3262123708e73750234ecd04ab9db2b96568630dd19334908b783e566fcc30feL127) [[5]](diffhunk://#diff-5163dce73a55334e96161253592a73a8c050f90a5caa98172bfdb54b3e9f5221L58-L60)

**Codebase Simplification:**

* Removed all Aurora DSQL-specific configuration fields and logic from the application configuration (`services/api/internal/config/config.go`, `services/api/internal/config/load.go`, and related test code). [[1]](diffhunk://#diff-5f901e02ed468393320d41f6a3f42a8418363f27dfe8c6b7b1b75196defcd38eL36-L43) [[2]](diffhunk://#diff-d956efd85fb8e468490ab3ce93932344a88c6a174917b0ee75ac8663b98ab4f6L54-L66) [[3]](diffhunk://#diff-d956efd85fb8e468490ab3ce93932344a88c6a174917b0ee75ac8663b98ab4f6L128-L129) [[4]](diffhunk://#diff-eb80465b699e2f0794482ec1dfd1d24733ba91c832fddaf7c1cc794137485bb0L58-L59) [[5]](diffhunk://#diff-eb80465b699e2f0794482ec1dfd1d24733ba91c832fddaf7c1cc794137485bb0L88-L97) [[6]](diffhunk://#diff-eb80465b699e2f0794482ec1dfd1d24733ba91c832fddaf7c1cc794137485bb0L117-L118) [[7]](diffhunk://#diff-eb80465b699e2f0794482ec1dfd1d24733ba91c832fddaf7c1cc794137485bb0L147-L211)
* Deleted the Aurora DSQL connection logic and dependencies from the database package, so only standard PostgreSQL connections are supported (`services/api/internal/platform/database/postgres.go`). [[1]](diffhunk://#diff-0978dd6b86f77a21091e999b51c6e510641a606fb73d72e64b3cce36949ac855L2-L19) [[2]](diffhunk://#diff-0978dd6b86f77a21091e999b51c6e510641a606fb73d72e64b3cce36949ac855L28-L43) [[3]](diffhunk://#diff-0978dd6b86f77a21091e999b51c6e510641a606fb73d72e64b3cce36949ac855L72-L139)

**Dependency Updates:**

* Removed Aurora DSQL-related Go module dependencies from `services/api/go.mod`. [[1]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991L10-L15) [[2]](diffhunk://#diff-5ff27325f4d13c094e15de0f9498f81ce7118d145851cb12153b90c7484eb991R73)

These changes significantly reduce complexity and maintenance overhead by focusing database support on standard PostgreSQL only.