### PR TITLE
fix: fix error cannot get llm model list

### DIFF
--- a/services/ai-agent/Dockerfile
+++ b/services/ai-agent/Dockerfile
@@ -9,6 +9,7 @@ COPY pyproject.toml .
 RUN uv pip install --system -e .
 
 COPY src/ ./src/
+COPY data/ ./data/
 
 ENV PYTHONPATH=/app
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary

- The `data/` directory (containing `llm_models.json`) was not being copied into the Docker image for the `ai-agent` service.
- This caused a runtime error when the service attempted to load the LLM model list, as the file did not exist inside the container.
- Added `COPY data/ ./data/` to `services/ai-agent/Dockerfile` to include the model list in the image.

## Root Cause

`services/ai-agent/Dockerfile` only copied `src/` and `pyproject.toml` — the `data/` directory holding static config files was never included, so `llm_models.json` was absent at runtime.

## Test Plan

- [x] Build the `ai-agent` Docker image and confirm the container starts without errors.
- [x] Verify the LLM model list endpoint returns the expected models.