### PR TITLE
refactor: improved selector ui

### DIFF
--- a/apps/web/src/components/projects/interactions/add-task-row.tsx
+++ b/apps/web/src/components/projects/interactions/add-task-row.tsx
@@ -1,27 +1,26 @@
-import { ChevronDown, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useRef, useState } from "react";
 
-import { getTaskTypeIconComponent } from "@/components/projects/task-types/task-type-icons";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import type { TaskType } from "@/lib/project-api";
-import { cn } from "@/lib/utils";
+import { TaskTypeSelector } from "./task-type-selector";
 
 interface AddTaskRowProps {
 	taskTypes: TaskType[];
 	onAdd: (title: string, taskTypeId: string | null) => void;
 	/** "list" renders an inline row; "board" renders a card-style box */
 	variant?: "list" | "board";
+	/** Text for the closed-state trigger button */
+	label?: string;
+	/** Placeholder for the title input */
+	placeholder?: string;
 }
 
 export function AddTaskRow({
 	taskTypes,
 	onAdd,
 	variant = "list",
+	label = "Add task",
+	placeholder = "Task title…",
 }: AddTaskRowProps) {
 	const [open, setOpen] = useState(false);
 	const [value, setValue] = useState("");
@@ -32,7 +31,6 @@ export function AddTaskRow({
 		taskTypes.find((tt) => tt.is_default) ?? taskTypes[0] ?? null;
 	const selectedType =
 		taskTypes.find((tt) => tt.id === selectedTypeId) ?? defaultType;
-	const SelectedIcon = getTaskTypeIconComponent(selectedType?.icon ?? null);
 
 	const openForm = () => {
 		setOpen(true);
@@ -56,41 +54,11 @@ export function AddTaskRow({
 
 	// Shared type-selector dropdown
 	const typeSelector = taskTypes.length > 0 && selectedType && (
-		<DropdownMenu>
-			<DropdownMenuTrigger
-				className={cn(
-					"flex items-center gap-1 rounded-lg px-1.5 py-1 text-xs font-semibold transition-all duration-150 hover:bg-muted/60 shrink-0",
-				)}
-				style={selectedType.color ? { color: selectedType.color } : undefined}
-			>
-				{SelectedIcon ? (
-					<SelectedIcon className="size-3" />
-				) : (
-					<span className="size-3 rounded-full bg-current opacity-60" />
-				)}
-				<span>{selectedType.name}</span>
-				{variant === "board" && <ChevronDown className="size-2.5 opacity-60" />}
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" sideOffset={2}>
-				{taskTypes.map((tt) => {
-					const Icon = getTaskTypeIconComponent(tt.icon ?? null);
-					return (
-						<DropdownMenuItem
-							key={tt.id}
-							onSelect={() => setSelectedTypeId(tt.id)}
-							style={tt.color ? { color: tt.color } : undefined}
-						>
-							{Icon ? (
-								<Icon className="size-3 mr-1.5" />
-							) : (
-								<span className="size-3 rounded-full bg-current opacity-60 mr-1.5" />
-							)}
-							{tt.name}
-						</DropdownMenuItem>
-					);
-				})}
-			</DropdownMenuContent>
-		</DropdownMenu>
+		<TaskTypeSelector
+			taskTypes={taskTypes}
+			value={selectedType.id}
+			onChange={setSelectedTypeId}
+		/>
 	);
 
 	// Shared action buttons
@@ -125,7 +93,7 @@ export function AddTaskRow({
 					className="flex w-full items-center gap-1.5 rounded-lg bg-primary/8 text-primary/80 hover:bg-primary/15 hover:text-primary px-2.5 py-1.5 text-sm font-semibold transition-all duration-150"
 				>
 					<Plus className="size-3" />
-					Add task
+					{label}
 				</button>
 			);
 		}
@@ -136,7 +104,7 @@ export function AddTaskRow({
 				className="flex items-center gap-1.5 px-4 py-2.5 text-sm text-muted-foreground/70 hover:text-foreground hover:bg-muted/30 transition-all duration-150 w-full"
 			>
 				<Plus className="size-3" />
-				Add task
+				{label}
 			</button>
 		);
 	}
@@ -157,7 +125,7 @@ export function AddTaskRow({
 						if (e.key === "Enter") submit();
 						if (e.key === "Escape") cancel();
 					}}
-					placeholder="Task title…"
+					placeholder={placeholder}
 					className="w-full rounded-lg border border-border/30 bg-muted/15 px-3 py-2 text-sm font-medium outline-none placeholder:text-muted-foreground/50 focus:border-primary/40 focus:ring-2 focus:ring-primary/15 transition-all duration-150"
 				/>
 				<div className="mt-2 flex items-center gap-1.5 justify-end">
@@ -181,7 +149,7 @@ export function AddTaskRow({
 						if (e.key === "Enter") submit();
 						if (e.key === "Escape") cancel();
 					}}
-					placeholder="Task title…"
+					placeholder={placeholder}
 					className="flex-1 bg-transparent text-sm font-medium outline-none placeholder:text-muted-foreground/50"
 				/>
 				{actionButtons}

--- a/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/properties-panel.tsx
@@ -28,6 +28,7 @@ import {
 	IMPORTANCE_BUCKET_VALUES,
 	PRIORITY_LEVELS,
 } from "../priority";
+import { TaskTypeSelector } from "../task-type-selector";
 import { AddFieldDialog } from "./add-field-dialog";
 import { FieldRow, FieldValue } from "./primitives";
 import type { SelectOption, UserOption } from "./property-field";
@@ -117,17 +118,6 @@ export function PropertiesPanel({
 		colorDot: s.color ?? undefined,
 	}));
 
-	const taskTypeOptions: SelectOption[] = taskTypes.map((tt) => {
-		const Ic = getTaskTypeIconComponent(tt.icon);
-		return {
-			value: tt.id,
-			label: tt.name,
-			icon: Ic ? (
-				<Ic className="size-3.5 text-muted-foreground/80 shrink-0" />
-			) : undefined,
-		};
-	});
-
 	const sprintOptions: SelectOption[] = [
 		{
 			value: "__backlog__",
@@ -181,17 +171,16 @@ export function PropertiesPanel({
 					</button>
 				</FieldRow>
 
-				<PropertyField
-					label="Type"
-					mode="select"
-					value={taskType?.id}
-					options={taskTypeOptions}
-					onChange={(v) =>
-						onUpdate?.({ task_type_id: typeof v === "string" ? v : null })
-					}
-					canEdit={canEdit && taskTypes.length > 0}
-					hidden={!taskType && !(canEdit && taskTypes.length > 0)}
-				/>
+				{(taskType || (canEdit && taskTypes.length > 0)) && (
+					<FieldRow label="Type">
+						<TaskTypeSelector
+							taskTypes={taskTypes}
+							value={taskType?.id}
+							canEdit={canEdit && taskTypes.length > 0}
+							onChange={(id) => onUpdate?.({ task_type_id: id })}
+						/>
+					</FieldRow>
+				)}
 
 				<FieldRow label="Relationships">
 					<button

--- a/apps/web/src/components/projects/interactions/task-detail/subtask-row.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/subtask-row.tsx
@@ -1,5 +1,4 @@
 import { Check, User } from "lucide-react";
-import { getTaskTypeIconComponent } from "@/components/projects/task-types/task-type-icons";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -19,6 +18,7 @@ import {
 	IMPORTANCE_BUCKET_VALUES,
 	PRIORITY_LEVELS,
 } from "../priority";
+import { TaskTypeSelector } from "../task-type-selector";
 
 type SubtaskUpdatePayload = Partial<{
 	status_id: string | null;
@@ -52,7 +52,6 @@ export function SubtaskRow({
 	onClick,
 }: SubtaskRowProps) {
 	const status = statuses.find((s) => s.id === task.status_id);
-	const taskType = taskTypes.find((t) => t.id === task.task_type_id);
 	const assignee = members.find((m) => m.id === task.assignee_id);
 	const priority = getPriority(task.importance ?? 0);
 	const canEditField = !!(canEdit && onUpdate);
@@ -91,79 +90,13 @@ export function SubtaskRow({
 					onClick={(e) => e.stopPropagation()}
 					onKeyDown={(e) => e.stopPropagation()}
 				>
-					{canEditField && taskTypes.length > 0 ? (
-						<Popover>
-							<PopoverTrigger
-								type="button"
-								className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-bold leading-tight tracking-wide border hover:opacity-80 transition-opacity"
-								style={
-									taskType
-										? {
-												borderColor: taskType.color
-													? `${taskType.color}44`
-													: "var(--border)",
-												backgroundColor: taskType.color
-													? `${taskType.color}15`
-													: "var(--muted)",
-												color: taskType.color ?? "inherit",
-											}
-										: undefined
-								}
-							>
-								{taskType ? (
-									taskType.name
-								) : (
-									<span className="text-muted-foreground/50">—</span>
-								)}
-							</PopoverTrigger>
-							<PopoverContent
-								className="w-44 p-1 rounded-xl border border-border/40 shadow-lg"
-								align="end"
-							>
-								{taskTypes.map((tt) => {
-									const TtIcon = getTaskTypeIconComponent(tt.icon);
-									return (
-										<button
-											key={tt.id}
-											type="button"
-											className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm hover:bg-muted/60 transition-colors duration-100"
-											onClick={() =>
-												onUpdate?.(task.id, { task_type_id: tt.id })
-											}
-										>
-											{TtIcon && (
-												<TtIcon
-													className="size-3.5 shrink-0"
-													style={tt.color ? { color: tt.color } : undefined}
-												/>
-											)}
-											<span className="flex-1 text-left">{tt.name}</span>
-											{tt.id === task.task_type_id && (
-												<Check className="size-3.5 text-primary" />
-											)}
-										</button>
-									);
-								})}
-							</PopoverContent>
-						</Popover>
-					) : (
-						taskType && (
-							<span
-								className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-bold leading-tight tracking-wide border"
-								style={{
-									borderColor: taskType.color
-										? `${taskType.color}44`
-										: "var(--border)",
-									backgroundColor: taskType.color
-										? `${taskType.color}15`
-										: "var(--muted)",
-									color: taskType.color ?? "inherit",
-								}}
-							>
-								{taskType.name}
-							</span>
-						)
-					)}
+					<TaskTypeSelector
+						taskTypes={taskTypes}
+						value={task.task_type_id}
+						canEdit={canEditField && taskTypes.length > 0}
+						onChange={(id) => onUpdate?.(task.id, { task_type_id: id })}
+						align="end"
+					/>
 				</div>
 			)}
 

--- a/apps/web/src/components/projects/interactions/task-detail/subtasks-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/subtasks-section.tsx
@@ -1,7 +1,7 @@
-import { ListChecks, Plus } from "lucide-react";
-import { useState } from "react";
+import { ListChecks } from "lucide-react";
 import type { Task } from "@/lib/interaction-api";
 import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
+import { AddTaskRow } from "../add-task-row";
 import { SubtaskRow } from "./subtask-row";
 
 interface SubtasksSectionProps {
@@ -45,43 +45,14 @@ export function SubtasksSection({
 	onSubtaskCreate,
 	onSubtaskClick,
 }: SubtasksSectionProps) {
-	const [adding, setAdding] = useState(false);
-	const [newTitle, setNewTitle] = useState("");
-	const [selectedTypeId, setSelectedTypeId] = useState<string>(
-		() => normalTaskTypes[0]?.id ?? "",
-	);
-
-	function handleCreate() {
-		const trimmed = newTitle.trim();
-		if (!trimmed) return;
-		onSubtaskCreate?.({
-			title: trimmed,
-			task_type_id: selectedTypeId || null,
-		});
-		setNewTitle("");
-		setAdding(false);
-	}
-
 	return (
 		<div className="space-y-3">
-			<div className="flex items-center justify-between">
-				<h3 className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground/70 flex items-center gap-2">
-					<span>Subtasks</span>
-					<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
-				</h3>
-				{canEdit && (
-					<button
-						type="button"
-						onClick={() => setAdding(true)}
-						className="flex items-center gap-1.5 rounded-lg bg-primary/8 text-primary/80 hover:bg-primary/15 hover:text-primary px-2.5 py-1.5 text-xs font-semibold transition-all duration-150"
-					>
-						<Plus className="size-3" />
-						Add Subtask
-					</button>
-				)}
-			</div>
+			<h3 className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground/70 flex items-center gap-2">
+				<span>Subtasks</span>
+				<div className="flex-1 h-px bg-linear-to-r from-border/40 to-transparent" />
+			</h3>
 
-			{subtasks.length > 0 && (
+			{(subtasks.length > 0 || canEdit) && (
 				<div className="rounded-xl border border-border/25 bg-card/50 divide-y divide-border/15 overflow-hidden">
 					{subtasks.map((sub) => (
 						<SubtaskRow
@@ -97,67 +68,21 @@ export function SubtasksSection({
 							onClick={onSubtaskClick ? () => onSubtaskClick(sub) : undefined}
 						/>
 					))}
+					{canEdit && (
+						<AddTaskRow
+							variant="list"
+							taskTypes={normalTaskTypes}
+							label="Add subtask"
+							placeholder="Subtask title…"
+							onAdd={(title, taskTypeId) =>
+								onSubtaskCreate?.({ title, task_type_id: taskTypeId })
+							}
+						/>
+					)}
 				</div>
 			)}
 
-			{adding && (
-				<form
-					className="flex flex-col gap-2"
-					onSubmit={(e) => {
-						e.preventDefault();
-						handleCreate();
-					}}
-				>
-					{normalTaskTypes.length > 0 && (
-						<select
-							value={selectedTypeId}
-							onChange={(e) => setSelectedTypeId(e.target.value)}
-							className="rounded-lg border border-border/30 bg-muted/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all duration-150 self-start"
-						>
-							{normalTaskTypes.map((t) => (
-								<option key={t.id} value={t.id}>
-									{t.name}
-								</option>
-							))}
-						</select>
-					)}
-					<div className="flex items-center gap-2">
-						<input
-							// biome-ignore lint/a11y/noAutofocus: intentional for inline form
-							autoFocus
-							type="text"
-							value={newTitle}
-							onChange={(e) => setNewTitle(e.target.value)}
-							placeholder="Subtask title..."
-							className="flex-1 rounded-lg border border-border/30 bg-muted/20 px-3 py-2.5 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all duration-150"
-							onKeyDown={(e) => {
-								if (e.key === "Escape") {
-									setAdding(false);
-									setNewTitle("");
-								}
-							}}
-						/>
-						<button
-							type="submit"
-							className="rounded-lg bg-primary px-3.5 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-colors duration-150 shadow-sm"
-						>
-							Add
-						</button>
-						<button
-							type="button"
-							onClick={() => {
-								setAdding(false);
-								setNewTitle("");
-							}}
-							className="rounded-lg border border-border/30 px-3.5 py-2.5 text-sm text-muted-foreground/80 hover:text-foreground hover:bg-muted/30 transition-all duration-150"
-						>
-							Cancel
-						</button>
-					</div>
-				</form>
-			)}
-
-			{!adding && subtasks.length === 0 && (
+			{!canEdit && subtasks.length === 0 && (
 				<div className="flex items-center gap-3 px-1 py-3 text-muted-foreground/45">
 					<ListChecks className="size-4 opacity-70" />
 					<p className="text-sm italic">No subtasks yet</p>

--- a/apps/web/src/components/projects/interactions/task-row.tsx
+++ b/apps/web/src/components/projects/interactions/task-row.tsx
@@ -1,6 +1,5 @@
 import { Check, GripVertical, Layers, Link, User } from "lucide-react";
 
-import { getTaskTypeIconComponent } from "@/components/projects/task-types/task-type-icons";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -26,6 +25,7 @@ import {
 	IMPORTANCE_BUCKET_VALUES,
 	PRIORITY_LEVELS,
 } from "./priority";
+import { TaskTypeSelector } from "./task-type-selector";
 import { DEFAULT_VISIBLE_FIELDS, type TaskFieldUpdate } from "./view-utils";
 
 // ── Column config ──────────────────────────────────────────────────────────────
@@ -42,7 +42,7 @@ export function getRowColConfig(
 ): ColConfig {
 	switch (fieldKey) {
 		case "type":
-			return { className: "w-16 shrink-0", headerLabel: "Type" };
+			return { className: "w-28 shrink-0", headerLabel: "Type" };
 		case "importance":
 			return {
 				className: "w-20 shrink-0",
@@ -149,7 +149,6 @@ export function TaskRow({
 	canEdit,
 	onUpdateTaskField,
 }: TaskRowProps) {
-	const taskType = taskTypes.find((t) => t.id === task.task_type_id);
 	const status = statuses.find((s) => s.id === task.status_id);
 
 	/** Renders a single cell value for the given field key. */
@@ -160,7 +159,7 @@ export function TaskRow({
 
 		switch (fieldKey) {
 			case "type":
-				return canEditField && taskTypes.length > 0 ? (
+				return canEditField ? (
 					// biome-ignore lint/a11y/noStaticElementInteractions: cell container stops propagation; inner controls are the interactive elements
 					<div
 						key="type"
@@ -168,84 +167,24 @@ export function TaskRow({
 						onClick={(e) => e.stopPropagation()}
 						onKeyDown={(e) => e.stopPropagation()}
 					>
-						<Popover>
-							<PopoverTrigger
-								type="button"
-								className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-bold leading-tight tracking-wide border truncate max-w-full hover:opacity-80 transition-opacity"
-								style={
-									taskType
-										? {
-												borderColor: taskType.color
-													? `${taskType.color}44`
-													: "var(--border)",
-												backgroundColor: taskType.color
-													? `${taskType.color}15`
-													: "var(--muted)",
-												color: taskType.color ?? "inherit",
-											}
-										: undefined
-								}
-							>
-								{taskType ? (
-									taskType.name
-								) : (
-									<span className="text-sm text-muted-foreground/50">—</span>
-								)}
-							</PopoverTrigger>
-							<PopoverContent
-								className="w-44 p-1 rounded-xl border border-border/40 shadow-lg"
-								align="start"
-							>
-								{taskTypes.map((tt) => {
-									const TtIcon = getTaskTypeIconComponent(tt.icon);
-									return (
-										<button
-											key={tt.id}
-											type="button"
-											className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm hover:bg-muted/60 transition-colors duration-100"
-											onClick={() =>
-												onUpdateTaskField(task.id, { task_type_id: tt.id })
-											}
-										>
-											{TtIcon && (
-												<TtIcon
-													className="size-3.5 shrink-0"
-													style={tt.color ? { color: tt.color } : undefined}
-												/>
-											)}
-											<span className="flex-1 text-left">{tt.name}</span>
-											{tt.id === taskType?.id && (
-												<Check className="size-3.5 text-primary" />
-											)}
-										</button>
-									);
-								})}
-							</PopoverContent>
-						</Popover>
+						<TaskTypeSelector
+							taskTypes={taskTypes}
+							value={task.task_type_id}
+							onChange={(id) =>
+								onUpdateTaskField(task.id, { task_type_id: id })
+							}
+						/>
 					</div>
 				) : (
 					<div
 						key="type"
 						className={cn(col.className, responsiveClass, "items-center")}
 					>
-						{taskType ? (
-							<span
-								className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-bold leading-tight tracking-wide border truncate max-w-full"
-								style={{
-									borderColor: taskType.color
-										? `${taskType.color}44`
-										: "var(--border)",
-									backgroundColor: taskType.color
-										? `${taskType.color}15`
-										: "var(--muted)",
-									color: taskType.color ?? "inherit",
-								}}
-							>
-								{taskType.name}
-							</span>
-						) : (
-							<span className="text-sm text-muted-foreground/50">—</span>
-						)}
+						<TaskTypeSelector
+							taskTypes={taskTypes}
+							value={task.task_type_id}
+							canEdit={false}
+						/>
 					</div>
 				);
 

--- a/apps/web/src/components/projects/interactions/task-type-selector.tsx
+++ b/apps/web/src/components/projects/interactions/task-type-selector.tsx
@@ -1,0 +1,97 @@
+import { Check } from "lucide-react";
+import { getTaskTypeIconComponent } from "@/components/projects/task-types/task-type-icons";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { TaskType } from "@/lib/project-api";
+
+interface TaskTypeSelectorProps {
+	taskTypes: TaskType[];
+	value: string | null | undefined;
+	onChange?: (taskTypeId: string) => void;
+	canEdit?: boolean;
+	align?: "start" | "end" | "center";
+}
+
+/** Badge + dropdown for picking a task's type. Used anywhere a task type can be set or changed. */
+export function TaskTypeSelector({
+	taskTypes,
+	value,
+	onChange,
+	canEdit = true,
+	align = "start",
+}: TaskTypeSelectorProps) {
+	const taskType = taskTypes.find((tt) => tt.id === value);
+	const Icon = taskType ? getTaskTypeIconComponent(taskType.icon) : null;
+
+	const badgeStyle = taskType
+		? {
+				borderColor: taskType.color ? `${taskType.color}44` : "var(--border)",
+				backgroundColor: taskType.color
+					? `${taskType.color}15`
+					: "var(--muted)",
+				color: taskType.color ?? "inherit",
+			}
+		: undefined;
+
+	const badgeContent = taskType ? (
+		<>
+			{Icon && <Icon className="size-3 shrink-0" />}
+			<span className="truncate">{taskType.name}</span>
+		</>
+	) : (
+		<span className="text-muted-foreground/50">—</span>
+	);
+
+	if (!canEdit || taskTypes.length === 0) {
+		return (
+			<span
+				className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-bold leading-tight tracking-wide border truncate max-w-full"
+				style={badgeStyle}
+			>
+				{badgeContent}
+			</span>
+		);
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				type="button"
+				className="inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-bold leading-tight tracking-wide border truncate max-w-full hover:opacity-80 transition-opacity"
+				style={badgeStyle}
+			>
+				{badgeContent}
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				className="w-44 p-1 rounded-xl border border-border/40 shadow-lg"
+				align={align}
+			>
+				{taskTypes.map((tt) => {
+					const TtIcon = getTaskTypeIconComponent(tt.icon);
+					return (
+						<DropdownMenuItem
+							key={tt.id}
+							className="rounded-lg px-3 py-2"
+							onClick={() => onChange?.(tt.id)}
+						>
+							{TtIcon && (
+								<TtIcon
+									className="size-3.5 shrink-0"
+									style={tt.color ? { color: tt.color } : undefined}
+								/>
+							)}
+							<span className="flex-1 text-left truncate">{tt.name}</span>
+							{tt.id === value && (
+								<Check className="size-3.5 text-primary shrink-0" />
+							)}
+						</DropdownMenuItem>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/web/src/components/projects/interactions/view-settings-panel.tsx
+++ b/apps/web/src/components/projects/interactions/view-settings-panel.tsx
@@ -100,20 +100,35 @@ function DynamicSelect({
 	options: { key: string; label: string }[];
 	onChange: (v: string | undefined) => void;
 }) {
+	const selected = options.find((o) => o.key === value);
 	return (
-		<select
-			value={value ?? ""}
-			onChange={(e) =>
-				onChange(e.target.value === "" ? undefined : e.target.value)
-			}
-			className="flex-1 cursor-pointer rounded-md border border-border/30 bg-background px-2 py-1 text-xs font-medium outline-none transition-all focus:border-primary/50 focus:ring-1 focus:ring-primary/20 min-w-0"
-		>
-			{options.map((o) => (
-				<option key={o.key} value={o.key}>
-					{o.label}
-				</option>
-			))}
-		</select>
+		<Popover>
+			<PopoverTrigger
+				type="button"
+				className="flex flex-1 items-center justify-between gap-1.5 cursor-pointer rounded-md border border-border/30 bg-background px-2 py-1 text-xs font-medium outline-none transition-all hover:border-border/50 focus:border-primary/50 focus:ring-1 focus:ring-primary/20 min-w-0"
+			>
+				<span className="truncate">{selected?.label ?? "—"}</span>
+				<ChevronDown className="size-3 shrink-0 text-muted-foreground/50" />
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-44 p-1 rounded-lg border border-border/40 shadow-lg"
+				align="start"
+			>
+				{options.map((o) => (
+					<button
+						key={o.key}
+						type="button"
+						className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-xs hover:bg-muted/60 transition-colors duration-100"
+						onClick={() => onChange(o.key)}
+					>
+						<span className="flex-1 text-left truncate">{o.label}</span>
+						{o.key === value && (
+							<Check className="size-3.5 text-primary shrink-0" />
+						)}
+					</button>
+				))}
+			</PopoverContent>
+		</Popover>
 	);
 }
 
@@ -947,17 +962,11 @@ export function ViewSettingsPanel({
 							</SettingRow>
 
 							<SettingRow label="Sort by">
-								<select
+								<DynamicSelect
 									value={sortByValue}
-									onChange={(e) => update({ sort_by: e.target.value })}
-									className="flex-1 cursor-pointer rounded-md border border-border/30 bg-background px-2 py-1 text-xs font-medium outline-none transition-all focus:border-primary/50 focus:ring-1 focus:ring-primary/20 min-w-0"
-								>
-									{sortByOpts.map((o) => (
-										<option key={o.key} value={o.key}>
-											{o.label}
-										</option>
-									))}
-								</select>
+									options={sortByOpts}
+									onChange={(v) => update({ sort_by: v })}
+								/>
 							</SettingRow>
 
 							<SettingRow label="Field sum">


### PR DESCRIPTION
## Summary

Consolidates the task-type badge/dropdown into one reusable `TaskTypeSelector` component, replacing five near-identical Popover/DropdownMenu implementations duplicated across the task list, board, properties panel, and subtask views. Also brings `view-settings-panel.tsx`'s native `<select>` dropdowns in line with the rest of the app's selector styling.

- **`task-type-selector.tsx`** (new) — shared badge + dropdown for picking a task's type, with a read-only badge mode for non-editable contexts.
- `task-row.tsx`, `add-task-row.tsx`, `properties-panel.tsx`, and `subtask-row.tsx` now render `TaskTypeSelector` instead of their own inline popover markup.
- `add-task-row.tsx` gains `label`/`placeholder` props so `subtasks-section.tsx` can reuse it for "Add subtask" instead of a bespoke inline form, removing ~100 lines of duplicated state and markup.
- `view-settings-panel.tsx`'s `DynamicSelect` and the "Sort by" control now use a Popover-based dropdown with a checkmark for the selected option, instead of a native `<select>`, matching the styling used everywhere else.
- Widened the "Type" column in the task list (`w-16` → `w-28`) to fit the new badge.

Net effect: -140 lines, no functional changes besides the `<select>` → custom-dropdown swap in view settings.
