### PR TITLE
feat: remove subtask type and enforce epic hierarchy constraints

### DIFF
--- a/apps/mcp/src/tools/task-tools.ts
+++ b/apps/mcp/src/tools/task-tools.ts
@@ -177,7 +177,7 @@ export function getTaskTools(): Tool[] {
 					parentTaskId: {
 						type: "string",
 						description:
-							"The technical UUID of the parent task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use this to set the epic for a task or to create a subtask under a parent task.",
+							"The technical UUID of the parent task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Story, Task, and Bug tasks can be nested under another Story, Task, or Bug. Epics cannot have a parent task.",
 					},
 					importance: {
 						type: "number",

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -378,8 +378,7 @@ export function TaskDetailModal({
 								if (!projectId) return;
 								updateTask(projectId, subtaskId, payload).then(() => {
 									qc.invalidateQueries({
-										queryKey: subtasksQueryOptions(projectId, task.id)
-											.queryKey,
+										queryKey: subtasksQueryOptions(projectId, task.id).queryKey,
 									});
 								});
 							}}
@@ -393,8 +392,7 @@ export function TaskDetailModal({
 									parent_task_id: task.id,
 								}).then(() => {
 									qc.invalidateQueries({
-										queryKey: subtasksQueryOptions(projectId, task.id)
-											.queryKey,
+										queryKey: subtasksQueryOptions(projectId, task.id).queryKey,
 									});
 								});
 							}}

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -14,10 +14,8 @@ import { ExtensionPoint } from "@/lib/plugins/extension-point";
 import {
 	customFieldsQueryOptions,
 	findEpicType,
-	findSubtaskType,
 	getNormalTaskTypes,
 	isEpicType,
-	isSubtaskType,
 	projectQueryOptions,
 } from "@/lib/project-api";
 import { cleanBlocks, cn } from "@/lib/utils";
@@ -106,11 +104,9 @@ export function TaskDetailModal({
 
 	// ── Task role detection ────────────────────────────────────────────────────
 	const isEpic = isEpicType(taskType);
-	const isSubtask = isSubtaskType(taskType);
-	const taskRole = isEpic ? "epic" : isSubtask ? "subtask" : "normal";
+	const taskRole = isEpic ? "epic" : "normal";
 
 	const epicType = findEpicType(taskTypes);
-	const subtaskType = findSubtaskType(taskTypes);
 	const normalTaskTypes = getNormalTaskTypes(taskTypes);
 
 	// For normal tasks: fetch all epics to populate the Epic picker
@@ -123,7 +119,7 @@ export function TaskDetailModal({
 			(open || mode === "page"),
 	});
 
-	// For subtasks: fetch parent task to display its title
+	// Fetch parent task to display its title/icon (for non-epic parents)
 	const { data: parentTask } = useQuery({
 		...taskQueryOptions(projectId ?? "", task?.parent_task_id ?? ""),
 		enabled: !!projectId && !!task?.parent_task_id && (open || mode === "page"),
@@ -365,48 +361,44 @@ export function TaskDetailModal({
 							taskId={task.id}
 							onUpdate={handleUpdate}
 						/>
-						{/* Subtasks / Tasks section – hidden for subtasks */}
-						{taskRole !== "subtask" && (
-							<SubtasksSection
-								projectId={projectId}
-								parentTaskId={task.id}
-								subtasks={subtasks}
-								statuses={statuses}
-								taskTypes={taskTypes}
-								members={members}
-								canEdit={canEdit}
-								task={task}
-								taskIdPrefix={taskIdPrefix}
-								mode={isEpic ? "tasks" : "subtasks"}
-								subtaskType={subtaskType}
-								normalTaskTypes={normalTaskTypes}
-								onSubtaskClick={(sub) => navigateToTask(sub.id)}
-								onSubtaskUpdate={(subtaskId, payload) => {
-									if (!projectId) return;
-									updateTask(projectId, subtaskId, payload).then(() => {
-										qc.invalidateQueries({
-											queryKey: subtasksQueryOptions(projectId, task.id)
-												.queryKey,
-										});
+						{/* Child tasks section */}
+						<SubtasksSection
+							projectId={projectId}
+							parentTaskId={task.id}
+							subtasks={subtasks}
+							statuses={statuses}
+							taskTypes={taskTypes}
+							members={members}
+							canEdit={canEdit}
+							task={task}
+							taskIdPrefix={taskIdPrefix}
+							normalTaskTypes={normalTaskTypes}
+							onSubtaskClick={(sub) => navigateToTask(sub.id)}
+							onSubtaskUpdate={(subtaskId, payload) => {
+								if (!projectId) return;
+								updateTask(projectId, subtaskId, payload).then(() => {
+									qc.invalidateQueries({
+										queryKey: subtasksQueryOptions(projectId, task.id)
+											.queryKey,
 									});
-								}}
-								onSubtaskCreate={(payload) => {
-									if (!projectId) return;
-									const todoStatus =
-										statuses.find((s) => s.category === "todo") ?? statuses[0];
-									createTask(projectId, {
-										...payload,
-										status_id: todoStatus?.id ?? payload.status_id ?? null,
-										parent_task_id: task.id,
-									}).then(() => {
-										qc.invalidateQueries({
-											queryKey: subtasksQueryOptions(projectId, task.id)
-												.queryKey,
-										});
+								});
+							}}
+							onSubtaskCreate={(payload) => {
+								if (!projectId) return;
+								const todoStatus =
+									statuses.find((s) => s.category === "todo") ?? statuses[0];
+								createTask(projectId, {
+									...payload,
+									status_id: todoStatus?.id ?? payload.status_id ?? null,
+									parent_task_id: task.id,
+								}).then(() => {
+									qc.invalidateQueries({
+										queryKey: subtasksQueryOptions(projectId, task.id)
+											.queryKey,
 									});
-								}}
-							/>
-						)}
+								});
+							}}
+						/>
 
 						{/* Plugin extension points */}
 						{projectId && (

--- a/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
@@ -18,7 +18,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Skeleton } from "@/components/ui/skeleton";
 import type { Sprint, Task } from "@/lib/interaction-api";
 import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
 import { getTaskTypeIconComponent } from "../../task-types/task-type-icons";

--- a/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
@@ -66,11 +66,11 @@ interface PropertiesPanelProps {
 	projectId?: string;
 	initialCustomFields?: CustomFieldDef[];
 	canEdit?: boolean;
-	/** Role of the current task: "epic", "normal", or "subtask" */
-	taskRole?: "epic" | "normal" | "subtask";
+	/** Role of the current task: "epic" or "normal" */
+	taskRole?: "epic" | "normal";
 	/** All epic tasks in the project, for the epic picker on normal tasks */
 	epicTasks?: Task[];
-	/** Parent task, shown for subtasks */
+	/** The resolved parent task object (when parent_task_id is set) */
 	parentTask?: Task;
 	onUpdate?: (payload: UpdatePayload) => void;
 	/** Navigate to a task's detail page */
@@ -403,11 +403,13 @@ export function PropertiesPanel({
 							</FieldRow>
 						);
 					})()}
-				{/* Parent task – subtasks only */}
-				{taskRole === "subtask" && (
-					<FieldRow label="Parent">
-						{parentTask ? (
-							(() => {
+				{/* Parent field – shown when the parent task is not an epic (story/task/bug nesting) */}
+				{taskRole === "normal" &&
+					task.parent_task_id &&
+					parentTask &&
+					!epicTasks.find((e) => e.id === task.parent_task_id) && (
+						<FieldRow label="Parent">
+							{(() => {
 								const parentType = taskTypes.find(
 									(tt) => tt.id === parentTask.task_type_id,
 								);
@@ -447,16 +449,9 @@ export function PropertiesPanel({
 										</DropdownMenuContent>
 									</DropdownMenu>
 								);
-							})()
-						) : task.parent_task_id ? (
-							<Skeleton className="h-3.5 w-28" />
-						) : (
-							<span className="text-[12px] text-muted-foreground/50 italic">
-								No parent
-							</span>
-						)}
-					</FieldRow>
-				)}
+							})()}
+						</FieldRow>
+					)}
 
 				{localCustomFields.map((cf) => (
 					<PropertyField

--- a/apps/web/src/components/projects/interactions/task-detail/subtasks-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/subtasks-section.tsx
@@ -14,11 +14,7 @@ interface SubtasksSectionProps {
 	canEdit?: boolean;
 	task: Task;
 	taskIdPrefix?: string;
-	/** "subtasks" – normal task creating subtasks; "tasks" – epic creating child tasks */
-	mode?: "subtasks" | "tasks";
-	/** Type to auto-assign when mode="subtasks" */
-	subtaskType?: TaskType;
-	/** Available types for the type picker when mode="tasks" (epic) */
+	/** Available types for the type picker when creating subtasks */
 	normalTaskTypes?: TaskType[];
 	onSubtaskUpdate?: (
 		subtaskId: string,
@@ -44,8 +40,6 @@ export function SubtasksSection({
 	members = [],
 	canEdit = true,
 	taskIdPrefix = "",
-	mode = "subtasks",
-	subtaskType,
 	normalTaskTypes = [],
 	onSubtaskUpdate,
 	onSubtaskCreate,
@@ -57,24 +51,13 @@ export function SubtasksSection({
 		() => normalTaskTypes[0]?.id ?? "",
 	);
 
-	const sectionLabel = mode === "tasks" ? "Tasks" : "Subtasks";
-	const emptyLabel = mode === "tasks" ? "No tasks yet" : "No subtasks yet";
-	const placeholder = mode === "tasks" ? "Task title..." : "Subtask title...";
-
 	function handleCreate() {
 		const trimmed = newTitle.trim();
 		if (!trimmed) return;
-		if (mode === "subtasks") {
-			onSubtaskCreate?.({
-				title: trimmed,
-				task_type_id: subtaskType?.id ?? null,
-			});
-		} else {
-			onSubtaskCreate?.({
-				title: trimmed,
-				task_type_id: selectedTypeId || null,
-			});
-		}
+		onSubtaskCreate?.({
+			title: trimmed,
+			task_type_id: selectedTypeId || null,
+		});
 		setNewTitle("");
 		setAdding(false);
 	}
@@ -83,7 +66,7 @@ export function SubtasksSection({
 		<div className="space-y-3">
 			<div className="flex items-center justify-between">
 				<h3 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70 flex items-center gap-2">
-					<span>{sectionLabel}</span>
+					<span>Subtasks</span>
 					<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
 				</h3>
 				{canEdit && (
@@ -93,7 +76,7 @@ export function SubtasksSection({
 						className="flex items-center gap-1.5 rounded-lg bg-primary/8 text-primary/80 hover:bg-primary/15 hover:text-primary px-2.5 py-1.5 text-[11px] font-semibold transition-all duration-150"
 					>
 						<Plus className="size-3" />
-						Add Task
+						Add Subtask
 					</button>
 				)}
 			</div>
@@ -108,7 +91,7 @@ export function SubtasksSection({
 							statuses={statuses}
 							taskTypes={taskTypes}
 							members={members}
-							showTypeField={mode === "tasks"}
+							showTypeField
 							canEdit={canEdit}
 							onUpdate={onSubtaskUpdate}
 							onClick={onSubtaskClick ? () => onSubtaskClick(sub) : undefined}
@@ -125,7 +108,7 @@ export function SubtasksSection({
 						handleCreate();
 					}}
 				>
-					{mode === "tasks" && normalTaskTypes.length > 0 && (
+					{normalTaskTypes.length > 0 && (
 						<select
 							value={selectedTypeId}
 							onChange={(e) => setSelectedTypeId(e.target.value)}
@@ -145,7 +128,7 @@ export function SubtasksSection({
 							type="text"
 							value={newTitle}
 							onChange={(e) => setNewTitle(e.target.value)}
-							placeholder={placeholder}
+							placeholder="Subtask title..."
 							className="flex-1 rounded-lg border border-border/30 bg-muted/20 px-3 py-2.5 text-[13px] placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all duration-150"
 							onKeyDown={(e) => {
 								if (e.key === "Escape") {
@@ -177,7 +160,7 @@ export function SubtasksSection({
 			{!adding && subtasks.length === 0 && (
 				<div className="flex items-center gap-3 px-1 py-3 text-muted-foreground/45">
 					<ListChecks className="size-4 opacity-70" />
-					<p className="text-[13px] italic">{emptyLabel}</p>
+					<p className="text-[13px] italic">No subtasks yet</p>
 				</div>
 			)}
 		</div>

--- a/apps/web/src/lib/project-api.test.ts
+++ b/apps/web/src/lib/project-api.test.ts
@@ -29,11 +29,9 @@ import {
 	deleteProject,
 	deleteProjectRole,
 	findEpicType,
-	findSubtaskType,
 	getNormalTaskTypes,
 	getProject,
 	isEpicType,
-	isSubtaskType,
 	listProjectMembers,
 	listProjectRoles,
 	listProjects,
@@ -390,51 +388,11 @@ describe("project-api", () => {
 		});
 	});
 
-	describe("isSubtaskType", () => {
-		it("returns true for a system type named Subtask", () => {
-			const subtask: TaskType = {
-				...mockTaskType,
-				name: "Subtask",
-				is_system: true,
-			};
-			expect(isSubtaskType(subtask)).toBe(true);
-		});
-
-		it("returns false when is_system is false even if name is Subtask", () => {
-			const nonSystem: TaskType = {
-				...mockTaskType,
-				name: "Subtask",
-				is_system: false,
-			};
-			expect(isSubtaskType(nonSystem)).toBe(false);
-		});
-
-		it("returns false for a system type with a different name", () => {
-			const epic: TaskType = {
-				...mockTaskType,
-				name: "Epic",
-				is_system: true,
-			};
-			expect(isSubtaskType(epic)).toBe(false);
-		});
-
-		it("returns false for null or undefined", () => {
-			expect(isSubtaskType(null)).toBe(false);
-			expect(isSubtaskType(undefined)).toBe(false);
-		});
-	});
-
-	describe("findEpicType / findSubtaskType / getNormalTaskTypes", () => {
+	describe("findEpicType / getNormalTaskTypes", () => {
 		const epicType: TaskType = {
 			...mockTaskType,
 			id: "tt-epic",
 			name: "Epic",
-			is_system: true,
-		};
-		const subtaskType: TaskType = {
-			...mockTaskType,
-			id: "tt-subtask",
-			name: "Subtask",
 			is_system: true,
 		};
 		const normalType: TaskType = {
@@ -443,30 +401,22 @@ describe("project-api", () => {
 			name: "Task",
 			is_system: false,
 		};
-		const types = [epicType, subtaskType, normalType];
+		const types = [epicType, normalType];
 
 		it("findEpicType returns the Epic system type", () => {
 			expect(findEpicType(types)).toEqual(epicType);
 		});
 
 		it("findEpicType returns undefined when no Epic system type exists", () => {
-			expect(findEpicType([subtaskType, normalType])).toBeUndefined();
+			expect(findEpicType([normalType])).toBeUndefined();
 		});
 
-		it("findSubtaskType returns the Subtask system type", () => {
-			expect(findSubtaskType(types)).toEqual(subtaskType);
-		});
-
-		it("findSubtaskType returns undefined when no Subtask system type exists", () => {
-			expect(findSubtaskType([epicType, normalType])).toBeUndefined();
-		});
-
-		it("getNormalTaskTypes returns only non-system types", () => {
+		it("getNormalTaskTypes returns only non-epic types", () => {
 			expect(getNormalTaskTypes(types)).toEqual([normalType]);
 		});
 
-		it("getNormalTaskTypes returns empty array when all types are system types", () => {
-			expect(getNormalTaskTypes([epicType, subtaskType])).toEqual([]);
+		it("getNormalTaskTypes returns empty array when all types are Epic", () => {
+			expect(getNormalTaskTypes([epicType])).toEqual([]);
 		});
 	});
 });

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -268,24 +268,14 @@ export function isEpicType(t: TaskType | undefined | null): boolean {
 	return !!t && !!t.is_system && t.name === "Epic";
 }
 
-/** Returns true if this task type is the system "Subtask" type. */
-export function isSubtaskType(t: TaskType | undefined | null): boolean {
-	return !!t && !!t.is_system && t.name === "Subtask";
-}
-
 /** Finds the Epic system type from a list of task types. */
 export function findEpicType(types: TaskType[]): TaskType | undefined {
 	return types.find(isEpicType);
 }
 
-/** Finds the Subtask system type from a list of task types. */
-export function findSubtaskType(types: TaskType[]): TaskType | undefined {
-	return types.find(isSubtaskType);
-}
-
-/** Returns non-system task types (Task, Bug, Story, etc). */
+/** Returns non-epic task types (Task, Bug, Story, etc). */
 export function getNormalTaskTypes(types: TaskType[]): TaskType[] {
-	return types.filter((t) => !t.is_system);
+	return types.filter((t) => !isEpicType(t));
 }
 
 // ── Task Statuses ─────────────────────────────────────────────────────────────

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -74,6 +74,8 @@ const (
 	CodeEpicCannotHaveParent Code = "TASK_EPIC_CANNOT_HAVE_PARENT"
 	// CodeTaskCannotBeOwnParent indicates an attempt to set a task as its own parent.
 	CodeTaskCannotBeOwnParent Code = "TASK_CANNOT_BE_OWN_PARENT"
+	// CodeTaskParentCycleDetected indicates the requested parent assignment would create a cycle.
+	CodeTaskParentCycleDetected Code = "TASK_PARENT_CYCLE_DETECTED"
 
 	// CodeTaskTypeNotFound indicates the requested task type does not exist.
 	CodeTaskTypeNotFound Code = "TASK_TYPE_NOT_FOUND"

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -70,6 +70,10 @@ const (
 	CodeTaskNotFound Code = "TASK_NOT_FOUND"
 	// CodeTaskTitleInvalid indicates an empty or invalid task title.
 	CodeTaskTitleInvalid Code = "TASK_TITLE_INVALID"
+	// CodeEpicCannotHaveParent indicates an attempt to set a parent on an epic task.
+	CodeEpicCannotHaveParent Code = "TASK_EPIC_CANNOT_HAVE_PARENT"
+	// CodeTaskCannotBeOwnParent indicates an attempt to set a task as its own parent.
+	CodeTaskCannotBeOwnParent Code = "TASK_CANNOT_BE_OWN_PARENT"
 
 	// CodeTaskTypeNotFound indicates the requested task type does not exist.
 	CodeTaskTypeNotFound Code = "TASK_TYPE_NOT_FOUND"

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -4,10 +4,11 @@ import "errors"
 
 // Sentinel domain errors for the task aggregate.
 var (
-	ErrTaskNotFound          = errors.New("task: not found")
-	ErrTaskTitleInvalid      = errors.New("task: title is empty or invalid")
-	ErrEpicCannotHaveParent  = errors.New("task: epic tasks cannot have a parent task")
-	ErrTaskCannotBeOwnParent = errors.New("task: a task cannot be its own parent")
+	ErrTaskNotFound              = errors.New("task: not found")
+	ErrTaskTitleInvalid          = errors.New("task: title is empty or invalid")
+	ErrEpicCannotHaveParent      = errors.New("task: epic tasks cannot have a parent task")
+	ErrTaskCannotBeOwnParent     = errors.New("task: a task cannot be its own parent")
+	ErrTaskParentCycleDetected   = errors.New("task: setting this parent would create a cycle")
 
 	ErrTypeNotFound     = errors.New("task type: not found")
 	ErrTypeNameInvalid  = errors.New("task type: name is empty or invalid")

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -4,8 +4,10 @@ import "errors"
 
 // Sentinel domain errors for the task aggregate.
 var (
-	ErrTaskNotFound     = errors.New("task: not found")
-	ErrTaskTitleInvalid = errors.New("task: title is empty or invalid")
+	ErrTaskNotFound          = errors.New("task: not found")
+	ErrTaskTitleInvalid      = errors.New("task: title is empty or invalid")
+	ErrEpicCannotHaveParent  = errors.New("task: epic tasks cannot have a parent task")
+	ErrTaskCannotBeOwnParent = errors.New("task: a task cannot be its own parent")
 
 	ErrTypeNotFound     = errors.New("task type: not found")
 	ErrTypeNameInvalid  = errors.New("task type: name is empty or invalid")

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -4,11 +4,11 @@ import "errors"
 
 // Sentinel domain errors for the task aggregate.
 var (
-	ErrTaskNotFound              = errors.New("task: not found")
-	ErrTaskTitleInvalid          = errors.New("task: title is empty or invalid")
-	ErrEpicCannotHaveParent      = errors.New("task: epic tasks cannot have a parent task")
-	ErrTaskCannotBeOwnParent     = errors.New("task: a task cannot be its own parent")
-	ErrTaskParentCycleDetected   = errors.New("task: setting this parent would create a cycle")
+	ErrTaskNotFound            = errors.New("task: not found")
+	ErrTaskTitleInvalid        = errors.New("task: title is empty or invalid")
+	ErrEpicCannotHaveParent    = errors.New("task: epic tasks cannot have a parent task")
+	ErrTaskCannotBeOwnParent   = errors.New("task: a task cannot be its own parent")
+	ErrTaskParentCycleDetected = errors.New("task: setting this parent would create a cycle")
 
 	ErrTypeNotFound     = errors.New("task type: not found")
 	ErrTypeNameInvalid  = errors.New("task type: name is empty or invalid")

--- a/services/api/internal/platform/messaging/publisher_test.go
+++ b/services/api/internal/platform/messaging/publisher_test.go
@@ -2,15 +2,9 @@ package messaging
 
 import (
 	"context"
-	"io"
-	"log/slog"
 	"strings"
 	"testing"
 )
-
-func loggerForTests() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
-}
 
 func TestPublish_NotInitialized(t *testing.T) {
 	p := &Publisher{}

--- a/services/api/internal/service/project/project_service.go
+++ b/services/api/internal/service/project/project_service.go
@@ -249,16 +249,14 @@ func (s *Service) Create(ctx context.Context, in projectdom.CreateProjectInput) 
 
 func ptr[T any](v T) *T { return &v }
 
-// seedDefaultTaskTypes creates the three built-in task types for a new project
-// plus two system-managed types (Epic, Subtask). The "Task" type is marked as
-// the default. System types are read-only and cannot be modified by users.
+// seedDefaultTaskTypes creates the built-in task types for a new project.
+// The "Task" type is the default. Epic is system-managed and read-only.
 func (s *Service) seedDefaultTaskTypes(ctx context.Context, projectID uuid.UUID, now time.Time) error {
 	defaults := []*taskdom.TaskType{
 		{ID: uuid.New(), ProjectID: projectID, Name: "Task", Icon: ptr("CheckSquare"), Color: ptr("#3b82f6"), Description: ptr("A general work item that needs to be completed"), IsDefault: true, CreatedAt: now, UpdatedAt: now},
 		{ID: uuid.New(), ProjectID: projectID, Name: "Bug", Icon: ptr("Bug"), Color: ptr("#ef4444"), Description: ptr("An issue or defect that needs to be fixed"), CreatedAt: now, UpdatedAt: now},
 		{ID: uuid.New(), ProjectID: projectID, Name: "Story", Icon: ptr("BookOpen"), Color: ptr("#22c55e"), Description: ptr("A user-facing feature or requirement"), CreatedAt: now, UpdatedAt: now},
 		{ID: uuid.New(), ProjectID: projectID, Name: "Epic", Icon: ptr("Layers"), Color: ptr("#a855f7"), Description: ptr("A large body of work that can be broken down into smaller tasks"), IsSystem: true, CreatedAt: now, UpdatedAt: now},
-		{ID: uuid.New(), ProjectID: projectID, Name: "Subtask", Icon: ptr("ClipboardList"), Color: ptr("#64748b"), Description: ptr("A smaller piece of work within a parent task"), IsSystem: true, CreatedAt: now, UpdatedAt: now},
 	}
 	for _, tt := range defaults {
 		if err := s.taskRepo.CreateTaskType(ctx, tt); err != nil {

--- a/services/api/internal/service/project/project_service_test.go
+++ b/services/api/internal/service/project/project_service_test.go
@@ -174,8 +174,8 @@ func TestCreate_SeedsDefaultTaskTypesAndStatuses(t *testing.T) {
 		t.Fatal("Create returned nil project")
 	}
 
-	// Verify 5 default task types are created (Task, Bug, Story + Epic, Subtask system types).
-	const wantTypes = 5
+	// Verify 4 default task types are created (Task, Bug, Story + Epic system type).
+	const wantTypes = 4
 	if got := len(tb.types); got != wantTypes {
 		t.Errorf("expected %d default task types, got %d", wantTypes, got)
 	}
@@ -189,15 +189,15 @@ func TestCreate_SeedsDefaultTaskTypesAndStatuses(t *testing.T) {
 		}
 		typeNames[tt.Name] = true
 	}
-	for _, name := range []string{"Task", "Bug", "Story", "Epic", "Subtask"} {
+	for _, name := range []string{"Task", "Bug", "Story", "Epic"} {
 		if !typeNames[name] {
 			t.Errorf("missing expected default task type %q", name)
 		}
 	}
 
-	// Verify Epic and Subtask are system types.
+	// Verify Epic is the only system type.
 	for _, tt := range tb.types {
-		if tt.Name == "Epic" || tt.Name == "Subtask" {
+		if tt.Name == "Epic" {
 			if !tt.IsSystem {
 				t.Errorf("expected task type %q to have IsSystem=true", tt.Name)
 			}

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -207,16 +207,34 @@ func (s *Service) SetDefaultTaskStatus(ctx context.Context, projectID, statusID 
 	return s.repo.FindTaskStatusByID(ctx, statusID)
 }
 
-// isEpicTaskType returns true when typeID belongs to the system Epic type.
-func (s *Service) isEpicTaskType(ctx context.Context, typeID *uuid.UUID) bool {
+// isEpicTaskType returns whether typeID belongs to the system Epic type.
+func (s *Service) isEpicTaskType(ctx context.Context, typeID *uuid.UUID) (bool, error) {
 	if typeID == nil {
-		return false
+		return false, nil
 	}
 	t, err := s.repo.FindTaskTypeByID(ctx, *typeID)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return t.IsSystem && t.Name == "Epic"
+	return t.IsSystem && t.Name == "Epic", nil
+}
+
+// wouldCreateCycle reports whether making proposedParentID the parent of taskID
+// would introduce a directed cycle in the task hierarchy.
+func (s *Service) wouldCreateCycle(ctx context.Context, taskID, proposedParentID uuid.UUID) bool {
+	current := proposedParentID
+	const maxDepth = 50
+	for range maxDepth {
+		if current == taskID {
+			return true
+		}
+		t, err := s.repo.FindTaskByID(ctx, current)
+		if err != nil || t.ParentTaskID == nil {
+			return false
+		}
+		current = *t.ParentTaskID
+	}
+	return false
 }
 
 // --- Tasks ------------------------------------------------------------------
@@ -257,7 +275,11 @@ func (s *Service) CreateTask(ctx context.Context, in taskdom.CreateTaskInput) (*
 	}
 
 	if in.ParentTaskID != nil {
-		if s.isEpicTaskType(ctx, in.TaskTypeID) {
+		isEpic, err := s.isEpicTaskType(ctx, in.TaskTypeID)
+		if err != nil {
+			return nil, err
+		}
+		if isEpic {
 			return nil, taskdom.ErrEpicCannotHaveParent
 		}
 	}
@@ -340,11 +362,19 @@ func (s *Service) UpdateTask(ctx context.Context, projectID, id uuid.UUID, in ta
 	if in.TaskTypeID != nil {
 		effectiveTypeID = *in.TaskTypeID
 	}
+	// Validate parent constraints using the post-update effective values.
 	if effectiveParentID != nil {
 		if *effectiveParentID == t.ID {
 			return nil, taskdom.ErrTaskCannotBeOwnParent
 		}
-		if s.isEpicTaskType(ctx, effectiveTypeID) {
+		if s.wouldCreateCycle(ctx, t.ID, *effectiveParentID) {
+			return nil, taskdom.ErrTaskParentCycleDetected
+		}
+		isEpic, err := s.isEpicTaskType(ctx, effectiveTypeID)
+		if err != nil {
+			return nil, err
+		}
+		if isEpic {
 			return nil, taskdom.ErrEpicCannotHaveParent
 		}
 	}

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -11,8 +11,7 @@ import (
 )
 
 var reservedSystemTypeNames = map[string]bool{
-	"Epic":    true,
-	"Subtask": true,
+	"Epic": true,
 }
 
 // Service is the concrete implementation of taskdom.Service.
@@ -208,6 +207,18 @@ func (s *Service) SetDefaultTaskStatus(ctx context.Context, projectID, statusID 
 	return s.repo.FindTaskStatusByID(ctx, statusID)
 }
 
+// isEpicTaskType returns true when typeID belongs to the system Epic type.
+func (s *Service) isEpicTaskType(ctx context.Context, typeID *uuid.UUID) bool {
+	if typeID == nil {
+		return false
+	}
+	t, err := s.repo.FindTaskTypeByID(ctx, *typeID)
+	if err != nil {
+		return false
+	}
+	return t.IsSystem && t.Name == "Epic"
+}
+
 // --- Tasks ------------------------------------------------------------------
 
 // ListTasks returns a page of tasks. When filter.CursorAfter is nil, returns from
@@ -243,6 +254,12 @@ func (s *Service) CreateTask(ctx context.Context, in taskdom.CreateTaskInput) (*
 	title := strings.TrimSpace(in.Title)
 	if title == "" {
 		return nil, taskdom.ErrTaskTitleInvalid
+	}
+
+	if in.ParentTaskID != nil {
+		if s.isEpicTaskType(ctx, in.TaskTypeID) {
+			return nil, taskdom.ErrEpicCannotHaveParent
+		}
 	}
 
 	taskTypeID := in.TaskTypeID
@@ -313,6 +330,25 @@ func (s *Service) UpdateTask(ctx context.Context, projectID, id uuid.UUID, in ta
 	if title := strings.TrimSpace(in.Title); title != "" {
 		t.Title = title
 	}
+
+	// Compute the effective parent and type IDs after the update to validate constraints.
+	effectiveParentID := t.ParentTaskID
+	if in.ParentTaskID != nil {
+		effectiveParentID = *in.ParentTaskID
+	}
+	effectiveTypeID := t.TaskTypeID
+	if in.TaskTypeID != nil {
+		effectiveTypeID = *in.TaskTypeID
+	}
+	if effectiveParentID != nil {
+		if *effectiveParentID == t.ID {
+			return nil, taskdom.ErrTaskCannotBeOwnParent
+		}
+		if s.isEpicTaskType(ctx, effectiveTypeID) {
+			return nil, taskdom.ErrEpicCannotHaveParent
+		}
+	}
+
 	if in.TaskTypeID != nil {
 		t.TaskTypeID = *in.TaskTypeID
 	}

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -865,18 +865,6 @@ func parseQueryUUIDs(raw string) ([]uuid.UUID, error) {
 	return ids, nil
 }
 
-func parseUUIDStrings(values []string) ([]uuid.UUID, error) {
-	ids := make([]uuid.UUID, 0, len(values))
-	for _, value := range values {
-		id, err := uuid.Parse(strings.TrimSpace(value))
-		if err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, nil
-}
-
 // --- Custom Field Definitions -----------------------------------------------
 
 // ListCustomFieldDefinitions handles GET /projects/:projectId/custom-fields.

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -136,6 +136,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeEpicCannotHaveParent
 	case errors.Is(err, taskdom.ErrTaskCannotBeOwnParent):
 		return http.StatusBadRequest, apierr.CodeTaskCannotBeOwnParent
+	case errors.Is(err, taskdom.ErrTaskParentCycleDetected):
+		return http.StatusBadRequest, apierr.CodeTaskParentCycleDetected
 	case errors.Is(err, taskdom.ErrTypeNotFound):
 		return http.StatusNotFound, apierr.CodeTaskTypeNotFound
 	case errors.Is(err, taskdom.ErrTypeNameInvalid):
@@ -333,6 +335,7 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeTaskTitleInvalid,
 		apierr.CodeEpicCannotHaveParent,
 		apierr.CodeTaskCannotBeOwnParent,
+		apierr.CodeTaskParentCycleDetected,
 		apierr.CodeTaskTypeNameInvalid,
 		apierr.CodeTaskStatusNameInvalid,
 		apierr.CodeTaskStatusCategoryInvalid,

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -132,6 +132,10 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusNotFound, apierr.CodeTaskNotFound
 	case errors.Is(err, taskdom.ErrTaskTitleInvalid):
 		return http.StatusBadRequest, apierr.CodeTaskTitleInvalid
+	case errors.Is(err, taskdom.ErrEpicCannotHaveParent):
+		return http.StatusBadRequest, apierr.CodeEpicCannotHaveParent
+	case errors.Is(err, taskdom.ErrTaskCannotBeOwnParent):
+		return http.StatusBadRequest, apierr.CodeTaskCannotBeOwnParent
 	case errors.Is(err, taskdom.ErrTypeNotFound):
 		return http.StatusNotFound, apierr.CodeTaskTypeNotFound
 	case errors.Is(err, taskdom.ErrTypeNameInvalid):
@@ -327,6 +331,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeUploadIDMismatch,
 		apierr.CodeMultipartPartsEmpty,
 		apierr.CodeTaskTitleInvalid,
+		apierr.CodeEpicCannotHaveParent,
+		apierr.CodeTaskCannotBeOwnParent,
 		apierr.CodeTaskTypeNameInvalid,
 		apierr.CodeTaskStatusNameInvalid,
 		apierr.CodeTaskStatusCategoryInvalid,

--- a/services/api/migrations/000012_demote_subtask_system_type.sql
+++ b/services/api/migrations/000012_demote_subtask_system_type.sql
@@ -1,0 +1,9 @@
+-- Demote the legacy "Subtask" system type to a regular user-visible type.
+-- Projects created before v0.5.0 were seeded with a system-managed Subtask type
+-- that can no longer be managed by users. Making it non-system lets users rename
+-- or delete it while preserving all existing task data.
+
+UPDATE task_types
+SET is_system = false
+WHERE name = 'Subtask'
+  AND is_system = true;

--- a/services/api/test/e2e/project_management_test.go
+++ b/services/api/test/e2e/project_management_test.go
@@ -968,8 +968,8 @@ func TestE2EProjectCreation_DefaultTaskRecords(t *testing.T) {
 		decodeJSON(t, resp, &env2)
 		data := assertDataMap(t, env2)
 		items, _ := data["items"].([]any)
-		if len(items) != 5 {
-			t.Errorf("expected 5 default task types, got %d", len(items))
+		if len(items) != 4 {
+			t.Errorf("expected 4 default task types, got %d", len(items))
 		}
 		gotNames := map[string]bool{}
 		for _, item := range items {
@@ -977,7 +977,7 @@ func TestE2EProjectCreation_DefaultTaskRecords(t *testing.T) {
 			name, _ := m["name"].(string)
 			gotNames[name] = true
 		}
-		for _, name := range []string{"Task", "Bug", "Story", "Epic", "Subtask"} {
+		for _, name := range []string{"Task", "Bug", "Story", "Epic"} {
 			if !gotNames[name] {
 				t.Errorf("missing default task type %q", name)
 			}
@@ -996,12 +996,12 @@ func TestE2EProjectCreation_DefaultTaskRecords(t *testing.T) {
 			}
 		}
 
-		// "Epic" and "Subtask" should have is_system: true; others false.
+		// "Epic" should have is_system: true; others false.
 		for _, item := range items {
 			m, _ := item.(map[string]any)
 			name, _ := m["name"].(string)
 			isSystem, _ := m["is_system"].(bool)
-			if name == "Epic" || name == "Subtask" {
+			if name == "Epic" {
 				if !isSystem {
 					t.Errorf("expected task type %q to have is_system=true", name)
 				}

--- a/services/api/test/e2e/user_management_test.go
+++ b/services/api/test/e2e/user_management_test.go
@@ -10,18 +10,6 @@ import (
 // Admin helpers
 // ---------------------------------------------------------------------------
 
-// adminLogin logs in with the seeded admin credentials and returns the client
-// whose cookie jar holds valid access/refresh tokens.
-func adminLogin(t *testing.T, env *e2eEnv) *http.Client {
-	t.Helper()
-	seedUser(t, env, "e2e-admin", "adminpass1", "E2E Admin")
-	assignGlobalRolesByName(t, env, "e2e-admin", "ADMIN")
-
-	resp := login(env.ctx, t, env.client, env.base, "e2e-admin", "adminpass1")
-	defer func() { _ = resp.Body.Close() }()
-	return env.client
-}
-
 // adminBearerToken logs in with admin credentials and returns the raw
 // access-token string for use in Authorization headers.
 func adminBearerToken(t *testing.T, env *e2eEnv, username, password string) string {

--- a/services/api/test/integration/project_test.go
+++ b/services/api/test/integration/project_test.go
@@ -779,7 +779,7 @@ func TestIntegrationProjectCreation_DefaultTaskRecords(t *testing.T) {
 	if err := json.NewDecoder(typesW.Body).Decode(&typesEnv); err != nil {
 		t.Fatalf("decode task types: %v", err)
 	}
-	const wantTypes = 5
+	const wantTypes = 4
 	if got := len(typesEnv.Data.Items); got != wantTypes {
 		t.Errorf("expected %d default task types, got %d", wantTypes, got)
 	}
@@ -788,7 +788,7 @@ func TestIntegrationProjectCreation_DefaultTaskRecords(t *testing.T) {
 		name, _ := item["name"].(string)
 		gotTypeNames[name] = true
 	}
-	for _, name := range []string{"Task", "Bug", "Story", "Epic", "Subtask"} {
+	for _, name := range []string{"Task", "Bug", "Story", "Epic"} {
 		if !gotTypeNames[name] {
 			t.Errorf("missing default task type %q", name)
 		}
@@ -806,11 +806,11 @@ func TestIntegrationProjectCreation_DefaultTaskRecords(t *testing.T) {
 		}
 	}
 
-	// "Epic" and "Subtask" should have is_system: true; others false.
+	// "Epic" should have is_system: true; others false.
 	for _, item := range typesEnv.Data.Items {
 		name, _ := item["name"].(string)
 		isSystem, _ := item["is_system"].(bool)
-		if name == "Epic" || name == "Subtask" {
+		if name == "Epic" {
 			if !isSystem {
 				t.Errorf("expected task type %q to have is_system=true", name)
 			}

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -2882,3 +2882,162 @@ func TestActivities_DeleteComment(t *testing.T) {
 		t.Fatalf("delete comment: expected 204, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Task hierarchy constraint tests
+// ---------------------------------------------------------------------------
+
+func TestIntegrationTasks_EpicCannotHaveParent(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/tasks", projectID)
+
+	// Seed Epic system type directly.
+	epicType := &taskdom.TaskType{ID: uuid.New(), ProjectID: projectID, Name: "Epic", IsSystem: true}
+	if err := taskRepo.CreateTaskType(t.Context(), epicType); err != nil {
+		t.Fatalf("seed epic type: %v", err)
+	}
+
+	// Create a plain parent task.
+	parentW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{"title": "Parent"}))
+	if parentW.Code != http.StatusCreated {
+		t.Fatalf("create parent: %d: %s", parentW.Code, parentW.Body.String())
+	}
+	parentID := taskIDFrom(t, "parent", parentW.Body.Bytes())
+
+	// Creating an Epic with a parent must be rejected.
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"title":          "Epic with parent",
+		"task_type_id":   epicType.ID.String(),
+		"parent_task_id": parentID,
+	}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	if code := decodeErrorCode(t, w); code != "TASK_EPIC_CANNOT_HAVE_PARENT" {
+		t.Errorf("expected TASK_EPIC_CANNOT_HAVE_PARENT, got %q", code)
+	}
+}
+
+func TestIntegrationTasks_UpdateToEpicWithParentRejected(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/tasks", projectID)
+
+	epicType := &taskdom.TaskType{ID: uuid.New(), ProjectID: projectID, Name: "Epic", IsSystem: true}
+	if err := taskRepo.CreateTaskType(t.Context(), epicType); err != nil {
+		t.Fatalf("seed epic type: %v", err)
+	}
+
+	// Create parent and child tasks.
+	parentW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{"title": "Parent"}))
+	if parentW.Code != http.StatusCreated {
+		t.Fatalf("create parent: %d: %s", parentW.Code, parentW.Body.String())
+	}
+	parentID := taskIDFrom(t, "parent", parentW.Body.Bytes())
+
+	childW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"title":          "Child",
+		"parent_task_id": parentID,
+	}))
+	if childW.Code != http.StatusCreated {
+		t.Fatalf("create child: %d: %s", childW.Code, childW.Body.String())
+	}
+	childID := taskIDFrom(t, "child", childW.Body.Bytes())
+
+	// Changing child's type to Epic while it still has a parent must be rejected.
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPatch, base+"/"+childID, tok, map[string]any{
+		"task_type_id": epicType.ID.String(),
+	}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	if code := decodeErrorCode(t, w); code != "TASK_EPIC_CANNOT_HAVE_PARENT" {
+		t.Errorf("expected TASK_EPIC_CANNOT_HAVE_PARENT, got %q", code)
+	}
+}
+
+func TestIntegrationTasks_SelfParentRejected(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/tasks", projectID)
+
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{"title": "Task A"}))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create task: %d: %s", w.Code, w.Body.String())
+	}
+	taskID := taskIDFrom(t, "task", w.Body.Bytes())
+
+	// Setting a task's parent to itself must be rejected.
+	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, base+"/"+taskID, tok, map[string]any{
+		"parent_task_id": taskID,
+	}))
+	if patchW.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", patchW.Code, patchW.Body.String())
+	}
+	if code := decodeErrorCode(t, patchW); code != "TASK_CANNOT_BE_OWN_PARENT" {
+		t.Errorf("expected TASK_CANNOT_BE_OWN_PARENT, got %q", code)
+	}
+}
+
+func TestIntegrationTasks_ParentCycleDetected(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/tasks", projectID)
+
+	// Create task A.
+	wA := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{"title": "Task A"}))
+	if wA.Code != http.StatusCreated {
+		t.Fatalf("create A: %d: %s", wA.Code, wA.Body.String())
+	}
+	taskAID := taskIDFrom(t, "A", wA.Body.Bytes())
+
+	// Create task B with parent = A.
+	wB := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"title":          "Task B",
+		"parent_task_id": taskAID,
+	}))
+	if wB.Code != http.StatusCreated {
+		t.Fatalf("create B: %d: %s", wB.Code, wB.Body.String())
+	}
+	taskBID := taskIDFrom(t, "B", wB.Body.Bytes())
+
+	// Attempting to set A's parent to B would form A → B → A; must be rejected.
+	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, base+"/"+taskAID, tok, map[string]any{
+		"parent_task_id": taskBID,
+	}))
+	if patchW.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", patchW.Code, patchW.Body.String())
+	}
+	if code := decodeErrorCode(t, patchW); code != "TASK_PARENT_CYCLE_DETECTED" {
+		t.Errorf("expected TASK_PARENT_CYCLE_DETECTED, got %q", code)
+	}
+}

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -888,7 +888,7 @@ func TestIntegrationTaskTypes_ReservedNameRejected(t *testing.T) {
 	tok := issueTaskToken(t, uuid.NewString())
 	base := fmt.Sprintf("/api/v1/projects/%s/task-types", projectID)
 
-	for _, reserved := range []string{"Epic", "Subtask"} {
+	for _, reserved := range []string{"Epic"} {
 		w := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{"name": reserved}))
 		if w.Code != http.StatusConflict {
 			t.Fatalf("expected 409 for reserved name %q, got %d (%s)", reserved, w.Code, w.Body.String())


### PR DESCRIPTION
## Summary

- Removes the system \"Subtask\" task type from all new projects — Story, Task, and Bug are now first-class types that can nest under one another
- Enforces that Epic tasks cannot have a parent (validated on both create and update in the API layer)
- Adds a self-parent guard so a task cannot be set as its own parent
- Simplifies the frontend task role model from three roles (epic / normal / subtask) to two (epic / normal)
- Shows the child-tasks section for **all** task types (not just non-subtasks), enabling arbitrary nesting of Story / Task / Bug
- Updates the MCP tool description for `parentTaskId` to reflect the new nesting rules

## Changes

### Backend (`services/api`)
- **`domain/task/errors.go`** — adds `ErrEpicCannotHaveParent` and `ErrTaskCannotBeOwnParent` sentinel errors
- **`apierr/codes.go`** — maps those errors to `TASK_EPIC_CANNOT_HAVE_PARENT` and `TASK_CANNOT_BE_OWN_PARENT` API error codes
- **`service/task/task_service.go`** — validates parent constraints on `CreateTask` and `UpdateTask`; removes \"Subtask\" from reserved system type names
- **`service/project/project_service.go`** — removes the Subtask type from the default seed list for new projects
- **`transport/http/presenter/response.go`** — returns `400 Bad Request` for both new error codes

### Frontend (`apps/web`)
- **`project-api.ts`** — removes `isSubtaskType` / `findSubtaskType` helpers; `getNormalTaskTypes` now filters out only Epics (not all system types)
- **`task-detail/index.tsx`** — drops the `isSubtask` / `subtask` role; `SubtasksSection` is always rendered (no longer gated on `taskRole !== "subtask"`)
- **`task-detail/properties-panel.tsx`** — narrows the Parent field to normal tasks whose parent is not an epic
- **`task-detail/subtasks-section.tsx`** — removes the `mode` / `subtaskType` props; the section always behaves as a uniform child-task list with type-picker enabled
- **`project-api.test.ts`** — removes `isSubtaskType` / `findSubtaskType` tests; updates `getNormalTaskTypes` tests

### MCP (`apps/mcp`)
- **`task-tools.ts`** — updates `parentTaskId` description to reflect that Story/Task/Bug can nest but Epics cannot have a parent

## Test plan
- [ ] Create a new project — confirm no \"Subtask\" type appears in the type list
- [ ] Create an Epic and attempt to set a parent task — confirm API returns `400 TASK_EPIC_CANNOT_HAVE_PARENT`
- [ ] Attempt to update a task's parent to itself — confirm API returns `400 TASK_CANNOT_BE_OWN_PARENT`
- [ ] Create a Story/Task/Bug and add child tasks via the subtasks panel — confirm child tasks appear and can be clicked
- [ ] Verify the Parent field in the properties panel shows only when a normal task is nested under another non-epic task
- [ ] Run existing tests: `pnpm test` in `apps/web`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)