### PR TITLE
Feature/update UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,86 @@ See [docs/guides/local-development.md](docs/guides/local-development.md) for run
 
 ---
 
+## MCP Server — Connect Any AI Agent to Paca
+
+Paca ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that gives any compatible AI agent direct, structured access to your workspace — projects, tasks, sprints, documents, members, and more. No scraping, no custom APIs to wire up.
+
+The server is published as **`@paca-ai/paca-mcp`** on npm. You run it with `npx`; your MCP client handles the rest.
+
+### Quick Setup — Claude Desktop
+
+1. Open (or create) the Claude Desktop config file:
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+2. Add the `paca` entry:
+
+```json
+{
+  "mcpServers": {
+    "paca": {
+      "command": "npx",
+      "args": ["-y", "@paca-ai/paca-mcp"],
+      "env": {
+        "PACA_API_KEY": "your-api-key-here",
+        "PACA_API_URL": "http://localhost:8080"
+      }
+    }
+  }
+}
+```
+
+3. Restart Claude Desktop. Claude now has access to all Paca tools and can answer requests like:
+   - *"List all active sprints in project X"*
+   - *"Create a task for implementing OAuth and assign it to sprint 3"*
+   - *"Add a comment to task #42 with my progress update"*
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|:--|:--|:--|:--|
+| `PACA_API_KEY` | Yes | — | API key from your Paca instance (Settings → API Keys) |
+| `PACA_API_URL` | No | `http://localhost:8080` | URL of your Paca API |
+| `PACA_PROJECT_ID` | No | — | Scope the agent to a single project |
+| `PACA_AGENT_ID` | No | — | Identity for agent-mode (requires `PACA_PROJECT_ID`) |
+
+### Other MCP-Compatible Clients
+
+Any client that speaks MCP works. Typical configuration:
+
+```json
+{
+  "name": "paca",
+  "command": "npx",
+  "args": ["-y", "@paca-ai/paca-mcp"],
+  "env": {
+    "PACA_API_KEY": "your-api-key-here",
+    "PACA_API_URL": "http://your-paca-instance:8080"
+  }
+}
+```
+
+### Available Tools
+
+The server exposes tools across these categories:
+
+| Category | Tools |
+|:--|:--|
+| Projects | `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project` |
+| Tasks | `list_tasks`, `get_task`, `create_task`, `update_task`, `delete_task`, + more |
+| Sprints | `list_sprints`, `create_sprint`, `update_sprint`, `complete_sprint`, + more |
+| Documents | `list_docs`, `read_doc`, `write_doc`, `delete_doc`, `move_doc` |
+| Members & Roles | `list_project_members`, `add_project_member`, `list_project_roles`, + more |
+| Task Types & Statuses | `list_task_types`, `create_task_type`, `list_task_statuses`, + more |
+| Views & Custom Fields | `list_views`, `create_view`, `list_custom_fields`, `create_custom_field`, + more |
+| Attachments | `list_task_attachments`, `get_attachment_download_url`, `delete_task_attachment` |
+| Activity & Comments | `list_task_activities`, `add_task_comment`, `update_task_comment`, `delete_task_comment` |
+| Plugin tools | Installed plugins can register additional tools at runtime |
+
+For a complete reference and advanced configuration (agent-mode, plugin tools, programmatic usage), see [docs/guides/mcp-server-setup.md](docs/guides/mcp-server-setup.md).
+
+---
+
 ## Architecture
 
 ```

--- a/apps/web/src/components/auth/login/BrandPanel.tsx
+++ b/apps/web/src/components/auth/login/BrandPanel.tsx
@@ -1,21 +1,21 @@
-import { BookOpen, Bot, RefreshCcw } from "lucide-react";
+import { BookOpen, Bot, Puzzle } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/github-icon";
 
 const FEATURES = [
 	{
 		icon: Bot,
-		title: "AI Agents as Peers",
-		desc: "AI Agents join your Scrum team as first-class members — not plugins — picking tasks from the same backlog as humans.",
+		title: "Sandboxed AI Agents",
+		desc: "Each agent runs in an isolated container — picking tasks from the board without touching your host environment.",
 	},
 	{
 		icon: BookOpen,
 		title: "BDD & SDD Hub",
-		desc: "Align POs, BAs, and Agents through Gherkin scenarios and System Design Docs that keep the whole team in sync.",
+		desc: "Co-author Gherkin scenarios and System Design Docs with your whole team — humans and AI alike.",
 	},
 	{
-		icon: RefreshCcw,
-		title: "The P-A-C-A Cycle",
-		desc: "Plan → Act → Check → Adapt. A Human-in-the-loop sprint loop built for complex, emergent projects where AI amplifies the team.",
+		icon: Puzzle,
+		title: "Plugin Marketplace",
+		desc: "Browse and install plugins from the UI. Customize everything via config and WASM plugins.",
 	},
 ] as const;
 
@@ -54,9 +54,8 @@ export function BrandPanel() {
 					<span className="text-[#9ed957]">human and AI.</span>
 				</h2>
 				<p className="mb-8 text-sm leading-relaxed text-white/55">
-					Paca is the open-source project management engine designed for Complex
-					Projects — where AI Agents and humans collaborate on the same Scrumban
-					board as equal, first-class teammates.
+					Open-source project management where AI agents and humans collaborate
+					as equal Scrum teammates — self-hosted, fully customizable.
 				</p>
 
 				{/* Feature cards */}

--- a/apps/web/src/routes/_authenticated/home/index.tsx
+++ b/apps/web/src/routes/_authenticated/home/index.tsx
@@ -616,9 +616,11 @@ function HomePage() {
 							</CardHeader>
 							<CardContent className="pt-3">
 								<ol className="space-y-1">
-									{GETTING_STARTED.map(({ step, title, description }) => (
-										<li key={step}>
-											<div className="flex items-start gap-3.5 rounded-xl border border-border/40 bg-muted/20 px-4 py-3.5 transition-all hover:bg-muted/50 hover:border-primary/20 group">
+									{GETTING_STARTED.map(({ step, title, description }) => {
+										const isActionable = step === 1 && canCreate;
+										const isLocked = step > 1;
+										const inner = (
+											<>
 												<div className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 border border-primary/20 font-mono text-[11px] font-bold text-primary tabular-nums">
 													{step}
 												</div>
@@ -628,13 +630,41 @@ function HomePage() {
 														{description}
 													</p>
 												</div>
-												<ArrowRight className="mt-1 size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-primary/50" />
-											</div>
-											{step < 4 && (
-												<div className="my-0.5 ml-7 h-1.5 w-px bg-linear-to-b from-border/60 to-transparent" />
-											)}
-										</li>
-									))}
+												<ArrowRight
+													className={cn(
+														"mt-1 size-3.5 shrink-0 text-muted-foreground/30 transition-all",
+														isActionable &&
+															"group-hover:translate-x-0.5 group-hover:text-primary/50",
+													)}
+												/>
+											</>
+										);
+										return (
+											<li key={step}>
+												{isActionable ? (
+													<button
+														type="button"
+														onClick={() => setCreateOpen(true)}
+														className="group flex w-full items-start gap-3.5 rounded-xl border border-border/40 bg-muted/20 px-4 py-3.5 text-left transition-all hover:bg-muted/50 hover:border-primary/20"
+													>
+														{inner}
+													</button>
+												) : (
+													<div
+														className={cn(
+															"flex items-start gap-3.5 rounded-xl border border-border/40 bg-muted/20 px-4 py-3.5",
+															isLocked && "opacity-50",
+														)}
+													>
+														{inner}
+													</div>
+												)}
+												{step < 4 && (
+													<div className="my-0.5 ml-7 h-1.5 w-px bg-linear-to-b from-border/60 to-transparent" />
+												)}
+											</li>
+										);
+									})}
 								</ol>
 							</CardContent>
 						</Card>
@@ -677,9 +707,20 @@ function HomePage() {
 												key={label}
 												type="button"
 												onClick={onClick}
-												className="group flex w-full cursor-pointer items-center gap-3 rounded-xl border border-border/50 bg-background/50 px-3.5 py-3 text-left transition-all hover:border-primary/30 hover:bg-primary/5 hover:shadow-sm hover:shadow-primary/5"
+												disabled={!onClick}
+												className={cn(
+													"group flex w-full items-center gap-3 rounded-xl border border-border/50 bg-background/50 px-3.5 py-3 text-left transition-all",
+													onClick
+														? "cursor-pointer hover:border-primary/30 hover:bg-primary/5 hover:shadow-sm hover:shadow-primary/5"
+														: "cursor-default opacity-50",
+												)}
 											>
-												<div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/20">
+												<div
+													className={cn(
+														"flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors",
+														onClick && "group-hover:bg-primary/20",
+													)}
+												>
 													<Icon className="size-4" />
 												</div>
 												<div className="min-w-0 flex-1">
@@ -690,7 +731,13 @@ function HomePage() {
 														{description}
 													</p>
 												</div>
-												<ArrowRight className="size-3.5 shrink-0 text-muted-foreground/30 transition-all group-hover:translate-x-0.5 group-hover:text-primary/60" />
+												<ArrowRight
+													className={cn(
+														"size-3.5 shrink-0 text-muted-foreground/30 transition-all",
+														onClick &&
+															"group-hover:translate-x-0.5 group-hover:text-primary/60",
+													)}
+												/>
 											</button>
 										))}
 									</div>

--- a/services/api/internal/repository/postgres/user_repository.go
+++ b/services/api/internal/repository/postgres/user_repository.go
@@ -58,13 +58,14 @@ func NewUserRepository(db *gorm.DB) *UserRepository {
 	return &UserRepository{db: db}
 }
 
-// List returns a page of non-deleted users ordered by creation date plus the
-// total count across all pages.
+// List returns a page of non-deleted, non-system users ordered by creation
+// date plus the total count across all pages.  The built-in agent bot account
+// is excluded because it is an internal system identity, not a real user.
 func (r *UserRepository) List(ctx context.Context, offset, limit int) ([]*userdom.User, int64, error) {
 	var total int64
 	if err := r.db.WithContext(ctx).
 		Table("users").
-		Where("deleted_at IS NULL").
+		Where("deleted_at IS NULL AND username != '_paca_agent_bot'").
 		Count(&total).Error; err != nil {
 		return nil, 0, fmt.Errorf("user repo: list count: %w", err)
 	}
@@ -74,7 +75,7 @@ func (r *UserRepository) List(ctx context.Context, offset, limit int) ([]*userdo
 		Select(userReadCols).
 		Table("users").
 		Joins(userReadJoin).
-		Where("users.deleted_at IS NULL").
+		Where("users.deleted_at IS NULL AND users.username != '_paca_agent_bot'").
 		Order("users.created_at ASC").
 		Offset(offset).
 		Limit(limit).


### PR DESCRIPTION
## Summary

- **MCP server docs** — Added a full MCP Server section to `README.md` documenting the `@paca-ai/paca-mcp` npm package: quick-start config for Claude Desktop and other MCP-compatible clients, environment variables reference, and a table of all available tool categories.
- **Brand panel refresh** — Updated login page feature cards: replaced \"The P-A-C-A Cycle\" with a **Plugin Marketplace** entry (new Puzzle icon), tightened the AI Agents card copy to emphasise sandboxed containers, and condensed the tagline.
- **Actionable onboarding steps** — Getting-Started step 1 is now a real `<button>` that opens the create-project dialog when the user has permission; subsequent steps render as locked (dimmed) until prerequisites are met.
- **Disabled quick-action buttons** — Quick-action items without an `onClick` handler are now visually disabled (`opacity-50`, `cursor-default`, no hover effects) instead of rendering as broken interactive elements.
- **Exclude agent bot from user list** — `UserRepository.List` now filters out the internal `_paca_agent_bot` account so it never appears in member pickers or admin user tables.

## Type of Change

- Documentation
- UI / Frontend
- Backend fix

## Checklist

- [x] The change is focused and scoped.
- [x] Related documentation is updated.
- [x] New structure or direction is explained clearly.
- [x] I avoided unnecessary detail or premature abstraction.