### PR TITLE
feat: implement cleanBlocks utility and integrate into doc and descri…

### DIFF
--- a/apps/web/src/components/projects/docs/doc-editor.tsx
+++ b/apps/web/src/components/projects/docs/doc-editor.tsx
@@ -17,6 +17,7 @@ import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
 import { useThemeMode } from "@/hooks/use-theme-mode";
 import { getDocFileDownloadURL, uploadDocFile } from "@/lib/doc-api";
 import { useMentionData } from "@/lib/mention-api";
+import { cleanBlocks } from "@/lib/utils";
 
 /** Custom URI scheme used to store doc file references in the block content. */
 const DOC_FILE_SCHEME = "docfile://";
@@ -52,6 +53,7 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 		const initializedRef = useRef(false);
 		const localSaveRef = useRef(false);
 		const readyRef = useRef(false);
+		const dirtyRef = useRef(false);
 
 		// Keep projectId / docId in refs so stable editor callbacks always
 		// reference the latest prop values without recreating the editor.
@@ -87,11 +89,15 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 		// Populate / re-populate editor from server content
 		useEffect(() => {
 			const normalized = content ?? null;
-			const normalizedStr = normalized ? JSON.stringify(normalized) : null;
+			const cleanedNormalized = cleanBlocks(normalized);
+			const normalizedStr = cleanedNormalized
+				? JSON.stringify(cleanedNormalized)
+				: null;
 
 			if (initializedRef.current && localSaveRef.current) {
 				localSaveRef.current = false;
 				lastSavedRef.current = normalizedStr;
+				dirtyRef.current = false;
 				return;
 			}
 
@@ -99,6 +105,8 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 				return;
 			initializedRef.current = true;
 			lastSavedRef.current = normalizedStr;
+			readyRef.current = false;
+			dirtyRef.current = false;
 
 			let blocks: Parameters<typeof editor.replaceBlocks>[1] | undefined;
 			if (normalized && Array.isArray(normalized) && normalized.length > 0) {
@@ -111,7 +119,7 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 		}, [content, editor]);
 
 		const save = useCallback(() => {
-			if (!editable) return;
+			if (!editable || !dirtyRef.current) return;
 			const blocks = editor.document;
 			const isEmpty =
 				blocks.length === 1 &&
@@ -120,12 +128,17 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 				blocks[0].content.length === 0;
 
 			const value: unknown[] | null = isEmpty ? null : (blocks as unknown[]);
-			const valueStr = value ? JSON.stringify(value) : null;
+			const cleanedValue = cleanBlocks(value);
+			const valueStr = cleanedValue ? JSON.stringify(cleanedValue) : null;
 			if (valueStr !== lastSavedRef.current) {
 				lastSavedRef.current = valueStr;
 				localSaveRef.current = true;
+				dirtyRef.current = false;
 				onDirtyChange?.(false);
 				onSave?.(value);
+			} else {
+				dirtyRef.current = false;
+				onDirtyChange?.(false);
 			}
 		}, [editable, editor, onSave, onDirtyChange]);
 
@@ -135,6 +148,7 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 
 		const handleChange = useCallback(() => {
 			if (!editable || !readyRef.current) return;
+			dirtyRef.current = true;
 			onDirtyChange?.(true);
 			debouncedSave();
 		}, [editable, debouncedSave, onDirtyChange]);

--- a/apps/web/src/components/projects/docs/doc-editor.tsx
+++ b/apps/web/src/components/projects/docs/doc-editor.tsx
@@ -135,7 +135,7 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 				localSaveRef.current = true;
 				dirtyRef.current = false;
 				onDirtyChange?.(false);
-				onSave?.(value);
+				onSave?.(cleanedValue);
 			} else {
 				dirtyRef.current = false;
 				onDirtyChange?.(false);

--- a/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
@@ -14,6 +14,7 @@ import {
 	uploadAttachment,
 } from "@/lib/attachment-api";
 import { useMentionData } from "@/lib/mention-api";
+import { cleanBlocks } from "@/lib/utils";
 
 type UpdateFn = (payload: { description?: unknown[] | null }) => void;
 
@@ -45,6 +46,8 @@ export function DescriptionSection({
 	const initializedRef = useRef(false);
 	// Whether there are unsaved changes pending a blur-save.
 	const pendingRef = useRef(false);
+	// Whether the editor has finished initial content population.
+	const readyRef = useRef(false);
 
 	// Keep projectId / taskId in refs so the stable editor callbacks always
 	// reference the latest prop values without recreating the editor.
@@ -90,22 +93,29 @@ export function DescriptionSection({
 	// externally (initial load or server refetch that differs from what we saved).
 	useEffect(() => {
 		const normalized = description ?? null;
+		const cleanedNormalized = cleanBlocks(normalized);
 		// Stringify for stable comparison (array identity changes on every response)
-		const normalizedStr = normalized ? JSON.stringify(normalized) : null;
+		const normalizedStr = cleanedNormalized
+			? JSON.stringify(cleanedNormalized)
+			: null;
 		if (initializedRef.current && normalizedStr === lastSavedRef.current)
 			return;
 		initializedRef.current = true;
 		lastSavedRef.current = normalizedStr;
+		readyRef.current = false;
 
 		let blocks: Parameters<typeof editor.replaceBlocks>[1] | undefined;
 		if (normalized && Array.isArray(normalized) && normalized.length > 0) {
 			blocks = normalized as Parameters<typeof editor.replaceBlocks>[1];
 		}
 		editor.replaceBlocks(editor.document, blocks ?? []);
+		queueMicrotask(() => {
+			readyRef.current = true;
+		});
 	}, [description, editor]);
 
 	const handleChange = useCallback(() => {
-		if (!canEdit) return;
+		if (!canEdit || !readyRef.current) return;
 		// Track dirty state so blur can save without re-reading document
 		pendingRef.current = true;
 	}, [canEdit]);
@@ -122,7 +132,8 @@ export function DescriptionSection({
 			blocks[0].content.length === 0;
 
 		const value: unknown[] | null = isEmpty ? null : (blocks as unknown[]);
-		const valueStr = value ? JSON.stringify(value) : null;
+		const cleanedValue = cleanBlocks(value);
+		const valueStr = cleanedValue ? JSON.stringify(cleanedValue) : null;
 		if (valueStr !== lastSavedRef.current) {
 			lastSavedRef.current = valueStr;
 			onUpdate?.({ description: value });

--- a/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
@@ -136,7 +136,7 @@ export function DescriptionSection({
 		const valueStr = cleanedValue ? JSON.stringify(cleanedValue) : null;
 		if (valueStr !== lastSavedRef.current) {
 			lastSavedRef.current = valueStr;
-			onUpdate?.({ description: value });
+			onUpdate?.({ description: cleanedValue });
 		}
 	}, [canEdit, editor, onUpdate]);
 

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -20,7 +20,7 @@ import {
 	isSubtaskType,
 	projectQueryOptions,
 } from "@/lib/project-api";
-import { cn } from "@/lib/utils";
+import { cleanBlocks, cn } from "@/lib/utils";
 import { getTaskTypeIconComponent } from "../../task-types/task-type-icons";
 import { getPriority } from "../priority";
 import { TaskActivityPane as ActivityPane } from "./activity-pane";
@@ -147,7 +147,49 @@ export function TaskDetailModal({
 	const updateMutation = useMutation({
 		mutationFn: (payload: Parameters<typeof updateTask>[2]) => {
 			if (!projectId || !task) throw new Error("missing context");
-			return updateTask(projectId, task.id, payload);
+
+			// Filter out fields that haven't actually changed
+			const filtered: typeof payload = {};
+			for (const key of Object.keys(payload) as Array<keyof typeof payload>) {
+				const newValue = payload[key];
+				const oldValue = task[key as keyof typeof task];
+
+				if (key === "tags") {
+					const a = newValue as string[] | undefined;
+					const b = oldValue as string[] | undefined;
+					const aStr = a ? [...a].sort().join(",") : "";
+					const bStr = b ? [...b].sort().join(",") : "";
+					if (aStr !== bStr) {
+						filtered.tags = a;
+					}
+				} else if (key === "custom_fields") {
+					const a = newValue as Record<string, unknown> | undefined;
+					const b = oldValue as Record<string, unknown> | undefined;
+					if (JSON.stringify(a) !== JSON.stringify(b)) {
+						filtered.custom_fields = a;
+					}
+				} else if (key === "description") {
+					const aClean = JSON.stringify(
+						cleanBlocks(newValue as unknown[] | null),
+					);
+					const bClean = JSON.stringify(
+						cleanBlocks(oldValue as unknown[] | null),
+					);
+					if (aClean !== bClean) {
+						filtered.description = newValue as unknown[] | null;
+					}
+				} else {
+					if (newValue !== oldValue) {
+						(filtered as Record<string, unknown>)[key] = newValue;
+					}
+				}
+			}
+
+			if (Object.keys(filtered).length === 0) {
+				return Promise.resolve(task);
+			}
+
+			return updateTask(projectId, task.id, filtered);
 		},
 		onSuccess: (updated) => {
 			if (!projectId) return;

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -169,14 +169,18 @@ export function TaskDetailModal({
 						filtered.custom_fields = a;
 					}
 				} else if (key === "description") {
+					const normalizedNewValue = newValue ?? null;
 					const aClean = JSON.stringify(
-						cleanBlocks(newValue as unknown[] | null),
+						cleanBlocks(normalizedNewValue as unknown[] | null),
 					);
 					const bClean = JSON.stringify(
 						cleanBlocks(oldValue as unknown[] | null),
 					);
-					if (aClean !== bClean) {
-						filtered.description = newValue as unknown[] | null;
+					if (
+						aClean !== bClean &&
+						(newValue === null || Array.isArray(newValue))
+					) {
+						filtered.description = newValue;
 					}
 				} else {
 					if (newValue !== oldValue) {

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cn } from "./utils";
+import { cleanBlocks, cn } from "./utils";
 
 describe("cn", () => {
 	it("joins class names and ignores falsy values", () => {
@@ -10,5 +10,52 @@ describe("cn", () => {
 	it("merges conflicting Tailwind classes", () => {
 		const value = cn("px-2", "px-4", "text-sm", "text-lg");
 		expect(value).toBe("px-4 text-lg");
+	});
+});
+
+describe("cleanBlocks", () => {
+	it("returns null when blocks is null", () => {
+		expect(cleanBlocks(null)).toBeNull();
+	});
+
+	it("strips id field recursively and preserves other properties", () => {
+		const input = [
+			{
+				id: "block-1",
+				type: "paragraph",
+				content: [{ text: "Hello" }],
+				children: [
+					{
+						id: "block-1-sub1",
+						type: "bullet",
+						content: [],
+					},
+				],
+			},
+			{
+				id: "block-2",
+				type: "heading",
+				content: [{ text: "Title" }],
+			},
+		];
+
+		const expected = [
+			{
+				type: "paragraph",
+				content: [{ text: "Hello" }],
+				children: [
+					{
+						type: "bullet",
+						content: [],
+					},
+				],
+			},
+			{
+				type: "heading",
+				content: [{ text: "Title" }],
+			},
+		];
+
+		expect(cleanBlocks(input)).toEqual(expected);
 	});
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
+
+export function cleanBlocks(blocks: unknown[] | null): unknown[] | null {
+	if (!blocks) return null;
+	const strip = (arr: unknown[]): unknown[] => {
+		return arr.map((item) => {
+			if (!item || typeof item !== "object") return item;
+			const { id, children, ...rest } = item as Record<string, unknown>;
+			const res: Record<string, unknown> = { ...rest };
+			if (Array.isArray(children)) {
+				res.children = strip(children as unknown[]);
+			}
+			return res;
+		});
+	};
+	return strip(blocks);
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -5,7 +5,9 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
 
-export function cleanBlocks(blocks: unknown[] | null): unknown[] | null {
+export function cleanBlocks(
+	blocks: unknown[] | null | undefined,
+): unknown[] | null {
 	if (!blocks) return null;
 	const strip = (arr: unknown[]): unknown[] => {
 		return arr.map((item) => {


### PR DESCRIPTION
This pull request introduces a new utility function, `cleanBlocks`, to standardize and sanitize block data by recursively removing `id` fields before saving or comparing content in project documentation and task descriptions. The change ensures that block data is compared and persisted based on meaningful content rather than ephemeral identifiers, reducing unnecessary updates and improving data consistency. The update also introduces tests for the new utility and refines the logic for detecting and saving changes in editors.

**Block data sanitization and consistency:**

* Added the `cleanBlocks` utility in `utils.ts` to recursively remove `id` fields from block objects, and updated all relevant code paths to use this function when saving or comparing block content in both the document editor and task description editor. [[1]](diffhunk://#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767R7-R22) [[2]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cR20) [[3]](diffhunk://#diff-6520e73191a646fd8e022eccdf1e80c0b16a47f6a1062eb4aeb091f07802b218R17) [[4]](diffhunk://#diff-6520e73191a646fd8e022eccdf1e80c0b16a47f6a1062eb4aeb091f07802b218R96-R118) [[5]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cL90-R109) [[6]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cL123-R141) [[7]](diffhunk://#diff-6520e73191a646fd8e022eccdf1e80c0b16a47f6a1062eb4aeb091f07802b218L125-R136)

**Editor state management improvements:**

* Improved editor state tracking by adding `dirtyRef` and `readyRef` flags to ensure that saves only occur when there are actual changes and the editor is ready, preventing unnecessary saves and race conditions. [[1]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cR56) [[2]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cL90-R109) [[3]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cL114-R122) [[4]](diffhunk://#diff-539d38a278f6564d8ce812993f20fde7ca1067eeadb0a2b544a82c2b15036a7cR151) [[5]](diffhunk://#diff-6520e73191a646fd8e022eccdf1e80c0b16a47f6a1062eb4aeb091f07802b218R49-R50) [[6]](diffhunk://#diff-6520e73191a646fd8e022eccdf1e80c0b16a47f6a1062eb4aeb091f07802b218R96-R118)

**Task update optimization:**

* Enhanced the task update mutation to filter out unchanged fields (including using `cleanBlocks` for block data), ensuring that only meaningful changes trigger updates to the backend. [[1]](diffhunk://#diff-c7ddfeb42ca1bb6f8545ca81ead5cad5847faa5e5566d8e16d81b5f40a9e8be9L23-R23) [[2]](diffhunk://#diff-c7ddfeb42ca1bb6f8545ca81ead5cad5847faa5e5566d8e16d81b5f40a9e8be9L150-R192)

**Testing:**

* Added comprehensive unit tests for `cleanBlocks` to verify correct behavior, including recursive removal of `id` fields and preservation of other properties. [[1]](diffhunk://#diff-dfd373d1dff4d704b38185f49d4c5eeb43a86af1dc5320ede98a7cf6ae509c12L2-R2) [[2]](diffhunk://#diff-dfd373d1dff4d704b38185f49d4c5eeb43a86af1dc5320ede98a7cf6ae509c12R15-R61)