### PR TITLE
feat: enhance roadmap view to support members, sprints, and column gr…

### DIFF
--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1549,6 +1549,9 @@ export function InteractionLayout({
 						taskIdPrefix={taskIdPrefix}
 						statuses={statuses}
 						taskTypes={creatableTaskTypes}
+						members={members}
+						sprints={sprints}
+						columnBy={columnBy}
 						searchQuery={searchQuery}
 						canCreate={canCreate}
 						pagination={globalPagination}

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1551,6 +1551,7 @@ export function InteractionLayout({
 						taskTypes={creatableTaskTypes}
 						members={members}
 						sprints={sprints}
+						customFields={customFields}
 						columnBy={columnBy}
 						searchQuery={searchQuery}
 						canCreate={canCreate}

--- a/apps/web/src/components/projects/interactions/roadmap-view.tsx
+++ b/apps/web/src/components/projects/interactions/roadmap-view.tsx
@@ -1,10 +1,15 @@
 import { CalendarDays } from "lucide-react";
 import { useMemo } from "react";
 
-import type { Task } from "@/lib/interaction-api";
-import type { TaskStatus, TaskType } from "@/lib/project-api";
+import type { Sprint, Task } from "@/lib/interaction-api";
+import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
 import { cn } from "@/lib/utils";
 import { AddTaskRow } from "./add-task-row";
+import {
+	getColumnGroupDefs,
+	getTaskColumnKeys,
+	type ColumnGroupDef,
+} from "./view-utils";
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
 const LEFT_COL_W = 280; // px — sticky task-name column
@@ -33,6 +38,9 @@ interface RoadmapViewProps {
 	taskIdPrefix?: string;
 	statuses: TaskStatus[];
 	taskTypes: TaskType[];
+	members?: ProjectMember[];
+	sprints?: Sprint[];
+	columnBy?: string;
 	searchQuery: string;
 	canCreate?: boolean;
 	onCreateTask?: (
@@ -68,6 +76,9 @@ export function RoadmapView({
 	taskIdPrefix = "",
 	statuses,
 	taskTypes,
+	members = [],
+	sprints = [],
+	columnBy = "status",
 	searchQuery,
 	canCreate = false,
 	onCreateTask,
@@ -92,9 +103,14 @@ export function RoadmapView({
 		[tasks, searchQuery, taskIdPrefix],
 	);
 
-	const sortedStatuses = useMemo(
-		() => [...statuses].sort((a, b) => a.position - b.position),
-		[statuses],
+	const viewCtx = useMemo(
+		() => ({ statuses, taskTypes, members, customFields: [], sprints }),
+		[statuses, taskTypes, members, sprints],
+	);
+
+	const groupDefs = useMemo(
+		() => getColumnGroupDefs(columnBy, viewCtx),
+		[columnBy, viewCtx],
 	);
 
 	const defaultStatusId = useMemo(
@@ -271,12 +287,10 @@ export function RoadmapView({
 
 	// ── Group header ──────────────────────────────────────────────────────────
 	function GroupHeader({
-		color,
-		name,
+		group,
 		count,
 	}: {
-		color?: string | null;
-		name: string;
+		group: ColumnGroupDef;
 		count: number;
 	}) {
 		return (
@@ -284,12 +298,12 @@ export function RoadmapView({
 				<span
 					className="size-2 shrink-0 rounded-full"
 					style={{
-						background: color ?? "oklch(var(--muted-foreground) / 0.4)",
-						boxShadow: color ? `0 0 6px ${color}40` : undefined,
+						background: group.color ?? "oklch(var(--muted-foreground) / 0.4)",
+						boxShadow: group.color ? `0 0 6px ${group.color}40` : undefined,
 					}}
 				/>
 				<span className="text-[10.5px] font-bold uppercase tracking-[0.07em] text-foreground/65">
-					{name}
+					{group.label}
 				</span>
 				<span className="rounded-full bg-muted/70 px-2 py-px text-[10px] font-bold tabular-nums text-muted-foreground/60">
 					{count}
@@ -369,47 +383,24 @@ export function RoadmapView({
 						</div>
 					) : (
 						<>
-							{sortedStatuses.map((status) => {
-								const groupTasks = filtered.filter(
-									(t) => t.status_id === status.id,
+							{groupDefs.map((group) => {
+								const groupTasks = filtered.filter((t) =>
+									getTaskColumnKeys(t, columnBy, viewCtx).includes(group.key),
 								);
-								if (groupTasks.length === 0 && !pagination?.hasMore)
-									return null;
+								if (groupTasks.length === 0) return null;
 
 								return (
 									<div
-										key={status.id}
+										key={group.key}
 										className="border-b border-border/20 last:border-0"
 									>
-										<GroupHeader
-											color={status.color}
-											name={status.name}
-											count={groupTasks.length}
-										/>
+										<GroupHeader group={group} count={groupTasks.length} />
 										{groupTasks.map((t) => (
 											<RoadmapTaskRow key={t.id} task={t} />
 										))}
 									</div>
 								);
 							})}
-
-							{/* Unstatused tasks */}
-							{(() => {
-								const uns = filtered.filter((t) => !t.status_id);
-								if (!uns.length && !pagination?.hasMore) return null;
-								return (
-									<div className="border-b border-border/20 last:border-0">
-										<GroupHeader
-											color={null}
-											name="No Status"
-											count={uns.length}
-										/>
-										{uns.map((t) => (
-											<RoadmapTaskRow key={t.id} task={t} />
-										))}
-									</div>
-								);
-							})()}
 						</>
 					)}
 

--- a/apps/web/src/components/projects/interactions/roadmap-view.tsx
+++ b/apps/web/src/components/projects/interactions/roadmap-view.tsx
@@ -6,9 +6,9 @@ import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
 import { cn } from "@/lib/utils";
 import { AddTaskRow } from "./add-task-row";
 import {
+	type ColumnGroupDef,
 	getColumnGroupDefs,
 	getTaskColumnKeys,
-	type ColumnGroupDef,
 } from "./view-utils";
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
@@ -382,26 +382,24 @@ export function RoadmapView({
 							<p className="text-[12px] font-medium">No tasks to display</p>
 						</div>
 					) : (
-						<>
-							{groupDefs.map((group) => {
-								const groupTasks = filtered.filter((t) =>
-									getTaskColumnKeys(t, columnBy, viewCtx).includes(group.key),
-								);
-								if (groupTasks.length === 0) return null;
+						groupDefs.map((group) => {
+							const groupTasks = filtered.filter((t) =>
+								getTaskColumnKeys(t, columnBy, viewCtx).includes(group.key),
+							);
+							if (groupTasks.length === 0) return null;
 
-								return (
-									<div
-										key={group.key}
-										className="border-b border-border/20 last:border-0"
-									>
-										<GroupHeader group={group} count={groupTasks.length} />
-										{groupTasks.map((t) => (
-											<RoadmapTaskRow key={t.id} task={t} />
-										))}
-									</div>
-								);
-							})}
-						</>
+							return (
+								<div
+									key={group.key}
+									className="border-b border-border/20 last:border-0"
+								>
+									<GroupHeader group={group} count={groupTasks.length} />
+									{groupTasks.map((t) => (
+										<RoadmapTaskRow key={t.id} task={t} />
+									))}
+								</div>
+							);
+						})
 					)}
 
 					{/* ── Pagination button ─────────────────────────────────── */}

--- a/apps/web/src/components/projects/interactions/roadmap-view.tsx
+++ b/apps/web/src/components/projects/interactions/roadmap-view.tsx
@@ -2,7 +2,12 @@ import { CalendarDays } from "lucide-react";
 import { useMemo } from "react";
 
 import type { Sprint, Task } from "@/lib/interaction-api";
-import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
+import type {
+	CustomFieldDefinition,
+	ProjectMember,
+	TaskStatus,
+	TaskType,
+} from "@/lib/project-api";
 import { cn } from "@/lib/utils";
 import { AddTaskRow } from "./add-task-row";
 import {
@@ -40,6 +45,7 @@ interface RoadmapViewProps {
 	taskTypes: TaskType[];
 	members?: ProjectMember[];
 	sprints?: Sprint[];
+	customFields?: CustomFieldDefinition[];
 	columnBy?: string;
 	searchQuery: string;
 	canCreate?: boolean;
@@ -78,6 +84,7 @@ export function RoadmapView({
 	taskTypes,
 	members = [],
 	sprints = [],
+	customFields = [],
 	columnBy = "status",
 	searchQuery,
 	canCreate = false,
@@ -104,8 +111,8 @@ export function RoadmapView({
 	);
 
 	const viewCtx = useMemo(
-		() => ({ statuses, taskTypes, members, customFields: [], sprints }),
-		[statuses, taskTypes, members, sprints],
+		() => ({ statuses, taskTypes, members, customFields, sprints }),
+		[statuses, taskTypes, members, customFields, sprints],
 	);
 
 	const groupDefs = useMemo(
@@ -115,9 +122,8 @@ export function RoadmapView({
 
 	const defaultStatusId = useMemo(
 		() =>
-			statuses.find((s) => s.category === "backlog")?.id ??
-			statuses.find((s) => s.category === "todo")?.id ??
-			statuses[0]?.id ??
+			statuses.find((s) => s.is_default)?.id ??
+			[...statuses].sort((a, b) => a.position - b.position)[0]?.id ??
 			"",
 		[statuses],
 	);

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -94,6 +94,17 @@ export function getColumnGroupDefs(
 		];
 	}
 
+	if (columnBy === "reporter") {
+		return [
+			...ctx.members.map((m) => ({
+				key: m.id,
+				label: m.full_name || m.username,
+				fieldValue: m.id,
+			})),
+			{ key: "__none", label: "No Reporter", fieldValue: null },
+		];
+	}
+
 	if (columnBy === "importance") {
 		return PRIORITY_LEVELS.map((p) => ({
 			key: String(p.value),
@@ -180,6 +191,9 @@ export function getTaskColumnKeys(
 	}
 	if (columnBy === "assignee") {
 		return [task.assignee_id ?? "__unassigned"];
+	}
+	if (columnBy === "reporter") {
+		return [task.reporter_id ?? "__none"];
 	}
 	if (columnBy === "importance") {
 		// Bucket the raw numeric importance into one of the 5 named levels

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -96,11 +96,15 @@ export function getColumnGroupDefs(
 
 	if (columnBy === "reporter") {
 		return [
-			...ctx.members.map((m) => ({
-				key: m.id,
-				label: m.full_name || m.username,
-				fieldValue: m.id,
-			})),
+			...[...ctx.members]
+				.sort((a, b) =>
+					(a.full_name || a.username).localeCompare(b.full_name || b.username),
+				)
+				.map((m) => ({
+					key: m.id,
+					label: m.full_name || m.username,
+					fieldValue: m.id,
+				})),
 			{ key: "__none", label: "No Reporter", fieldValue: null },
 		];
 	}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
@@ -118,7 +118,7 @@ function CreateAgentDialog({
 	const [customModel, setCustomModel] = useState("");
 	const [llmApiKey, setLlmApiKey] = useState("");
 	const [llmBaseUrl, setLlmBaseUrl] = useState(
-		llmModels["anthropic"]?.base_url ?? "",
+		llmModels.anthropic?.base_url ?? "",
 	);
 	const [systemPrompt, setSystemPrompt] = useState("");
 	const [showApiKey, setShowApiKey] = useState(false);
@@ -139,7 +139,7 @@ function CreateAgentDialog({
 		setModelSelect("claude-sonnet-4-5-20250929");
 		setCustomModel("");
 		setLlmApiKey("");
-		setLlmBaseUrl(llmModels["anthropic"]?.base_url ?? "");
+		setLlmBaseUrl(llmModels.anthropic?.base_url ?? "");
 		setSystemPrompt("");
 		setShowApiKey(false);
 	};


### PR DESCRIPTION
## Summary

- Extends `RoadmapView` to accept `members`, `sprints`, and `columnBy` props, so it can now group tasks by any column dimension (not just status).
- Replaces the hardcoded status-based grouping loop with a call to the shared `getColumnGroupDefs` / `getTaskColumnKeys` helpers from `view-utils.ts`, bringing the roadmap view in line with how other views handle column grouping.
- Adds **reporter** as a new grouping option in `view-utils.ts` — tasks are bucketed by `reporter_id`, with a "No Reporter" fallback group.
- `interaction-layout.tsx` now forwards `members`, `sprints`, and `columnBy` down to `RoadmapView`.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] The change is focused and scoped.
- [x] Related documentation is updated.
- [x] New structure or direction is explained clearly.
- [x] I avoided unnecessary detail or premature abstraction.