### PR TITLE
fix: update model string construction for LLM to handle openai prefix…

### DIFF
--- a/services/ai-agent/src/agent/builder.py
+++ b/services/ai-agent/src/agent/builder.py
@@ -24,7 +24,11 @@ def build_llm(agent_config: AgentConfig) -> LLM:
     # For providers not natively known to LiteLLM, route through the OpenAI-compatible
     # client by prefixing with "openai/" — LiteLLM uses base_url to reach the endpoint.
     if llm_base_url and provider not in litellm.provider_list:
-        model_str = agent_config.llm_model if agent_config.llm_model.startswith("openai/") else f"openai/{agent_config.llm_model}"
+        model_str = (
+            agent_config.llm_model
+            if agent_config.llm_model.startswith("openai/")
+            else f"openai/{agent_config.llm_model}"
+        )
     else:
         model_str = f"{provider}/{agent_config.llm_model}"
 

--- a/services/ai-agent/src/agent/builder.py
+++ b/services/ai-agent/src/agent/builder.py
@@ -24,7 +24,7 @@ def build_llm(agent_config: AgentConfig) -> LLM:
     # For providers not natively known to LiteLLM, route through the OpenAI-compatible
     # client by prefixing with "openai/" — LiteLLM uses base_url to reach the endpoint.
     if llm_base_url and provider not in litellm.provider_list:
-        model_str = f"openai/{agent_config.llm_model}"
+        model_str = agent_config.llm_model if agent_config.llm_model.startswith("openai/") else f"openai/{agent_config.llm_model}"
     else:
         model_str = f"{provider}/{agent_config.llm_model}"
 


### PR DESCRIPTION
## Summary

- Fixed a bug in `build_llm` where the `openai/` prefix was unconditionally prepended to the model string, causing double-prefixing (e.g. `openai/openai/gpt-4o`) when the model name already included it.
- The fix checks whether `llm_model` already starts with `openai/` before adding the prefix, ensuring LiteLLM receives a correctly formatted model string.

## Root cause

In `services/ai-agent/src/agent/builder.py`, the routing path for providers not natively known to LiteLLM always built the string as `f"openai/{agent_config.llm_model}"`. If the caller already supplied a fully-qualified model name (e.g. `openai/gpt-4o`), this produced an invalid `openai/openai/gpt-4o` string that LiteLLM could not resolve.

## Test plan

- [ ] Confirm that a model string without the `openai/` prefix (e.g. `gpt-4o`) still gets correctly prefixed to `openai/gpt-4o`.
- [ ] Confirm that a model string already prefixed with `openai/` (e.g. `openai/gpt-4o`) is passed through unchanged.
- [ ] Run the ai-agent service with a custom provider endpoint and verify routing succeeds for both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)