### PR TITLE
chore: update development nginx gateway port

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -177,6 +177,8 @@ Start the full local stack in containers (no tunnel, plain localhost):
 docker compose -f deploy/docker-compose.dev.yml up -d
 ```
 
+Open `http://localhost:3000` once all services are healthy.
+
 Start only shared dependencies:
 
 ```bash
@@ -190,10 +192,11 @@ and use Docker Compose only for PostgreSQL and Valkey.
 
 | Service | Port | Notes |
 |---|---|---|
+| Gateway (nginx) | **3000** | Main entry point — `http://localhost:3000` |
 | PostgreSQL | 5432 | Local database for development |
 | Valkey | 6379 | Local cache / event streams |
-| API | 8080 | Containerized Go service |
-| Web | 3000 | Containerized React app |
+| API | 8080 (internal) | Routed via gateway at `/api/` |
+| Web | 3000 (internal) | Routed via gateway at `/` |
 | MinIO S3 API | 9000 | Local object store (S3-compatible) |
 | MinIO Console | 9001 | MinIO web UI (credentials: `minioadmin` / `minioadmin`) |
 

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -153,7 +153,7 @@ services:
     image: nginx:1.27-alpine
     restart: unless-stopped
     ports:
-      - "80:80"
+      - "3000:80"
     volumes:
       - ./nginx/gateway.conf:/etc/nginx/conf.d/default.conf:ro
       # Frontend plugin store — built JS bundles, served at /plugins/.
@@ -231,8 +231,6 @@ services:
       - ../services/ai-agent:/app
       - ../apps/mcp:/mcp:ro
       - /var/run/docker.sock:/var/run/docker.sock
-    ports:
-      - "8082:8080"
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -226,8 +226,6 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    ports:
-      - "${AI_AGENT_PORT:-8082}:8080"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -51,7 +51,7 @@ git clone https://github.com/Paca-AI/paca.git && cd paca
 docker compose -f deploy/docker-compose.dev.yml up -d
 ```
 
-All services start with hot-reload — the API, web app, and realtime service all watch your local source files and rebuild automatically. Open `http://localhost` when the stack is healthy.
+All services start with hot-reload — the API, web app, and realtime service all watch your local source files and rebuild automatically. Open `http://localhost:3000` when the stack is healthy.
 
 See [local-development.md](local-development.md) for details on the dev stack and running services on the host.
 

--- a/docs/guides/local-development.md
+++ b/docs/guides/local-development.md
@@ -8,7 +8,7 @@ One command starts the full stack with hot-reload from your local source files:
 docker compose -f deploy/docker-compose.dev.yml up -d
 ```
 
-Open `http://localhost`. All services watch the source tree and reload automatically — no manual rebuild needed.
+Open `http://localhost:3000`. All services watch the source tree and reload automatically — no manual rebuild needed.
 
 To stop:
 ```bash
@@ -26,16 +26,17 @@ docker compose -f deploy/docker-compose.dev.yml down -v
 
 | Service | Technology | Port | Hot-reload |
 |---|---|---|---|
-| `apps/web` | React + TanStack Start + shadcn/ui | 3000 (via nginx on 80) | Vite HMR |
-| `services/api` | Go + Gin | 8080 (via nginx on 80) | [air](https://github.com/air-verse/air) |
+| Gateway (nginx) | nginx:1.27-alpine | **3000** (host) | — |
+| `apps/web` | React + TanStack Start + shadcn/ui | 3000 (internal) | Vite HMR |
+| `services/api` | Go + Gin | 8080 (internal) | [air](https://github.com/air-verse/air) |
 | `services/realtime` | Node.js + Socket.IO | 3001 (internal) | `bun --watch` |
-| `services/ai-agent` | Python + FastAPI + OpenHands SDK | 8082 (external) | source volume |
+| `services/ai-agent` | Python + FastAPI + OpenHands SDK | 8080 (internal) | source volume |
 | PostgreSQL | postgres:16-alpine | 5432 | — |
 | Valkey | valkey/valkey:8-alpine | 6379 | — |
 | MinIO S3 API | minio/minio | 9000 | — |
 | MinIO Console | minio/minio | 9001 | http://localhost:9001 (user: `minioadmin`, pass: `minioadmin`) |
 
-The nginx gateway (port 80) routes `/api/v1/…` to the API, socket traffic to realtime, and `/storage/…` to MinIO. `apps/web` is served at the root.
+The nginx gateway (port 3000) routes `/api/v1/…` to the API, socket traffic to realtime, and `/storage/…` to MinIO. `apps/web` is served at the root.
 
 ---
 


### PR DESCRIPTION
## Summary

- Moves the nginx gateway from port **80** to **3000** in the dev Docker Compose stack, so developers no longer need root/sudo privileges to bind a privileged port.
- Removes the externally exposed port (`8082`) for the `ai-agent` service in both dev and prod — the agent is now only reachable internally through the gateway.
- Updates all documentation (`README.md`, `getting-started.md`, `local-development.md`) to reflect the new entry point at `http://localhost:3000`.

## Test plan

- [x] Run `docker compose -f deploy/docker-compose.dev.yml up -d` and confirm the stack comes up without port-binding errors.
- [x] Open `http://localhost:3000` and verify the web app loads correctly.
- [x] Confirm `/api/v1/` requests route through the gateway to the API service.
- [x] Confirm the `ai-agent` service is no longer directly accessible on port 8082 from the host.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)