### PR TITLE
feat: add username validation for minimum length and error handling

### DIFF
--- a/apps/web/src/components/admin/users/UserFormDialog.tsx
+++ b/apps/web/src/components/admin/users/UserFormDialog.tsx
@@ -94,6 +94,8 @@ export function UserFormDialog({
 			}
 
 			if (!username.trim()) throw new Error("Username is required.");
+			if (username.trim().length < 3)
+				throw new Error("Username must be at least 3 characters.");
 
 			const password = generatePassword();
 			await createUser({
@@ -121,6 +123,13 @@ export function UserFormDialog({
 			const code = getApiErrorCode(err);
 			if (code === ApiErrorCode.UsernameTaken) {
 				setUsernameError("This username is already taken.");
+				return;
+			}
+			if (
+				err instanceof Error &&
+				err.message.toLowerCase().includes("username")
+			) {
+				setUsernameError(err.message);
 				return;
 			}
 			const messages: Partial<Record<string, string>> = {


### PR DESCRIPTION
## Summary

- Adds a minimum length validation (3 characters) for usernames in the admin user creation form
- Routes any `Error` whose message mentions "username" into the username field error state, so validation messages surface inline rather than being silently swallowed

## Changes

**`apps/web/src/components/admin/users/UserFormDialog.tsx`**
- Throws `"Username must be at least 3 characters."` before the create-user call if the trimmed username is shorter than 3 characters
- In the `catch` block, checks whether the caught error is a username-related `Error` and, if so, sets it as the username field error and returns early — keeping the existing downstream error-code map intact

## Test plan

- [x] Create a user with a 1- or 2-character username → inline error appears under the username field
- [x] Create a user with a valid username (3+ chars) → form submits successfully
- [x] Duplicate username still shows the "already taken" error
- [x] Other API errors (e.g. user-not-found) still map to their existing messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)