### PR TITLE
Feature/implement task link management

### DIFF
--- a/apps/mcp/src/__tests__/tools/task-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/task-tools.test.ts
@@ -40,6 +40,7 @@ function makeExtendedClient(overrides: Record<string, any> = {}) {
 		listProjectMembers: vi.fn().mockResolvedValue([]),
 		listSubtasks: vi.fn().mockResolvedValue([]),
 		listTaskActivities: vi.fn().mockResolvedValue([]),
+		listTaskLinks: vi.fn().mockResolvedValue([]),
 		...overrides,
 	} as any;
 }

--- a/apps/mcp/src/api/task-extended-client.ts
+++ b/apps/mcp/src/api/task-extended-client.ts
@@ -1,8 +1,10 @@
 import type {
 	CreateCommentInput,
+	CreateTaskLinkInput,
 	PacaConfig,
 	SuccessEnvelope,
 	TaskActivity,
+	TaskLink,
 	UpdateCommentInput,
 } from "../types/index.js";
 import { markdownToBlocknote } from "../utils/index.js";
@@ -183,5 +185,38 @@ export class PacaAPITaskExtendedClient {
 			return response;
 		}
 		return response.items || response.members || response.data || [];
+	}
+
+	// ==================== Task Links ====================
+
+	async listTaskLinks(projectId: string, taskId: string): Promise<TaskLink[]> {
+		const response = await this.get(
+			`/api/v1/projects/${projectId}/tasks/${taskId}/links`,
+		);
+		if (Array.isArray(response)) {
+			return response;
+		}
+		return response.items || response.links || response.data || [];
+	}
+
+	async createTaskLink(
+		projectId: string,
+		taskId: string,
+		input: CreateTaskLinkInput,
+	): Promise<TaskLink> {
+		return this.post(
+			`/api/v1/projects/${projectId}/tasks/${taskId}/links`,
+			input,
+		);
+	}
+
+	async deleteTaskLink(
+		projectId: string,
+		taskId: string,
+		linkId: string,
+	): Promise<void> {
+		await this.delete(
+			`/api/v1/projects/${projectId}/tasks/${taskId}/links/${linkId}`,
+		);
 	}
 }

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -25,6 +25,10 @@ import {
 	getTaskActivityTools,
 	handleTaskActivityTool,
 } from "./task-activity-tools.js";
+import {
+	getTaskLinkTools,
+	handleTaskLinkTool,
+} from "./task-link-tools.js";
 import { getTaskTools, handleTaskTool } from "./task-tools.js";
 import {
 	getTaskStatusTools,
@@ -54,6 +58,7 @@ export function getAllTools(): Tool[] {
 		...getCustomFieldTools(),
 		...getAttachmentTools(),
 		...getTaskActivityTools(),
+		...getTaskLinkTools(),
 	];
 }
 
@@ -199,6 +204,15 @@ export async function handleToolCall(
 			name === "delete_task_comment"
 		) {
 			return handleTaskActivityTool(name, args, clients.taskExtendedClient);
+		}
+
+		// Task link tools
+		if (
+			name === "list_task_links" ||
+			name === "create_task_link" ||
+			name === "delete_task_link"
+		) {
+			return handleTaskLinkTool(name, args, clients.taskExtendedClient);
 		}
 
 		throw new Error(`Unknown tool: ${name}`);

--- a/apps/mcp/src/tools/task-link-tools.ts
+++ b/apps/mcp/src/tools/task-link-tools.ts
@@ -1,0 +1,175 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { PacaAPITaskExtendedClient } from "../api/index.js";
+
+const ListTaskLinksSchema = z.object({
+	projectId: z.string(),
+	taskId: z.string(),
+});
+
+const CreateTaskLinkSchema = z.object({
+	projectId: z.string(),
+	taskId: z.string(),
+	targetTaskId: z.string(),
+	linkType: z.enum(["blocks", "relates_to", "duplicates"]),
+});
+
+const DeleteTaskLinkSchema = z.object({
+	projectId: z.string(),
+	taskId: z.string(),
+	linkId: z.string(),
+});
+
+const PROJECT_ID_DESC =
+	"The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.";
+
+const TASK_ID_DESC =
+	"The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.";
+
+/**
+ * Returns all task-link MCP tools.
+ */
+export function getTaskLinkTools(): Tool[] {
+	return [
+		{
+			name: "list_task_links",
+			description:
+				"List all links for a task, showing how it relates to other tasks (blocks, is blocked by, relates to, duplicates, is duplicated by)",
+			inputSchema: {
+				type: "object",
+				properties: {
+					projectId: { type: "string", description: PROJECT_ID_DESC },
+					taskId: { type: "string", description: TASK_ID_DESC },
+				},
+				required: ["projectId", "taskId"],
+			},
+		},
+		{
+			name: "create_task_link",
+			description:
+				"Create a link between two tasks. Use 'blocks' when this task blocks another, 'relates_to' for a general relationship, or 'duplicates' when this task duplicates another.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					projectId: { type: "string", description: PROJECT_ID_DESC },
+					taskId: {
+						type: "string",
+						description:
+							"The technical UUID of the source task (the task you are linking from). Use list_tasks to get the task ID.",
+					},
+					targetTaskId: {
+						type: "string",
+						description:
+							"The technical UUID of the target task (the task you are linking to). Must be different from taskId.",
+					},
+					linkType: {
+						type: "string",
+						enum: ["blocks", "relates_to", "duplicates"],
+						description:
+							"The type of link: 'blocks' (this task blocks the target), 'relates_to' (general relationship, symmetric), 'duplicates' (this task duplicates the target).",
+					},
+				},
+				required: ["projectId", "taskId", "targetTaskId", "linkType"],
+			},
+		},
+		{
+			name: "delete_task_link",
+			description: "Remove a link between two tasks",
+			inputSchema: {
+				type: "object",
+				properties: {
+					projectId: { type: "string", description: PROJECT_ID_DESC },
+					taskId: { type: "string", description: TASK_ID_DESC },
+					linkId: {
+						type: "string",
+						description:
+							"The technical UUID of the link to delete. Use list_task_links to get the link ID.",
+					},
+				},
+				required: ["projectId", "taskId", "linkId"],
+			},
+		},
+	];
+}
+
+const DISPLAY_LINK_LABELS: Record<string, string> = {
+	blocks: "Blocks",
+	is_blocked_by: "Is blocked by",
+	relates_to: "Relates to",
+	duplicates: "Duplicates",
+	is_duplicated_by: "Is duplicated by",
+};
+
+function formatTaskLink(link: any): string {
+	const label =
+		DISPLAY_LINK_LABELS[link.display_link_type] || link.display_link_type;
+	const task = link.linked_task;
+	const taskRef = task
+		? `#${task.task_number} — ${task.title} (ID: ${task.id})`
+		: link.target_task_id;
+	return `- **${label}:** ${taskRef}\n  Link ID: ${link.id}`;
+}
+
+/**
+ * Handles task-link tool calls.
+ */
+export async function handleTaskLinkTool(
+	toolName: string,
+	args: any,
+	taskExtendedClient: PacaAPITaskExtendedClient,
+): Promise<any> {
+	switch (toolName) {
+		case "list_task_links": {
+			const { projectId, taskId } = ListTaskLinksSchema.parse(args);
+			const links = await taskExtendedClient.listTaskLinks(projectId, taskId);
+			if (links.length === 0) {
+				return {
+					content: [{ type: "text", text: "No links found for this task." }],
+				};
+			}
+			const formatted = links.map(formatTaskLink).join("\n");
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task links (${links.length}):\n\n${formatted}`,
+					},
+				],
+			};
+		}
+
+		case "create_task_link": {
+			const { projectId, taskId, targetTaskId, linkType } =
+				CreateTaskLinkSchema.parse(args);
+			const link = await taskExtendedClient.createTaskLink(
+				projectId,
+				taskId,
+				{ target_task_id: targetTaskId, link_type: linkType },
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task link created successfully:\n\n${formatTaskLink(link)}`,
+					},
+				],
+			};
+		}
+
+		case "delete_task_link": {
+			const { projectId, taskId, linkId } = DeleteTaskLinkSchema.parse(args);
+			await taskExtendedClient.deleteTaskLink(projectId, taskId, linkId);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Task link ${linkId} deleted successfully`,
+					},
+				],
+			};
+		}
+
+		default:
+			throw new Error(`Unknown task link tool: ${toolName}`);
+	}
+}

--- a/apps/mcp/src/tools/task-tools.ts
+++ b/apps/mcp/src/tools/task-tools.ts
@@ -508,6 +508,7 @@ async function getTaskDetail(
 		attachments,
 		activities,
 		customFields,
+		links,
 	] = await Promise.all([
 		client.getProject(projectId).catch(() => undefined),
 		extendedClient?.listTaskStatuses(projectId)?.catch(() => []) ||
@@ -524,6 +525,8 @@ async function getTaskDetail(
 		extendedClient?.listTaskActivities(projectId, taskId)?.catch(() => []) ||
 			Promise.resolve([]),
 		viewsClient?.listCustomFieldDefinitions(projectId)?.catch(() => []) ||
+			Promise.resolve([]),
+		extendedClient?.listTaskLinks(projectId, taskId)?.catch(() => []) ||
 			Promise.resolve([]),
 	]);
 
@@ -554,6 +557,7 @@ async function getTaskDetail(
 		attachments,
 		activities,
 		customFields,
+		links,
 	);
 
 	return {

--- a/apps/mcp/src/types/index.ts
+++ b/apps/mcp/src/types/index.ts
@@ -689,6 +689,40 @@ export interface CreateBranchResult {
 	branch_name: string;
 }
 
+// ==================== Task Links ====================
+
+export type LinkType = "blocks" | "relates_to" | "duplicates";
+export type DisplayLinkType =
+	| "blocks"
+	| "relates_to"
+	| "duplicates"
+	| "is_blocked_by"
+	| "is_duplicated_by";
+
+export interface LinkedTaskSummary {
+	id: string;
+	task_number: number;
+	title: string;
+	status_id?: string | null;
+	task_type_id?: string | null;
+}
+
+export interface TaskLink {
+	id: string;
+	source_task_id: string;
+	target_task_id: string;
+	link_type: LinkType;
+	display_link_type: DisplayLinkType;
+	linked_task: LinkedTaskSummary;
+	created_by?: string | null;
+	created_at: string;
+}
+
+export interface CreateTaskLinkInput {
+	target_task_id: string;
+	link_type: LinkType;
+}
+
 // ==================== API Response Helpers ====================
 
 export interface APIResponse<T> {

--- a/apps/mcp/src/utils/formatters.ts
+++ b/apps/mcp/src/utils/formatters.ts
@@ -7,6 +7,7 @@ import type {
 	Sprint,
 	Task,
 	TaskActivity,
+	TaskLink,
 	TaskStatus,
 	TaskType,
 } from "../types/index.js";
@@ -57,6 +58,14 @@ ${description}`;
  * @param customFields - Array of custom field definitions (if available)
  * @returns Comprehensive formatted task detail string
  */
+const DISPLAY_LINK_LABELS: Record<string, string> = {
+	blocks: "Blocks",
+	is_blocked_by: "Is blocked by",
+	relates_to: "Relates to",
+	duplicates: "Duplicates",
+	is_duplicated_by: "Is duplicated by",
+};
+
 export function formatTaskDetail(
 	task: Task,
 	project?: Project,
@@ -70,6 +79,7 @@ export function formatTaskDetail(
 	attachments?: Attachment[],
 	activities?: TaskActivity[],
 	customFields?: CustomFieldDefinition[],
+	links?: TaskLink[],
 ): string {
 	const description = task.description
 		? blocknoteToMarkdown(task.description)
@@ -174,6 +184,18 @@ export function formatTaskDetail(
 			sections.push(
 				`- **${attachment.file.file_name}** (${formatFileSize(attachment.file.file_size)}) - Uploaded: ${attachment.created_at}`,
 			);
+		});
+	}
+
+	if (links && links.length > 0) {
+		sections.push("");
+		sections.push("## Linked Tasks");
+		links.forEach((link) => {
+			const label =
+				DISPLAY_LINK_LABELS[link.display_link_type] || link.display_link_type;
+			const t = link.linked_task;
+			const taskRef = t ? `#${t.task_number} — ${t.title} (ID: ${t.id})` : "";
+			sections.push(`- **${label}:** ${taskRef} *(Link ID: ${link.id})*`);
 		});
 	}
 

--- a/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
@@ -130,6 +130,12 @@ function activityDescription(
 			return `added attachment${content.file_name ? `: ${content.file_name}` : ""}`;
 		case "task.attachment.removed":
 			return `removed attachment${content.file_name ? `: ${content.file_name}` : ""}`;
+		case "task.link.added": {
+			const linkType = content.link_type === "blocks" ? "blocked by" : content.link_type === "relates_to" ? "related to" : "duplicated";
+			return `added task link (${linkType})`;
+		}
+		case "task.link.removed":
+			return "removed task link";
 		default:
 			return (content._description as string | undefined) ?? "made a change";
 	}

--- a/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
@@ -131,7 +131,12 @@ function activityDescription(
 		case "task.attachment.removed":
 			return `removed attachment${content.file_name ? `: ${content.file_name}` : ""}`;
 		case "task.link.added": {
-			const linkType = content.link_type === "blocks" ? "blocked by" : content.link_type === "relates_to" ? "related to" : "duplicated";
+			const linkType =
+				content.link_type === "blocks"
+					? "blocked by"
+					: content.link_type === "relates_to"
+						? "related to"
+						: "duplicated";
 			return `added task link (${linkType})`;
 		}
 		case "task.link.removed":

--- a/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
@@ -133,10 +133,10 @@ function activityDescription(
 		case "task.link.added": {
 			const linkType =
 				content.link_type === "blocks"
-					? "blocked by"
+					? "blocks"
 					: content.link_type === "relates_to"
 						? "related to"
-						: "duplicated";
+						: "duplicates";
 			return `added task link (${linkType})`;
 		}
 		case "task.link.removed":

--- a/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
@@ -88,6 +88,17 @@ export function TaskActivityPane({
 					return `added attachment${(c as Record<string, unknown>).file_name ? `: ${(c as Record<string, unknown>).file_name}` : ""}`;
 				case "task.attachment.removed":
 					return `removed attachment${(c as Record<string, unknown>).file_name ? `: ${(c as Record<string, unknown>).file_name}` : ""}`;
+				case "task.link.added": {
+					const linkType =
+						(c as Record<string, unknown>).link_type === "blocks"
+							? "blocked by"
+							: (c as Record<string, unknown>).link_type === "relates_to"
+								? "related to"
+								: "duplicated";
+					return `added task link (${linkType})`;
+				}
+				case "task.link.removed":
+					return "removed task link";
 				case "agent.session.started": {
 					const convId = (c as Record<string, unknown>).conversation_id as
 						| string

--- a/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-pane.tsx
@@ -91,10 +91,10 @@ export function TaskActivityPane({
 				case "task.link.added": {
 					const linkType =
 						(c as Record<string, unknown>).link_type === "blocks"
-							? "blocked by"
+							? "blocks"
 							: (c as Record<string, unknown>).link_type === "relates_to"
 								? "related to"
-								: "duplicated";
+								: "duplicates";
 					return `added task link (${linkType})`;
 				}
 				case "task.link.removed":

--- a/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link2, Search, X } from "lucide-react";
+import {
+	type LinkType,
+	listAllTasks,
+	type Task,
+} from "@/lib/interaction-api";
+
+interface AddTaskLinkModalProps {
+	open: boolean;
+	onClose: () => void;
+	onAdd: (targetTaskId: string, linkType: LinkType) => void;
+	projectId: string;
+	currentTaskId: string;
+	taskIdPrefix?: string;
+}
+
+const LINK_TYPE_OPTIONS: { value: LinkType; label: string; description: string }[] = [
+	{ value: "blocks", label: "Blocks", description: "This task must be completed before the other" },
+	{ value: "is_blocked_by" as LinkType, label: "Is blocked by", description: "This task cannot start until the other is done" },
+	{ value: "relates_to", label: "Relates to", description: "These tasks are related but not dependent" },
+	{ value: "duplicates", label: "Duplicates", description: "This task is a duplicate of the other" },
+];
+
+// Maps display types back to the canonical storage type and direction
+const DISPLAY_TO_CANONICAL: Record<string, { linkType: LinkType; swap: boolean }> = {
+	blocks: { linkType: "blocks", swap: false },
+	is_blocked_by: { linkType: "blocks", swap: true },
+	relates_to: { linkType: "relates_to", swap: false },
+	duplicates: { linkType: "duplicates", swap: false },
+};
+
+export function AddTaskLinkModal({
+	open,
+	onClose,
+	onAdd,
+	projectId,
+	currentTaskId,
+	taskIdPrefix = "",
+}: AddTaskLinkModalProps) {
+	const [selectedLinkType, setSelectedLinkType] = useState<string>("blocks");
+	const [query, setQuery] = useState("");
+	const [tasks, setTasks] = useState<Task[]>([]);
+	const [loading, setLoading] = useState(false);
+	const searchRef = useRef<HTMLInputElement>(null);
+
+	// Load tasks once when modal opens
+	useEffect(() => {
+		if (!open) return;
+		setLoading(true);
+		listAllTasks(projectId, { pageSize: 200 })
+			.then((result) => setTasks(result.items))
+			.finally(() => setLoading(false));
+		setTimeout(() => searchRef.current?.focus(), 50);
+	}, [open, projectId]);
+
+	const filteredTasks = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		return tasks.filter((t) => {
+			if (t.id === currentTaskId) return false;
+			if (!q) return true;
+			const prefix = taskIdPrefix ? `${taskIdPrefix}-${t.task_number}` : String(t.task_number);
+			return (
+				t.title.toLowerCase().includes(q) ||
+				prefix.toLowerCase().includes(q)
+			);
+		});
+	}, [tasks, query, currentTaskId, taskIdPrefix]);
+
+	function handleSelect(task: Task) {
+		const canonical = DISPLAY_TO_CANONICAL[selectedLinkType];
+		if (!canonical) return;
+		if (canonical.swap) {
+			// "is blocked by" means target blocks source — we store it as target→source
+			// but the API takes (source=currentTask, target=otherTask, type=blocks).
+			// For "is_blocked_by", we flip: the other task IS the source.
+			// We handle this by calling onAdd with the other task as source using a
+			// reversed direction: CreateTaskLink(source=target, target=current).
+			// Since our API creates source→target, for "is_blocked_by" we need to
+			// create a link where target_task_id = currentTaskId and source = this task.
+			// We pass a special signal via a negative swap — the parent will call the
+			// API as: CreateTaskLink(source=task.id, target=currentTaskId, type="blocks").
+			onAdd(`__swap__${task.id}`, canonical.linkType);
+		} else {
+			onAdd(task.id, canonical.linkType);
+		}
+	}
+
+	if (!open) return null;
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+			onKeyDown={(e) => {
+				if (e.key === "Escape") onClose();
+			}}
+		>
+			<div className="bg-card border border-border/40 rounded-2xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden">
+				{/* Header */}
+				<div className="flex items-center justify-between px-5 py-4 border-b border-border/20">
+					<div className="flex items-center gap-2.5">
+						<div className="size-7 rounded-lg bg-primary/10 flex items-center justify-center">
+							<Link2 className="size-3.5 text-primary" />
+						</div>
+						<h2 className="text-[14px] font-semibold text-foreground">Link task</h2>
+					</div>
+					<button
+						type="button"
+						onClick={onClose}
+						className="size-7 rounded-lg flex items-center justify-center text-muted-foreground/60 hover:text-foreground hover:bg-muted/30 transition-all duration-150"
+					>
+						<X className="size-4" />
+					</button>
+				</div>
+
+				{/* Link type selector */}
+				<div className="px-5 pt-4 pb-3">
+					<p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60 mb-2">
+						Relationship
+					</p>
+					<div className="grid grid-cols-2 gap-1.5">
+						{LINK_TYPE_OPTIONS.map((opt) => (
+							<button
+								key={opt.value}
+								type="button"
+								onClick={() => setSelectedLinkType(opt.value)}
+								className={`px-3 py-2 rounded-lg text-left text-[12px] font-medium transition-all duration-150 border ${
+									selectedLinkType === opt.value
+										? "bg-primary/10 border-primary/30 text-primary"
+										: "bg-muted/20 border-border/20 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+								}`}
+								title={opt.description}
+							>
+								{opt.label}
+							</button>
+						))}
+					</div>
+				</div>
+
+				{/* Search */}
+				<div className="px-5 pb-3">
+					<div className="relative">
+						<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground/50" />
+						<input
+							ref={searchRef}
+							type="text"
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder="Search tasks by title or number..."
+							className="w-full pl-9 pr-3 py-2.5 rounded-lg border border-border/30 bg-muted/20 text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all duration-150"
+						/>
+					</div>
+				</div>
+
+				{/* Task list */}
+				<div className="mx-5 mb-5 rounded-xl border border-border/20 overflow-hidden max-h-64 overflow-y-auto [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/40">
+					{loading && (
+						<div className="flex items-center justify-center py-8 text-muted-foreground/50 text-[13px]">
+							Loading tasks…
+						</div>
+					)}
+					{!loading && filteredTasks.length === 0 && (
+						<div className="flex items-center justify-center py-8 text-muted-foreground/45 text-[13px] italic">
+							No tasks found
+						</div>
+					)}
+					{!loading &&
+						filteredTasks.map((task) => {
+							const prefix = taskIdPrefix
+								? `${taskIdPrefix}-${task.task_number}`
+								: `#${task.task_number}`;
+							return (
+								<button
+									key={task.id}
+									type="button"
+									onClick={() => handleSelect(task)}
+									className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted/30 transition-colors duration-100 border-b border-border/10 last:border-0"
+								>
+									<span className="shrink-0 text-[11px] font-mono text-muted-foreground/60 min-w-13">
+										{prefix}
+									</span>
+									<span className="text-[13px] text-foreground truncate">
+										{task.title}
+									</span>
+								</button>
+							);
+						})}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
 import { Link2, Search, X } from "lucide-react";
-import {
-	type LinkType,
-	listAllTasks,
-	type Task,
-} from "@/lib/interaction-api";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { type LinkType, listAllTasks, type Task } from "@/lib/interaction-api";
 
 interface AddTaskLinkModalProps {
 	open: boolean;
@@ -15,15 +11,38 @@ interface AddTaskLinkModalProps {
 	taskIdPrefix?: string;
 }
 
-const LINK_TYPE_OPTIONS: { value: LinkType; label: string; description: string }[] = [
-	{ value: "blocks", label: "Blocks", description: "This task must be completed before the other" },
-	{ value: "is_blocked_by" as LinkType, label: "Is blocked by", description: "This task cannot start until the other is done" },
-	{ value: "relates_to", label: "Relates to", description: "These tasks are related but not dependent" },
-	{ value: "duplicates", label: "Duplicates", description: "This task is a duplicate of the other" },
+const LINK_TYPE_OPTIONS: {
+	value: LinkType;
+	label: string;
+	description: string;
+}[] = [
+	{
+		value: "blocks",
+		label: "Blocks",
+		description: "This task must be completed before the other",
+	},
+	{
+		value: "is_blocked_by" as LinkType,
+		label: "Is blocked by",
+		description: "This task cannot start until the other is done",
+	},
+	{
+		value: "relates_to",
+		label: "Relates to",
+		description: "These tasks are related but not dependent",
+	},
+	{
+		value: "duplicates",
+		label: "Duplicates",
+		description: "This task is a duplicate of the other",
+	},
 ];
 
 // Maps display types back to the canonical storage type and direction
-const DISPLAY_TO_CANONICAL: Record<string, { linkType: LinkType; swap: boolean }> = {
+const DISPLAY_TO_CANONICAL: Record<
+	string,
+	{ linkType: LinkType; swap: boolean }
+> = {
 	blocks: { linkType: "blocks", swap: false },
 	is_blocked_by: { linkType: "blocks", swap: true },
 	relates_to: { linkType: "relates_to", swap: false },
@@ -59,10 +78,11 @@ export function AddTaskLinkModal({
 		return tasks.filter((t) => {
 			if (t.id === currentTaskId) return false;
 			if (!q) return true;
-			const prefix = taskIdPrefix ? `${taskIdPrefix}-${t.task_number}` : String(t.task_number);
+			const prefix = taskIdPrefix
+				? `${taskIdPrefix}-${t.task_number}`
+				: String(t.task_number);
 			return (
-				t.title.toLowerCase().includes(q) ||
-				prefix.toLowerCase().includes(q)
+				t.title.toLowerCase().includes(q) || prefix.toLowerCase().includes(q)
 			);
 		});
 	}, [tasks, query, currentTaskId, taskIdPrefix]);
@@ -89,6 +109,7 @@ export function AddTaskLinkModal({
 	if (!open) return null;
 
 	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop element for modal
 		<div
 			className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
 			onClick={(e) => {
@@ -105,7 +126,9 @@ export function AddTaskLinkModal({
 						<div className="size-7 rounded-lg bg-primary/10 flex items-center justify-center">
 							<Link2 className="size-3.5 text-primary" />
 						</div>
-						<h2 className="text-[14px] font-semibold text-foreground">Link task</h2>
+						<h2 className="text-[14px] font-semibold text-foreground">
+							Link task
+						</h2>
 					</div>
 					<button
 						type="button"

--- a/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
@@ -1,18 +1,29 @@
 import { Link2, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { type LinkType, listAllTasks, type Task } from "@/lib/interaction-api";
+import {
+	type DisplayLinkType,
+	type LinkType,
+	listAllTasks,
+	type Task,
+} from "@/lib/interaction-api";
+
+export interface AddTaskLinkPayload {
+	sourceTaskId: string;
+	targetTaskId: string;
+	linkType: LinkType;
+}
 
 interface AddTaskLinkModalProps {
 	open: boolean;
 	onClose: () => void;
-	onAdd: (targetTaskId: string, linkType: LinkType) => void;
+	onAdd: (payload: AddTaskLinkPayload) => void;
 	projectId: string;
 	currentTaskId: string;
 	taskIdPrefix?: string;
 }
 
 const LINK_TYPE_OPTIONS: {
-	value: LinkType;
+	value: DisplayLinkType;
 	label: string;
 	description: string;
 }[] = [
@@ -22,7 +33,7 @@ const LINK_TYPE_OPTIONS: {
 		description: "This task must be completed before the other",
 	},
 	{
-		value: "is_blocked_by" as LinkType,
+		value: "is_blocked_by",
 		label: "Is blocked by",
 		description: "This task cannot start until the other is done",
 	},
@@ -38,16 +49,36 @@ const LINK_TYPE_OPTIONS: {
 	},
 ];
 
-// Maps display types back to the canonical storage type and direction
-const DISPLAY_TO_CANONICAL: Record<
-	string,
-	{ linkType: LinkType; swap: boolean }
+// Maps the display type chosen in the UI to the canonical (source, target)
+// orientation the API stores. "is_blocked_by" is the only option where the
+// other task is the source: the API only has "blocks", so "X is blocked by
+// Y" is created as source=Y, target=currentTask, link_type=blocks.
+const DISPLAY_TO_CANONICAL: Partial<
+	Record<DisplayLinkType, { linkType: LinkType; otherTaskIsSource: boolean }>
 > = {
-	blocks: { linkType: "blocks", swap: false },
-	is_blocked_by: { linkType: "blocks", swap: true },
-	relates_to: { linkType: "relates_to", swap: false },
-	duplicates: { linkType: "duplicates", swap: false },
+	blocks: { linkType: "blocks", otherTaskIsSource: false },
+	is_blocked_by: { linkType: "blocks", otherTaskIsSource: true },
+	relates_to: { linkType: "relates_to", otherTaskIsSource: false },
+	duplicates: { linkType: "duplicates", otherTaskIsSource: false },
 };
+
+// The task list API caps page_size at 200, so the search box needs to page
+// through the full project rather than fetching a single page - otherwise
+// tasks past the first 200 are invisible to the search.
+const MAX_TASK_PAGES = 25;
+
+async function fetchAllProjectTasks(projectId: string): Promise<Task[]> {
+	const all: Task[] = [];
+	let cursor: string | undefined;
+	for (let page = 0; page < MAX_TASK_PAGES; page++) {
+		const result = await listAllTasks(projectId, { pageSize: 200, cursor });
+		all.push(...result.items);
+		const next = result.next_cursor;
+		if (!next) break;
+		cursor = next;
+	}
+	return all;
+}
 
 export function AddTaskLinkModal({
 	open,
@@ -57,7 +88,8 @@ export function AddTaskLinkModal({
 	currentTaskId,
 	taskIdPrefix = "",
 }: AddTaskLinkModalProps) {
-	const [selectedLinkType, setSelectedLinkType] = useState<string>("blocks");
+	const [selectedLinkType, setSelectedLinkType] =
+		useState<DisplayLinkType>("blocks");
 	const [query, setQuery] = useState("");
 	const [tasks, setTasks] = useState<Task[]>([]);
 	const [loading, setLoading] = useState(false);
@@ -67,8 +99,9 @@ export function AddTaskLinkModal({
 	useEffect(() => {
 		if (!open) return;
 		setLoading(true);
-		listAllTasks(projectId, { pageSize: 200 })
-			.then((result) => setTasks(result.items))
+		fetchAllProjectTasks(projectId)
+			.then(setTasks)
+			.catch(() => setTasks([]))
 			.finally(() => setLoading(false));
 		setTimeout(() => searchRef.current?.focus(), 50);
 	}, [open, projectId]);
@@ -90,20 +123,11 @@ export function AddTaskLinkModal({
 	function handleSelect(task: Task) {
 		const canonical = DISPLAY_TO_CANONICAL[selectedLinkType];
 		if (!canonical) return;
-		if (canonical.swap) {
-			// "is blocked by" means target blocks source — we store it as target→source
-			// but the API takes (source=currentTask, target=otherTask, type=blocks).
-			// For "is_blocked_by", we flip: the other task IS the source.
-			// We handle this by calling onAdd with the other task as source using a
-			// reversed direction: CreateTaskLink(source=target, target=current).
-			// Since our API creates source→target, for "is_blocked_by" we need to
-			// create a link where target_task_id = currentTaskId and source = this task.
-			// We pass a special signal via a negative swap — the parent will call the
-			// API as: CreateTaskLink(source=task.id, target=currentTaskId, type="blocks").
-			onAdd(`__swap__${task.id}`, canonical.linkType);
-		} else {
-			onAdd(task.id, canonical.linkType);
-		}
+		onAdd({
+			sourceTaskId: canonical.otherTaskIsSource ? task.id : currentTaskId,
+			targetTaskId: canonical.otherTaskIsSource ? currentTaskId : task.id,
+			linkType: canonical.linkType,
+		});
 	}
 
 	if (!open) return null;

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -28,6 +28,7 @@ import { mapApiFieldToUi } from "./helpers";
 import { PropertiesPanel } from "./properties-panel";
 import { SubtasksSection } from "./subtasks-section";
 import { TaskHeader } from "./task-header";
+import { TaskLinksSection } from "./task-links-section";
 import type { TaskDetailModalProps } from "./types";
 
 // Re-exports for consumers
@@ -408,6 +409,17 @@ export function TaskDetailModal({
 								});
 							}}
 						/>
+
+						{/* Linked tasks */}
+						{projectId && (
+							<TaskLinksSection
+								projectId={projectId}
+								taskId={task.id}
+								taskIdPrefix={taskIdPrefix}
+								canEdit={canEdit}
+								onNavigateToTask={navigateToTask}
+							/>
+						)}
 
 						{/* Plugin extension points */}
 						{projectId && (

--- a/apps/web/src/components/projects/interactions/task-detail/task-links-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/task-links-section.tsx
@@ -1,0 +1,198 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Link2, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import {
+	type DisplayLinkType,
+	type LinkType,
+	LINK_TYPE_LABELS,
+	createTaskLink,
+	deleteTaskLink,
+	taskLinksQueryOptions,
+	type TaskLink,
+} from "@/lib/interaction-api";
+import { AddTaskLinkModal } from "./add-task-link-modal";
+
+interface TaskLinksSectionProps {
+	projectId: string;
+	taskId: string;
+	taskIdPrefix?: string;
+	canEdit?: boolean;
+	onNavigateToTask?: (taskId: string) => void;
+}
+
+// Groups links by their display type label
+type GroupedLinks = Record<string, TaskLink[]>;
+
+const DISPLAY_ORDER: DisplayLinkType[] = [
+	"blocks",
+	"is_blocked_by",
+	"relates_to",
+	"duplicates",
+	"is_duplicated_by",
+];
+
+function groupLinks(links: TaskLink[]): GroupedLinks {
+	const groups: GroupedLinks = {};
+	for (const link of links) {
+		const key = link.display_link_type;
+		if (!groups[key]) groups[key] = [];
+		groups[key].push(link);
+	}
+	return groups;
+}
+
+export function TaskLinksSection({
+	projectId,
+	taskId,
+	taskIdPrefix = "",
+	canEdit = true,
+	onNavigateToTask,
+}: TaskLinksSectionProps) {
+	const qc = useQueryClient();
+	const [modalOpen, setModalOpen] = useState(false);
+
+	const { data: links = [] } = useQuery(taskLinksQueryOptions(projectId, taskId));
+
+	const createMutation = useMutation({
+		mutationFn: ({
+			targetTaskId,
+			linkType,
+			sourceTaskId,
+		}: {
+			targetTaskId: string;
+			linkType: LinkType;
+			sourceTaskId: string;
+		}) => createTaskLink(projectId, sourceTaskId, { target_task_id: targetTaskId, link_type: linkType }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: taskLinksQueryOptions(projectId, taskId).queryKey });
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: (linkId: string) => deleteTaskLink(projectId, taskId, linkId),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: taskLinksQueryOptions(projectId, taskId).queryKey });
+		},
+	});
+
+	function handleAdd(targetTaskId: string, linkType: LinkType) {
+		setModalOpen(false);
+		// The "__swap__" prefix signals that source/target are reversed (for "is_blocked_by")
+		if (targetTaskId.startsWith("__swap__")) {
+			const realTargetId = targetTaskId.replace("__swap__", "");
+			// Create link with the other task as source and current task as target
+			createTaskLink(projectId, realTargetId, {
+				target_task_id: taskId,
+				link_type: linkType,
+			}).then(() => {
+				qc.invalidateQueries({ queryKey: taskLinksQueryOptions(projectId, taskId).queryKey });
+			});
+		} else {
+			createMutation.mutate({ targetTaskId, linkType, sourceTaskId: taskId });
+		}
+	}
+
+	const grouped = groupLinks(links);
+	const orderedKeys = DISPLAY_ORDER.filter((k) => grouped[k]?.length > 0);
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between">
+				<h3 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70 flex items-center gap-2">
+					<span>Linked Tasks</span>
+					<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
+				</h3>
+				{canEdit && (
+					<button
+						type="button"
+						onClick={() => setModalOpen(true)}
+						className="flex items-center gap-1.5 rounded-lg bg-primary/8 text-primary/80 hover:bg-primary/15 hover:text-primary px-2.5 py-1.5 text-[11px] font-semibold transition-all duration-150"
+					>
+						<Plus className="size-3" />
+						Add Link
+					</button>
+				)}
+			</div>
+
+			{orderedKeys.length > 0 && (
+				<div className="space-y-3">
+					{orderedKeys.map((displayType) => (
+						<div key={displayType}>
+							<p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/50 mb-1.5 px-0.5">
+								{LINK_TYPE_LABELS[displayType as DisplayLinkType]}
+							</p>
+							<div className="rounded-xl border border-border/25 bg-card/50 divide-y divide-border/15 overflow-hidden">
+								{grouped[displayType].map((link) => {
+									const t = link.linked_task;
+									const prefix = taskIdPrefix
+										? `${taskIdPrefix}-${t.task_number}`
+										: `#${t.task_number}`;
+									return (
+										<div
+											key={link.id}
+											className="flex items-center gap-3 px-4 py-2.5 group"
+										>
+											<Link2 className="size-3 text-muted-foreground/40 shrink-0" />
+											<span className="shrink-0 text-[11px] font-mono text-muted-foreground/50">
+												{prefix}
+											</span>
+											{/* biome-ignore lint/a11y/useKeyWithClickEvents: click-to-navigate */}
+											<span
+												className={`flex-1 text-[13px] text-foreground truncate ${
+													onNavigateToTask
+														? "cursor-pointer hover:text-primary transition-colors duration-100"
+														: ""
+												}`}
+												onClick={() => onNavigateToTask?.(t.id)}
+											>
+												{t.title}
+											</span>
+											<div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+												{onNavigateToTask && (
+													<button
+														type="button"
+														onClick={() => onNavigateToTask(t.id)}
+														className="size-6 rounded flex items-center justify-center text-muted-foreground/50 hover:text-foreground hover:bg-muted/30 transition-all duration-100"
+														title="Open task"
+													>
+														<ExternalLink className="size-3" />
+													</button>
+												)}
+												{canEdit && (
+													<button
+														type="button"
+														onClick={() => deleteMutation.mutate(link.id)}
+														className="size-6 rounded flex items-center justify-center text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-all duration-100"
+														title="Remove link"
+													>
+														<Trash2 className="size-3" />
+													</button>
+												)}
+											</div>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+
+			{orderedKeys.length === 0 && (
+				<div className="flex items-center gap-3 px-1 py-3 text-muted-foreground/45">
+					<Link2 className="size-4 opacity-70" />
+					<p className="text-[13px] italic">No linked tasks</p>
+				</div>
+			)}
+
+			<AddTaskLinkModal
+				open={modalOpen}
+				onClose={() => setModalOpen(false)}
+				onAdd={handleAdd}
+				projectId={projectId}
+				currentTaskId={taskId}
+				taskIdPrefix={taskIdPrefix}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/interactions/task-detail/task-links-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/task-links-section.tsx
@@ -2,13 +2,13 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, Link2, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import {
-	type DisplayLinkType,
-	type LinkType,
-	LINK_TYPE_LABELS,
 	createTaskLink,
+	type DisplayLinkType,
 	deleteTaskLink,
-	taskLinksQueryOptions,
+	LINK_TYPE_LABELS,
+	type LinkType,
 	type TaskLink,
+	taskLinksQueryOptions,
 } from "@/lib/interaction-api";
 import { AddTaskLinkModal } from "./add-task-link-modal";
 
@@ -51,7 +51,9 @@ export function TaskLinksSection({
 	const qc = useQueryClient();
 	const [modalOpen, setModalOpen] = useState(false);
 
-	const { data: links = [] } = useQuery(taskLinksQueryOptions(projectId, taskId));
+	const { data: links = [] } = useQuery(
+		taskLinksQueryOptions(projectId, taskId),
+	);
 
 	const createMutation = useMutation({
 		mutationFn: ({
@@ -62,16 +64,24 @@ export function TaskLinksSection({
 			targetTaskId: string;
 			linkType: LinkType;
 			sourceTaskId: string;
-		}) => createTaskLink(projectId, sourceTaskId, { target_task_id: targetTaskId, link_type: linkType }),
+		}) =>
+			createTaskLink(projectId, sourceTaskId, {
+				target_task_id: targetTaskId,
+				link_type: linkType,
+			}),
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: taskLinksQueryOptions(projectId, taskId).queryKey });
+			qc.invalidateQueries({
+				queryKey: taskLinksQueryOptions(projectId, taskId).queryKey,
+			});
 		},
 	});
 
 	const deleteMutation = useMutation({
 		mutationFn: (linkId: string) => deleteTaskLink(projectId, taskId, linkId),
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: taskLinksQueryOptions(projectId, taskId).queryKey });
+			qc.invalidateQueries({
+				queryKey: taskLinksQueryOptions(projectId, taskId).queryKey,
+			});
 		},
 	});
 
@@ -85,7 +95,9 @@ export function TaskLinksSection({
 				target_task_id: taskId,
 				link_type: linkType,
 			}).then(() => {
-				qc.invalidateQueries({ queryKey: taskLinksQueryOptions(projectId, taskId).queryKey });
+				qc.invalidateQueries({
+					queryKey: taskLinksQueryOptions(projectId, taskId).queryKey,
+				});
 			});
 		} else {
 			createMutation.mutate({ targetTaskId, linkType, sourceTaskId: taskId });
@@ -136,14 +148,22 @@ export function TaskLinksSection({
 											<span className="shrink-0 text-[11px] font-mono text-muted-foreground/50">
 												{prefix}
 											</span>
-											{/* biome-ignore lint/a11y/useKeyWithClickEvents: click-to-navigate */}
+											{/* biome-ignore lint/a11y/useSemanticElements: span for styling and truncation */}
 											<span
+												role="button"
+												tabIndex={onNavigateToTask ? 0 : -1}
 												className={`flex-1 text-[13px] text-foreground truncate ${
 													onNavigateToTask
 														? "cursor-pointer hover:text-primary transition-colors duration-100"
 														: ""
 												}`}
 												onClick={() => onNavigateToTask?.(t.id)}
+												onKeyDown={(e) => {
+													if (e.key === "Enter" || e.key === " ") {
+														e.preventDefault();
+														onNavigateToTask?.(t.id);
+													}
+												}}
 											>
 												{t.title}
 											</span>

--- a/apps/web/src/components/projects/interactions/task-detail/task-links-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/task-links-section.tsx
@@ -6,11 +6,13 @@ import {
 	type DisplayLinkType,
 	deleteTaskLink,
 	LINK_TYPE_LABELS,
-	type LinkType,
 	type TaskLink,
 	taskLinksQueryOptions,
 } from "@/lib/interaction-api";
-import { AddTaskLinkModal } from "./add-task-link-modal";
+import {
+	AddTaskLinkModal,
+	type AddTaskLinkPayload,
+} from "./add-task-link-modal";
 
 interface TaskLinksSectionProps {
 	projectId: string;
@@ -57,14 +59,10 @@ export function TaskLinksSection({
 
 	const createMutation = useMutation({
 		mutationFn: ({
+			sourceTaskId,
 			targetTaskId,
 			linkType,
-			sourceTaskId,
-		}: {
-			targetTaskId: string;
-			linkType: LinkType;
-			sourceTaskId: string;
-		}) =>
+		}: AddTaskLinkPayload) =>
 			createTaskLink(projectId, sourceTaskId, {
 				target_task_id: targetTaskId,
 				link_type: linkType,
@@ -85,23 +83,9 @@ export function TaskLinksSection({
 		},
 	});
 
-	function handleAdd(targetTaskId: string, linkType: LinkType) {
+	function handleAdd(payload: AddTaskLinkPayload) {
 		setModalOpen(false);
-		// The "__swap__" prefix signals that source/target are reversed (for "is_blocked_by")
-		if (targetTaskId.startsWith("__swap__")) {
-			const realTargetId = targetTaskId.replace("__swap__", "");
-			// Create link with the other task as source and current task as target
-			createTaskLink(projectId, realTargetId, {
-				target_task_id: taskId,
-				link_type: linkType,
-			}).then(() => {
-				qc.invalidateQueries({
-					queryKey: taskLinksQueryOptions(projectId, taskId).queryKey,
-				});
-			});
-		} else {
-			createMutation.mutate({ targetTaskId, linkType, sourceTaskId: taskId });
-		}
+		createMutation.mutate(payload);
 	}
 
 	const grouped = groupLinks(links);
@@ -125,6 +109,12 @@ export function TaskLinksSection({
 					</button>
 				)}
 			</div>
+
+			{createMutation.error && (
+				<p className="text-xs text-destructive">
+					{createMutation.error.message}
+				</p>
+			)}
 
 			{orderedKeys.length > 0 && (
 				<div className="space-y-3">

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -722,3 +722,81 @@ export const taskActivitiesQueryOptions = (projectId: string, taskId: string) =>
 		staleTime: 15_000,
 		enabled: !!projectId && !!taskId,
 	});
+
+// ── Task Links ────────────────────────────────────────────────────────────────
+
+export type LinkType = "blocks" | "relates_to" | "duplicates";
+
+export type DisplayLinkType =
+	| "blocks"
+	| "is_blocked_by"
+	| "relates_to"
+	| "duplicates"
+	| "is_duplicated_by";
+
+export interface LinkedTaskSummary {
+	id: string;
+	task_number: number;
+	title: string;
+	status_id?: string | null;
+	task_type_id?: string | null;
+}
+
+export interface TaskLink {
+	id: string;
+	source_task_id: string;
+	target_task_id: string;
+	link_type: LinkType;
+	display_link_type: DisplayLinkType;
+	linked_task: LinkedTaskSummary;
+	created_by?: string | null;
+	created_at: string;
+}
+
+export const LINK_TYPE_LABELS: Record<DisplayLinkType, string> = {
+	blocks: "blocks",
+	is_blocked_by: "is blocked by",
+	relates_to: "relates to",
+	duplicates: "duplicates",
+	is_duplicated_by: "is duplicated by",
+};
+
+export async function listTaskLinks(
+	projectId: string,
+	taskId: string,
+): Promise<TaskLink[]> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<{ items: TaskLink[] }>
+	>(`/projects/${projectId}/tasks/${taskId}/links`);
+	return data.data.items;
+}
+
+export async function createTaskLink(
+	projectId: string,
+	taskId: string,
+	payload: { target_task_id: string; link_type: LinkType },
+): Promise<TaskLink> {
+	const { data } = await apiClient.instance.post<SuccessEnvelope<TaskLink>>(
+		`/projects/${projectId}/tasks/${taskId}/links`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function deleteTaskLink(
+	projectId: string,
+	taskId: string,
+	linkId: string,
+): Promise<void> {
+	await apiClient.instance.delete(
+		`/projects/${projectId}/tasks/${taskId}/links/${linkId}`,
+	);
+}
+
+export const taskLinksQueryOptions = (projectId: string, taskId: string) =>
+	queryOptions({
+		queryKey: ["projects", projectId, "tasks", taskId, "links"],
+		queryFn: () => listTaskLinks(projectId, taskId),
+		staleTime: 15_000,
+		enabled: !!projectId && !!taskId,
+	});

--- a/docs/api/task-activity.md
+++ b/docs/api/task-activity.md
@@ -44,6 +44,8 @@ Indexes: `(task_id, created_at)` for efficient chronological listing.
 | `task.deleted`                | Task soft-deleted                         |
 | `task.attachment.added`       | Attachment linked                         |
 | `task.attachment.removed`     | Attachment unlinked                       |
+| `task.link.added`             | Task link created                         |
+| `task.link.removed`           | Task link deleted                         |
 | `comment`                     | User comment (user-created)               |
 
 > **Plugin activities**: Installed plugins may emit additional activity types
@@ -82,6 +84,16 @@ Tracked fields: `title`, `status_id`, `assignee_id`, `reporter_id`,
 ### `task.attachment.added` / `task.attachment.removed`
 ```json
 { "file_name": "screenshot.png", "file_size": 102400 }
+```
+
+### `task.link.added`
+```json
+{ "target_task_id": "uuid", "link_type": "blocks" }
+```
+
+### `task.link.removed`
+```json
+{ "link_id": "uuid" }
 ```
 
 ### `comment`

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -150,6 +150,19 @@ const (
 	// CodeCommentContentInvalid indicates an empty or invalid comment content.
 	CodeCommentContentInvalid Code = "ACTIVITY_COMMENT_CONTENT_INVALID"
 
+	// --- Task link errors ------------------------------------------------
+
+	// CodeTaskLinkNotFound indicates the requested task link does not exist.
+	CodeTaskLinkNotFound Code = "TASK_LINK_NOT_FOUND"
+	// CodeTaskLinkSelf indicates an attempt to link a task to itself.
+	CodeTaskLinkSelf Code = "TASK_LINK_CANNOT_LINK_TO_SELF"
+	// CodeTaskLinkDuplicate indicates the relationship already exists.
+	CodeTaskLinkDuplicate Code = "TASK_LINK_ALREADY_EXISTS"
+	// CodeTaskLinkCrossProject indicates an attempt to link tasks from different projects.
+	CodeTaskLinkCrossProject Code = "TASK_LINK_CROSS_PROJECT"
+
+	// --- Document errors --------------------------------------------------
+
 	// CodeDocNotFound indicates the requested document does not exist.
 	CodeDocNotFound Code = "DOC_NOT_FOUND"
 	// CodeDocTitleInvalid indicates an empty or invalid document title.

--- a/services/api/internal/domain/task/activity.go
+++ b/services/api/internal/domain/task/activity.go
@@ -35,6 +35,13 @@ const (
 	// ActivityTypeComment is a user-authored comment on the task.
 	ActivityTypeComment ActivityType = "comment"
 
+	// --- Link events ----------------------------------------------------------
+
+	// ActivityTypeTaskLinkAdded is recorded when a link is created between tasks.
+	ActivityTypeTaskLinkAdded ActivityType = "task.link.added"
+	// ActivityTypeTaskLinkRemoved is recorded when a link between tasks is deleted.
+	ActivityTypeTaskLinkRemoved ActivityType = "task.link.removed"
+
 	// --- Agent session events -------------------------------------------------
 
 	// ActivityTypeAgentSessionStarted is recorded when an AI agent begins a

--- a/services/api/internal/domain/task/entity.go
+++ b/services/api/internal/domain/task/entity.go
@@ -97,6 +97,50 @@ type CustomFieldDefinition struct {
 	UpdatedAt   time.Time
 }
 
+// LinkType describes the directional relationship stored in a TaskLink row.
+// Inverse display types (is_blocked_by, is_duplicated_by) are computed at
+// the service layer and never persisted.
+type LinkType string
+
+const (
+	LinkTypeBlocks    LinkType = "blocks"
+	LinkTypeRelatesTo LinkType = "relates_to"
+	LinkTypeDuplicates LinkType = "duplicates"
+)
+
+// ValidLinkTypes is the set of persisted link type values.
+var ValidLinkTypes = map[LinkType]bool{
+	LinkTypeBlocks:     true,
+	LinkTypeRelatesTo:  true,
+	LinkTypeDuplicates: true,
+}
+
+// TaskLink represents a directed relationship between two tasks.
+type TaskLink struct {
+	ID           uuid.UUID
+	SourceTaskID uuid.UUID
+	TargetTaskID uuid.UUID
+	LinkType     LinkType
+	CreatedBy    *uuid.UUID
+	CreatedAt    time.Time
+	// LinkedTask is populated on read with a summary of the other task.
+	LinkedTask *LinkedTaskSummary
+	// DisplayLinkType is the relationship label from the requesting task's
+	// perspective (e.g. "is_blocked_by" when this task is the target of a
+	// "blocks" link). It is never persisted.
+	DisplayLinkType string
+}
+
+// LinkedTaskSummary is a lightweight projection of a Task embedded in
+// TaskLink responses to avoid N+1 lookups.
+type LinkedTaskSummary struct {
+	ID         uuid.UUID
+	TaskNumber int64
+	Title      string
+	StatusID   *uuid.UUID
+	TaskTypeID *uuid.UUID
+}
+
 // Task is the core work item aggregate.
 type Task struct {
 	ID           uuid.UUID

--- a/services/api/internal/domain/task/entity.go
+++ b/services/api/internal/domain/task/entity.go
@@ -103,8 +103,11 @@ type CustomFieldDefinition struct {
 type LinkType string
 
 const (
-	LinkTypeBlocks    LinkType = "blocks"
+	// LinkTypeBlocks indicates the source task blocks completion of the target.
+	LinkTypeBlocks LinkType = "blocks"
+	// LinkTypeRelatesTo indicates the source and target tasks are related.
 	LinkTypeRelatesTo LinkType = "relates_to"
+	// LinkTypeDuplicates indicates the source task duplicates the target.
 	LinkTypeDuplicates LinkType = "duplicates"
 )
 

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -25,6 +25,13 @@ var (
 	ErrCustomFieldTypeInvalid = errors.New("custom field: invalid field type")
 	ErrCustomFieldNameInvalid = errors.New("custom field: display name is empty or invalid")
 
+	// Task link errors.
+	ErrTaskLinkNotFound     = errors.New("task link: not found")
+	ErrTaskLinkSelf         = errors.New("task link: a task cannot be linked to itself")
+	ErrTaskLinkDuplicate    = errors.New("task link: this relationship already exists")
+	ErrTaskLinkTypInvalid   = errors.New("task link: invalid link type")
+	ErrTaskLinkCrossProject = errors.New("task link: cannot link tasks from different projects")
+
 	// Activity / comment errors.
 	ErrActivityNotFound      = errors.New("activity: not found")
 	ErrActivityForbidden     = errors.New("activity: only the author can modify this comment")

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -29,7 +29,7 @@ var (
 	ErrTaskLinkNotFound     = errors.New("task link: not found")
 	ErrTaskLinkSelf         = errors.New("task link: a task cannot be linked to itself")
 	ErrTaskLinkDuplicate    = errors.New("task link: this relationship already exists")
-	ErrTaskLinkTypInvalid   = errors.New("task link: invalid link type")
+	ErrTaskLinkTypeInvalid  = errors.New("task link: invalid link type")
 	ErrTaskLinkCrossProject = errors.New("task link: cannot link tasks from different projects")
 
 	// Activity / comment errors.

--- a/services/api/internal/domain/task/repository.go
+++ b/services/api/internal/domain/task/repository.go
@@ -11,7 +11,24 @@ type Repository interface {
 	TaskTypeRepository
 	TaskStatusRepository
 	TaskRepository
+	TaskLinkRepository
 	CustomFieldDefinitionRepository
+}
+
+// TaskLinkRepository defines persistence operations for task links.
+type TaskLinkRepository interface {
+	// ListTaskLinks returns all links where taskID is either source or target,
+	// with LinkedTask populated. Links are ordered by created_at ascending.
+	ListTaskLinks(ctx context.Context, taskID uuid.UUID) ([]*TaskLink, error)
+	// FindTaskLinkByID returns a single link by primary key.
+	FindTaskLinkByID(ctx context.Context, id uuid.UUID) (*TaskLink, error)
+	// LinkExists reports whether a link of linkType between source and target
+	// already exists (checked in both directions for relates_to).
+	LinkExists(ctx context.Context, sourceID, targetID uuid.UUID, linkType LinkType) (bool, error)
+	// CreateTaskLink persists a new link.
+	CreateTaskLink(ctx context.Context, l *TaskLink) error
+	// DeleteTaskLink removes the link identified by id.
+	DeleteTaskLink(ctx context.Context, id uuid.UUID) error
 }
 
 // TaskTypeRepository defines persistence operations for task types.

--- a/services/api/internal/domain/task/repository.go
+++ b/services/api/internal/domain/task/repository.go
@@ -22,11 +22,13 @@ type TaskLinkRepository interface {
 	ListTaskLinks(ctx context.Context, taskID uuid.UUID) ([]*TaskLink, error)
 	// FindTaskLinkByID returns a single link by primary key.
 	FindTaskLinkByID(ctx context.Context, id uuid.UUID) (*TaskLink, error)
-	// LinkExists reports whether a link of linkType between source and target
-	// already exists (checked in both directions for relates_to).
-	LinkExists(ctx context.Context, sourceID, targetID uuid.UUID, linkType LinkType) (bool, error)
-	// CreateTaskLink persists a new link.
-	CreateTaskLink(ctx context.Context, l *TaskLink) error
+	// CreateTaskLinkIfNotExists persists l, unless an equivalent link already
+	// exists (checked in both directions for relates_to), in which case it
+	// returns created=false and no error. The existence check and insert run
+	// in the same transaction with both task rows locked, so concurrent
+	// attempts to link the same pair of tasks serialize instead of racing
+	// past the duplicate check.
+	CreateTaskLinkIfNotExists(ctx context.Context, l *TaskLink) (created bool, err error)
 	// DeleteTaskLink removes the link identified by id.
 	DeleteTaskLink(ctx context.Context, id uuid.UUID) error
 }

--- a/services/api/internal/domain/task/service.go
+++ b/services/api/internal/domain/task/service.go
@@ -13,7 +13,28 @@ type Service interface {
 	TaskTypeService
 	TaskStatusService
 	TaskService
+	TaskLinkService
 	CustomFieldDefinitionService
+}
+
+// TaskLinkService defines task-link use cases.
+type TaskLinkService interface {
+	// ListTaskLinks returns all links for taskID, computing inverse display labels.
+	ListTaskLinks(ctx context.Context, projectID, taskID uuid.UUID) ([]*TaskLink, error)
+	// CreateTaskLink creates a directed link between two tasks in the same project.
+	CreateTaskLink(ctx context.Context, in CreateTaskLinkInput) (*TaskLink, error)
+	// DeleteTaskLink removes the link identified by linkID, verifying it
+	// belongs to a task within projectID.
+	DeleteTaskLink(ctx context.Context, projectID, taskID, linkID uuid.UUID) error
+}
+
+// CreateTaskLinkInput carries the fields required to create a task link.
+type CreateTaskLinkInput struct {
+	ProjectID    uuid.UUID
+	SourceTaskID uuid.UUID
+	TargetTaskID uuid.UUID
+	LinkType     LinkType
+	CreatedBy    *uuid.UUID
 }
 
 // --- Task Type Service -----------------------------------------------------

--- a/services/api/internal/repository/postgres/task_link_repository.go
+++ b/services/api/internal/repository/postgres/task_link_repository.go
@@ -1,0 +1,267 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// taskLinkRecord mirrors a row in the task_links table.
+type taskLinkRecord struct {
+	ID           string     `db:"id"`
+	SourceTaskID string     `db:"source_task_id"`
+	TargetTaskID string     `db:"target_task_id"`
+	LinkType     string     `db:"link_type"`
+	CreatedBy    *string    `db:"created_by"`
+	CreatedAt    time.Time  `db:"created_at"`
+}
+
+// taskLinkWithTaskRow is used for the join query that fetches linked task info.
+type taskLinkWithTaskRow struct {
+	// link columns
+	ID           string     `db:"id"`
+	SourceTaskID string     `db:"source_task_id"`
+	TargetTaskID string     `db:"target_task_id"`
+	LinkType     string     `db:"link_type"`
+	CreatedBy    *string    `db:"created_by"`
+	CreatedAt    time.Time  `db:"created_at"`
+	// linked task columns (the "other" side of the link)
+	LinkedTaskID         string  `db:"linked_task_id"`
+	LinkedTaskNumber     int64   `db:"linked_task_number"`
+	LinkedTaskTitle      string  `db:"linked_task_title"`
+	LinkedTaskStatusID   *string `db:"linked_task_status_id"`
+	LinkedTaskTypeID     *string `db:"linked_task_type_id"`
+	// perspective: "source" means the queried task is the source, "target" means it's the target
+	Perspective string `db:"perspective"`
+}
+
+// TaskLinkRepository is the sqlx implementation of taskdom.TaskLinkRepository.
+type TaskLinkRepository struct {
+	db *sqlx.DB
+}
+
+// NewTaskLinkRepository returns a new TaskLinkRepository.
+func NewTaskLinkRepository(db *sqlx.DB) *TaskLinkRepository {
+	return &TaskLinkRepository{db: db}
+}
+
+// ListTaskLinks returns all links where taskID is either source or target.
+func (r *TaskLinkRepository) ListTaskLinks(ctx context.Context, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
+	const q = `
+		SELECT
+		    tl.id,
+		    tl.source_task_id,
+		    tl.target_task_id,
+		    tl.link_type,
+		    tl.created_by,
+		    tl.created_at,
+		    linked.id           AS linked_task_id,
+		    linked.task_number  AS linked_task_number,
+		    linked.title        AS linked_task_title,
+		    linked.status_id    AS linked_task_status_id,
+		    linked.task_type_id AS linked_task_type_id,
+		    CASE WHEN tl.source_task_id = $1 THEN 'source' ELSE 'target' END AS perspective
+		FROM task_links tl
+		JOIN tasks linked ON linked.id = CASE
+		    WHEN tl.source_task_id = $1 THEN tl.target_task_id
+		    ELSE tl.source_task_id
+		END
+		WHERE (tl.source_task_id = $1 OR tl.target_task_id = $1)
+		  AND linked.deleted_at IS NULL
+		ORDER BY tl.created_at ASC`
+
+	var rows []taskLinkWithTaskRow
+	if err := r.db.SelectContext(ctx, &rows, q, taskID.String()); err != nil {
+		return nil, err
+	}
+
+	links := make([]*taskdom.TaskLink, 0, len(rows))
+	for i := range rows {
+		row := &rows[i]
+		link, err := row.toDomain()
+		if err != nil {
+			return nil, err
+		}
+		links = append(links, link)
+	}
+	return links, nil
+}
+
+// FindTaskLinkByID returns a single link by primary key (no task join).
+func (r *TaskLinkRepository) FindTaskLinkByID(ctx context.Context, id uuid.UUID) (*taskdom.TaskLink, error) {
+	const q = `
+		SELECT id, source_task_id, target_task_id, link_type, created_by, created_at
+		FROM task_links WHERE id = $1`
+
+	var rec taskLinkRecord
+	if err := r.db.GetContext(ctx, &rec, q, id.String()); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, taskdom.ErrTaskLinkNotFound
+		}
+		return nil, err
+	}
+	return rec.toDomain()
+}
+
+// LinkExists reports whether a link of linkType between source and target already exists.
+// For relates_to it checks both directions.
+func (r *TaskLinkRepository) LinkExists(ctx context.Context, sourceID, targetID uuid.UUID, linkType taskdom.LinkType) (bool, error) {
+	var q string
+	var args []interface{}
+
+	if linkType == taskdom.LinkTypeRelatesTo {
+		q = `SELECT EXISTS (
+			SELECT 1 FROM task_links
+			WHERE link_type = $1
+			  AND ((source_task_id = $2 AND target_task_id = $3)
+			    OR (source_task_id = $3 AND target_task_id = $2))
+		)`
+		args = []interface{}{string(linkType), sourceID.String(), targetID.String()}
+	} else {
+		q = `SELECT EXISTS (
+			SELECT 1 FROM task_links
+			WHERE source_task_id = $1 AND target_task_id = $2 AND link_type = $3
+		)`
+		args = []interface{}{sourceID.String(), targetID.String(), string(linkType)}
+	}
+
+	var exists bool
+	if err := r.db.GetContext(ctx, &exists, q, args...); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// CreateTaskLink inserts a new task_links row.
+func (r *TaskLinkRepository) CreateTaskLink(ctx context.Context, l *taskdom.TaskLink) error {
+	const q = `
+		INSERT INTO task_links (id, source_task_id, target_task_id, link_type, created_by, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`
+
+	var createdBy *string
+	if l.CreatedBy != nil {
+		s := l.CreatedBy.String()
+		createdBy = &s
+	}
+
+	_, err := r.db.ExecContext(ctx, q,
+		l.ID.String(),
+		l.SourceTaskID.String(),
+		l.TargetTaskID.String(),
+		string(l.LinkType),
+		createdBy,
+		l.CreatedAt,
+	)
+	return err
+}
+
+// DeleteTaskLink removes a task_links row by primary key.
+func (r *TaskLinkRepository) DeleteTaskLink(ctx context.Context, id uuid.UUID) error {
+	const q = `DELETE FROM task_links WHERE id = $1`
+	res, err := r.db.ExecContext(ctx, q, id.String())
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return taskdom.ErrTaskLinkNotFound
+	}
+	return nil
+}
+
+// --- row-to-domain helpers --------------------------------------------------
+
+func (rec *taskLinkRecord) toDomain() (*taskdom.TaskLink, error) {
+	id, err := uuid.Parse(rec.ID)
+	if err != nil {
+		return nil, err
+	}
+	sourceID, err := uuid.Parse(rec.SourceTaskID)
+	if err != nil {
+		return nil, err
+	}
+	targetID, err := uuid.Parse(rec.TargetTaskID)
+	if err != nil {
+		return nil, err
+	}
+	var createdBy *uuid.UUID
+	if rec.CreatedBy != nil {
+		p, err := uuid.Parse(*rec.CreatedBy)
+		if err != nil {
+			return nil, err
+		}
+		createdBy = &p
+	}
+	return &taskdom.TaskLink{
+		ID:           id,
+		SourceTaskID: sourceID,
+		TargetTaskID: targetID,
+		LinkType:     taskdom.LinkType(rec.LinkType),
+		CreatedBy:    createdBy,
+		CreatedAt:    rec.CreatedAt,
+	}, nil
+}
+
+func (row *taskLinkWithTaskRow) toDomain() (*taskdom.TaskLink, error) {
+	rec := taskLinkRecord{
+		ID:           row.ID,
+		SourceTaskID: row.SourceTaskID,
+		TargetTaskID: row.TargetTaskID,
+		LinkType:     row.LinkType,
+		CreatedBy:    row.CreatedBy,
+		CreatedAt:    row.CreatedAt,
+	}
+	link, err := rec.toDomain()
+	if err != nil {
+		return nil, err
+	}
+
+	linkedID, err := uuid.Parse(row.LinkedTaskID)
+	if err != nil {
+		return nil, err
+	}
+	var linkedStatusID *uuid.UUID
+	if row.LinkedTaskStatusID != nil {
+		p, err := uuid.Parse(*row.LinkedTaskStatusID)
+		if err != nil {
+			return nil, err
+		}
+		linkedStatusID = &p
+	}
+	var linkedTypeID *uuid.UUID
+	if row.LinkedTaskTypeID != nil {
+		p, err := uuid.Parse(*row.LinkedTaskTypeID)
+		if err != nil {
+			return nil, err
+		}
+		linkedTypeID = &p
+	}
+	link.LinkedTask = &taskdom.LinkedTaskSummary{
+		ID:         linkedID,
+		TaskNumber: row.LinkedTaskNumber,
+		Title:      row.LinkedTaskTitle,
+		StatusID:   linkedStatusID,
+		TaskTypeID: linkedTypeID,
+	}
+
+	// Compute the display label from the queried task's perspective.
+	if row.Perspective == "source" {
+		link.DisplayLinkType = row.LinkType
+	} else {
+		switch taskdom.LinkType(row.LinkType) {
+		case taskdom.LinkTypeBlocks:
+			link.DisplayLinkType = "is_blocked_by"
+		case taskdom.LinkTypeDuplicates:
+			link.DisplayLinkType = "is_duplicated_by"
+		default: // relates_to is symmetric
+			link.DisplayLinkType = row.LinkType
+		}
+	}
+
+	return link, nil
+}

--- a/services/api/internal/repository/postgres/task_link_repository.go
+++ b/services/api/internal/repository/postgres/task_link_repository.go
@@ -13,29 +13,29 @@ import (
 
 // taskLinkRecord mirrors a row in the task_links table.
 type taskLinkRecord struct {
-	ID           string     `db:"id"`
-	SourceTaskID string     `db:"source_task_id"`
-	TargetTaskID string     `db:"target_task_id"`
-	LinkType     string     `db:"link_type"`
-	CreatedBy    *string    `db:"created_by"`
-	CreatedAt    time.Time  `db:"created_at"`
+	ID           string    `db:"id"`
+	SourceTaskID string    `db:"source_task_id"`
+	TargetTaskID string    `db:"target_task_id"`
+	LinkType     string    `db:"link_type"`
+	CreatedBy    *string   `db:"created_by"`
+	CreatedAt    time.Time `db:"created_at"`
 }
 
 // taskLinkWithTaskRow is used for the join query that fetches linked task info.
 type taskLinkWithTaskRow struct {
 	// link columns
-	ID           string     `db:"id"`
-	SourceTaskID string     `db:"source_task_id"`
-	TargetTaskID string     `db:"target_task_id"`
-	LinkType     string     `db:"link_type"`
-	CreatedBy    *string    `db:"created_by"`
-	CreatedAt    time.Time  `db:"created_at"`
+	ID           string    `db:"id"`
+	SourceTaskID string    `db:"source_task_id"`
+	TargetTaskID string    `db:"target_task_id"`
+	LinkType     string    `db:"link_type"`
+	CreatedBy    *string   `db:"created_by"`
+	CreatedAt    time.Time `db:"created_at"`
 	// linked task columns (the "other" side of the link)
-	LinkedTaskID         string  `db:"linked_task_id"`
-	LinkedTaskNumber     int64   `db:"linked_task_number"`
-	LinkedTaskTitle      string  `db:"linked_task_title"`
-	LinkedTaskStatusID   *string `db:"linked_task_status_id"`
-	LinkedTaskTypeID     *string `db:"linked_task_type_id"`
+	LinkedTaskID       string  `db:"linked_task_id"`
+	LinkedTaskNumber   int64   `db:"linked_task_number"`
+	LinkedTaskTitle    string  `db:"linked_task_title"`
+	LinkedTaskStatusID *string `db:"linked_task_status_id"`
+	LinkedTaskTypeID   *string `db:"linked_task_type_id"`
 	// perspective: "source" means the queried task is the source, "target" means it's the target
 	Perspective string `db:"perspective"`
 }
@@ -256,10 +256,10 @@ func (row *taskLinkWithTaskRow) toDomain() (*taskdom.TaskLink, error) {
 		switch taskdom.LinkType(row.LinkType) {
 		case taskdom.LinkTypeBlocks:
 			link.DisplayLinkType = "is_blocked_by"
+		case taskdom.LinkTypeRelatesTo:
+			link.DisplayLinkType = row.LinkType
 		case taskdom.LinkTypeDuplicates:
 			link.DisplayLinkType = "is_duplicated_by"
-		default: // relates_to is symmetric
-			link.DisplayLinkType = row.LinkType
 		}
 	}
 

--- a/services/api/internal/repository/postgres/task_link_repository.go
+++ b/services/api/internal/repository/postgres/task_link_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
@@ -108,9 +109,60 @@ func (r *TaskLinkRepository) FindTaskLinkByID(ctx context.Context, id uuid.UUID)
 	return rec.toDomain()
 }
 
-// LinkExists reports whether a link of linkType between source and target already exists.
-// For relates_to it checks both directions.
-func (r *TaskLinkRepository) LinkExists(ctx context.Context, sourceID, targetID uuid.UUID, linkType taskdom.LinkType) (bool, error) {
+// CreateTaskLinkIfNotExists creates l unless an equivalent link already
+// exists (checked in both directions for relates_to). Both task rows are
+// locked (in a stable, id-ascending order to avoid deadlocks) for the
+// duration of the transaction, so two concurrent requests linking the same
+// pair of tasks - including the two row-orderings possible for the
+// symmetric relates_to type, which the unique index alone cannot catch -
+// serialize instead of both passing the existence check.
+func (r *TaskLinkRepository) CreateTaskLinkIfNotExists(ctx context.Context, l *taskdom.TaskLink) (bool, error) {
+	created := false
+	err := WithTx(ctx, r.db, func(tx *sqlx.Tx) error {
+		var locked []string
+		if err := tx.SelectContext(ctx, &locked,
+			`SELECT id FROM tasks WHERE id IN ($1, $2) ORDER BY id FOR UPDATE`,
+			l.SourceTaskID.String(), l.TargetTaskID.String(),
+		); err != nil {
+			return fmt.Errorf("task link repo: lock tasks: %w", err)
+		}
+
+		exists, err := linkExistsTx(ctx, tx, l.SourceTaskID, l.TargetTaskID, l.LinkType)
+		if err != nil {
+			return fmt.Errorf("task link repo: check exists: %w", err)
+		}
+		if exists {
+			return nil
+		}
+
+		var createdBy *string
+		if l.CreatedBy != nil {
+			s := l.CreatedBy.String()
+			createdBy = &s
+		}
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO task_links (id, source_task_id, target_task_id, link_type, created_by, created_at)
+			VALUES ($1, $2, $3, $4, $5, $6)`,
+			l.ID.String(), l.SourceTaskID.String(), l.TargetTaskID.String(),
+			string(l.LinkType), createdBy, l.CreatedAt,
+		)
+		if err != nil {
+			if isUniqueViolation(err) {
+				// Lost a race to a concurrent insert outside this lock's scope
+				// (e.g. a differently-ordered id pair); treat as already-exists.
+				return nil
+			}
+			return fmt.Errorf("task link repo: create: %w", err)
+		}
+		created = true
+		return nil
+	})
+	return created, err
+}
+
+// linkExistsTx reports whether a link of linkType between source and target
+// already exists. For relates_to it checks both directions.
+func linkExistsTx(ctx context.Context, tx *sqlx.Tx, sourceID, targetID uuid.UUID, linkType taskdom.LinkType) (bool, error) {
 	var q string
 	var args []interface{}
 
@@ -131,33 +183,10 @@ func (r *TaskLinkRepository) LinkExists(ctx context.Context, sourceID, targetID 
 	}
 
 	var exists bool
-	if err := r.db.GetContext(ctx, &exists, q, args...); err != nil {
+	if err := tx.GetContext(ctx, &exists, q, args...); err != nil {
 		return false, err
 	}
 	return exists, nil
-}
-
-// CreateTaskLink inserts a new task_links row.
-func (r *TaskLinkRepository) CreateTaskLink(ctx context.Context, l *taskdom.TaskLink) error {
-	const q = `
-		INSERT INTO task_links (id, source_task_id, target_task_id, link_type, created_by, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6)`
-
-	var createdBy *string
-	if l.CreatedBy != nil {
-		s := l.CreatedBy.String()
-		createdBy = &s
-	}
-
-	_, err := r.db.ExecContext(ctx, q,
-		l.ID.String(),
-		l.SourceTaskID.String(),
-		l.TargetTaskID.String(),
-		string(l.LinkType),
-		createdBy,
-		l.CreatedAt,
-	)
-	return err
 }
 
 // DeleteTaskLink removes a task_links row by primary key.

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -125,13 +125,16 @@ func (r *taskWithPositionRow) asTaskRecord() taskRecord {
 // --- Repository struct -------------------------------------------------------
 
 // TaskRepository is the sqlx implementation of taskdom.Repository.
+// It embeds TaskLinkRepository so that a single pointer satisfies the full
+// taskdom.Repository interface (which now includes TaskLinkRepository).
 type TaskRepository struct {
 	db *sqlx.DB
+	*TaskLinkRepository
 }
 
 // NewTaskRepository returns a new TaskRepository.
 func NewTaskRepository(db *sqlx.DB) *TaskRepository {
-	return &TaskRepository{db: db}
+	return &TaskRepository{db: db, TaskLinkRepository: NewTaskLinkRepository(db)}
 }
 
 // --- queryBuilder is a small helper for building parameterized SQL queries ---

--- a/services/api/internal/service/sprint/sprint_service_test.go
+++ b/services/api/internal/service/sprint/sprint_service_test.go
@@ -174,6 +174,26 @@ func (r *fakeTaskRepo) SumTaskField(_ context.Context, _ uuid.UUID, _ taskdom.Ta
 	return 0, nil
 }
 
+func (r *fakeTaskRepo) ListTaskLinks(_ context.Context, _ uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return []*taskdom.TaskLink{}, nil
+}
+
+func (r *fakeTaskRepo) FindTaskLinkByID(_ context.Context, _ uuid.UUID) (*taskdom.TaskLink, error) {
+	return nil, taskdom.ErrTaskLinkNotFound
+}
+
+func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.LinkType) (bool, error) {
+	return false, nil
+}
+
+func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, l *taskdom.TaskLink) error {
+	return nil
+}
+
+func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
 func (r *fakeTaskRepo) BulkMoveSprintTasks(_ context.Context, projectID, sourceSprintID uuid.UUID, targetSprintID *uuid.UUID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/services/api/internal/service/sprint/sprint_service_test.go
+++ b/services/api/internal/service/sprint/sprint_service_test.go
@@ -186,7 +186,7 @@ func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.L
 	return false, nil
 }
 
-func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, l *taskdom.TaskLink) error {
+func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, _ *taskdom.TaskLink) error {
 	return nil
 }
 

--- a/services/api/internal/service/sprint/sprint_service_test.go
+++ b/services/api/internal/service/sprint/sprint_service_test.go
@@ -182,12 +182,8 @@ func (r *fakeTaskRepo) FindTaskLinkByID(_ context.Context, _ uuid.UUID) (*taskdo
 	return nil, taskdom.ErrTaskLinkNotFound
 }
 
-func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.LinkType) (bool, error) {
-	return false, nil
-}
-
-func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, _ *taskdom.TaskLink) error {
-	return nil
+func (r *fakeTaskRepo) CreateTaskLinkIfNotExists(_ context.Context, _ *taskdom.TaskLink) (bool, error) {
+	return true, nil
 }
 
 func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error {

--- a/services/api/internal/service/task/cached_service.go
+++ b/services/api/internal/service/task/cached_service.go
@@ -318,3 +318,20 @@ func (c *CachedService) DeleteCustomFieldDefinition(ctx context.Context, project
 	}
 	return nil
 }
+
+// --- Task Links (pass-through) -----------------------------------------------
+
+// ListTaskLinks delegates directly to the underlying service (not cached).
+func (c *CachedService) ListTaskLinks(ctx context.Context, projectID, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return c.svc.ListTaskLinks(ctx, projectID, taskID)
+}
+
+// CreateTaskLink delegates directly to the underlying service (not cached).
+func (c *CachedService) CreateTaskLink(ctx context.Context, in taskdom.CreateTaskLinkInput) (*taskdom.TaskLink, error) {
+	return c.svc.CreateTaskLink(ctx, in)
+}
+
+// DeleteTaskLink delegates directly to the underlying service (not cached).
+func (c *CachedService) DeleteTaskLink(ctx context.Context, projectID, taskID, linkID uuid.UUID) error {
+	return c.svc.DeleteTaskLink(ctx, projectID, taskID, linkID)
+}

--- a/services/api/internal/service/task/cached_service_test.go
+++ b/services/api/internal/service/task/cached_service_test.go
@@ -202,6 +202,23 @@ func (s *stubTaskSvc) DeleteCustomFieldDefinition(ctx context.Context, projectID
 	return nil
 }
 
+// --- TaskLinkService stubs --------------------------------------------------
+
+func (s *stubTaskSvc) ListTaskLinks(_ context.Context, _, _ uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return []*taskdom.TaskLink{}, nil
+}
+
+func (s *stubTaskSvc) CreateTaskLink(_ context.Context, in taskdom.CreateTaskLinkInput) (*taskdom.TaskLink, error) {
+	return &taskdom.TaskLink{
+		ID:           uuid.New(),
+		SourceTaskID: in.SourceTaskID,
+		TargetTaskID: in.TargetTaskID,
+		LinkType:     in.LinkType,
+	}, nil
+}
+
+func (s *stubTaskSvc) DeleteTaskLink(_ context.Context, _, _, _ uuid.UUID) error { return nil }
+
 // ---------------------------------------------------------------------------
 // ListTaskTypes
 // ---------------------------------------------------------------------------

--- a/services/api/internal/service/task/task_link_service.go
+++ b/services/api/internal/service/task/task_link_service.go
@@ -1,0 +1,96 @@
+package tasksvc
+
+import (
+	"context"
+	"time"
+
+	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	"github.com/google/uuid"
+)
+
+// ListTaskLinks returns all links for a task, computing display labels.
+func (s *Service) ListTaskLinks(ctx context.Context, projectID, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
+	// Verify task belongs to project.
+	if _, err := s.repo.FindTaskByID(ctx, taskID); err != nil {
+		return nil, err
+	}
+	return s.repo.ListTaskLinks(ctx, taskID)
+}
+
+// CreateTaskLink validates and persists a new directed link.
+func (s *Service) CreateTaskLink(ctx context.Context, in taskdom.CreateTaskLinkInput) (*taskdom.TaskLink, error) {
+	if in.SourceTaskID == in.TargetTaskID {
+		return nil, taskdom.ErrTaskLinkSelf
+	}
+	if !taskdom.ValidLinkTypes[in.LinkType] {
+		return nil, taskdom.ErrTaskLinkTypInvalid
+	}
+
+	source, err := s.repo.FindTaskByID(ctx, in.SourceTaskID)
+	if err != nil {
+		return nil, err
+	}
+	if source.ProjectID != in.ProjectID {
+		return nil, taskdom.ErrTaskNotFound
+	}
+
+	target, err := s.repo.FindTaskByID(ctx, in.TargetTaskID)
+	if err != nil {
+		return nil, err
+	}
+	if target.ProjectID != in.ProjectID {
+		return nil, taskdom.ErrTaskLinkCrossProject
+	}
+
+	exists, err := s.repo.LinkExists(ctx, in.SourceTaskID, in.TargetTaskID, in.LinkType)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, taskdom.ErrTaskLinkDuplicate
+	}
+
+	link := &taskdom.TaskLink{
+		ID:           uuid.New(),
+		SourceTaskID: in.SourceTaskID,
+		TargetTaskID: in.TargetTaskID,
+		LinkType:     in.LinkType,
+		CreatedBy:    in.CreatedBy,
+		CreatedAt:    time.Now(),
+	}
+	if err := s.repo.CreateTaskLink(ctx, link); err != nil {
+		return nil, err
+	}
+
+	// Populate the linked task summary for the response.
+	link.LinkedTask = &taskdom.LinkedTaskSummary{
+		ID:         target.ID,
+		TaskNumber: target.TaskNumber,
+		Title:      target.Title,
+		StatusID:   target.StatusID,
+		TaskTypeID: target.TaskTypeID,
+	}
+	link.DisplayLinkType = string(in.LinkType)
+	return link, nil
+}
+
+// DeleteTaskLink removes a link after verifying it belongs to a task in projectID.
+func (s *Service) DeleteTaskLink(ctx context.Context, projectID, taskID, linkID uuid.UUID) error {
+	link, err := s.repo.FindTaskLinkByID(ctx, linkID)
+	if err != nil {
+		return err
+	}
+	// Verify the link actually belongs to the given task and project.
+	if link.SourceTaskID != taskID && link.TargetTaskID != taskID {
+		return taskdom.ErrTaskLinkNotFound
+	}
+	// Ensure the task is in the requested project.
+	task, err := s.repo.FindTaskByID(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	if task.ProjectID != projectID {
+		return taskdom.ErrTaskLinkNotFound
+	}
+	return s.repo.DeleteTaskLink(ctx, linkID)
+}

--- a/services/api/internal/service/task/task_link_service.go
+++ b/services/api/internal/service/task/task_link_service.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ListTaskLinks returns all links for a task, computing display labels.
-func (s *Service) ListTaskLinks(ctx context.Context, projectID, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
+func (s *Service) ListTaskLinks(ctx context.Context, _, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
 	// Verify task belongs to project.
 	if _, err := s.repo.FindTaskByID(ctx, taskID); err != nil {
 		return nil, err

--- a/services/api/internal/service/task/task_link_service.go
+++ b/services/api/internal/service/task/task_link_service.go
@@ -9,10 +9,13 @@ import (
 )
 
 // ListTaskLinks returns all links for a task, computing display labels.
-func (s *Service) ListTaskLinks(ctx context.Context, _, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
-	// Verify task belongs to project.
-	if _, err := s.repo.FindTaskByID(ctx, taskID); err != nil {
+func (s *Service) ListTaskLinks(ctx context.Context, projectID, taskID uuid.UUID) ([]*taskdom.TaskLink, error) {
+	task, err := s.repo.FindTaskByID(ctx, taskID)
+	if err != nil {
 		return nil, err
+	}
+	if task.ProjectID != projectID {
+		return nil, taskdom.ErrTaskNotFound
 	}
 	return s.repo.ListTaskLinks(ctx, taskID)
 }
@@ -23,7 +26,7 @@ func (s *Service) CreateTaskLink(ctx context.Context, in taskdom.CreateTaskLinkI
 		return nil, taskdom.ErrTaskLinkSelf
 	}
 	if !taskdom.ValidLinkTypes[in.LinkType] {
-		return nil, taskdom.ErrTaskLinkTypInvalid
+		return nil, taskdom.ErrTaskLinkTypeInvalid
 	}
 
 	source, err := s.repo.FindTaskByID(ctx, in.SourceTaskID)
@@ -42,14 +45,6 @@ func (s *Service) CreateTaskLink(ctx context.Context, in taskdom.CreateTaskLinkI
 		return nil, taskdom.ErrTaskLinkCrossProject
 	}
 
-	exists, err := s.repo.LinkExists(ctx, in.SourceTaskID, in.TargetTaskID, in.LinkType)
-	if err != nil {
-		return nil, err
-	}
-	if exists {
-		return nil, taskdom.ErrTaskLinkDuplicate
-	}
-
 	link := &taskdom.TaskLink{
 		ID:           uuid.New(),
 		SourceTaskID: in.SourceTaskID,
@@ -58,8 +53,12 @@ func (s *Service) CreateTaskLink(ctx context.Context, in taskdom.CreateTaskLinkI
 		CreatedBy:    in.CreatedBy,
 		CreatedAt:    time.Now(),
 	}
-	if err := s.repo.CreateTaskLink(ctx, link); err != nil {
+	created, err := s.repo.CreateTaskLinkIfNotExists(ctx, link)
+	if err != nil {
 		return nil, err
+	}
+	if !created {
+		return nil, taskdom.ErrTaskLinkDuplicate
 	}
 
 	// Populate the linked task summary for the response.

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -1564,6 +1564,24 @@ func (r *fakeTaskRepo) DeleteCustomFieldDefinition(_ context.Context, id uuid.UU
 	return nil
 }
 
+// --- TaskLinkRepository stubs -----------------------------------------------
+
+func (r *fakeTaskRepo) ListTaskLinks(_ context.Context, _ uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return []*taskdom.TaskLink{}, nil
+}
+
+func (r *fakeTaskRepo) FindTaskLinkByID(_ context.Context, _ uuid.UUID) (*taskdom.TaskLink, error) {
+	return nil, taskdom.ErrTaskLinkNotFound
+}
+
+func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.LinkType) (bool, error) {
+	return false, nil
+}
+
+func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, l *taskdom.TaskLink) error { return nil }
+
+func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error { return nil }
+
 // ---------------------------------------------------------------------------
 // Task Number tests
 // ---------------------------------------------------------------------------

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -1578,7 +1578,7 @@ func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.L
 	return false, nil
 }
 
-func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, l *taskdom.TaskLink) error { return nil }
+func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, _ *taskdom.TaskLink) error { return nil }
 
 func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error { return nil }
 

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -1574,11 +1574,9 @@ func (r *fakeTaskRepo) FindTaskLinkByID(_ context.Context, _ uuid.UUID) (*taskdo
 	return nil, taskdom.ErrTaskLinkNotFound
 }
 
-func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.LinkType) (bool, error) {
-	return false, nil
+func (r *fakeTaskRepo) CreateTaskLinkIfNotExists(_ context.Context, _ *taskdom.TaskLink) (bool, error) {
+	return true, nil
 }
-
-func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, _ *taskdom.TaskLink) error { return nil }
 
 func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error { return nil }
 

--- a/services/api/internal/transport/http/dto/task_dto.go
+++ b/services/api/internal/transport/http/dto/task_dto.go
@@ -473,3 +473,58 @@ type AddCommentRequest struct {
 type UpdateCommentRequest struct {
 	Content json.RawMessage `json:"content" binding:"required"`
 }
+
+// --- Task Link DTOs ---------------------------------------------------------
+
+// CreateTaskLinkRequest is the body for
+// POST /projects/:projectId/tasks/:taskId/links.
+type CreateTaskLinkRequest struct {
+	TargetTaskID uuid.UUID        `json:"target_task_id"`
+	LinkType     taskdom.LinkType `json:"link_type"`
+}
+
+// LinkedTaskSummaryResponse is the embedded task info returned alongside a link.
+type LinkedTaskSummaryResponse struct {
+	ID         uuid.UUID  `json:"id"`
+	TaskNumber int64      `json:"task_number"`
+	Title      string     `json:"title"`
+	StatusID   *uuid.UUID `json:"status_id,omitempty"`
+	TaskTypeID *uuid.UUID `json:"task_type_id,omitempty"`
+}
+
+// TaskLinkResponse is the public representation of a task link.
+// DisplayLinkType is the relationship label from the queried task's perspective
+// (e.g. "is_blocked_by" when the queried task is the target of a "blocks" link).
+type TaskLinkResponse struct {
+	ID              uuid.UUID                 `json:"id"`
+	SourceTaskID    uuid.UUID                 `json:"source_task_id"`
+	TargetTaskID    uuid.UUID                 `json:"target_task_id"`
+	LinkType        taskdom.LinkType          `json:"link_type"`
+	DisplayLinkType string                    `json:"display_link_type"`
+	LinkedTask      LinkedTaskSummaryResponse `json:"linked_task"`
+	CreatedBy       *uuid.UUID                `json:"created_by,omitempty"`
+	CreatedAt       time.Time                 `json:"created_at"`
+}
+
+// TaskLinkFromEntity maps a domain TaskLink to a TaskLinkResponse DTO.
+func TaskLinkFromEntity(l *taskdom.TaskLink) TaskLinkResponse {
+	resp := TaskLinkResponse{
+		ID:              l.ID,
+		SourceTaskID:    l.SourceTaskID,
+		TargetTaskID:    l.TargetTaskID,
+		LinkType:        l.LinkType,
+		DisplayLinkType: l.DisplayLinkType,
+		CreatedBy:       l.CreatedBy,
+		CreatedAt:       l.CreatedAt,
+	}
+	if l.LinkedTask != nil {
+		resp.LinkedTask = LinkedTaskSummaryResponse{
+			ID:         l.LinkedTask.ID,
+			TaskNumber: l.LinkedTask.TaskNumber,
+			Title:      l.LinkedTask.Title,
+			StatusID:   l.LinkedTask.StatusID,
+			TaskTypeID: l.LinkedTask.TaskTypeID,
+		}
+	}
+	return resp
+}

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -1243,3 +1243,153 @@ func (h *TaskHandler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 	}
 	presenter.NoContent(w)
 }
+
+// --- Task Links -------------------------------------------------------------
+
+// ListTaskLinks handles GET /projects/:projectId/tasks/:taskId/links.
+func (h *TaskHandler) ListTaskLinks(w http.ResponseWriter, r *http.Request) {
+	projectID, err := parseProjectID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	taskID, err := parseTaskID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	links, err := h.svc.ListTaskLinks(r.Context(), projectID, taskID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	resp := make([]dto.TaskLinkResponse, 0, len(links))
+	for _, l := range links {
+		resp = append(resp, dto.TaskLinkFromEntity(l))
+	}
+	presenter.OK(w, r, map[string]any{"items": resp})
+}
+
+// CreateTaskLink handles POST /projects/:projectId/tasks/:taskId/links.
+func (h *TaskHandler) CreateTaskLink(w http.ResponseWriter, r *http.Request) {
+	projectID, err := parseProjectID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	taskID, err := parseTaskID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	var req dto.CreateTaskLinkRequest
+	if !middleware.BindJSON(w, r, &req) {
+		return
+	}
+	if req.TargetTaskID == uuid.Nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "target_task_id is required"))
+		return
+	}
+	if !taskdom.ValidLinkTypes[req.LinkType] {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid link_type"))
+		return
+	}
+
+	actorID, _ := middleware.ActorIDFromContext(r.Context())
+	var createdBy *uuid.UUID
+	if actorID != uuid.Nil {
+		createdBy = &actorID
+	}
+
+	link, err := h.svc.CreateTaskLink(r.Context(), taskdom.CreateTaskLinkInput{
+		ProjectID:    projectID,
+		SourceTaskID: taskID,
+		TargetTaskID: req.TargetTaskID,
+		LinkType:     req.LinkType,
+		CreatedBy:    createdBy,
+	})
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	// Record link creation activity (best-effort).
+	if actorID, ok := middleware.ActorIDFromContext(r.Context()); ok {
+		agentID, _ := middleware.AgentIDFromContext(r.Context())
+		var agentIDPtr *uuid.UUID
+		if agentID != uuid.Nil {
+			agentIDPtr = &agentID
+		}
+		content, _ := json.Marshal(map[string]any{
+			"target_task_id": req.TargetTaskID,
+			"link_type":      req.LinkType,
+		})
+		_ = h.activitySvc.RecordActivity(r.Context(), taskdom.RecordActivityInput{
+			TaskID:       taskID,
+			ProjectID:    projectID,
+			ActorID:      &actorID,
+			ActorAgentID: agentIDPtr,
+			ActivityType: taskdom.ActivityTypeTaskLinkAdded,
+			Content:      content,
+		})
+	}
+
+	presenter.Created(w, r, dto.TaskLinkFromEntity(link))
+}
+
+// DeleteTaskLink handles DELETE /projects/:projectId/tasks/:taskId/links/:linkId.
+func (h *TaskHandler) DeleteTaskLink(w http.ResponseWriter, r *http.Request) {
+	projectID, err := parseProjectID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	taskID, err := parseTaskID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	linkID, err := parseLinkID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	if err := h.svc.DeleteTaskLink(r.Context(), projectID, taskID, linkID); err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	// Record link deletion activity (best-effort).
+	if actorID, ok := middleware.ActorIDFromContext(r.Context()); ok {
+		agentID, _ := middleware.AgentIDFromContext(r.Context())
+		var agentIDPtr *uuid.UUID
+		if agentID != uuid.Nil {
+			agentIDPtr = &agentID
+		}
+		content, _ := json.Marshal(map[string]any{"link_id": linkID})
+		_ = h.activitySvc.RecordActivity(r.Context(), taskdom.RecordActivityInput{
+			TaskID:       taskID,
+			ProjectID:    projectID,
+			ActorID:      &actorID,
+			ActorAgentID: agentIDPtr,
+			ActivityType: taskdom.ActivityTypeTaskLinkRemoved,
+			Content:      content,
+		})
+	}
+
+	presenter.NoContent(w)
+}
+
+// parseLinkID parses the :linkId path parameter.
+func parseLinkID(r *http.Request) (uuid.UUID, error) {
+	raw := chi.URLParam(r, "linkId")
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, apierr.New(apierr.CodeBadRequest, "invalid link id")
+	}
+	return id, nil
+}

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -250,6 +250,24 @@ func (f *fakeTaskSvc) DeleteCustomFieldDefinition(_ context.Context, _, _ uuid.U
 	return nil
 }
 
+// --- TaskLinkService stubs --------------------------------------------------
+
+func (f *fakeTaskSvc) ListTaskLinks(_ context.Context, _, _ uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return []*taskdom.TaskLink{}, nil
+}
+
+func (f *fakeTaskSvc) CreateTaskLink(_ context.Context, in taskdom.CreateTaskLinkInput) (*taskdom.TaskLink, error) {
+	return &taskdom.TaskLink{
+		ID:           uuid.New(),
+		SourceTaskID: in.SourceTaskID,
+		TargetTaskID: in.TargetTaskID,
+		LinkType:     in.LinkType,
+		CreatedBy:    in.CreatedBy,
+	}, nil
+}
+
+func (f *fakeTaskSvc) DeleteTaskLink(_ context.Context, _, _, _ uuid.UUID) error { return nil }
+
 // ---------------------------------------------------------------------------
 // Fake activity service
 // ---------------------------------------------------------------------------

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -210,6 +210,14 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeActivityNotAComment
 	case errors.Is(err, taskdom.ErrCommentContentInvalid):
 		return http.StatusBadRequest, apierr.CodeCommentContentInvalid
+	case errors.Is(err, taskdom.ErrTaskLinkNotFound):
+		return http.StatusNotFound, apierr.CodeTaskLinkNotFound
+	case errors.Is(err, taskdom.ErrTaskLinkSelf):
+		return http.StatusBadRequest, apierr.CodeTaskLinkSelf
+	case errors.Is(err, taskdom.ErrTaskLinkDuplicate):
+		return http.StatusConflict, apierr.CodeTaskLinkDuplicate
+	case errors.Is(err, taskdom.ErrTaskLinkCrossProject):
+		return http.StatusBadRequest, apierr.CodeTaskLinkCrossProject
 	case errors.Is(err, docdom.ErrDocNotFound):
 		return http.StatusNotFound, apierr.CodeDocNotFound
 	case errors.Is(err, docdom.ErrDocTitleInvalid):

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -329,6 +329,7 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeTaskTypeNotFound,
 		apierr.CodeTaskStatusNotFound,
 		apierr.CodeSprintNotFound,
+		apierr.CodeTaskLinkNotFound,
 		apierr.CodeViewNotFound,
 		apierr.CodeCustomFieldNotFound,
 		apierr.CodeFileNotFound,
@@ -344,6 +345,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeEpicCannotHaveParent,
 		apierr.CodeTaskCannotBeOwnParent,
 		apierr.CodeTaskParentCycleDetected,
+		apierr.CodeTaskLinkSelf,
+		apierr.CodeTaskLinkCrossProject,
 		apierr.CodeTaskTypeNameInvalid,
 		apierr.CodeTaskStatusNameInvalid,
 		apierr.CodeTaskStatusCategoryInvalid,
@@ -364,6 +367,7 @@ func httpStatusForCode(code apierr.Code) int {
 		return http.StatusForbidden
 	case apierr.CodeViewIsLastView,
 		apierr.CodeSprintAlreadyComplete,
+		apierr.CodeTaskLinkDuplicate,
 		apierr.CodeCustomFieldKeyTaken,
 		apierr.CodeTaskTypeNameReserved:
 		return http.StatusConflict

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -310,6 +310,18 @@ func New(deps Deps) http.Handler {
 							Delete("/comments/{commentId}", deps.Task.DeleteComment)
 					})
 
+					// Links
+					r.Route("/{taskId}/links", func(r chi.Router) {
+						r.With(httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+						)).Get("/", deps.Task.ListTaskLinks)
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).
+							Post("/", deps.Task.CreateTaskLink)
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).
+							Delete("/{linkId}", deps.Task.DeleteTaskLink)
+					})
+
 					// Attachments
 					r.Route("/{taskId}/attachments", func(r chi.Router) {
 						r.With(httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,

--- a/services/api/migrations/000015_add_task_links.sql
+++ b/services/api/migrations/000015_add_task_links.sql
@@ -1,0 +1,23 @@
+-- 000015_add_task_links.sql
+-- Introduces a task_links join table that stores directional relationships
+-- between tasks (blocks/relates_to/duplicates).  Inverse relationships
+-- (is_blocked_by, is_duplicated_by) are computed at read time.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS task_links (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    target_task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    link_type      VARCHAR(50) NOT NULL
+                       CHECK (link_type IN ('blocks', 'relates_to', 'duplicates')),
+    created_by     UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_task_links UNIQUE (source_task_id, target_task_id, link_type),
+    CONSTRAINT no_self_link    CHECK  (source_task_id <> target_task_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_links_source ON task_links (source_task_id);
+CREATE INDEX IF NOT EXISTS idx_task_links_target ON task_links (target_task_id);
+
+COMMIT;

--- a/services/api/test/e2e/task_link_management_test.go
+++ b/services/api/test/e2e/task_link_management_test.go
@@ -1,0 +1,569 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	globalroledom "github.com/Paca-AI/api/internal/domain/globalrole"
+	"github.com/google/uuid"
+)
+
+// createTaskViaAPI is a helper to create a task via the API
+func createTaskViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, projectID, title string) string {
+	t.Helper()
+	body := jsonBody(t, map[string]any{
+		"title":        title,
+		"importance":   1,
+		"story_points": 1,
+	})
+	req := mustRequest(env.ctx, t, http.MethodPost,
+		fmt.Sprintf("%s/api/v1/projects/%s/tasks", env.base, projectID), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	data := assertDataMap(t, env2)
+	id, _ := data["id"].(string)
+	if id == "" {
+		t.Fatal("expected non-empty task id")
+	}
+	return id
+}
+
+// ---------------------------------------------------------------------------
+// Task Link Management E2E Tests
+// ---------------------------------------------------------------------------
+
+func TestE2ETaskLinkManagement_TaskLinkingLifecycle(t *testing.T) {
+	env := newE2EEnv(t)
+	username := "tasklink-user-" + uuid.NewString()
+	seedTaskMemberUser(t, env, username, "tasklinkpass1")
+	client, token := taskMemberLogin(t, env, username, "tasklinkpass1")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+
+	// Create two tasks to link between
+	taskID1 := createTaskViaAPI(t, env, client, token, projID, "Task 1 - Source Task")
+	taskID2 := createTaskViaAPI(t, env, client, token, projID, "Task 2 - Target Task")
+	taskID3 := createTaskViaAPI(t, env, client, token, projID, "Task 3 - Another Task")
+
+	var linkID string
+
+	t.Run("create_task_link_blocks", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskID2,
+			"link_type":      "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		linkID, _ = data["id"].(string)
+		if linkID == "" {
+			t.Fatal("expected non-empty link id")
+		}
+		if sourceID, _ := data["source_task_id"].(string); sourceID != taskID1 {
+			t.Errorf("expected source_task_id %q, got %q", taskID1, sourceID)
+		}
+		if targetID, _ := data["target_task_id"].(string); targetID != taskID2 {
+			t.Errorf("expected target_task_id %q, got %q", taskID2, targetID)
+		}
+		if linkType, _ := data["link_type"].(string); linkType != "blocks" {
+			t.Errorf("expected link_type \"blocks\", got %q", linkType)
+		}
+		// Verify linked_task is present
+		linkedTask, ok := data["linked_task"].(map[string]any)
+		if !ok {
+			t.Fatal("expected linked_task to be an object")
+		}
+		if linkedTaskID, _ := linkedTask["id"].(string); linkedTaskID != taskID2 {
+			t.Errorf("expected linked_task.id %q, got %q", taskID2, linkedTaskID)
+		}
+	})
+
+	t.Run("create_task_link_relates_to", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskID3,
+			"link_type":      "relates_to",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		if linkType, _ := data["link_type"].(string); linkType != "relates_to" {
+			t.Errorf("expected link_type \"relates_to\", got %q", linkType)
+		}
+	})
+
+	t.Run("create_task_link_duplicates", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskID2,
+			"link_type":      "duplicates",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID3), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+	})
+
+	t.Run("list_task_links_for_task1", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, ok := data["items"].([]any)
+		if !ok {
+			t.Fatalf("expected items array, got %T", data["items"])
+		}
+		// Should have 2 links: blocks and relates_to
+		if len(items) != 2 {
+			t.Errorf("expected 2 links for task1, got %d", len(items))
+		}
+	})
+
+	t.Run("list_task_links_for_task2", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID2), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, ok := data["items"].([]any)
+		if !ok {
+			t.Fatalf("expected items array, got %T", data["items"])
+		}
+		// Should have at least duplicates link created from task3
+		if len(items) < 1 {
+			t.Errorf("expected at least 1 link for task2, got %d", len(items))
+		}
+	})
+
+	t.Run("delete_task_link", func(t *testing.T) {
+		if linkID == "" {
+			t.Skip("link_id not available (create_task_link may have failed)")
+		}
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links/%s", env.base, projID, taskID1, linkID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNoContent)
+	})
+
+	t.Run("verify_link_deleted", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, ok := data["items"].([]any)
+		if !ok {
+			t.Fatalf("expected items array, got %T", data["items"])
+		}
+		// Should now have only 1 link (relates_to), as the blocks link was deleted
+		if len(items) != 1 {
+			t.Errorf("expected 1 link after deletion, got %d", len(items))
+		}
+	})
+}
+
+// TestE2ETaskLinkManagement_ErrorCases tests various error scenarios
+func TestE2ETaskLinkManagement_ErrorCases(t *testing.T) {
+	env := newE2EEnv(t)
+	username := "tasklink-error-user-" + uuid.NewString()
+	seedTaskMemberUser(t, env, username, "tasklinkerror1")
+	loginClient, loginToken := taskMemberLogin(t, env, username, "tasklinkerror1")
+	projID := createProjectForTasksViaAPI(t, env, loginClient, loginToken)
+
+	taskID := createTaskViaAPI(t, env, loginClient, loginToken, projID, "Task A")
+	otherTaskID := createTaskViaAPI(t, env, loginClient, loginToken, projID, "Task B")
+
+	t.Run("create_link_missing_target_task_id", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"link_type": "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+	})
+
+	t.Run("create_link_invalid_target_task_id", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": "not-a-uuid",
+			"link_type":      "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+	})
+
+	t.Run("create_link_missing_link_type", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": otherTaskID,
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+	})
+
+	t.Run("create_link_invalid_link_type", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": otherTaskID,
+			"link_type":      "invalid_type",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+	})
+
+	t.Run("create_link_to_nonexistent_task", func(t *testing.T) {
+		nonexistentTaskID := uuid.NewString()
+		body := jsonBody(t, map[string]any{
+			"target_task_id": nonexistentTaskID,
+			"link_type":      "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+	})
+
+	t.Run("create_link_to_task_in_different_project", func(t *testing.T) {
+		// Create a task in a different project
+		otherProjID := createProjectForTasksViaAPI(t, env, loginClient, loginToken)
+		taskInOtherProj := createTaskViaAPI(t, env, loginClient, loginToken, otherProjID, "Task in other project")
+
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskInOtherProj,
+			"link_type":      "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		// Should fail - cannot link to tasks in different projects
+		assertStatus(t, resp, http.StatusBadRequest)
+	})
+
+	t.Run("delete_nonexistent_link", func(t *testing.T) {
+		nonexistentLinkID := uuid.NewString()
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links/%s", env.base, projID, taskID, nonexistentLinkID), nil)
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusNotFound)
+	})
+
+	t.Run("delete_link_invalid_link_id", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links/not-a-uuid", env.base, projID, taskID), nil)
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+	})
+}
+
+// TestE2ETaskLinkManagement_Authorization tests permission requirements
+func TestE2ETaskLinkManagement_Authorization(t *testing.T) {
+	env := newE2EEnv(t)
+
+	// Create two users: one with write access, one with read-only access
+	writeUser := "tasklink-write-" + uuid.NewString()
+	readUser := "tasklink-read-" + uuid.NewString()
+	seedTaskMemberUser(t, env, writeUser, "tasklinkwrite1")
+
+	// Create a user with only read permissions
+	readonlyUsername := "readonly-user-" + uuid.NewString()
+	seedUser(t, env, readonlyUsername, "readonlypass", "Read Only User")
+	readonlyRoleName := "READONLY_" + uuid.NewString()
+	if err := env.roleRepo.Create(env.ctx, &globalroledom.GlobalRole{
+		ID:   uuid.New(),
+		Name: readonlyRoleName,
+		Permissions: map[string]any{
+			"projects.read": true,
+			"tasks.read":    true,
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create readonly role: %v", err)
+	}
+	assignGlobalRolesByName(t, env, readonlyUsername, readonlyRoleName)
+
+	writeClient, writeToken := taskMemberLogin(t, env, writeUser, "tasklinkwrite1")
+	seedTaskMemberUser(t, env, readUser, "tasklinkread1")
+	readClient, readToken := taskMemberLogin(t, env, readUser, "tasklinkread1")
+	readonlyClient, readonlyToken := taskMemberLogin(t, env, readonlyUsername, "readonlypass")
+
+	// Create tasks using write user
+	projID := createProjectForTasksViaAPI(t, env, writeClient, writeToken)
+	taskID1 := createTaskViaAPI(t, env, writeClient, writeToken, projID, "Task Write 1")
+	taskID2 := createTaskViaAPI(t, env, writeClient, writeToken, projID, "Task Write 2")
+
+	var linkID string
+
+	t.Run("read_user_can_list_links", func(t *testing.T) {
+		// First create a link with write user
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskID2,
+			"link_type":      "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+writeToken)
+		resp := mustDo(t, writeClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		linkID, _ = data["id"].(string)
+
+		// Now read user should be able to list links
+		req = mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), nil)
+		req.Header.Set("Authorization", "Bearer "+readToken)
+		resp = mustDo(t, readClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+
+		var env3 envelope
+		decodeJSON(t, resp, &env3)
+		data2 := assertDataMap(t, env3)
+		items, _ := data2["items"].([]any)
+		if len(items) < 1 {
+			t.Errorf("expected at least 1 link, got %d", len(items))
+		}
+	})
+
+	t.Run("readonly_user_cannot_create_link", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskID1,
+			"link_type":      "relates_to",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID2), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+readonlyToken)
+		resp := mustDo(t, readonlyClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+	})
+
+	t.Run("readonly_user_cannot_delete_link", func(t *testing.T) {
+		if linkID == "" {
+			t.Skip("link_id not available")
+		}
+
+		req := mustRequest(env.ctx, t, http.MethodDelete,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links/%s", env.base, projID, taskID1, linkID), nil)
+		req.Header.Set("Authorization", "Bearer "+readonlyToken)
+		resp := mustDo(t, readonlyClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusForbidden)
+	})
+}
+
+// TestE2ETaskLinkManagement_AllLinkTypes tests that all valid link types work correctly
+func TestE2ETaskLinkManagement_AllLinkTypes(t *testing.T) {
+	env := newE2EEnv(t)
+	username := "tasklink-alltypes-" + uuid.NewString()
+	seedTaskMemberUser(t, env, username, "tasklinkalltypes1")
+	client, token := taskMemberLogin(t, env, username, "tasklinkalltypes1")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+
+	taskID := createTaskViaAPI(t, env, client, token, projID, "Main Task")
+	targetTaskID := createTaskViaAPI(t, env, client, token, projID, "Target Task")
+
+	validLinkTypes := []string{"blocks", "relates_to", "duplicates"}
+
+	for _, linkType := range validLinkTypes {
+		t.Run("create_link_type_"+linkType, func(t *testing.T) {
+			body := jsonBody(t, map[string]any{
+				"target_task_id": targetTaskID,
+				"link_type":      linkType,
+			})
+			req := mustRequest(env.ctx, t, http.MethodPost,
+				fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp := mustDo(t, client, req)
+			defer func() { _ = resp.Body.Close() }()
+			assertStatus(t, resp, http.StatusCreated)
+
+			var env2 envelope
+			decodeJSON(t, resp, &env2)
+			data := assertDataMap(t, env2)
+
+			if returnedType, _ := data["link_type"].(string); returnedType != linkType {
+				t.Errorf("expected link_type %q, got %q", linkType, returnedType)
+			}
+
+			// Verify display_link_type is present
+			if _, ok := data["display_link_type"].(string); !ok {
+				t.Error("expected display_link_type to be present")
+			}
+		})
+	}
+
+	t.Run("list_links_shows_all_types", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, ok := data["items"].([]any)
+		if !ok {
+			t.Fatalf("expected items array, got %T", data["items"])
+		}
+
+		if len(items) != 3 {
+			t.Errorf("expected 3 links (one for each type), got %d", len(items))
+		}
+	})
+}
+
+// TestE2ETaskLinkManagement_BidirectionalLinks tests that links can be viewed from both source and target
+func TestE2ETaskLinkManagement_BidirectionalLinks(t *testing.T) {
+	env := newE2EEnv(t)
+	username := "tasklink-bi-" + uuid.NewString()
+	seedTaskMemberUser(t, env, username, "tasklinkbi1")
+	client, token := taskMemberLogin(t, env, username, "tasklinkbi1")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+
+	taskID1 := createTaskViaAPI(t, env, client, token, projID, "Task A")
+	taskID2 := createTaskViaAPI(t, env, client, token, projID, "Task B")
+
+	// Create a link from task1 to task2
+	t.Run("create_link_task1_to_task2", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": taskID2,
+			"link_type":      "blocks",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+	})
+
+	t.Run("list_links_from_source_task", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID1), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, ok := data["items"].([]any)
+		if !ok {
+			t.Fatalf("expected items array, got %T", data["items"])
+		}
+
+		if len(items) != 1 {
+			t.Errorf("expected 1 link from task1, got %d", len(items))
+		}
+
+		link := items[0].(map[string]any)
+		if sourceID, _ := link["source_task_id"].(string); sourceID != taskID1 {
+			t.Errorf("expected source_task_id %q, got %q", taskID1, sourceID)
+		}
+		if targetID, _ := link["target_task_id"].(string); targetID != taskID2 {
+			t.Errorf("expected target_task_id %q, got %q", taskID2, targetID)
+		}
+	})
+
+	t.Run("list_links_from_target_task", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID2), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		items, ok := data["items"].([]any)
+		if !ok {
+			t.Fatalf("expected items array, got %T", data["items"])
+		}
+
+		// The target task should also show the link (displayed as "is_blocked_by")
+		if len(items) != 1 {
+			t.Errorf("expected 1 link for task2, got %d", len(items))
+		}
+
+		link := items[0].(map[string]any)
+		if displayType, _ := link["display_link_type"].(string); displayType == "" {
+			t.Error("expected display_link_type to be present")
+		}
+	})
+}

--- a/services/api/test/e2e/task_link_management_test.go
+++ b/services/api/test/e2e/task_link_management_test.go
@@ -298,6 +298,62 @@ func TestE2ETaskLinkManagement_ErrorCases(t *testing.T) {
 		assertStatus(t, resp, http.StatusBadRequest)
 	})
 
+	t.Run("create_duplicate_link_rejected", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"target_task_id": otherTaskID,
+			"link_type":      "relates_to",
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+
+		// Creating the exact same link again should be rejected as a duplicate.
+		dupBody := jsonBody(t, map[string]any{
+			"target_task_id": otherTaskID,
+			"link_type":      "relates_to",
+		})
+		req2 := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskID), dupBody)
+		req2.Header.Set("Content-Type", "application/json")
+		req2.Header.Set("Authorization", "Bearer "+loginToken)
+		resp2 := mustDo(t, loginClient, req2)
+		defer func() { _ = resp2.Body.Close() }()
+		assertStatus(t, resp2, http.StatusConflict)
+
+		// relates_to is symmetric: the reverse direction is the same relationship
+		// and must also be rejected as a duplicate.
+		reverseBody := jsonBody(t, map[string]any{
+			"target_task_id": taskID,
+			"link_type":      "relates_to",
+		})
+		req3 := mustRequest(env.ctx, t, http.MethodPost,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, otherTaskID), reverseBody)
+		req3.Header.Set("Content-Type", "application/json")
+		req3.Header.Set("Authorization", "Bearer "+loginToken)
+		resp3 := mustDo(t, loginClient, req3)
+		defer func() { _ = resp3.Body.Close() }()
+		assertStatus(t, resp3, http.StatusConflict)
+	})
+
+	t.Run("list_links_for_task_in_different_project_not_found", func(t *testing.T) {
+		// A task that exists, but in a different project than the one in the URL.
+		otherProjID := createProjectForTasksViaAPI(t, env, loginClient, loginToken)
+		taskInOtherProj := createTaskViaAPI(t, env, loginClient, loginToken, otherProjID, "Task in other project")
+
+		req := mustRequest(env.ctx, t, http.MethodGet,
+			fmt.Sprintf("%s/api/v1/projects/%s/tasks/%s/links", env.base, projID, taskInOtherProj), nil)
+		req.Header.Set("Authorization", "Bearer "+loginToken)
+		resp := mustDo(t, loginClient, req)
+		defer func() { _ = resp.Body.Close() }()
+		// The task does not belong to projID, so listing its links through that
+		// project's URL must not leak data across the project boundary.
+		assertStatus(t, resp, http.StatusNotFound)
+	})
+
 	t.Run("delete_nonexistent_link", func(t *testing.T) {
 		nonexistentLinkID := uuid.NewString()
 		req := mustRequest(env.ctx, t, http.MethodDelete,

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -551,6 +551,28 @@ func (r *fakeTaskRepo) DeleteCustomFieldDefinition(_ context.Context, id uuid.UU
 	return nil
 }
 
+// -- fakeTaskRepo: TaskLink methods --
+
+func (r *fakeTaskRepo) ListTaskLinks(_ context.Context, _ uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return []*taskdom.TaskLink{}, nil
+}
+
+func (r *fakeTaskRepo) FindTaskLinkByID(_ context.Context, _ uuid.UUID) (*taskdom.TaskLink, error) {
+	return nil, taskdom.ErrTaskLinkNotFound
+}
+
+func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.LinkType) (bool, error) {
+	return false, nil
+}
+
+func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, l *taskdom.TaskLink) error {
+	return nil
+}
+
+func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // In-memory fake activity repository
 // ---------------------------------------------------------------------------
@@ -3789,22 +3811,4 @@ func taskListItemIDs(t *testing.T, body []byte) []string {
 		ids = append(ids, id)
 	}
 	return ids
-}
-
-// taskListNextCursor extracts data.next_cursor from a list-tasks response.
-// Returns "" when next_cursor is absent or null.
-func taskListNextCursor(t *testing.T, body []byte) string {
-	t.Helper()
-	var env struct {
-		Data struct {
-			NextCursor *string `json:"next_cursor"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &env); err != nil {
-		t.Fatalf("decode next_cursor: %v", err)
-	}
-	if env.Data.NextCursor == nil {
-		return ""
-	}
-	return *env.Data.NextCursor
 }

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -565,7 +565,7 @@ func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.L
 	return false, nil
 }
 
-func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, l *taskdom.TaskLink) error {
+func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, _ *taskdom.TaskLink) error {
 	return nil
 }
 

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -561,12 +561,8 @@ func (r *fakeTaskRepo) FindTaskLinkByID(_ context.Context, _ uuid.UUID) (*taskdo
 	return nil, taskdom.ErrTaskLinkNotFound
 }
 
-func (r *fakeTaskRepo) LinkExists(_ context.Context, _, _ uuid.UUID, _ taskdom.LinkType) (bool, error) {
-	return false, nil
-}
-
-func (r *fakeTaskRepo) CreateTaskLink(_ context.Context, _ *taskdom.TaskLink) error {
-	return nil
+func (r *fakeTaskRepo) CreateTaskLinkIfNotExists(_ context.Context, _ *taskdom.TaskLink) (bool, error) {
+	return true, nil
 }
 
 func (r *fakeTaskRepo) DeleteTaskLink(_ context.Context, _ uuid.UUID) error {


### PR DESCRIPTION
## Summary

Adds task linking so tasks can declare relationships to one another — blocking dependencies, general relations, and duplicates — surfaced in the API, the web UI, and the MCP server.

- **Backend**: new `task_links` table, repository, service, and REST endpoints for creating/listing/deleting links, with activity log entries for audit history.
- **Frontend**: a "Links" section on the task detail view, grouped by relationship type, with a modal to search for a task and pick a link type.
- **MCP**: `list_task_links`, `create_task_link`, and `delete_task_link` tools so agents can manage links programmatically.

## What's included

**Database**
- `000015_add_task_links.sql` — `task_links` join table (`source_task_id`, `target_task_id`, `link_type`), unique constraint on `(source, target, type)`, a check constraint preventing self-links, and indexes on both task columns.

**API** (`services/api`)
- `LinkType` domain type (`blocks` / `relates_to` / `duplicates`) plus `TaskLink` and `LinkedTaskSummary` entities (`internal/domain/task/entity.go`).
- `TaskLinkRepository` / `TaskLinkService` wired into the existing `task` package interfaces and `cached_service.go`.
- New error codes (`TASK_LINK_NOT_FOUND`, `TASK_LINK_CANNOT_LINK_TO_SELF`, `TASK_LINK_ALREADY_EXISTS`, `TASK_LINK_CROSS_PROJECT`) in `apierr/codes.go`.
- New endpoints under `/projects/{projectId}/tasks/{taskId}/links` (read gated by `tasks:read`, write gated by `tasks:write` — see Endpoints below).
- `task.link.added` / `task.link.removed` activity entries, documented in [`docs/api/task-activity.md`](docs/api/task-activity.md).

**Web** (`apps/web`)
- `task-links-section.tsx` — displays links grouped by relationship (Blocks / Is blocked by / Relates to / Duplicates / Is duplicated by).
- `add-task-link-modal.tsx` — task search + link type picker for creating new links.
- Wired into the task detail view above attachments, and activity feed entries for link add/remove.

**MCP** (`apps/mcp`)
- `task-link-tools.ts` — `list_task_links`, `create_task_link`, `delete_task_link` tools, registered in `tools/index.ts`.
- `task-extended-client.ts` — `listTaskLinks` / `createTaskLink` / `deleteTaskLink` API client methods.

## Endpoints

| Method | Path | Permission |
|---|---|---|
| `GET` | `/api/v1/projects/{projectId}/tasks/{taskId}/links` | `tasks:read` (or public project) |
| `POST` | `/api/v1/projects/{projectId}/tasks/{taskId}/links` | `tasks:write` |
| `DELETE` | `/api/v1/projects/{projectId}/tasks/{taskId}/links/{linkId}` | `tasks:write` |

`POST` body: `{ "target_task_id": "uuid", "link_type": "blocks" | "relates_to" | "duplicates" }`

## Design decisions

- Only canonical directions (`blocks`, `relates_to`, `duplicates`) are persisted. Inverse labels (`is_blocked_by`, `is_duplicated_by`) are computed at read time from the requesting task's perspective, so there's a single row per relationship instead of two.
- `relates_to` is symmetric — duplicate-prevention checks both directions before insert.
- Links across different projects are rejected (`TASK_LINK_CROSS_PROJECT`), as are self-links (`TASK_LINK_CANNOT_LINK_TO_SELF`).
- Parent/child relationships are intentionally out of scope here — that's already handled by the existing `parent_task_id` column.

## Test plan

- [x] Unit tests for the new service logic (`task_service_test.go`, `cached_service_test.go`) and updated handler tests (`task_handler_test.go`).
- [x] Repository/integration coverage in `task_test.go`.
- [x] New e2e suite (`task_link_management_test.go`) covering the full lifecycle (create/list/delete), all three link types, bidirectional visibility from both source and target task, error cases (missing/invalid fields, nonexistent task, cross-project), and authorization (read vs. write permissions).
- [x] MCP tool tests in `task-tools.test.ts`.
- [x] Lint clean (separate fixup commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
