### PR TITLE
feat(task): add delete functionality for tasks with confirmation dialog

### DIFF
--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -234,7 +234,18 @@ export function TaskDetailModal({
 				interactionName={interactionName}
 				projectId={projectId}
 				taskIdPrefix={taskIdPrefix}
+				canDelete={canEdit}
 				onClose={() => onOpenChange(false)}
+				onDeleted={() => {
+					if (mode === "page" && projectId) {
+						navigate({
+							to: "/projects/$projectId",
+							params: { projectId },
+						});
+					} else {
+						onOpenChange(false);
+					}
+				}}
 			/>
 
 			{/* ── Body: stacks on mobile, side-by-side on lg+ ── */}

--- a/apps/web/src/components/projects/interactions/task-detail/task-header.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/task-header.tsx
@@ -1,6 +1,32 @@
-import { Check, ChevronRight, Hash, Share2, X } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	Check,
+	ChevronRight,
+	Hash,
+	Loader2,
+	MoreVertical,
+	Share2,
+	Trash2,
+	X,
+} from "lucide-react";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { Task } from "@/lib/interaction-api";
+import { deleteTask } from "@/lib/interaction-api";
 import { cn } from "@/lib/utils";
 import { formatDate, shortId } from "./helpers";
 
@@ -11,7 +37,9 @@ interface TaskHeaderProps {
 	interactionName?: string;
 	projectId?: string;
 	taskIdPrefix?: string;
+	canDelete?: boolean;
 	onClose: () => void;
+	onDeleted?: () => void;
 }
 
 export function TaskHeader({
@@ -21,9 +49,33 @@ export function TaskHeader({
 	interactionName,
 	projectId,
 	taskIdPrefix = "",
+	canDelete = false,
 	onClose,
+	onDeleted,
 }: TaskHeaderProps) {
+	const qc = useQueryClient();
 	const [linkCopied, setLinkCopied] = useState(false);
+	const [confirmDelete, setConfirmDelete] = useState(false);
+
+	const deleteMutation = useMutation({
+		mutationFn: () => {
+			if (!projectId || !task) throw new Error("missing context");
+			return deleteTask(projectId, task.id);
+		},
+		onSuccess: () => {
+			if (projectId) {
+				qc.invalidateQueries({
+					queryKey: ["projects", projectId],
+					predicate: (q) => {
+						const key = q.queryKey as string[];
+						return key.includes("tasks") || key.includes("backlog-tasks");
+					},
+				});
+			}
+			setConfirmDelete(false);
+			onDeleted?.();
+		},
+	});
 
 	const handleShare = () => {
 		// Always share the canonical task detail page URL, not modal URLs with query params
@@ -96,6 +148,26 @@ export function TaskHeader({
 					)}
 				</button>
 
+				{canDelete && (
+					<DropdownMenu>
+						<DropdownMenuTrigger
+							className="flex size-7 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/60 transition-all duration-150"
+							aria-label="Task actions"
+						>
+							<MoreVertical className="size-4" />
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="w-40">
+							<DropdownMenuItem
+								className="text-destructive focus:text-destructive"
+								onClick={() => setConfirmDelete(true)}
+							>
+								<Trash2 className="size-3.5 mr-2" />
+								Delete
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				)}
+
 				{mode === "modal" && (
 					<button
 						type="button"
@@ -107,6 +179,39 @@ export function TaskHeader({
 					</button>
 				)}
 			</div>
+
+			{/* Delete confirmation dialog */}
+			<Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>Delete task?</DialogTitle>
+						<DialogDescription>
+							This permanently deletes "{task.title}" and all of its data. This
+							action cannot be undone.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setConfirmDelete(false)}
+							disabled={deleteMutation.isPending}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={() => deleteMutation.mutate()}
+							disabled={deleteMutation.isPending}
+						>
+							{deleteMutation.isPending ? (
+								<Loader2 className="size-4 animate-spin" />
+							) : (
+								"Delete"
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/apps/web/src/lib/interaction-api.test.ts
+++ b/apps/web/src/lib/interaction-api.test.ts
@@ -20,6 +20,7 @@ vi.mock("./api-client", () => ({
 
 import {
 	createTask,
+	deleteTask,
 	getTask,
 	layoutToViewType,
 	listAllTasks,
@@ -170,6 +171,30 @@ describe("interaction-api", () => {
 			expect(mockPatch).toHaveBeenCalledWith(
 				`/projects/${PROJECT_ID}/tasks/${TASK_ID}`,
 				expect.any(Object),
+			);
+		});
+	});
+
+	// ── deleteTask ────────────────────────────────────────────────────────────
+
+	describe("deleteTask", () => {
+		it("sends a DELETE request to the correct path and resolves void", async () => {
+			mockDelete.mockResolvedValue({ data: { data: null, success: true } });
+
+			await expect(deleteTask(PROJECT_ID, TASK_ID)).resolves.toBeUndefined();
+			expect(mockDelete).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/tasks/${TASK_ID}`,
+			);
+		});
+
+		it("does not send a request body", async () => {
+			mockDelete.mockResolvedValue({ data: { data: null, success: true } });
+
+			await deleteTask(PROJECT_ID, TASK_ID);
+
+			expect(mockDelete).toHaveBeenCalledTimes(1);
+			expect(mockDelete).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/tasks/${TASK_ID}`,
 			);
 		});
 	});

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -538,6 +538,13 @@ export async function updateTask(
 	return data.data;
 }
 
+export async function deleteTask(
+	projectId: string,
+	taskId: string,
+): Promise<void> {
+	await apiClient.instance.delete(`/projects/${projectId}/tasks/${taskId}`);
+}
+
 export async function listSubtasks(
 	projectId: string,
 	parentTaskId: string,


### PR DESCRIPTION
## Add Delete Task feature to task detail

### Summary

Adds the ability to delete a task directly from the task detail component via a vertical ellipsis (⋮) menu in the header. This gives users a quick way to remove tasks without leaving the task view.

### Changes

**New API function**
- Added `deleteTask(projectId, taskId)` to `interaction-api.ts` — sends a `DELETE` request to `/projects/{projectId}/tasks/{taskId}`, consistent with the existing `deleteViewById` pattern.

**Task header ellipsis menu** (`task-header.tsx`)
- Added a vertical ellipsis (⋮) dropdown menu to the header action bar, positioned between the **Share** button and the **Close** button
- Menu contains a **Delete** item styled as destructive
- Clicking it opens a confirmation dialog showing the task title and a "cannot be undone" warning
- On confirm, calls `deleteTask`, invalidates task-related React Query caches, then triggers the `onDeleted` callback
- Two new props on `TaskHeader`:
  - `canDelete` — controls menu visibility (gated behind `tasks.write`)
  - `onDeleted` — post-delete callback for parent-driven navigation

**Wiring in `TaskDetailModal`** (`index.tsx`)
- Passes `canDelete={canEdit}` (tied to `tasks.write` permission)
- `onDeleted` behavior adapts to the mode:
  - **Page mode**: navigates back to the project page
  - **Modal mode**: closes the modal

**Unit tests** (`interaction-api.test.ts`)
- Added a `deleteTask` test block with 2 tests:
  - Verifies the correct `DELETE` endpoint and URL are called
  - Verifies no request body is sent

### Testing

- ✅ All 14 tests in `interaction-api.test.ts` pass
- Manually verify in both modal and page mode that:
  - The ⋮ menu appears only when the user has write permission
  - The confirmation dialog works and the task is removed
  - Navigation returns appropriately after deletion
