### PR TITLE
fix(web): accept short usernames at login

### DIFF
--- a/apps/e2e/features/validation/form.feature
+++ b/apps/e2e/features/validation/form.feature
@@ -17,12 +17,11 @@ Feature: Login form validation
     And the user moves focus to the password field
     Then the validation message "Username is required" should be visible
 
-  Scenario: Username must be at least three characters
-    When the user fills the username field with "a"
-    And the user fills the password field with "b"
-    And the user clears the username field
-    Then the validation message "Username must be at least 3 characters" should be visible
-    And the sign-in button should be disabled
+  Scenario: Short usernames are accepted at login
+    When the user fills the username field with "ab"
+    And the user fills the password field with "validpass1"
+    Then no username validation message should be visible
+    And the sign-in button should be enabled
 
   Scenario: Sign-in is enabled only when both fields contain values
     When the user fills the username field with the configured valid username

--- a/apps/e2e/tests/validation/form.spec.ts
+++ b/apps/e2e/tests/validation/form.spec.ts
@@ -32,15 +32,13 @@ test.describe("Form Validation", () => {
 		).toBeVisible();
 	});
 
-	test("shows minimum-length error when username is too short", async ({
-		loginPage,
-	}) => {
+	test("accepts short usernames at login", async ({ loginPage }) => {
 		await loginPage.usernameInput.fill("ab");
 		await loginPage.passwordInput.fill("validpass1");
 		await loginPage.passwordInput.click();
 		await expect(
 			loginPage.page.getByText("Username must be at least 3 characters"),
-		).toBeVisible();
+		).toHaveCount(0);
 		await expect(loginPage.signInButton).toBeEnabled();
 	});
 

--- a/apps/web/src/components/auth/login/LoginFormPanel.tsx
+++ b/apps/web/src/components/auth/login/LoginFormPanel.tsx
@@ -14,9 +14,9 @@ function validateUsername(value: string) {
 	if (!value.trim()) {
 		return "Username is required";
 	}
-	if (value.trim().length < 3) {
-		return "Username must be at least 3 characters";
-	}
+	// Login must accept any existing username. Length/format are registration
+	// concerns enforced at account creation; applying them here locks out valid
+	// accounts (e.g. a 2-char admin username the installer allows to be created).
 	return undefined;
 }
 


### PR DESCRIPTION
## Summary

Thanks for Paca.

The login form blocks usernames shorter than 3 characters.
But the installer and backend let you create them.
So an admin account the installer made can get locked out.

This change makes login check that the field is filled, not how long it is.
Length stays a sign up rule.

## Type of Change

Other (bug fix, frontend)

## Checklist

One concern: the login username check.
Test updated: short usernames are now accepted.
Docs updated: the BDD scenario.
A short comment says why login checks presence, not length.

## Evidence

Tested on the latest images.
Backend logged in 911 of 911 usernames, length 1 to 8. No minimum.
The login form blocked all 161 that were under 3 characters.
Real case: installer makes a 2 char admin, API login returns 200, the form still blocks it.

## CI

web-pr-ci: install ok, lint ok, tests 243 of 243, build ok.
e2e-ci: install ok, lint ok.
Browser check: the login test passes with the fix, and fails without it.
