### PR TITLE
feat(auth): implement validation for username and password across for…

### DIFF
--- a/apps/web/src/components/admin/users/UserFormDialog.tsx
+++ b/apps/web/src/components/admin/users/UserFormDialog.tsx
@@ -29,6 +29,7 @@ import {
 	usersQueryOptions,
 } from "@/lib/admin-api";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import { validateUsername } from "@/lib/auth-validation";
 import { generatePassword } from "@/lib/generate-password";
 
 interface UserFormDialogProps {
@@ -93,9 +94,8 @@ export function UserFormDialog({
 				});
 			}
 
-			if (!username.trim()) throw new Error("Username is required.");
-			if (username.trim().length < 3)
-				throw new Error("Username must be at least 3 characters.");
+			const usernameError = validateUsername(username);
+			if (usernameError) throw new Error(usernameError);
 
 			const password = generatePassword();
 			await createUser({

--- a/apps/web/src/components/auth/login/LoginFormPanel.tsx
+++ b/apps/web/src/components/auth/login/LoginFormPanel.tsx
@@ -6,29 +6,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useLoginForm } from "@/hooks/use-login-form";
+import { validatePassword, validateUsername } from "@/lib/auth-validation";
 import { cn } from "@/lib/utils";
 
 import { FieldError } from "./FieldError";
-
-function validateUsername(value: string) {
-	if (!value.trim()) {
-		return "Username is required";
-	}
-	if (value.trim().length < 3) {
-		return "Username must be at least 3 characters";
-	}
-	return undefined;
-}
-
-function validatePassword(value: string) {
-	if (!value.trim()) {
-		return "Password is required";
-	}
-	if (value.length < 8) {
-		return "Password must be at least 8 characters";
-	}
-	return undefined;
-}
 
 export function LoginFormPanel() {
 	const { form, serverError } = useLoginForm();

--- a/apps/web/src/components/profile/ChangePasswordCard.tsx
+++ b/apps/web/src/components/profile/ChangePasswordCard.tsx
@@ -15,6 +15,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { changeMyPassword } from "@/lib/auth-api";
+import {
+	validateConfirmPassword,
+	validateNewPassword,
+} from "@/lib/auth-validation";
 
 interface ChangePasswordCardProps {
 	mustChange: boolean;
@@ -30,10 +34,13 @@ export function ChangePasswordCard({ mustChange }: ChangePasswordCardProps) {
 
 	const mutation = useMutation({
 		mutationFn: async () => {
-			if (newPassword.length < 8)
-				throw new Error("New password must be at least 8 characters.");
-			if (newPassword !== confirmPassword)
-				throw new Error("Passwords do not match.");
+			const lengthError = validateNewPassword(newPassword, currentPassword);
+			if (lengthError) throw new Error(lengthError);
+			const confirmError = validateConfirmPassword(
+				confirmPassword,
+				newPassword,
+			);
+			if (confirmError) throw new Error(confirmError);
 			return changeMyPassword(currentPassword, newPassword);
 		},
 		onSuccess: () => {

--- a/apps/web/src/components/profile/ChangePasswordForm.tsx
+++ b/apps/web/src/components/profile/ChangePasswordForm.tsx
@@ -7,6 +7,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import { changeMyPassword } from "@/lib/auth-api";
+import {
+	validateConfirmPassword,
+	validateNewPassword,
+	validatePassword,
+} from "@/lib/auth-validation";
 import { cn } from "@/lib/utils";
 
 interface ChangePasswordFormProps {
@@ -31,36 +36,7 @@ function validateCurrentPassword(value: string) {
 	if (!value) {
 		return "Current password is required.";
 	}
-
-	return undefined;
-}
-
-function validateNewPassword(currentPassword: string, value: string) {
-	if (!value) {
-		return "New password is required.";
-	}
-
-	if (value.length < 8) {
-		return "New password must be at least 8 characters.";
-	}
-
-	if (value === currentPassword) {
-		return "New password must be different from current password.";
-	}
-
-	return undefined;
-}
-
-function validateConfirmPassword(newPassword: string, value: string) {
-	if (!value) {
-		return "Please confirm your new password.";
-	}
-
-	if (newPassword !== value) {
-		return "Passwords do not match.";
-	}
-
-	return undefined;
+	return validatePassword(value);
 }
 
 export function ChangePasswordForm({ onSuccess }: ChangePasswordFormProps) {
@@ -80,10 +56,10 @@ export function ChangePasswordForm({ onSuccess }: ChangePasswordFormProps) {
 
 	const currentPasswordError =
 		currentPasswordServerError ?? validateCurrentPassword(currentPassword);
-	const newPasswordError = validateNewPassword(currentPassword, newPassword);
+	const newPasswordError = validateNewPassword(newPassword, currentPassword);
 	const confirmPasswordError = validateConfirmPassword(
-		newPassword,
 		confirmPassword,
+		newPassword,
 	);
 	const hasValidationErrors = Boolean(
 		currentPasswordError || newPasswordError || confirmPasswordError,

--- a/apps/web/src/lib/auth-validation.test.ts
+++ b/apps/web/src/lib/auth-validation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	MIN_PASSWORD_LENGTH,
+	MIN_USERNAME_LENGTH,
+	validateConfirmPassword,
+	validateNewPassword,
+	validatePassword,
+	validateUsername,
+} from "./auth-validation";
+
+describe("validateUsername", () => {
+	it("requires a non-empty value", () => {
+		expect(validateUsername("")).toBe("Username is required.");
+	});
+
+	it("requires a non-whitespace value", () => {
+		expect(validateUsername("   ")).toBe("Username is required.");
+	});
+
+	it("enforces the minimum length", () => {
+		expect(validateUsername("ab")).toBe(
+			`Username must be at least ${MIN_USERNAME_LENGTH} characters.`,
+		);
+	});
+
+	it("accepts a sufficiently long value", () => {
+		expect(validateUsername("alice")).toBeUndefined();
+	});
+});
+
+describe("validatePassword", () => {
+	it("requires a non-empty value", () => {
+		expect(validatePassword("")).toBe("Password is required.");
+	});
+
+	it("enforces the minimum length", () => {
+		expect(validatePassword("short")).toBe(
+			`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+		);
+	});
+
+	it("accepts a sufficiently long value", () => {
+		expect(validatePassword("validpass1")).toBeUndefined();
+	});
+});
+
+describe("validateNewPassword", () => {
+	it("requires a non-empty value", () => {
+		expect(validateNewPassword("")).toBe("New password is required.");
+	});
+
+	it("enforces the minimum length", () => {
+		expect(validateNewPassword("short")).toBe(
+			`New password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+		);
+	});
+
+	it("rejects the same value as the current password", () => {
+		expect(validateNewPassword("SamePass1", "SamePass1")).toBe(
+			"New password must be different from current password.",
+		);
+	});
+
+	it("accepts a sufficiently long, different value", () => {
+		expect(validateNewPassword("NewPass123", "OldPass123")).toBeUndefined();
+	});
+});
+
+describe("validateConfirmPassword", () => {
+	it("requires a non-empty value", () => {
+		expect(validateConfirmPassword("", "NewPass123")).toBe(
+			"Please confirm your new password.",
+		);
+	});
+
+	it("rejects a mismatch", () => {
+		expect(validateConfirmPassword("OtherPass1", "NewPass123")).toBe(
+			"Passwords do not match.",
+		);
+	});
+
+	it("accepts a matching value", () => {
+		expect(validateConfirmPassword("NewPass123", "NewPass123")).toBeUndefined();
+	});
+});

--- a/apps/web/src/lib/auth-validation.ts
+++ b/apps/web/src/lib/auth-validation.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared validation constants and helpers for auth-related forms.
+ *
+ * Used by the login form, the change-password form, and the admin user
+ * dialog so that every surface applies the same rules and messages.
+ */
+
+/** Minimum number of characters a password must contain. */
+export const MIN_PASSWORD_LENGTH = 8;
+
+/** Minimum number of characters a username must contain. */
+export const MIN_USERNAME_LENGTH = 3;
+
+/**
+ * Validate a username.
+ *
+ * Returns `undefined` when the value is valid, or an error message otherwise.
+ */
+export function validateUsername(value: string): string | undefined {
+	if (!value.trim()) {
+		return "Username is required.";
+	}
+
+	if (value.trim().length < MIN_USERNAME_LENGTH) {
+		return `Username must be at least ${MIN_USERNAME_LENGTH} characters.`;
+	}
+
+	return undefined;
+}
+
+/**
+ * Validate a password that is being entered "as-is" — i.e. a login password
+ * or a "current password" field.
+ *
+ * Returns `undefined` when the value is valid, or an error message otherwise.
+ */
+export function validatePassword(value: string): string | undefined {
+	if (!value) {
+		return "Password is required.";
+	}
+
+	if (value.length < MIN_PASSWORD_LENGTH) {
+		return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+	}
+
+	return undefined;
+}
+
+/**
+ * Validate a password that the user is choosing for the first time (or
+ * replacing an old one with).
+ *
+ * `currentPassword` is passed so that the new password can be checked against
+ * the current password to ensure they differ.
+ *
+ * Returns `undefined` when the value is valid, or an error message otherwise.
+ */
+export function validateNewPassword(
+	value: string,
+	currentPassword?: string,
+): string | undefined {
+	if (!value) {
+		return "New password is required.";
+	}
+
+	if (value.length < MIN_PASSWORD_LENGTH) {
+		return `New password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
+	}
+
+	if (currentPassword && value === currentPassword) {
+		return "New password must be different from current password.";
+	}
+
+	return undefined;
+}
+
+/**
+ * Validate that the confirm-password field matches the new password.
+ *
+ * Returns `undefined` when the value is valid, or an error message otherwise.
+ */
+export function validateConfirmPassword(
+	value: string,
+	newPassword: string,
+): string | undefined {
+	if (!value) {
+		return "Please confirm your new password.";
+	}
+
+	if (newPassword !== value) {
+		return "Passwords do not match.";
+	}
+
+	return undefined;
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -194,16 +194,71 @@ info "Working directory: $(pwd)"
 heading "Admin account"
 
 ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
-ask ADMIN_USERNAME "Admin username" "$ADMIN_USERNAME"
+
+# validate_username VALUE
+# Mirrors the frontend validateUsername: non-empty and at least 3 characters.
+validate_username() {
+    local v="$1"
+    local stripped="${v// /}"
+    if [[ -z "$stripped" ]]; then
+        error "Username is required."
+        return 1
+    fi
+    if (( ${#stripped} < 3 )); then
+        error "Username must be at least 3 characters."
+        return 1
+    fi
+    return 0
+}
+
+while true; do
+    ask ADMIN_USERNAME "Admin username" "$ADMIN_USERNAME"
+    if validate_username "$ADMIN_USERNAME"; then
+        break
+    fi
+done
+
+# validate_password VALUE
+# Mirrors the frontend validatePassword: non-empty and at least 8 characters.
+validate_password() {
+    local v="$1"
+    if [[ -z "$v" ]]; then
+        error "Password is required."
+        return 1
+    fi
+    if (( ${#v} < 8 )); then
+        error "Password must be at least 8 characters."
+        return 1
+    fi
+    return 0
+}
 
 _GENERATED_PW="$(rand_alnum 16)"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
-ask_secret ADMIN_PASSWORD "Admin password (leave blank to auto-generate)"
-if [[ -z "$ADMIN_PASSWORD" ]]; then
-    ADMIN_PASSWORD="$_GENERATED_PW"
-    ADMIN_PASSWORD_GENERATED=1
+ADMIN_PASSWORD_GENERATED=0
+
+# If a password was supplied via env var, validate it before proceeding.
+if [[ -n "$ADMIN_PASSWORD" ]]; then
+    if ! validate_password "$ADMIN_PASSWORD"; then
+        die "ADMIN_PASSWORD must be at least 8 characters. Fix the env var or unset it to auto-generate."
+    fi
 else
-    ADMIN_PASSWORD_GENERATED=0
+    # Interactive: prompt until a valid, non-empty password is entered (or blank → generate).
+    ask_secret ADMIN_PASSWORD "Admin password (leave blank to auto-generate)"
+    if [[ -z "$ADMIN_PASSWORD" ]]; then
+        ADMIN_PASSWORD="$_GENERATED_PW"
+        ADMIN_PASSWORD_GENERATED=1
+    else
+        while ! validate_password "$ADMIN_PASSWORD"; do
+            ADMIN_PASSWORD=""
+            ask_secret ADMIN_PASSWORD "Admin password (leave blank to auto-generate)"
+            if [[ -z "$ADMIN_PASSWORD" ]]; then
+                ADMIN_PASSWORD="$_GENERATED_PW"
+                ADMIN_PASSWORD_GENERATED=1
+                break
+            fi
+        done
+    fi
 fi
 
 # ── Encryption key ────────────────────────────────────────────────────────────

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -7,9 +7,17 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
+)
+
+// Minimum lenths enforced across the entire stack — install.sh, the Go
+// config loader, and the frontend auth-validation module all use these.
+const (
+	minUsernameLength = 3
+	minPasswordLength = 8
 )
 
 // Load reads .env (if present) then environment variables and returns a
@@ -77,11 +85,17 @@ func Load() (*Config, error) {
 	adminUser, err := requireEnv("ADMIN_USERNAME")
 	if err != nil {
 		errs = append(errs, err)
+	} else if len(strings.TrimSpace(adminUser)) < minUsernameLength {
+		errs = append(errs, fmt.Errorf(
+			"config: ADMIN_USERNAME must be at least %d characters", minUsernameLength))
 	}
 
 	adminPass, err := requireEnv("ADMIN_PASSWORD")
 	if err != nil {
 		errs = append(errs, err)
+	} else if len(adminPass) < minPasswordLength {
+		errs = append(errs, fmt.Errorf(
+			"config: ADMIN_PASSWORD must be at least %d characters", minPasswordLength))
 	}
 
 	storageAccessKey, err := requireEnv("STORAGE_ACCESS_KEY_ID")

--- a/services/api/internal/config/load_test.go
+++ b/services/api/internal/config/load_test.go
@@ -123,6 +123,32 @@ func TestLoad_InvalidBoolOrDuration(t *testing.T) {
 	}
 }
 
+func TestLoad_AdminUsernameTooShort(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("ADMIN_USERNAME", "ab")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for short admin username")
+	}
+	if !strings.Contains(err.Error(), "ADMIN_USERNAME") || !strings.Contains(err.Error(), "3") {
+		t.Fatalf("expected ADMIN_USERNAME length error, got %q", err.Error())
+	}
+}
+
+func TestLoad_AdminPasswordTooShort(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("ADMIN_PASSWORD", "short")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for short admin password")
+	}
+	if !strings.Contains(err.Error(), "ADMIN_PASSWORD") || !strings.Contains(err.Error(), "8") {
+		t.Fatalf("expected ADMIN_PASSWORD length error, got %q", err.Error())
+	}
+}
+
 // setLoadDefaults is a helper that seeds the minimum valid env vars so that
 // individual driver tests only need to set the vars they are exercising.
 func setLoadDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the username/password validation mismatch between user creation and login that allowed admins to create accounts which could never sign in. Validation rules are now centralized in a single shared module and enforced consistently across the **frontend forms**, **install script**, and **Go config loader**.

Closes #167.

## Problem

As reported in #167:
- An admin could create a user with a **2-character username**, but the login form requires at least **3 characters** → the user could never log in.
- The same applied to **passwords** — an `admin` / `1234` account was creatable but unloginable (login requires ≥ 8 chars).

Validation logic was duplicated and inconsistent across multiple components, with no enforcement on the backend or install script side.

## Changes

### 🆕 New shared validation module (`apps/web/src/lib/auth-validation.ts`)
- Exports `MIN_USERNAME_LENGTH` (3) and `MIN_PASSWORD_LENGTH` (8) constants
- Provides reusable functions: `validateUsername`, `validatePassword`, `validateNewPassword`, `validateConfirmPassword`
- All auth surfaces now import from this single source of truth

### 🔄 Frontend — consolidated inline validators
- **`LoginFormPanel.tsx`** — removed duplicated `validateUsername` / `validatePassword`, now imports from shared module
- **`UserFormDialog.tsx`** — admin user creation now uses shared `validateUsername`, ensuring the same ≥ 3 char rule as login
- **`ChangePasswordForm.tsx`** — removed inline validators, delegates to shared module (fixed argument order: `validateNewPassword(value, currentPassword)`)
- **`ChangePasswordCard.tsx`** — uses shared `validateNewPassword` / `validateConfirmPassword`

### 🧪 Tests (`apps/web/src/lib/auth-validation.test.ts`)
- 86 lines of unit tests covering all four validators (required, min-length, mismatch, and happy-path cases)

### 🔧 Install script (`scripts/install.sh`)
- Added `validate_username` and `validate_password` bash functions mirroring the frontend rules
- Interactive prompts now loop until valid input is provided
- Non-interactive (`ADMIN_PASSWORD` env var) inputs are validated and rejected with a clear error

### ⚙️ Go config loader (`services/api/internal/config/load.go`)
- Added `minUsernameLength` / `minPasswordLength` constants
- `ADMIN_USERNAME` and `ADMIN_PASSWORD` env vars are now validated at startup (fail fast with a descriptive error)
- Added `TestLoad_AdminUsernameTooShort` and `TestLoad_AdminPasswordTooShort`

## Checklist
- [x] Shared validation module with single source of truth for rules
- [x] All frontend forms use the shared validators
- [x] Backend config loader validates at startup
- [x] Install script validates interactive and env-var inputs
- [x] Unit tests added for frontend validators and Go config