### PR TITLE
fix(nginx): update backend configuration to use variables for optiona…

### DIFF
--- a/deploy/nginx/gateway.conf
+++ b/deploy/nginx/gateway.conf
@@ -51,24 +51,17 @@ map $http_upgrade $connection_upgrade {
 # successive requests reuse TCP/TLS sessions instead of opening new ones.
 # Pair with "proxy_set_header Connection \"\"" (empty) in each location to
 # prevent the forwarded Connection header from closing those idle connections.
+#
+# Note: For optional services (web, minio), we use nginx variables to allow
+# graceful startup when services are not running (e.g., minio=0 for S3).
 
 upstream api_backend {
     server api:8080;
     keepalive 32;
 }
 
-upstream web_backend {
-    server web:3000;
-    keepalive 32;
-}
-
 upstream realtime_backend {
     server realtime:3001;
-    keepalive 16;
-}
-
-upstream minio_backend {
-    server minio:9000;
     keepalive 16;
 }
 
@@ -138,7 +131,8 @@ server {
     # Large uploads bypass the gateway body-size limit via client_max_body_size 0.
 
     location /storage/ {
-        proxy_pass         http://minio_backend/;
+        set $minio_backend http://minio:9000;
+        proxy_pass         $minio_backend/;
         proxy_http_version 1.1;
         proxy_set_header   Connection        "";
         proxy_set_header   Host              minio:9000;
@@ -255,7 +249,8 @@ server {
     # for Vite HMR in the dev compose stack.
 
     location / {
-        proxy_pass         http://web_backend;
+        set $web_backend http://web:3000;
+        proxy_pass         $web_backend;
         proxy_http_version 1.1;
         proxy_set_header   Upgrade           $http_upgrade;
         proxy_set_header   Connection        $connection_upgrade;

--- a/deploy/nginx/gateway.conf
+++ b/deploy/nginx/gateway.conf
@@ -45,6 +45,9 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# Resolve Docker service names for variable-based proxy_pass targets.
+resolver 127.0.0.11 ipv6=off valid=30s;
+
 # -- Upstream pools -----------------------------------------------------------
 #
 # keepalive N keeps N idle connections open to each upstream so that


### PR DESCRIPTION
This pull request updates the NGINX gateway configuration to improve flexibility and reliability when handling optional backend services. The changes remove static upstream blocks for services that may not always be running (such as `web` and `minio`) and instead use NGINX variables for dynamic backend resolution. This approach allows for more graceful startup and operation when optional services are unavailable.

**Improvements to NGINX backend configuration:**

* Removed static `upstream` blocks for `web` and `minio` services, replacing them with NGINX variables to allow for conditional backend resolution and more graceful handling when these services are not running.
* Updated the `/storage/` location to use a variable (`$minio_backend`) for the MinIO backend address, instead of referencing a static upstream block.
* Updated the root `/` location to use a variable (`$web_backend`) for the web backend address, instead of referencing a static upstream block.