### PR TITLE
fix(auth-api): improve error handling in getMeOptional function

### DIFF
--- a/apps/web/src/lib/auth-api.ts
+++ b/apps/web/src/lib/auth-api.ts
@@ -1,4 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
+import axios from "axios";
 
 import { apiClient } from "./api-client";
 import type { SuccessEnvelope } from "./api-error";
@@ -47,13 +48,17 @@ export async function getMe(): Promise<User> {
 
 export async function getMeOptional(): Promise<User | null> {
 	try {
-		const { data } = await apiClient.instance.get<SuccessEnvelope<User>>(
-			"/users/me",
-			{ _skipAuthRefresh: true } as Record<string, unknown>,
-		);
+		const { data } =
+			await apiClient.instance.get<SuccessEnvelope<User>>("/users/me");
 		return data.data;
-	} catch {
-		return null;
+	} catch (err) {
+		// Only treat a definitive 401 as "not authenticated"; re-throw everything
+		// else (network errors, timeouts) so React Query keeps the last good data
+		// instead of overwriting it with null.
+		if (axios.isAxiosError(err) && err.response?.status === 401) {
+			return null;
+		}
+		throw err;
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Tighten the error catch in `getMeOptional`**: previously, any error (network failures, timeouts, server errors) caused the function to silently return `null`, which React Query would treat as a successful empty response and overwrite the last cached user data.
- Now only a definitive **401 Unauthorized** response returns `null` (genuinely unauthenticated). All other errors are re-thrown so React Query retains the last good data and surfaces the error properly.
- Removes the `_skipAuthRefresh: true` option that was suppressing the token-refresh interceptor on this call.

## Test plan

- [x] Sign in, then temporarily disconnect the network — verify the UI retains the previously loaded user instead of resetting to unauthenticated.
- [x] Sign out (real 401) — verify the app correctly treats the user as unauthenticated and returns `null`.
- [x] Sign in normally — verify the authenticated flow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)