### PR TITLE
fix(api-client): improve token refresh error handling and queued request rejection

### DIFF
--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -24,7 +24,10 @@ export class ApiClient {
 	readonly instance: AxiosInstance;
 
 	private isRefreshing = false;
-	private refreshSubscribers: Array<() => void> = [];
+	private refreshSubscribers: Array<{
+		retry: () => void;
+		reject: (err: unknown) => void;
+	}> = [];
 
 	constructor() {
 		this.instance = axios.create({
@@ -86,12 +89,15 @@ export class ApiClient {
 				if (this.isRefreshing) {
 					// Queue the request until refresh completes
 					return new Promise((resolve, reject) => {
-						this.refreshSubscribers.push(() => {
-							originalRequest._retry = true;
-							this.instance
-								.request(originalRequest)
-								.then(resolve)
-								.catch(reject);
+						this.refreshSubscribers.push({
+							retry: () => {
+								originalRequest._retry = true;
+								this.instance
+									.request(originalRequest)
+									.then(resolve)
+									.catch(reject);
+							},
+							reject,
 						});
 					});
 				}
@@ -103,13 +109,13 @@ export class ApiClient {
 					await this.instance.post("/auth/refresh");
 
 					// Flush queued requests
-					this.refreshSubscribers.forEach((cb) => {
-						cb();
-					});
+					this.refreshSubscribers.forEach(({ retry }) => retry());
 					this.refreshSubscribers = [];
 
 					return this.instance.request(originalRequest);
 				} catch (refreshError) {
+					// Reject all queued requests so their promises settle instead of hanging
+					this.refreshSubscribers.forEach(({ reject }) => reject(refreshError));
 					this.refreshSubscribers = [];
 					return Promise.reject(refreshError);
 				} finally {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -109,13 +109,17 @@ export class ApiClient {
 					await this.instance.post("/auth/refresh");
 
 					// Flush queued requests
-					this.refreshSubscribers.forEach(({ retry }) => retry());
+					this.refreshSubscribers.forEach(({ retry }) => {
+						retry();
+					});
 					this.refreshSubscribers = [];
 
 					return this.instance.request(originalRequest);
 				} catch (refreshError) {
 					// Reject all queued requests so their promises settle instead of hanging
-					this.refreshSubscribers.forEach(({ reject }) => reject(refreshError));
+					this.refreshSubscribers.forEach(({ reject }) => {
+						reject(refreshError);
+					});
 					this.refreshSubscribers = [];
 					return Promise.reject(refreshError);
 				} finally {

--- a/apps/web/src/routes/_authenticated/projects/$projectId/interactions/sprints/$sprintId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/interactions/sprints/$sprintId.tsx
@@ -21,13 +21,18 @@ export const Route = createFileRoute(
 		context: { queryClient },
 		params: { projectId, sprintId },
 	}) => {
+		const user = queryClient.getQueryData(["auth", "me-optional"]);
 		await queryClient
 			.ensureQueryData(sprintQueryOptions(projectId, sprintId))
 			.catch(() => {
-				throw redirect({
-					to: "/projects/$projectId/interactions/backlog",
-					params: { projectId },
-				});
+				throw redirect(
+					user
+						? {
+								to: "/projects/$projectId/interactions/backlog",
+								params: { projectId },
+							}
+						: { to: "/" },
+				);
 			});
 	},
 	component: SprintPage,


### PR DESCRIPTION
## Summary

- **`api-client.ts`**: Refactored `refreshSubscribers` from a plain `Array<() => void>` to `Array<{ retry: () => void; reject: (err: unknown) => void }>`. When a token refresh fails, all queued requests are now explicitly rejected — previously their promises would hang indefinitely.
- **`sprintId.tsx`**: Fixed the error-redirect logic in the sprint route loader. Unauthenticated users who fail to load sprint data are now redirected to `/` (login) instead of the backlog page, which would itself require authentication.

## Problem

Before this fix, if the token refresh request failed while other requests were queued:
1. All queued requests would never settle — their `Promise` callbacks were never called.
2. Unauthenticated users hitting a sprint URL would be bounced to a page that still required auth, causing a redirect loop.

## Test plan

- [ ] Simulate a failed token refresh (e.g. expire the refresh token) and confirm in-flight requests reject cleanly rather than hanging
- [ ] Visit a sprint URL while logged out and confirm redirect goes to `/`
- [ ] Visit a sprint URL while logged in with an invalid sprint ID and confirm redirect goes to the backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)