### PR TITLE
refactor: enhance encryption handling and error reporting in agent re…

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -221,6 +221,9 @@ services:
       PORT_POOL_SIZE: ${PORT_POOL_SIZE:-100}
       WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-10}
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      # Must match ENCRYPTION_KEY in the api service so that LLM API keys
+      # stored encrypted in the database can be decrypted before use.
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -223,7 +223,7 @@ ENCRYPTION_KEY_GENERATED=0
 ask_secret ENCRYPTION_KEY "Encryption key — 64-char hex (leave blank to generate)"
 
 if [[ -z "$ENCRYPTION_KEY" ]]; then
-    ENCRYPTION_KEY="$(rand_hex 32)"
+    ENCRYPTION_KEY="$(rand_hex 64)"
     ENCRYPTION_KEY_GENERATED=1
     info "Encryption key generated."
 else

--- a/services/ai-agent/src/agent/docker_workspace.py
+++ b/services/ai-agent/src/agent/docker_workspace.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import io
 import logging
 import os
 import platform as platform_module
 import secrets
 import socket
+import tarfile
 import threading
 import time
 from collections.abc import Iterator
@@ -95,10 +97,10 @@ def _get_app_host_path(client: docker.DockerClient) -> str | None:
 def _find_host_path_for(client: docker.DockerClient, container_path: str) -> str | None:
     """Return the host-side source of a bind mount in the current container.
 
-    Used to re-share a directory (e.g. /mcp) that is already bind-mounted into
-    this container into the sibling sandbox containers we spawn.  The Docker
-    socket gives access to the *host* daemon, so volumes must be expressed as
-    host paths — not paths that only exist inside this container.
+    Used to re-share a directory that is already bind-mounted into this
+    container into the sibling sandbox containers we spawn.  The Docker socket
+    gives access to the *host* daemon, so volumes must be expressed as host
+    paths — not paths that only exist inside this container.
     """
     try:
         hostname = socket.gethostname()
@@ -124,6 +126,46 @@ def _wait_for_ready(host: str, timeout: float = 120.0) -> None:
     raise TimeoutError(f"Agent server at {host} not ready after {timeout}s")
 
 
+# ─── Repo tools injection ─────────────────────────────────────────────────────
+
+_REPO_TOOLS_DEST = "/tmp/paca_tools"
+_REPO_TOOLS_FILES = [
+    ("src/__init__.py", "paca_tools/src/__init__.py"),
+    ("src/agent/__init__.py", "paca_tools/src/agent/__init__.py"),
+    ("src/agent/repo_tools.py", "paca_tools/src/agent/repo_tools.py"),
+]
+
+
+def _copy_repo_tools_to_container(container: Container) -> bool:
+    """Copy src.agent.repo_tools into /tmp/paca_tools in the sandbox.
+
+    Used in production where /app is baked into the image instead of
+    bind-mounted from the host.  After this call, the agent server can
+    run importlib.import_module("src.agent.repo_tools") when
+    OH_EXTRA_PYTHON_PATH=/tmp/paca_tools is set.
+
+    Returns True on success, False if any required source file is missing.
+    """
+    src_root = Path("/app")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for dir_name in ["paca_tools", "paca_tools/src", "paca_tools/src/agent"]:
+            info = tarfile.TarInfo(name=dir_name)
+            info.type = tarfile.DIRTYPE
+            info.mode = 0o755
+            tar.addfile(info)
+        for src_rel, dest_rel in _REPO_TOOLS_FILES:
+            path = src_root / src_rel
+            if not path.exists():
+                logger.warning("Cannot copy repo_tools into sandbox: missing %s", path)
+                return False
+            tar.add(str(path), arcname=dest_rel)
+    buf.seek(0)
+    container.put_archive("/tmp", buf.getvalue())
+    logger.debug("Copied repo_tools into sandbox container at %s", _REPO_TOOLS_DEST)
+    return True
+
+
 # ─── Context manager ──────────────────────────────────────────────────────────
 
 
@@ -142,14 +184,10 @@ def docker_sandbox(
     sandbox — MCP servers (including the built-in Paca MCP) call those services
     directly, so they must be reachable from within the container.
 
-    The MCP build directory (/mcp) is re-shared into the sandbox using the
-    host-side bind-mount path, so `node /mcp/build/index.js` works inside the
-    container without baking the file into the agent-server image.
-
     Outside Docker (local dev)
     ──────────────────────────
     The container port is mapped to a host port from the pool and accessed via
-    localhost.  MCP volume sharing is attempted on a best-effort basis.
+    localhost.
     """
     client = docker.DockerClient(base_url=f"unix://{settings.docker_socket}")
     container: Container | None = None
@@ -159,17 +197,6 @@ def docker_sandbox(
         # ── Volumes ───────────────────────────────────────────────────────────
         volumes: dict = {}
 
-        # Share the MCP build directory so `node /mcp/build/index.js` works.
-        mcp_host_path = _find_host_path_for(client, "/mcp")
-        if mcp_host_path:
-            volumes[mcp_host_path] = {"bind": "/mcp", "mode": "ro"}
-            logger.debug("Sharing MCP build into sandbox from host path: %s", mcp_host_path)
-        else:
-            logger.warning(
-                "Could not detect host path for /mcp — the built-in Paca MCP "
-                "server may not be available inside the agent sandbox."
-            )
-
         # Share the ai-agent source tree so the remote server can import
         # src.agent.repo_tools to register the custom repository tools.
         app_host_path = _get_app_host_path(client)
@@ -177,9 +204,11 @@ def docker_sandbox(
             volumes[app_host_path] = {"bind": "/app", "mode": "ro"}
             logger.debug("Sharing app source into sandbox from host path: %s", app_host_path)
         else:
-            logger.warning(
-                "Could not detect host path for /app — custom repository tools "
-                "(list_repositories, clone_repository, …) will not be available."
+            # Production: /app is baked into the image (not bind-mounted).
+            # We will copy the necessary files into the container after it starts.
+            logger.debug(
+                "No host bind-mount for /app detected — "
+                "will inject repo_tools into the sandbox container directly."
             )
 
         # ── Environment ───────────────────────────────────────────────────────
@@ -194,12 +223,11 @@ def docker_sandbox(
             "GIT_AUTHOR_EMAIL": git_committer_email,
             "GIT_COMMITTER_NAME": git_committer_name,
             "GIT_COMMITTER_EMAIL": git_committer_email,
+            # Add the app source to Python's module search path so the agent
+            # server can run importlib.import_module("src.agent.repo_tools").
+            # Value depends on whether we share via bind-mount or file injection.
+            "OH_EXTRA_PYTHON_PATH": "/app" if app_host_path else _REPO_TOOLS_DEST,
         }
-        if app_host_path:
-            # Add the mounted app directory to Python's module search path so
-            # `importlib.import_module("src.agent.repo_tools")` succeeds inside
-            # the container.
-            environment["OH_EXTRA_PYTHON_PATH"] = "/app"
 
         run_kwargs: dict = {
             "image": settings.agent_server_image,
@@ -246,6 +274,19 @@ def docker_sandbox(
             )
             container = client.containers.run(**run_kwargs)
             host = f"http://localhost:{host_port}"
+
+        if not app_host_path:
+            # Production path: inject repo_tools directly into the container
+            # filesystem before the server finishes starting up.
+            try:
+                _copy_repo_tools_to_container(container)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to inject repo_tools into sandbox — "
+                    "repository tools (list_repositories, clone_repository, …) "
+                    "will not be available: %s",
+                    exc,
+                )
 
         _wait_for_ready(host)
         logger.info("Agent sandbox ready: conversation=%s host=%s", conversation_id, host)

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -36,17 +36,43 @@ _DONE_STATUSES = frozenset(
     }
 )
 
+_ERROR_STATUSES = frozenset(
+    {
+        ConversationExecutionStatus.ERROR,
+        ConversationExecutionStatus.STUCK,
+    }
+)
+
+
+def _get_conversation_error_detail(conversation) -> str | None:
+    """Extract the error detail from a conversation's ConversationErrorEvent, if any."""
+    try:
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+
+        events = conversation.state.events
+        for event in reversed(list(events)):
+            if isinstance(event, ConversationErrorEvent):
+                code = (event.code or "").strip()
+                detail = (event.detail or "").strip()
+                if code and detail:
+                    return f"{code}: {detail}"
+                return detail or code or None
+    except Exception:
+        pass
+    return None
+
 
 def _wait_for_done_or_stop(
     conversation,
     stop_event: threading.Event,
     poll_interval: float = 2.0,
     timeout: float = 3600.0,
-) -> bool:
+) -> tuple[bool, bool]:
     """Poll the remote conversation until it finishes or a stop is signaled.
 
-    Returns True if the loop exited because stop was requested (so the caller
-    knows not to update status to "finished").
+    Returns (stopped, errored):
+      stopped  — True if the loop exited because a stop was requested.
+      errored  — True if the conversation ended with ERROR or STUCK status.
     """
     start = time.monotonic()
     while True:
@@ -57,16 +83,24 @@ def _wait_for_done_or_stop(
                 conversation.pause()
             except Exception as exc:
                 logger.warning("Failed to pause conversation on stop request: %s", exc)
-            return True
+            return True, False
 
         if time.monotonic() - start > timeout:
             logger.warning("Conversation polling timed out after %.0f seconds", timeout)
-            return False
+            return False, False
 
         try:
             status = conversation.state.execution_status
             if status in _DONE_STATUSES:
-                return False
+                errored = status in _ERROR_STATUSES
+                if errored:
+                    detail = _get_conversation_error_detail(conversation)
+                    logger.error(
+                        "Conversation ended with status %s — %s",
+                        status.value,
+                        detail or "no detail available",
+                    )
+                return False, errored
         except Exception as exc:
             logger.debug("Failed to read conversation execution status: %s", exc)
 
@@ -408,7 +442,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                     callbacks=[_make_event_callback(trigger, loop, counter)],
                     token_callbacks=[_make_token_callback(trigger, loop, counter)],
                     max_iteration_per_run=agent_config.max_iterations,
-                    visualizer=_QuietVisualizer,
+                    visualizer=_QuietVisualizer(),
                 )
 
                 # Register so the worker's stop handler can find this conversation.
@@ -444,16 +478,26 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 finally:
                     active_conversations.pop(trigger.conversation_id, None)
 
-        interrupted = await asyncio.get_event_loop().run_in_executor(None, _run_sync)
-        if not interrupted:
-            await conversation_repository.update_conversation_status(
-                trigger.conversation_id, "finished"
-            )
-            await stream_store.publish_realtime(
-                project_id=trigger.project_id,
-                conversation_id=trigger.conversation_id,
-                event_type="agent.conversation.finished",
-            )
+        stopped, errored = await asyncio.get_event_loop().run_in_executor(None, _run_sync)
+        if not stopped:
+            if errored:
+                await conversation_repository.update_conversation_status(
+                    trigger.conversation_id, "failed"
+                )
+                await stream_store.publish_realtime(
+                    project_id=trigger.project_id,
+                    conversation_id=trigger.conversation_id,
+                    event_type="agent.conversation.failed",
+                )
+            else:
+                await conversation_repository.update_conversation_status(
+                    trigger.conversation_id, "finished"
+                )
+                await stream_store.publish_realtime(
+                    project_id=trigger.project_id,
+                    conversation_id=trigger.conversation_id,
+                    event_type="agent.conversation.finished",
+                )
 
     except Exception as exc:
         if not stop_event.is_set():

--- a/services/ai-agent/src/repositories/agent_repository.py
+++ b/services/ai-agent/src/repositories/agent_repository.py
@@ -17,10 +17,19 @@ def _decrypt_secret(ciphertext: str) -> str:
     """Decrypt an AES-256-GCM ciphertext produced by the Go API's secret.Encryptor.
 
     If ENCRYPTION_KEY is not configured the value is returned as-is (plaintext
-    backward-compat mode).  Any decryption error falls back to returning the raw
-    value so the worker log captures the failure without crashing the service.
+    backward-compat mode).  Any decryption error returns an empty string so
+    that a clear "missing API key" error surfaces at the LLM call rather than
+    the misleading "token expired / incorrect" that results from forwarding the
+    raw ciphertext to the provider.
     """
-    if not settings.encryption_key or not ciphertext:
+    if not ciphertext:
+        return ciphertext
+    if not settings.encryption_key:
+        logger.warning(
+            "ENCRYPTION_KEY is not set — LLM API key will be used as-is from the "
+            "database. If the api service encrypts secrets, set ENCRYPTION_KEY in "
+            "the ai-agent environment to the same value."
+        )
         return ciphertext
     try:
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -33,8 +42,13 @@ def _decrypt_secret(ciphertext: str) -> str:
         plaintext = AESGCM(key).decrypt(nonce, ct_with_tag, None)
         return plaintext.decode()
     except Exception as exc:
-        logger.error("Failed to decrypt LLM API key secret: %s", exc)
-        return ciphertext
+        logger.error(
+            "Failed to decrypt LLM API key secret — the LLM will receive an empty "
+            "key. Verify that ENCRYPTION_KEY in the ai-agent service matches the "
+            "api service. Error: %s",
+            exc,
+        )
+        return ""
 
 
 async def load_agent_config(agent_id: str) -> AgentConfig | None:


### PR DESCRIPTION
## Summary

This PR fixes several production-environment issues in the AI agent service: encryption key misconfiguration, repo tools unavailability in production containers, and silent swallowing of agent errors.

### Changes

**Fix encryption key propagation (`deploy/docker-compose.prod.yml`, `scripts/install.sh`)**
- Added `ENCRYPTION_KEY` to the ai-agent service in the production docker-compose — without it, the service couldn't decrypt LLM API keys stored encrypted by the API service.
- Fixed the install script to generate a proper 64-character hex key (32 bytes for AES-256), up from 32 characters (16 bytes).

**Fix repo tools injection in production (`docker_workspace.py`)**
- In development, `/app` is bind-mounted from the host into the agent container, so sibling sandbox containers could share it via a volume mount. In production, `/app` is baked into the image and the host path detection fails.
- Added `_copy_repo_tools_to_container()` which uses Docker's `put_archive` API to inject `repo_tools.py` and the required `__init__.py` files directly into the running sandbox container at `/tmp/paca_tools` when no bind-mount is detected.
- `OH_EXTRA_PYTHON_PATH` is now always set — to `/app` (dev) or `/tmp/paca_tools` (prod).
- Removed the MCP build directory (`/mcp`) volume sharing, which is no longer needed.

**Improve error reporting (`executor.py`)**
- `_wait_for_done_or_stop` now returns `(stopped, errored)` instead of a single bool.
- Conversations ending with `ERROR` or `STUCK` status now correctly set the conversation to `"failed"` and emit `agent.conversation.failed`, instead of being reported as finished.
- Added `_get_conversation_error_detail()` to extract and log the `ConversationErrorEvent` detail for observability.
- Fixed `visualizer=_QuietVisualizer` → `visualizer=_QuietVisualizer()` (was passing the class, not an instance).

**Improve decryption failure handling (`agent_repository.py`)**
- On decryption failure, return `""` instead of the raw ciphertext. Forwarding ciphertext to the LLM provider produced misleading "token expired / incorrect key" errors; an empty key surfaces a clear "missing API key" error instead.
- Added an explicit warning when `ENCRYPTION_KEY` is unset, pointing to the fix.