### PR TITLE
fix: increase default max iterations for agents to improve performanc…

### DIFF
--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -7,7 +7,6 @@ import json
 import logging
 import threading
 import time
-import uuid
 
 import httpx
 from openhands.sdk import Agent, AgentContext, Conversation
@@ -435,10 +434,15 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 agent = Agent(**agent_kwargs)
                 # RemoteWorkspace → RemoteConversation; persistence_dir is not
                 # supported for remote conversations (state lives in the sandbox).
+                # Do not pass conversation_id: the sandbox server assigns its own
+                # UUID internally.  Passing our application ID causes the server
+                # to return 400 on subsequent GET /api/conversations/{id} calls
+                # (the sandbox only handles IDs it generated itself).  Event
+                # callbacks persist to our DB using trigger.conversation_id
+                # directly, so the mapping stays correct regardless.
                 conversation = Conversation(
                     agent=agent,
                     workspace=workspace,
-                    conversation_id=uuid.UUID(trigger.conversation_id),
                     callbacks=[_make_event_callback(trigger, loop, counter)],
                     token_callbacks=[_make_token_callback(trigger, loop, counter)],
                     max_iteration_per_run=agent_config.max_iterations,
@@ -477,6 +481,15 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                     return _wait_for_done_or_stop(conversation, stop_event)
                 finally:
                     active_conversations.pop(trigger.conversation_id, None)
+                    # Stop the SDK's WebSocket client thread so it does not
+                    # linger after the sandbox container is stopped.  Without
+                    # this, Docker may recycle the container IP before the
+                    # thread exits, causing the thread to send requests for the
+                    # old conversation ID to the new container and get 400s.
+                    try:
+                        conversation.close()
+                    except Exception as exc:
+                        logger.debug("Failed to close conversation: %s", exc)
 
         stopped, errored = await asyncio.get_event_loop().run_in_executor(None, _run_sync)
         if not stopped:

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -117,11 +117,12 @@ func (s *Service) CreateAgent(ctx context.Context, projectID uuid.UUID, in agent
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
-	const maxIterationsLimit = 200
+	const maxIterationsLimit = 500
+	const defaultMaxIterations = 500
 	const timeoutMinutesLimit = 480 // 8 hours
 
 	if a.MaxIterations <= 0 {
-		a.MaxIterations = 50
+		a.MaxIterations = defaultMaxIterations
 	} else if a.MaxIterations > maxIterationsLimit {
 		a.MaxIterations = maxIterationsLimit
 	}
@@ -194,13 +195,14 @@ func (s *Service) UpdateAgent(ctx context.Context, projectID, agentID uuid.UUID,
 	if in.CanCreatePRs != nil {
 		a.CanCreatePRs = *in.CanCreatePRs
 	}
-	const maxIterationsLimit = 200
+	const maxIterationsLimit = 500
+	const defaultMaxIterations = 500
 	const timeoutMinutesLimit = 480
 
 	if in.MaxIterations != nil {
 		v := *in.MaxIterations
 		if v <= 0 {
-			v = 50
+			v = defaultMaxIterations
 		} else if v > maxIterationsLimit {
 			v = maxIterationsLimit
 		}

--- a/services/api/migrations/000008_add_ai_agents.sql
+++ b/services/api/migrations/000008_add_ai_agents.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS agents (
     system_prompt         TEXT        NOT NULL DEFAULT '',
     can_clone_repos       BOOLEAN     NOT NULL DEFAULT TRUE,
     can_create_prs        BOOLEAN     NOT NULL DEFAULT TRUE,
-    max_iterations        INTEGER     NOT NULL DEFAULT 50,
+    max_iterations        INTEGER     NOT NULL DEFAULT 500,
     timeout_minutes       INTEGER     NOT NULL DEFAULT 30,
     git_committer_name    TEXT        NOT NULL DEFAULT 'paca-agent',
     git_committer_email   TEXT        NOT NULL DEFAULT '280579135+paca-agent@users.noreply.github.com',


### PR DESCRIPTION
## Summary

- **Increase default and maximum iteration limits for agents** — default `max_iterations` raised from 50 → 500, and the upper cap from 200 → 500, both in the Go service and the DB migration.
- **Fix 400 errors from sandbox on conversation lookup** — removed `conversation_id` from the `Conversation` constructor. The sandbox server assigns its own internal UUID; passing our application ID caused `GET /api/conversations/{id}` to return 400 on all subsequent calls. Event callbacks already persist to our DB using `trigger.conversation_id` directly, so the mapping stays correct.
- **Fix lingering WebSocket thread after sandbox shutdown** — added `conversation.close()` in the executor `finally` block. Without this, the SDK's WebSocket client thread outlived the sandbox container; when Docker recycled the container IP, the thread would send requests for the old conversation ID to the new container and receive 400s.

## Changes

| File | Change |
|------|--------|
| `services/api/internal/service/agent/agent_service.go` | `maxIterationsLimit` 200 → 500; default 50 → 500 (both `CreateAgent` and `UpdateAgent`) |
| `services/api/migrations/000008_add_ai_agents.sql` | `max_iterations` column default 50 → 500 |
| `services/ai-agent/src/agent/executor.py` | Remove `conversation_id` arg; add `conversation.close()` in `finally`; remove unused `import uuid` |

## Test plan

- [ ] Create a new agent and confirm `max_iterations` defaults to 500
- [ ] Trigger an agent run and verify no 400 errors appear in logs for conversation lookup
- [ ] Stop a sandbox mid-run and confirm no lingering WebSocket thread errors in subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)