### PR TITLE
refactor: update EnsureBucket logic to assume manual bucket creation …

### DIFF
--- a/services/api/internal/platform/storage/s3.go
+++ b/services/api/internal/platform/storage/s3.go
@@ -232,20 +232,21 @@ func (c *S3Client) DeleteObject(ctx context.Context, bucket, key string) error {
 }
 
 // EnsureBucket creates the bucket if it does not already exist.
+// For AWS S3 (when Endpoint is empty), this only checks if the bucket exists
+// and assumes it has been manually created. For MinIO, it creates the bucket.
 func (c *S3Client) EnsureBucket(ctx context.Context, bucket string) error {
 	_, err := c.s3.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
 	if err == nil {
 		return nil // already exists
 	}
 
-	input := &s3.CreateBucketInput{Bucket: aws.String(bucket)}
-
-	// AWS S3 requires a LocationConstraint for all regions except us-east-1.
-	if c.cfg.Region != "" && c.cfg.Region != "us-east-1" && c.cfg.Endpoint == "" {
-		input.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
-			LocationConstraint: s3types.BucketLocationConstraint(c.cfg.Region),
-		}
+	// For AWS S3 (Endpoint is empty), don't attempt to create the bucket.
+	// The bucket should already exist and have been manually created.
+	if c.cfg.Endpoint == "" {
+		return nil // assume bucket exists or will be created manually
 	}
+
+	input := &s3.CreateBucketInput{Bucket: aws.String(bucket)}
 
 	if _, err := c.s3.CreateBucket(ctx, input); err != nil {
 		return fmt.Errorf("storage: create bucket %q: %w", bucket, err)


### PR DESCRIPTION
This pull request updates the `EnsureBucket` logic in the S3 storage client to better distinguish between AWS S3 and MinIO environments. The method now avoids attempting to create buckets on AWS S3 (assuming they are manually created), while still creating buckets as needed for MinIO.

**S3 bucket management improvements:**

* Updated `EnsureBucket` in `s3.go` to only create buckets automatically when using MinIO (i.e., when a custom endpoint is set). For AWS S3 (when `Endpoint` is empty), the method now assumes the bucket is managed externally and skips creation.
* Improved documentation for `EnsureBucket` to clarify the different behaviors for AWS S3 and MinIO.