### PR TITLE
feat(assignee-filter): enhance assignee filtering with unassigned opt…

### DIFF
--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -77,10 +77,7 @@ import { NewViewPopover } from "./new-view-popover";
 import { RenameViewDialog } from "./rename-view-dialog";
 import { RoadmapView } from "./roadmap-view";
 import { TaskDetailModal } from "./task-detail-modal";
-import {
-	UNASSIGNED_FILTER_ID,
-	ViewSettingsPanel,
-} from "./view-settings-panel";
+import { UNASSIGNED_FILTER_ID, ViewSettingsPanel } from "./view-settings-panel";
 import {
 	getColumnGroupDefs,
 	sortTasksByConfig,
@@ -529,64 +526,61 @@ export function InteractionLayout({
 	const isRealView = !!activeViewId && !activeViewId.startsWith("__default-");
 	const effectiveViewId = isManualSort && isRealView ? activeViewId : undefined;
 	const hasExplicitFilterConfig = activeViewConfig?.filters !== undefined;
-	const apiFilters = useMemo(
-		() => {
-			let assignee_ids: string[] | undefined;
-			let assignee_null: true | undefined;
-			if (activeViewConfig?.filters?.assignees) {
-				const resolved = resolveFilterConfig(
-					activeViewConfig.filters.assignees,
-					members.map((m) => m.id),
-				);
-				const hasUnassigned = resolved.includes(UNASSIGNED_FILTER_ID);
-				const memberIds = resolved.filter((id) => id !== UNASSIGNED_FILTER_ID);
-				assignee_ids = memberIds.length > 0 ? memberIds : undefined;
-				assignee_null = hasUnassigned || undefined;
-			}
+	const apiFilters = useMemo(() => {
+		let assignee_ids: string[] | undefined;
+		let assignee_null: true | undefined;
+		if (activeViewConfig?.filters?.assignees) {
+			const resolved = resolveFilterConfig(
+				activeViewConfig.filters.assignees,
+				members.map((m) => m.id),
+			);
+			const hasUnassigned = resolved.includes(UNASSIGNED_FILTER_ID);
+			const memberIds = resolved.filter((id) => id !== UNASSIGNED_FILTER_ID);
+			assignee_ids = memberIds.length > 0 ? memberIds : undefined;
+			assignee_null = hasUnassigned || undefined;
+		}
 
-			let task_type_ids: string[] | undefined;
-			if (!activeViewConfig?.filters) {
-				task_type_ids = defaultPageTaskTypeIds;
-			} else if (activeViewConfig.filters.task_types) {
-				task_type_ids = resolveTaskTypeFilter(
-					activeViewConfig.filters.task_types,
-					taskTypes,
-				);
-			}
+		let task_type_ids: string[] | undefined;
+		if (!activeViewConfig?.filters) {
+			task_type_ids = defaultPageTaskTypeIds;
+		} else if (activeViewConfig.filters.task_types) {
+			task_type_ids = resolveTaskTypeFilter(
+				activeViewConfig.filters.task_types,
+				taskTypes,
+			);
+		}
 
-			return {
-				sprint_ids:
-					activeViewConfig?.filters !== undefined
-						? activeViewConfig.filters.sprints
-							? resolveFilterConfig(
-									activeViewConfig.filters.sprints,
-									sprints.map((s) => s.id),
-								)
-							: undefined
-						: sprintId
-							? [sprintId]
-							: undefined,
-				status_ids: activeViewConfig?.filters?.statuses
-					? resolveFilterConfig(
-							activeViewConfig.filters.statuses,
-							statuses.map((s) => s.id),
-						)
-					: undefined,
-				assignee_ids,
-				assignee_null,
-				task_type_ids,
-			};
-		},
-		[
-			activeViewConfig?.filters,
-			defaultPageTaskTypeIds,
-			members,
-			sprints,
-			sprintId,
-			statuses,
-			taskTypes,
-		],
-	);
+		return {
+			sprint_ids:
+				activeViewConfig?.filters !== undefined
+					? activeViewConfig.filters.sprints
+						? resolveFilterConfig(
+								activeViewConfig.filters.sprints,
+								sprints.map((s) => s.id),
+							)
+						: undefined
+					: sprintId
+						? [sprintId]
+						: undefined,
+			status_ids: activeViewConfig?.filters?.statuses
+				? resolveFilterConfig(
+						activeViewConfig.filters.statuses,
+						statuses.map((s) => s.id),
+					)
+				: undefined,
+			assignee_ids,
+			assignee_null,
+			task_type_ids,
+		};
+	}, [
+		activeViewConfig?.filters,
+		defaultPageTaskTypeIds,
+		members,
+		sprints,
+		sprintId,
+		statuses,
+		taskTypes,
+	]);
 	const viewCtx: ViewContext = useMemo(
 		() => ({ statuses, taskTypes, members, customFields, sprints }),
 		[statuses, taskTypes, members, customFields, sprints],

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -77,7 +77,10 @@ import { NewViewPopover } from "./new-view-popover";
 import { RenameViewDialog } from "./rename-view-dialog";
 import { RoadmapView } from "./roadmap-view";
 import { TaskDetailModal } from "./task-detail-modal";
-import { ViewSettingsPanel } from "./view-settings-panel";
+import {
+	UNASSIGNED_FILTER_ID,
+	ViewSettingsPanel,
+} from "./view-settings-panel";
 import {
 	getColumnGroupDefs,
 	sortTasksByConfig,
@@ -527,46 +530,53 @@ export function InteractionLayout({
 	const effectiveViewId = isManualSort && isRealView ? activeViewId : undefined;
 	const hasExplicitFilterConfig = activeViewConfig?.filters !== undefined;
 	const apiFilters = useMemo(
-		() => ({
-			sprint_ids:
-				activeViewConfig?.filters !== undefined
-					? activeViewConfig.filters.sprints
-						? resolveFilterConfig(
-								activeViewConfig.filters.sprints,
-								sprints.map((s) => s.id),
-							)
-						: undefined
-					: sprintId
-						? [sprintId]
-						: undefined,
-			status_ids: activeViewConfig?.filters?.statuses
-				? resolveFilterConfig(
-						activeViewConfig.filters.statuses,
-						statuses.map((s) => s.id),
-					)
-				: undefined,
-			...(() => {
-				if (!activeViewConfig?.filters?.assignees) return {};
+		() => {
+			let assignee_ids: string[] | undefined;
+			let assignee_null: true | undefined;
+			if (activeViewConfig?.filters?.assignees) {
 				const resolved = resolveFilterConfig(
 					activeViewConfig.filters.assignees,
 					members.map((m) => m.id),
 				);
-				const hasUnassigned = resolved.includes("__unassigned");
-				const memberIds = resolved.filter((id) => id !== "__unassigned");
-				return {
-					assignee_ids: memberIds.length > 0 ? memberIds : undefined,
-					assignee_null: hasUnassigned || undefined,
-				};
-			})(),
-			task_type_ids: (() => {
-				if (!activeViewConfig?.filters) return defaultPageTaskTypeIds;
-				if (!activeViewConfig.filters.task_types) return undefined;
-				return resolveTaskTypeFilter(
+				const hasUnassigned = resolved.includes(UNASSIGNED_FILTER_ID);
+				const memberIds = resolved.filter((id) => id !== UNASSIGNED_FILTER_ID);
+				assignee_ids = memberIds.length > 0 ? memberIds : undefined;
+				assignee_null = hasUnassigned || undefined;
+			}
+
+			let task_type_ids: string[] | undefined;
+			if (!activeViewConfig?.filters) {
+				task_type_ids = defaultPageTaskTypeIds;
+			} else if (activeViewConfig.filters.task_types) {
+				task_type_ids = resolveTaskTypeFilter(
 					activeViewConfig.filters.task_types,
 					taskTypes,
 				);
-			})(),
-		}),
+			}
+
+			return {
+				sprint_ids:
+					activeViewConfig?.filters !== undefined
+						? activeViewConfig.filters.sprints
+							? resolveFilterConfig(
+									activeViewConfig.filters.sprints,
+									sprints.map((s) => s.id),
+								)
+							: undefined
+						: sprintId
+							? [sprintId]
+							: undefined,
+				status_ids: activeViewConfig?.filters?.statuses
+					? resolveFilterConfig(
+							activeViewConfig.filters.statuses,
+							statuses.map((s) => s.id),
+						)
+					: undefined,
+				assignee_ids,
+				assignee_null,
+				task_type_ids,
+			};
+		},
 		[
 			activeViewConfig?.filters,
 			defaultPageTaskTypeIds,

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -545,12 +545,19 @@ export function InteractionLayout({
 						statuses.map((s) => s.id),
 					)
 				: undefined,
-			assignee_ids: activeViewConfig?.filters?.assignees
-				? resolveFilterConfig(
-						activeViewConfig.filters.assignees,
-						members.map((m) => m.id),
-					)
-				: undefined,
+			...(() => {
+				if (!activeViewConfig?.filters?.assignees) return {};
+				const resolved = resolveFilterConfig(
+					activeViewConfig.filters.assignees,
+					members.map((m) => m.id),
+				);
+				const hasUnassigned = resolved.includes("__unassigned");
+				const memberIds = resolved.filter((id) => id !== "__unassigned");
+				return {
+					assignee_ids: memberIds.length > 0 ? memberIds : undefined,
+					assignee_null: hasUnassigned || undefined,
+				};
+			})(),
 			task_type_ids: (() => {
 				if (!activeViewConfig?.filters) return defaultPageTaskTypeIds;
 				if (!activeViewConfig.filters.task_types) return undefined;
@@ -606,6 +613,8 @@ export function InteractionLayout({
 			statusIds: columnBy !== "status" ? apiFilters.status_ids : undefined,
 			assigneeIds:
 				columnBy !== "assignee" ? apiFilters.assignee_ids : undefined,
+			assigneeNull:
+				columnBy !== "assignee" ? apiFilters.assignee_null : undefined,
 			taskTypeIds: columnBy !== "type" ? apiFilters.task_type_ids : undefined,
 			pageSize: initialColPageSize,
 		}),
@@ -678,6 +687,7 @@ export function InteractionLayout({
 			sprintIds: apiFilters.sprint_ids,
 			statusIds: apiFilters.status_ids,
 			assigneeIds: apiFilters.assignee_ids,
+			assigneeNull: apiFilters.assignee_null,
 			taskTypeIds: apiFilters.task_type_ids,
 		}),
 		[context, hasExplicitFilterConfig, sprintId, apiFilters],

--- a/apps/web/src/components/projects/interactions/view-settings-panel.tsx
+++ b/apps/web/src/components/projects/interactions/view-settings-panel.tsx
@@ -457,6 +457,8 @@ function StatusFilterSection({
 
 // ── Assignee filter ───────────────────────────────────────────────────────────
 
+const UNASSIGNED_FILTER_ID = "__unassigned";
+
 function AssigneeFilterSection({
 	members,
 	selectedIds,
@@ -466,18 +468,18 @@ function AssigneeFilterSection({
 	selectedIds: string[];
 	onChange: (ids: string[]) => void;
 }) {
-	const allIds = members.map((m) => m.id);
+	const allFilterIds = [...members.map((m) => m.id), UNASSIGNED_FILTER_ID];
 	const isAll = selectedIds.length === 0;
 
 	const toggle = (id: string) => {
 		if (isAll) {
-			onChange(allIds.filter((x) => x !== id));
+			onChange([id]);
 		} else if (selectedIds.includes(id)) {
 			const next = selectedIds.filter((x) => x !== id);
-			onChange(next.length === allIds.length ? [] : next);
+			onChange(next.length === allFilterIds.length ? [] : next);
 		} else {
 			const next = [...selectedIds, id];
-			onChange(next.length === allIds.length ? [] : next);
+			onChange(next.length === allFilterIds.length ? [] : next);
 		}
 	};
 
@@ -513,6 +515,17 @@ function AssigneeFilterSection({
 					);
 				})
 			)}
+			<CheckRow
+				id="assignee-unassigned"
+				label="Unassigned"
+				checked={isAll || selectedIds.includes(UNASSIGNED_FILTER_ID)}
+				onChange={() => toggle(UNASSIGNED_FILTER_ID)}
+				icon={
+					<div className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground text-[10px] ring-1 ring-border">
+						–
+					</div>
+				}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/components/projects/interactions/view-settings-panel.tsx
+++ b/apps/web/src/components/projects/interactions/view-settings-panel.tsx
@@ -457,7 +457,7 @@ function StatusFilterSection({
 
 // ── Assignee filter ───────────────────────────────────────────────────────────
 
-const UNASSIGNED_FILTER_ID = "__unassigned";
+export const UNASSIGNED_FILTER_ID = "__unassigned";
 
 function AssigneeFilterSection({
 	members,

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -422,10 +422,15 @@ function buildTaskQueryParams(opts: ListTasksOptions = {}) {
 	if (opts.statusId) params.status_id = opts.statusId;
 	if (opts.statusIds && opts.statusIds.length > 0)
 		params.status_ids = opts.statusIds.join(",");
-	if (opts.assigneeNull) params.assignee_id = "null";
-	else if (opts.assigneeId) params.assignee_id = opts.assigneeId;
-	else if (opts.assigneeIds && opts.assigneeIds.length > 0)
+	if (opts.assigneeNull) {
+		params.assignee_id = "null";
+		if (opts.assigneeIds && opts.assigneeIds.length > 0)
+			params.assignee_ids = opts.assigneeIds.join(",");
+	} else if (opts.assigneeId) {
+		params.assignee_id = opts.assigneeId;
+	} else if (opts.assigneeIds && opts.assigneeIds.length > 0) {
 		params.assignee_ids = opts.assigneeIds.join(",");
+	}
 	if (opts.taskTypeNull) params.task_type_id = "null";
 	else if (opts.taskTypeIds && opts.taskTypeIds.length > 0)
 		params.task_type_ids = opts.taskTypeIds.join(",");

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -342,12 +342,13 @@ func (r *TaskRepository) ListTasks(ctx context.Context, projectID uuid.UUID, fil
 		q = q.Where("status_id = ?", filter.StatusID.String())
 	}
 
-	switch {
-	case filter.AssigneeNull:
+	if filter.AssigneeNull && len(filter.AssigneeIDs) > 0 {
+		q = q.Where("assignee_id IS NULL OR assignee_id IN ?", uuidSliceToStrSlice(filter.AssigneeIDs))
+	} else if filter.AssigneeNull {
 		q = q.Where("assignee_id IS NULL")
-	case len(filter.AssigneeIDs) > 0:
+	} else if len(filter.AssigneeIDs) > 0 {
 		q = q.Where("assignee_id IN ?", uuidSliceToStrSlice(filter.AssigneeIDs))
-	case filter.AssigneeID != nil:
+	} else if filter.AssigneeID != nil {
 		q = q.Where("assignee_id = ?", filter.AssigneeID.String())
 	}
 

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -342,13 +342,14 @@ func (r *TaskRepository) ListTasks(ctx context.Context, projectID uuid.UUID, fil
 		q = q.Where("status_id = ?", filter.StatusID.String())
 	}
 
-	if filter.AssigneeNull && len(filter.AssigneeIDs) > 0 {
+	switch {
+	case filter.AssigneeNull && len(filter.AssigneeIDs) > 0:
 		q = q.Where("assignee_id IS NULL OR assignee_id IN ?", uuidSliceToStrSlice(filter.AssigneeIDs))
-	} else if filter.AssigneeNull {
+	case filter.AssigneeNull:
 		q = q.Where("assignee_id IS NULL")
-	} else if len(filter.AssigneeIDs) > 0 {
+	case len(filter.AssigneeIDs) > 0:
 		q = q.Where("assignee_id IN ?", uuidSliceToStrSlice(filter.AssigneeIDs))
-	} else if filter.AssigneeID != nil {
+	case filter.AssigneeID != nil:
 		q = q.Where("assignee_id = ?", filter.AssigneeID.String())
 	}
 

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -510,6 +510,25 @@ func TestTaskHandler_ListTasks_SprintNullMeansBacklog(t *testing.T) {
 	}
 }
 
+func TestTaskHandler_ListTasks_AssigneeNullAndIDsTogether(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	assigneeID := uuid.New()
+
+	path := fmt.Sprintf("/projects/%s/tasks?assignee_id=null&assignee_ids=%s", projectID, assigneeID)
+	w := doTaskRequest(r, http.MethodGet, path, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !svc.lastFilter.AssigneeNull {
+		t.Fatal("expected AssigneeNull=true when assignee_id=null")
+	}
+	if len(svc.lastFilter.AssigneeIDs) != 1 || svc.lastFilter.AssigneeIDs[0] != assigneeID {
+		t.Fatalf("expected AssigneeIDs=[%s], got %+v", assigneeID, svc.lastFilter.AssigneeIDs)
+	}
+}
+
 func TestTaskHandler_ListTasks_TaskTypeIDsDriveFiltering(t *testing.T) {
 	svc := newFakeTaskSvc()
 	r := buildTaskHandlerRouter(svc)


### PR DESCRIPTION
## Summary

- Adds an **Unassigned** option to the assignee filter in the view settings panel, allowing users to filter tasks with no assignee alongside specific members
- Introduces a `__unassigned` sentinel value that is resolved into a separate `assignee_null` query parameter instead of being passed as a member ID
- Updates the backend query logic to support a combined `assignee_id IS NULL OR assignee_id IN (...)` condition when both unassigned and specific assignees are selected

## Changes

### Frontend

- **`view-settings-panel.tsx`**: Adds an "Unassigned" row to the assignee filter UI with a dedicated sentinel constant (`UNASSIGNED_FILTER_ID = "__unassigned"`). Updates the `toggle` logic to account for the expanded filter options list that now includes the unassigned option.
- **`interaction-layout.tsx`**: Splits the assignee filter resolution into two separate API params — `assignee_ids` (specific member IDs) and `assignee_null` (boolean flag for unassigned tasks). Both are forwarded to the column view and global view query hooks.
- **`interaction-api.ts`**: Extends `buildTaskQueryParams` to handle the combined case where `assigneeNull` and `assigneeIds` are both set, sending `assignee_id=null` and `assignee_ids=...` together in the request.

### Backend

- **`task_repository.go`**: Replaces the `switch` statement with an `if/else if` chain to support the new combined filter case, generating `assignee_id IS NULL OR assignee_id IN (...)` when both `AssigneeNull` and `AssigneeIDs` are present.

## Test plan

- [ ] Open a project view and click the assignee filter
- [ ] Verify an "Unassigned" option appears at the bottom of the assignee list
- [ ] Select only "Unassigned" — confirm only tasks with no assignee are shown
- [ ] Select a specific member alongside "Unassigned" — confirm tasks from that member AND unassigned tasks are both shown
- [ ] Deselect all filters (revert to "All") — confirm all tasks appear regardless of assignee
- [ ] Verify column views (grouped by assignee) correctly exclude the `__unassigned` sentinel from member ID lists