### PR TITLE
feat: enhancements for oversized plugin payload handling

### DIFF
--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -93,3 +93,7 @@ PLUGINS_S3_PREFIX=plugins
 # Public GitHub marketplace catalog URL (raw JSON)
 PLUGINS_MARKETPLACE_CATALOG_URL=https://raw.githubusercontent.com/Paca-AI/paca-plugins/master/catalog/plugins.json
 PLUGINS_MARKETPLACE_TIMEOUT=20s
+# Resource limits enforced on plugin WASM execution.
+PLUGINS_MAX_CALL_DURATION=5s
+PLUGINS_MAX_MEMORY_PAGES=1024
+PLUGINS_MAX_REQUEST_BODY_BYTES=10485760

--- a/docs/plugins/backend-plugin-system.md
+++ b/docs/plugins/backend-plugin-system.md
@@ -249,6 +249,7 @@ Each WASM module instance is constrained by `wazero`'s resource controls:
 | CPU (via instruction counting) | Configurable; default prevents runaway loops |
 | Concurrent goroutines | N/A — WASM is single-threaded per instance |
 | DB connections | Plugins use the host's connection pool; max 5 concurrent queries per plugin |
+| Inbound HTTP request body | 10 MB per request to a plugin route; larger requests are rejected with `413` before reaching the plugin |
 
 Limits are configurable in the server config under `plugins.limits`.
 
@@ -277,4 +278,5 @@ plugins:
 - All DB host functions enforce **project-scope isolation** — a plugin enabled for project A cannot query project B data.
 - Plugin WASM binaries should be **signed** by the publisher. The host verifies the signature against a public key stored in the plugin manifest before loading. (v1: signature check is enforced for third-party plugins; first-party plugins bypass in dev mode.)
 - WASM execution errors are caught by wazero and converted to 500 responses; the host never panics due to a plugin crash.
+- Inbound request bodies are capped (see Resource Limits) before being handed to a plugin. Plugin SDK allocators are simple bump allocators with no bounds checking of their own, so an oversized payload would otherwise advance a plugin's allocator cursor past the end of its memory; the host always resets a plugin's allocator after each call, including on failure, so a single bad request cannot leave an instance unable to serve later ones.
 - Secrets (e.g., API keys the plugin needs) are stored encrypted in the host's secrets store and passed to the plugin through `paca.config_get` — never baked into the WASM binary.

--- a/docs/plugins/backend-plugin-system.md
+++ b/docs/plugins/backend-plugin-system.md
@@ -251,7 +251,13 @@ Each WASM module instance is constrained by `wazero`'s resource controls:
 | DB connections | Plugins use the host's connection pool; max 5 concurrent queries per plugin |
 | Inbound HTTP request body | 10 MB per request to a plugin route; larger requests are rejected with `413` before reaching the plugin |
 
-Limits are configurable in the server config under `plugins.limits`.
+Limits are configurable via environment variables (see `services/api/.env.example`):
+
+| Variable | Default | Controls |
+|---|---|---|
+| `PLUGINS_MAX_CALL_DURATION` | `5s` | Max time for a single plugin function call |
+| `PLUGINS_MAX_MEMORY_PAGES` | `1024` (64 MiB) | Max WASM linear-memory pages per module instance |
+| `PLUGINS_MAX_REQUEST_BODY_BYTES` | `10485760` (10 MiB) | Max inbound HTTP request body / event payload size |
 
 ## Plugin Storage Location
 

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -56,3 +56,7 @@ PLUGINS_MCP_DIR=./plugins/local/mcp
 PLUGINS_S3_PREFIX=plugins
 PLUGINS_MARKETPLACE_CATALOG_URL=https://raw.githubusercontent.com/Paca-AI/paca-plugins/master/catalog/plugins.json
 PLUGINS_MARKETPLACE_TIMEOUT=20s
+# Resource limits enforced on plugin WASM execution.
+PLUGINS_MAX_CALL_DURATION=5s
+PLUGINS_MAX_MEMORY_PAGES=1024
+PLUGINS_MAX_REQUEST_BODY_BYTES=10485760

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -241,6 +241,8 @@ const (
 	CodePluginAlreadyUpToDate Code = "PLUGIN_ALREADY_UP_TO_DATE"
 	// CodePluginDowngradeNotAllowed indicates the marketplace version is older than the installed version.
 	CodePluginDowngradeNotAllowed Code = "PLUGIN_DOWNGRADE_NOT_ALLOWED"
+	// CodePayloadTooLarge indicates the request body exceeds the server's size limit.
+	CodePayloadTooLarge Code = "PAYLOAD_TOO_LARGE"
 
 	// --- Agent errors -------------------------------------------------------
 

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -213,7 +213,11 @@ func New(cfg *config.Config) (*App, error) {
 			"ENCRYPTION_KEY": cfg.Security.EncryptionKey,
 			"PUBLIC_URL":     cfg.Server.PublicURL,
 		},
-	}, pluginrt.DefaultResourceLimits(), log)
+	}, pluginrt.ResourceLimits{
+		MaxCallDuration:     cfg.Plugins.Limits.MaxCallDuration,
+		MaxMemoryPages:      cfg.Plugins.Limits.MaxMemoryPages,
+		MaxRequestBodyBytes: cfg.Plugins.Limits.MaxRequestBodyBytes,
+	}, log)
 	marketplaceClient := pluginrt.NewMarketplaceClient(cfg.Plugins.MarketplaceCatalogURL, cfg.Plugins.MarketplaceTimeout)
 	installerHTTPClient := &http.Client{Timeout: cfg.Plugins.MarketplaceTimeout}
 	pluginInstaller := pluginrt.NewInstaller(cfg.Plugins.WASMDir, cfg.Plugins.FrontendDir, cfg.Plugins.MCPDir, installerHTTPClient, log)

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -122,6 +122,25 @@ type PluginsConfig struct {
 	// MarketplaceTimeout is the HTTP timeout used when fetching marketplace
 	// metadata and artifacts.
 	MarketplaceTimeout time.Duration
+
+	// Limits holds resource limits enforced on plugin WASM execution.
+	Limits PluginLimitsConfig
+}
+
+// PluginLimitsConfig holds resource limits enforced on plugin WASM module
+// execution. Mirrors platform/plugin.ResourceLimits; see that type's field
+// docs for why each limit exists.
+type PluginLimitsConfig struct {
+	// MaxCallDuration is the maximum time allowed for a single plugin
+	// function call.
+	MaxCallDuration time.Duration
+	// MaxMemoryPages is the maximum number of 64-KiB WASM linear-memory pages
+	// a plugin module may allocate.
+	MaxMemoryPages uint32
+	// MaxRequestBodyBytes is the maximum size of an inbound HTTP request body
+	// that may be proxied to a plugin route, and of an event payload
+	// dispatched to a plugin. 0 means "no limit".
+	MaxRequestBodyBytes int64
 }
 
 // SecurityConfig holds secrets used by first-party and plugin features.

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -82,6 +82,20 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("config: PLUGINS_MARKETPLACE_TIMEOUT: %w", err)
 	}
 
+	// Defaults here must match pluginrt.DefaultResourceLimits().
+	pluginMaxCallDuration, err := parseDuration(env("PLUGINS_MAX_CALL_DURATION", "5s"))
+	if err != nil {
+		return nil, fmt.Errorf("config: PLUGINS_MAX_CALL_DURATION: %w", err)
+	}
+	pluginMaxMemoryPages, err := parseUint32(env("PLUGINS_MAX_MEMORY_PAGES", "1024"))
+	if err != nil {
+		return nil, fmt.Errorf("config: PLUGINS_MAX_MEMORY_PAGES: %w", err)
+	}
+	pluginMaxRequestBodyBytes, err := parseInt64(env("PLUGINS_MAX_REQUEST_BODY_BYTES", "10485760"))
+	if err != nil {
+		return nil, fmt.Errorf("config: PLUGINS_MAX_REQUEST_BODY_BYTES: %w", err)
+	}
+
 	adminUser, err := requireEnv("ADMIN_USERNAME")
 	if err != nil {
 		errs = append(errs, err)
@@ -175,6 +189,11 @@ func Load() (*Config, error) {
 			S3Prefix:              env("PLUGINS_S3_PREFIX", "plugins"),
 			MarketplaceCatalogURL: env("PLUGINS_MARKETPLACE_CATALOG_URL", "https://raw.githubusercontent.com/Paca-AI/paca-plugins/master/catalog/plugins.json"),
 			MarketplaceTimeout:    marketplaceTimeout,
+			Limits: PluginLimitsConfig{
+				MaxCallDuration:     pluginMaxCallDuration,
+				MaxMemoryPages:      pluginMaxMemoryPages,
+				MaxRequestBodyBytes: pluginMaxRequestBodyBytes,
+			},
 		},
 		AIAgentURL: env("AI_AGENT_URL", "http://ai-agent:8080"),
 	}, nil
@@ -203,4 +222,20 @@ func parseDuration(s string) (time.Duration, error) {
 		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
 	}
 	return d, nil
+}
+
+func parseUint32(s string) (uint32, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid uint32 %q: %w", s, err)
+	}
+	return uint32(v), nil
+}
+
+func parseInt64(s string) (int64, error) {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid int64 %q: %w", s, err)
+	}
+	return v, nil
 }

--- a/services/api/internal/config/load_test.go
+++ b/services/api/internal/config/load_test.go
@@ -46,6 +46,37 @@ func TestParseDuration(t *testing.T) {
 	}
 }
 
+func TestParseUint32(t *testing.T) {
+	v, err := parseUint32("1024")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 1024 {
+		t.Fatalf("expected 1024, got %d", v)
+	}
+
+	if _, err := parseUint32("not-a-uint"); err == nil {
+		t.Fatal("expected parse error")
+	}
+	if _, err := parseUint32("-1"); err == nil {
+		t.Fatal("expected parse error for negative value")
+	}
+}
+
+func TestParseInt64(t *testing.T) {
+	v, err := parseInt64("10485760")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 10485760 {
+		t.Fatalf("expected 10485760, got %d", v)
+	}
+
+	if _, err := parseInt64("not-an-int"); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
 func TestLoad_Success(t *testing.T) {
 	t.Setenv("ENV", "test")
 	t.Setenv("PORT", "9090")
@@ -120,6 +151,65 @@ func TestLoad_InvalidBoolOrDuration(t *testing.T) {
 	t.Setenv("JWT_ACCESS_TTL", "invalid")
 	if _, err := Load(); err == nil {
 		t.Fatal("expected duration parse error")
+	}
+}
+
+func TestLoad_PluginLimits_Defaults(t *testing.T) {
+	setLoadDefaults(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Plugins.Limits.MaxCallDuration != 5*time.Second {
+		t.Fatalf("expected default MaxCallDuration 5s, got %v", cfg.Plugins.Limits.MaxCallDuration)
+	}
+	if cfg.Plugins.Limits.MaxMemoryPages != 1024 {
+		t.Fatalf("expected default MaxMemoryPages 1024, got %d", cfg.Plugins.Limits.MaxMemoryPages)
+	}
+	if cfg.Plugins.Limits.MaxRequestBodyBytes != 10*1024*1024 {
+		t.Fatalf("expected default MaxRequestBodyBytes 10MiB, got %d", cfg.Plugins.Limits.MaxRequestBodyBytes)
+	}
+}
+
+func TestLoad_PluginLimits_Custom(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("PLUGINS_MAX_CALL_DURATION", "30s")
+	t.Setenv("PLUGINS_MAX_MEMORY_PAGES", "2048")
+	t.Setenv("PLUGINS_MAX_REQUEST_BODY_BYTES", "1048576")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Plugins.Limits.MaxCallDuration != 30*time.Second {
+		t.Fatalf("expected MaxCallDuration 30s, got %v", cfg.Plugins.Limits.MaxCallDuration)
+	}
+	if cfg.Plugins.Limits.MaxMemoryPages != 2048 {
+		t.Fatalf("expected MaxMemoryPages 2048, got %d", cfg.Plugins.Limits.MaxMemoryPages)
+	}
+	if cfg.Plugins.Limits.MaxRequestBodyBytes != 1048576 {
+		t.Fatalf("expected MaxRequestBodyBytes 1048576, got %d", cfg.Plugins.Limits.MaxRequestBodyBytes)
+	}
+}
+
+func TestLoad_PluginLimits_InvalidValues(t *testing.T) {
+	setLoadDefaults(t)
+	t.Setenv("PLUGINS_MAX_CALL_DURATION", "not-a-duration")
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error for invalid PLUGINS_MAX_CALL_DURATION")
+	}
+
+	setLoadDefaults(t)
+	t.Setenv("PLUGINS_MAX_MEMORY_PAGES", "not-a-uint")
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error for invalid PLUGINS_MAX_MEMORY_PAGES")
+	}
+
+	setLoadDefaults(t)
+	t.Setenv("PLUGINS_MAX_REQUEST_BODY_BYTES", "not-an-int")
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error for invalid PLUGINS_MAX_REQUEST_BODY_BYTES")
 	}
 }
 

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -256,8 +256,8 @@ func (r *Runtime) HandleRequest(ctx context.Context, pluginName string, reqPaylo
 		return nil, fmt.Errorf("plugin %q not loaded", pluginName)
 	}
 
-	if max := r.limits.MaxRequestBodyBytes; max > 0 && int64(len(reqPayload)) > max {
-		return nil, fmt.Errorf("plugin %q: request payload of %d bytes exceeds limit of %d bytes", pluginName, len(reqPayload), max)
+	if maxBytes := r.limits.MaxRequestBodyBytes; maxBytes > 0 && int64(len(reqPayload)) > maxBytes {
+		return nil, fmt.Errorf("plugin %q: request payload of %d bytes exceeds limit of %d bytes", pluginName, len(reqPayload), maxBytes)
 	}
 
 	fn := inst.mod.ExportedFunction("HandleRequest")

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -30,13 +30,23 @@ type ResourceLimits struct {
 	// MaxMemoryPages is the maximum number of 64-KiB WASM linear-memory pages
 	// a plugin module may allocate.  0 means "use wazero default".
 	MaxMemoryPages uint32
+	// MaxRequestBodyBytes is the maximum size of an inbound HTTP request
+	// payload (as handed to HandleRequest, after JSON envelope encoding) that
+	// the host will attempt to write into a plugin's linear memory.  Plugin
+	// allocators are simple bump allocators with no bounds checking of their
+	// own; handing them a payload larger than the module's memory advances
+	// their internal cursor past the end of memory before the host's write
+	// fails, which would otherwise leave the plugin instance permanently
+	// unable to serve any further request.  0 means "no limit".
+	MaxRequestBodyBytes int64
 }
 
 // DefaultResourceLimits returns conservative defaults for plugin execution.
 func DefaultResourceLimits() ResourceLimits {
 	return ResourceLimits{
-		MaxCallDuration: 5 * time.Second,
-		MaxMemoryPages:  1024, // 64 MiB
+		MaxCallDuration:     5 * time.Second,
+		MaxMemoryPages:      1024,             // 64 MiB
+		MaxRequestBodyBytes: 10 * 1024 * 1024, // 10 MiB
 	}
 }
 
@@ -120,6 +130,13 @@ func NewRuntime(store *Store, services HostServices, limits ResourceLimits, log 
 		log:      log,
 		plugins:  make(map[string]*pluginInstance),
 	}
+}
+
+// MaxRequestBodyBytes returns the configured request-payload size limit so
+// HTTP transport code can reject oversized bodies before they ever reach a
+// plugin's WASM memory.  0 means "no limit".
+func (r *Runtime) MaxRequestBodyBytes() int64 {
+	return r.limits.MaxRequestBodyBytes
 }
 
 // LoadAll instantiates wazero modules for every enabled plugin in the list.
@@ -239,10 +256,39 @@ func (r *Runtime) HandleRequest(ctx context.Context, pluginName string, reqPaylo
 		return nil, fmt.Errorf("plugin %q not loaded", pluginName)
 	}
 
+	if max := r.limits.MaxRequestBodyBytes; max > 0 && int64(len(reqPayload)) > max {
+		return nil, fmt.Errorf("plugin %q: request payload of %d bytes exceeds limit of %d bytes", pluginName, len(reqPayload), max)
+	}
+
 	fn := inst.mod.ExportedFunction("HandleRequest")
 	if fn == nil {
 		return nil, fmt.Errorf("plugin %q: HandleRequest not exported", pluginName)
 	}
+
+	// Hold the per-instance lock for the entire interaction, including the
+	// initial write. wazero module calls are not safe to interleave: two
+	// concurrent malloc calls into the same instance can race on the
+	// plugin's bump-allocator cursor the same way an oversized payload does
+	// below.
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+
+	// Always give the plugin's allocator a chance to reset, even if a step
+	// below fails. A plugin's malloc export is a bump allocator with no
+	// bounds checking: it advances its internal cursor unconditionally, so a
+	// write that the host rejects as out-of-bounds still leaves that cursor
+	// corrupted. Without this reset, every later call computes addresses
+	// from the corrupted cursor and fails too, permanently "poisoning" the
+	// instance after a single oversized request.
+	defer func() {
+		resetFn := inst.mod.ExportedFunction("ResetAllocator")
+		if resetFn == nil {
+			return
+		}
+		resetCtx, cancel := context.WithTimeout(context.Background(), r.limits.MaxCallDuration)
+		_, _ = resetFn.Call(resetCtx) // Best-effort; ignore errors
+		cancel()
+	}()
 
 	// Write the request payload into the plugin's linear memory.
 	ptrLen, err := writeToMemory(inst.mod, reqPayload)
@@ -250,17 +296,14 @@ func (r *Runtime) HandleRequest(ctx context.Context, pluginName string, reqPaylo
 		return nil, fmt.Errorf("plugin %q: write request: %w", pluginName, err)
 	}
 
-	inst.mu.Lock()
 	callCtx, cancel := context.WithTimeout(ctx, r.limits.MaxCallDuration)
 	results, callErr := fn.Call(callCtx, ptrLen[0], ptrLen[1])
 	cancel()
 
 	if callErr != nil {
-		inst.mu.Unlock()
 		return nil, fmt.Errorf("plugin %q: HandleRequest: %w", pluginName, callErr)
 	}
 	if len(results) < 1 {
-		inst.mu.Unlock()
 		return nil, fmt.Errorf("plugin %q: HandleRequest returned wrong number of values", pluginName)
 	}
 
@@ -268,14 +311,6 @@ func (r *Runtime) HandleRequest(ctx context.Context, pluginName string, reqPaylo
 	outPtr := uint64(combined) >> 32
 	outLen := uint64(combined) & 0xFFFFFFFF
 	resp, readErr := readFromMemory(inst.mod, outPtr, outLen)
-
-	// Reset the allocator before releasing the mutex so the next caller cannot
-	// start writing into mallocBuffer while we are still reading the response.
-	if resetFn := inst.mod.ExportedFunction("ResetAllocator"); resetFn != nil {
-		_, _ = resetFn.Call(ctx) // Best-effort; ignore errors
-	}
-	inst.mu.Unlock()
-
 	if readErr != nil {
 		return nil, readErr
 	}
@@ -305,28 +340,48 @@ func (r *Runtime) EmitEvent(ctx context.Context, topic string, payload any) {
 	r.mu.RUnlock()
 
 	for _, inst := range instances {
-		fn := inst.mod.ExportedFunction("HandleEvent")
-		if fn == nil {
-			continue
-		}
-		ptrLen, err := writeToMemory(inst.mod, data)
-		if err != nil {
-			r.log.Error("plugin: write event payload", "name", inst.plugin.Name, "error", err)
-			continue
-		}
-		topicBytes := []byte(topic)
-		topicPtrLen, err := writeToMemory(inst.mod, topicBytes)
-		if err != nil {
-			r.log.Error("plugin: write topic", "name", inst.plugin.Name, "error", err)
-			continue
-		}
-
-		inst.mu.Lock()
-		callCtx, cancel := context.WithTimeout(ctx, r.limits.MaxCallDuration)
-		_, _ = fn.Call(callCtx, topicPtrLen[0], topicPtrLen[1], ptrLen[0], ptrLen[1])
-		cancel()
-		inst.mu.Unlock()
+		r.dispatchEvent(ctx, inst, topic, data)
 	}
+}
+
+// dispatchEvent invokes a single plugin instance's HandleEvent export. It
+// holds the instance lock for the full write+call+reset cycle, mirroring
+// HandleRequest: concurrent calls into the same module must not interleave
+// malloc invocations, and the allocator must be reset on every exit path so
+// a write the host rejects as out-of-bounds cannot leave the plugin's bump
+// allocator cursor permanently corrupted.
+func (r *Runtime) dispatchEvent(ctx context.Context, inst *pluginInstance, topic string, data []byte) {
+	fn := inst.mod.ExportedFunction("HandleEvent")
+	if fn == nil {
+		return
+	}
+
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	defer func() {
+		resetFn := inst.mod.ExportedFunction("ResetAllocator")
+		if resetFn == nil {
+			return
+		}
+		resetCtx, cancel := context.WithTimeout(context.Background(), r.limits.MaxCallDuration)
+		_, _ = resetFn.Call(resetCtx) // Best-effort; ignore errors
+		cancel()
+	}()
+
+	ptrLen, err := writeToMemory(inst.mod, data)
+	if err != nil {
+		r.log.Error("plugin: write event payload", "name", inst.plugin.Name, "error", err)
+		return
+	}
+	topicPtrLen, err := writeToMemory(inst.mod, []byte(topic))
+	if err != nil {
+		r.log.Error("plugin: write topic", "name", inst.plugin.Name, "error", err)
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, r.limits.MaxCallDuration)
+	_, _ = fn.Call(callCtx, topicPtrLen[0], topicPtrLen[1], ptrLen[0], ptrLen[1])
+	cancel()
 }
 
 // PluginRoutes returns the Gin-compatible route definitions for the named plugin.

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -30,14 +30,15 @@ type ResourceLimits struct {
 	// MaxMemoryPages is the maximum number of 64-KiB WASM linear-memory pages
 	// a plugin module may allocate.  0 means "use wazero default".
 	MaxMemoryPages uint32
-	// MaxRequestBodyBytes is the maximum size of an inbound HTTP request
-	// payload (as handed to HandleRequest, after JSON envelope encoding) that
-	// the host will attempt to write into a plugin's linear memory.  Plugin
-	// allocators are simple bump allocators with no bounds checking of their
-	// own; handing them a payload larger than the module's memory advances
-	// their internal cursor past the end of memory before the host's write
-	// fails, which would otherwise leave the plugin instance permanently
-	// unable to serve any further request.  0 means "no limit".
+	// MaxRequestBodyBytes is the maximum size of a payload that the host will
+	// attempt to write into a plugin's linear memory: an inbound HTTP request
+	// body (as handed to HandleRequest, after JSON envelope encoding) or an
+	// event payload (as handed to dispatchEvent).  Plugin allocators are
+	// simple bump allocators with no bounds checking of their own; handing
+	// them a payload larger than the module's memory advances their internal
+	// cursor past the end of memory before the host's write fails, which
+	// would otherwise leave the plugin instance permanently unable to serve
+	// any further request.  0 means "no limit".
 	MaxRequestBodyBytes int64
 }
 
@@ -353,6 +354,12 @@ func (r *Runtime) EmitEvent(ctx context.Context, topic string, payload any) {
 func (r *Runtime) dispatchEvent(ctx context.Context, inst *pluginInstance, topic string, data []byte) {
 	fn := inst.mod.ExportedFunction("HandleEvent")
 	if fn == nil {
+		return
+	}
+
+	if maxBytes := r.limits.MaxRequestBodyBytes; maxBytes > 0 && int64(len(data)) > maxBytes {
+		r.log.Warn("plugin: event payload exceeds size limit, dropping",
+			"name", inst.plugin.Name, "topic", topic, "size", len(data), "limit", maxBytes)
 		return
 	}
 

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -1,0 +1,176 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+)
+
+const testPluginName = "test.poison"
+
+var (
+	poisonWasmOnce sync.Once
+	poisonWasmPath string
+	poisonWasmErr  error
+)
+
+// buildPoisonFixture compiles testdata/poisonplugin into a WASI-reactor wasm
+// binary the first time it's needed, then reuses the result for the rest of
+// the test binary's run. The compiled binary isn't committed to the repo
+// (the project's .gitignore excludes *.wasm everywhere), so it's built here
+// on demand with the standard Go toolchain: GOOS=wasip1 GOARCH=wasm
+// cross-compilation needs nothing beyond the Go distribution already
+// required to run these tests.
+func buildPoisonFixture(t *testing.T) string {
+	t.Helper()
+	poisonWasmOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "poisonplugin-*")
+		if err != nil {
+			poisonWasmErr = err
+			return
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			poisonWasmErr = err
+			return
+		}
+		out := filepath.Join(dir, "poison.wasm")
+		cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, "./testdata/poisonplugin")
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
+		if output, buildErr := cmd.CombinedOutput(); buildErr != nil {
+			poisonWasmErr = fmt.Errorf("build poison fixture: %w: %s", buildErr, output)
+			return
+		}
+		poisonWasmPath = out
+	})
+	if poisonWasmErr != nil {
+		t.Fatalf("build poison fixture: %v", poisonWasmErr)
+	}
+	return poisonWasmPath
+}
+
+// loadPoisonPlugin compiles (see buildPoisonFixture) and loads the poison
+// fixture into a fresh Runtime. The fixture's malloc export is an
+// intentionally unsafe bump allocator -- it advances its cursor with no
+// bounds check, the same shape a real plugin SDK allocator has -- so tests
+// can deterministically trigger the out-of-bounds write that used to poison
+// plugin instances.
+func loadPoisonPlugin(t *testing.T, limits ResourceLimits) *Runtime {
+	t.Helper()
+
+	wasmPath := buildPoisonFixture(t)
+	wasmBytes, err := os.ReadFile(wasmPath)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, testPluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "backend.wasm"), wasmBytes, 0o644); err != nil {
+		t.Fatalf("write fixture wasm: %v", err)
+	}
+
+	store := &Store{cfg: StoreConfig{Store: "local", WASMDir: dir}}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rt := NewRuntime(store, HostServices{}, limits, log)
+
+	p := plugindom.Plugin{
+		Name:    testPluginName,
+		Enabled: true,
+		Manifest: plugindom.PluginManifest{
+			Backend: &plugindom.BackendManifest{},
+		},
+	}
+	ctx := context.Background()
+	if err := rt.Load(ctx, p); err != nil {
+		t.Fatalf("load fixture plugin: %v", err)
+	}
+	t.Cleanup(func() { rt.Unload(ctx, testPluginName) })
+	return rt
+}
+
+// TestHandleRequest_OversizedPayload_RejectedWithoutTouchingPlugin pins the
+// fast path: when a payload exceeds ResourceLimits.MaxRequestBodyBytes,
+// HandleRequest must reject it before ever calling the plugin's malloc
+// export. A normal request right after must still succeed, proving the
+// rejected call left no trace in the plugin's allocator state.
+func TestHandleRequest_OversizedPayload_RejectedWithoutTouchingPlugin(t *testing.T) {
+	limits := DefaultResourceLimits()
+	limits.MaxRequestBodyBytes = 1024 // far smaller than the fixture's actual memory
+	rt := loadPoisonPlugin(t, limits)
+	ctx := context.Background()
+
+	oversized := make([]byte, 2048)
+	if _, err := rt.HandleRequest(ctx, testPluginName, oversized); err == nil {
+		t.Fatal("expected oversized request to be rejected")
+	}
+
+	if _, err := rt.HandleRequest(ctx, testPluginName, []byte("hello")); err != nil {
+		t.Fatalf("expected normal request to succeed after rejection, got: %v", err)
+	}
+}
+
+// TestHandleRequest_AllocatorFailure_RecoveredByReset reproduces the
+// reported bug directly: with the pre-check disabled, an oversized payload
+// reaches wazero's own memory-bounds check inside writeToMemory. Before the
+// fix, HandleRequest returned that error without ever calling
+// ResetAllocator, so the plugin's bump-allocator cursor stayed corrupted and
+// every later call -- including tiny, well-formed ones -- failed the same
+// way forever. This test fails on the old code and passes on the fix.
+func TestHandleRequest_AllocatorFailure_RecoveredByReset(t *testing.T) {
+	limits := DefaultResourceLimits()
+	limits.MaxRequestBodyBytes = 0 // disabled, so the write reaches wazero's bounds check
+	rt := loadPoisonPlugin(t, limits)
+	ctx := context.Background()
+
+	huge := make([]byte, 200*1024*1024) // far beyond the module's actual linear memory
+	if _, err := rt.HandleRequest(ctx, testPluginName, huge); err == nil {
+		t.Fatal("expected the oversized write to fail at the wazero memory-bounds check")
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := rt.HandleRequest(ctx, testPluginName, []byte("hi")); err != nil {
+			t.Fatalf("call %d after the oversized request failed -- instance still poisoned: %v", i, err)
+		}
+	}
+}
+
+// TestHandleRequest_Concurrent_DoesNotCorruptSharedInstance pins the
+// lock-ordering fix: writeToMemory (which calls the plugin's malloc export)
+// must happen while holding the per-instance lock, not before acquiring it,
+// since wazero module calls are not safe to interleave. Run with -race.
+func TestHandleRequest_Concurrent_DoesNotCorruptSharedInstance(t *testing.T) {
+	rt := loadPoisonPlugin(t, DefaultResourceLimits())
+	ctx := context.Background()
+
+	const workers = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := rt.HandleRequest(ctx, testPluginName, []byte("concurrent"))
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent HandleRequest failed: %v", err)
+		}
+	}
+}

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -43,7 +43,7 @@ func buildPoisonFixture(t *testing.T) string {
 			return
 		}
 		out := filepath.Join(dir, "poison.wasm")
-		cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, "./testdata/poisonplugin")
+		cmd := exec.CommandContext(t.Context(), "go", "build", "-buildmode=c-shared", "-o", out, "./testdata/poisonplugin")
 		cmd.Dir = wd
 		cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
 		if output, buildErr := cmd.CombinedOutput(); buildErr != nil {

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -66,6 +68,14 @@ func buildPoisonFixture(t *testing.T) string {
 // plugin instances.
 func loadPoisonPlugin(t *testing.T, limits ResourceLimits) *Runtime {
 	t.Helper()
+	return loadPoisonPluginWithLogger(t, limits, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// loadPoisonPluginWithLogger is loadPoisonPlugin with an injectable logger, so
+// tests can assert on log output (e.g. the dispatchEvent size-limit warning)
+// without scraping stderr.
+func loadPoisonPluginWithLogger(t *testing.T, limits ResourceLimits, log *slog.Logger) *Runtime {
+	t.Helper()
 
 	wasmPath := buildPoisonFixture(t)
 	wasmBytes, err := os.ReadFile(wasmPath)
@@ -83,7 +93,6 @@ func loadPoisonPlugin(t *testing.T, limits ResourceLimits) *Runtime {
 	}
 
 	store := &Store{cfg: StoreConfig{Store: "local", WASMDir: dir}}
-	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	rt := NewRuntime(store, HostServices{}, limits, log)
 
 	p := plugindom.Plugin{
@@ -99,6 +108,15 @@ func loadPoisonPlugin(t *testing.T, limits ResourceLimits) *Runtime {
 	}
 	t.Cleanup(func() { rt.Unload(ctx, testPluginName) })
 	return rt
+}
+
+// instanceFor looks up the loaded poison-plugin instance directly, for tests
+// that need to call dispatchEvent (an unexported method) without going
+// through EmitEvent's topic-subscription filtering.
+func instanceFor(rt *Runtime, name string) *pluginInstance {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+	return rt.plugins[name]
 }
 
 // TestHandleRequest_OversizedPayload_RejectedWithoutTouchingPlugin pins the
@@ -144,6 +162,36 @@ func TestHandleRequest_AllocatorFailure_RecoveredByReset(t *testing.T) {
 		if _, err := rt.HandleRequest(ctx, testPluginName, []byte("hi")); err != nil {
 			t.Fatalf("call %d after the oversized request failed -- instance still poisoned: %v", i, err)
 		}
+	}
+}
+
+// TestDispatchEvent_OversizedPayload_RejectedWithoutTouchingPlugin mirrors
+// TestHandleRequest_OversizedPayload_RejectedWithoutTouchingPlugin for the
+// event-dispatch path: dispatchEvent must reject a payload over
+// ResourceLimits.MaxRequestBodyBytes before ever calling the plugin's malloc
+// export, rather than relying solely on the unconditional allocator reset to
+// recover afterward. A normal call right after must still succeed.
+func TestDispatchEvent_OversizedPayload_RejectedWithoutTouchingPlugin(t *testing.T) {
+	limits := DefaultResourceLimits()
+	limits.MaxRequestBodyBytes = 1024 // far smaller than the fixture's actual memory
+
+	var logBuf bytes.Buffer
+	rt := loadPoisonPluginWithLogger(t, limits, slog.New(slog.NewTextHandler(&logBuf, nil)))
+	inst := instanceFor(rt, testPluginName)
+	ctx := context.Background()
+
+	oversized := make([]byte, 2048)
+	rt.dispatchEvent(ctx, inst, "some.topic", oversized)
+
+	if !strings.Contains(logBuf.String(), "exceeds size limit") {
+		t.Fatalf("expected a size-limit warning to be logged, got: %s", logBuf.String())
+	}
+	if strings.Contains(logBuf.String(), "write event payload") {
+		t.Fatalf("dispatchEvent should reject before ever attempting to write into plugin memory, got: %s", logBuf.String())
+	}
+
+	if _, err := rt.HandleRequest(ctx, testPluginName, []byte("hello")); err != nil {
+		t.Fatalf("expected normal request to succeed after oversized event, got: %v", err)
 	}
 }
 

--- a/services/api/internal/platform/plugin/testdata/poisonplugin/main.go
+++ b/services/api/internal/platform/plugin/testdata/poisonplugin/main.go
@@ -1,0 +1,59 @@
+// Command poisonplugin is a minimal WASI-reactor fixture used by
+// runtime_test.go to exercise Runtime.HandleRequest against a real wazero
+// module instead of mocks.
+//
+// Its malloc export deliberately reproduces the allocator shape that a real
+// plugin SDK uses: a bump allocator that advances its cursor unconditionally,
+// with no bounds check against the module's actual memory size. That is what
+// lets an oversized request "poison" a plugin instance — see runtime.go's
+// HandleRequest doc comment for the full mechanism. This fixture lets the
+// test trigger that failure deterministically without depending on the real
+// (externally hosted) plugin-sdk-go allocator implementation.
+//
+// Rebuild after editing with:
+//
+//	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared \
+//	  -o ../poison.wasm .
+package main
+
+// offset is the bump allocator's cursor. Starting it away from 0 mirrors a
+// real plugin reserving low memory for its own static data.
+var offset uint32 = 4096
+
+// malloc returns the current cursor and advances it by size, with no check
+// against the module's actual memory size. The host (Runtime.HandleRequest)
+// is responsible for rejecting writes that would land out of bounds; this
+// fixture intentionally does not protect itself, since the bug under test is
+// about the host's behavior when that happens.
+//
+//go:wasmexport malloc
+func malloc(size uint32) uint32 {
+	ptr := offset
+	offset += size
+	return ptr
+}
+
+// ResetAllocator restores the cursor, simulating the per-call reset a real
+// plugin SDK performs so its arena can be reused by the next request.
+//
+//go:wasmexport ResetAllocator
+func resetAllocator() {
+	offset = 4096
+}
+
+// HandleRequest ignores the request payload and reports an empty response
+// (outPtr=0, outLen=0), which the host reads without touching memory. The
+// test only cares whether this call succeeds, not what it returns.
+//
+//go:wasmexport HandleRequest
+func handleRequest(ptr uint32, length uint32) uint64 {
+	return 0
+}
+
+// HandleEvent mirrors HandleRequest for the event-dispatch path.
+//
+//go:wasmexport HandleEvent
+func handleEvent(topicPtr uint32, topicLen uint32, payloadPtr uint32, payloadLen uint32) {
+}
+
+func main() {}

--- a/services/api/internal/transport/http/handler/plugin_handler.go
+++ b/services/api/internal/transport/http/handler/plugin_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -573,9 +574,19 @@ func (h *PluginHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Read request body.
+	// Read request body, capped so an oversized body can never reach the
+	// plugin's WASM memory (see Runtime.HandleRequest for why that matters).
+	if maxBody := h.runtime.MaxRequestBodyBytes(); maxBody > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBody)
+	}
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			presenter.Error(w, r, apierr.New(apierr.CodePayloadTooLarge,
+				fmt.Sprintf("request body exceeds the %d byte limit", maxBytesErr.Limit)))
+			return
+		}
 		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "failed to read request body"))
 		return
 	}

--- a/services/api/internal/transport/http/handler/plugin_handler_test.go
+++ b/services/api/internal/transport/http/handler/plugin_handler_test.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+	pluginrt "github.com/Paca-AI/api/internal/platform/plugin"
 	"github.com/Paca-AI/api/internal/transport/http/handler"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -22,9 +26,13 @@ import (
 type mockPluginSvc struct {
 	install                func(ctx context.Context, in plugindom.InstallInput) (*plugindom.Plugin, error)
 	updateExtensionSetting func(ctx context.Context, in plugindom.UpdateExtensionSettingInput) (*plugindom.PluginExtensionSetting, error)
+	listPlugins            func(ctx context.Context) ([]*plugindom.Plugin, error)
 }
 
-func (m *mockPluginSvc) ListPlugins(_ context.Context) ([]*plugindom.Plugin, error) {
+func (m *mockPluginSvc) ListPlugins(ctx context.Context) ([]*plugindom.Plugin, error) {
+	if m.listPlugins != nil {
+		return m.listPlugins(ctx)
+	}
 	return nil, nil
 }
 func (m *mockPluginSvc) InstallPlugin(ctx context.Context, in plugindom.InstallInput) (*plugindom.Plugin, error) {
@@ -124,5 +132,89 @@ func TestUpdateExtensionSetting_MissingExtensionPoint_Returns400(t *testing.T) {
 		map[string]any{"plugin_id": uuid.New(), "extension_point": ""})
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing extension_point, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ProxyRequest body-size limit
+// ---------------------------------------------------------------------------
+
+// newPluginProxyRouter mounts ProxyRequest the same way router.go does, on a
+// real *pluginrt.Runtime so its configured MaxRequestBodyBytes is enforced.
+// The runtime is never asked to Load a plugin: a request that is rejected
+// for being oversized must never reach Runtime.HandleRequest, so no WASM
+// module is needed to exercise that path.
+func newPluginProxyRouter(svc plugindom.Service, rt *pluginrt.Runtime) chi.Router {
+	h := handler.NewPluginHandler(svc, rt, nil)
+	r := chi.NewRouter()
+	r.Handle("/plugins/{pluginId}/*", http.HandlerFunc(h.ProxyRequest))
+	return r
+}
+
+func TestProxyRequest_OversizedBody_Returns413(t *testing.T) {
+	svc := &mockPluginSvc{
+		listPlugins: func(_ context.Context) ([]*plugindom.Plugin, error) {
+			return []*plugindom.Plugin{{
+				Name:    "test.plugin",
+				Enabled: true,
+				Manifest: plugindom.PluginManifest{
+					Backend: &plugindom.BackendManifest{
+						Routes: []plugindom.PluginRoute{
+							// Explicit empty Middlewares: skip host auth so the
+							// test can focus solely on the body-size check.
+							{Method: http.MethodPost, Path: "/echo", Middlewares: []plugindom.PluginRouteMiddleware{}},
+						},
+					},
+				},
+			}}, nil
+		},
+	}
+	rt := pluginrt.NewRuntime(nil, pluginrt.HostServices{}, pluginrt.ResourceLimits{
+		MaxCallDuration:     time.Second,
+		MaxRequestBodyBytes: 16,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	r := newPluginProxyRouter(svc, rt)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/plugins/test.plugin/echo", bytes.NewReader(make([]byte, 1024)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestProxyRequest_BodyWithinLimit_PassesSizeCheck(t *testing.T) {
+	svc := &mockPluginSvc{
+		listPlugins: func(_ context.Context) ([]*plugindom.Plugin, error) {
+			return []*plugindom.Plugin{{
+				Name:    "test.plugin",
+				Enabled: true,
+				Manifest: plugindom.PluginManifest{
+					Backend: &plugindom.BackendManifest{
+						Routes: []plugindom.PluginRoute{
+							{Method: http.MethodPost, Path: "/echo", Middlewares: []plugindom.PluginRouteMiddleware{}},
+						},
+					},
+				},
+			}}, nil
+		},
+	}
+	rt := pluginrt.NewRuntime(nil, pluginrt.HostServices{}, pluginrt.ResourceLimits{
+		MaxCallDuration:     time.Second,
+		MaxRequestBodyBytes: 16,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	r := newPluginProxyRouter(svc, rt)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/plugins/test.plugin/echo", bytes.NewReader(make([]byte, 4)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// The body itself is within the limit, so the request must fail past the
+	// size check -- on plugin dispatch (no WASM module loaded), not on 413.
+	if w.Code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected the size check to pass for a body within the limit, got 413: %s", w.Body.String())
 	}
 }

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -423,6 +423,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodePluginAlreadyUpToDate,
 		apierr.CodePluginDowngradeNotAllowed:
 		return http.StatusConflict
+	case apierr.CodePayloadTooLarge:
+		return http.StatusRequestEntityTooLarge
 	case apierr.CodeAgentNotFound,
 		apierr.CodeAgentTypeNotFound,
 		apierr.CodeAgentMCPServerNotFound,

--- a/services/api/test/e2e/plugin_runtime_test.go
+++ b/services/api/test/e2e/plugin_runtime_test.go
@@ -62,7 +62,7 @@ func buildEchoPluginFixture(t *testing.T) string {
 			return
 		}
 		out := filepath.Join(dir, "echo.wasm")
-		cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, "./testdata/echoplugin")
+		cmd := exec.CommandContext(t.Context(), "go", "build", "-buildmode=c-shared", "-o", out, "./testdata/echoplugin")
 		cmd.Dir = wd
 		cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
 		if output, buildErr := cmd.CombinedOutput(); buildErr != nil {

--- a/services/api/test/e2e/plugin_runtime_test.go
+++ b/services/api/test/e2e/plugin_runtime_test.go
@@ -1,0 +1,495 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Paca-AI/api/internal/platform/authz"
+	pluginrt "github.com/Paca-AI/api/internal/platform/plugin"
+	jwttoken "github.com/Paca-AI/api/internal/platform/token"
+	pgRepo "github.com/Paca-AI/api/internal/repository/postgres"
+	pluginsvc "github.com/Paca-AI/api/internal/service/plugin"
+	"github.com/Paca-AI/api/internal/transport/http/handler"
+	"github.com/Paca-AI/api/internal/transport/http/router"
+
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+)
+
+// ---------------------------------------------------------------------------
+// echoplugin fixture
+// ---------------------------------------------------------------------------
+//
+// Unlike plugin_test.go (which exercises only the plugin management API
+// against a nil runtime), these tests wire a real *pluginrt.Runtime backed
+// by a real wazero-loaded WASM module, so a request actually flows:
+// HTTP -> router -> PluginHandler.ProxyRequest -> Runtime.HandleRequest ->
+// wasm -> back. See testdata/echoplugin for the fixture's behavior.
+
+var (
+	echoWasmOnce sync.Once
+	echoWasmPath string
+	echoWasmErr  error
+)
+
+// buildEchoPluginFixture compiles testdata/echoplugin into a WASI-reactor
+// wasm binary the first time it's needed and reuses the result for the rest
+// of the test binary's run. It isn't committed to the repo (the project's
+// .gitignore excludes *.wasm everywhere), so it's built on demand with the
+// standard Go toolchain -- GOOS=wasip1 GOARCH=wasm cross-compilation needs
+// nothing beyond the Go distribution already required to run these tests.
+func buildEchoPluginFixture(t *testing.T) string {
+	t.Helper()
+	echoWasmOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "echoplugin-*")
+		if err != nil {
+			echoWasmErr = err
+			return
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			echoWasmErr = err
+			return
+		}
+		out := filepath.Join(dir, "echo.wasm")
+		cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, "./testdata/echoplugin")
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
+		if output, buildErr := cmd.CombinedOutput(); buildErr != nil {
+			echoWasmErr = fmt.Errorf("build echoplugin fixture: %w: %s", buildErr, output)
+			return
+		}
+		echoWasmPath = out
+	})
+	if echoWasmErr != nil {
+		t.Fatalf("build echoplugin fixture: %v", echoWasmErr)
+	}
+	return echoWasmPath
+}
+
+// ---------------------------------------------------------------------------
+// Runtime-backed plugin e2e environment
+// ---------------------------------------------------------------------------
+
+type pluginRuntimeE2EEnv struct {
+	base          string
+	client        *http.Client
+	env           *e2eEnv
+	pluginService plugindom.Service
+	runtime       *pluginrt.Runtime
+	wasmDir       string
+}
+
+// newPluginRuntimeE2EEnv wires a real *pluginrt.Runtime (instead of nil) into
+// the router, parameterized by limits so individual tests can configure a
+// small MaxRequestBodyBytes or MaxMemoryPages to exercise the size-limit and
+// allocator-recovery paths.
+func newPluginRuntimeE2EEnv(t *testing.T, limits pluginrt.ResourceLimits) *pluginRuntimeE2EEnv {
+	t.Helper()
+
+	env := newE2EEnv(t)
+	db := env.db
+
+	wasmDir := t.TempDir()
+	store, err := pluginrt.NewStore(env.ctx, pluginrt.StoreConfig{Store: "local", WASMDir: wasmDir})
+	if err != nil {
+		t.Fatalf("create plugin store: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	runtime := pluginrt.NewRuntime(store, pluginrt.HostServices{DB: db.DB, Log: log}, limits, log)
+
+	authzStore := pgRepo.NewAuthzPermissionStore(db)
+	pluginRepo := pgRepo.NewPluginRepository(db)
+	pluginService := pluginsvc.New(pluginRepo)
+
+	tm := jwttoken.New(e2eJWTSecret, e2eAccessTTL, e2eRefreshTTL)
+	authorizer := authz.NewAuthorizer(authzStore)
+
+	// WithRouteAuth wires the handler's own auth dependencies, used by
+	// ProxyRequest's per-route middleware policy (e.g. a plugin route
+	// declaring "authn" in its manifest) -- separate from the router-level
+	// Authn middleware that only guards the /admin/plugins management routes.
+	pluginHandler := handler.NewPluginHandler(pluginService, runtime, env.projectRepo).
+		WithRouteAuth(tm, nil, authorizer)
+
+	engine := router.New(router.Deps{
+		TokenManager: tm,
+		Authorizer:   authorizer,
+		Health:       handler.NewHealthHandler(),
+		Plugin:       pluginHandler,
+		Log:          log,
+	})
+
+	srv := httptest.NewServer(engine)
+	t.Cleanup(srv.Close)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar, Timeout: 30 * time.Second}
+
+	return &pluginRuntimeE2EEnv{
+		base:          srv.URL,
+		client:        client,
+		env:           env,
+		pluginService: pluginService,
+		runtime:       runtime,
+		wasmDir:       wasmDir,
+	}
+}
+
+func (p *pluginRuntimeE2EEnv) issueAdminToken(t *testing.T) string {
+	t.Helper()
+	seedUser(t, p.env, "plugin-rt-admin", "Admin1234!", "Plugin Runtime Admin")
+	admin, err := p.env.userRepo.FindByUsername(p.env.ctx, "plugin-rt-admin")
+	if err != nil {
+		t.Fatalf("find admin user: %v", err)
+	}
+	token, err := jwttoken.New(e2eJWTSecret, e2eAccessTTL, e2eRefreshTTL).
+		IssueAccess(admin.ID.String(), admin.Username, "ADMIN", "fam-plugin-rt-admin", false)
+	if err != nil {
+		t.Fatalf("issue admin token: %v", err)
+	}
+	return token
+}
+
+func (p *pluginRuntimeE2EEnv) issueUserToken(t *testing.T, username string) string {
+	t.Helper()
+	seedUser(t, p.env, username, "User1234!", "Plugin Runtime User")
+	u, err := p.env.userRepo.FindByUsername(p.env.ctx, username)
+	if err != nil {
+		t.Fatalf("find user: %v", err)
+	}
+	token, err := jwttoken.New(e2eJWTSecret, e2eAccessTTL, e2eRefreshTTL).
+		IssueAccess(u.ID.String(), u.Username, "USER", "fam-"+username, false)
+	if err != nil {
+		t.Fatalf("issue user token: %v", err)
+	}
+	return token
+}
+
+func (p *pluginRuntimeE2EEnv) doPlugin(t *testing.T, method, path, token string, body any) *http.Response {
+	t.Helper()
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(context.Background(), method, p.base+path, jsonBody(t, body))
+	} else {
+		req, err = http.NewRequestWithContext(context.Background(), method, p.base+path, http.NoBody)
+	}
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// doRawBody sends a request with a raw byte body instead of a JSON-encoded
+// one, needed for the large-request tests where the body's exact size
+// matters and must not be inflated/altered by JSON encoding.
+func (p *pluginRuntimeE2EEnv) doRawBody(t *testing.T, method, path, token string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), method, p.base+path, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// installAndLoad installs pluginName via the real admin HTTP API (proving
+// the install endpoint works end to end) with a manifest declaring the given
+// routes, then -- since a plain install only registers a DB row and never
+// touches the runtime (only InstallMarketplacePlugin/UpgradeMarketplacePlugin
+// and the process-startup LoadAll do) -- explicitly loads it into the
+// runtime, mirroring what happens for a real deployment after a restart.
+func (p *pluginRuntimeE2EEnv) installAndLoad(t *testing.T, token, pluginName string, routes []map[string]any, enabled bool) string {
+	t.Helper()
+
+	wasmBytes, err := os.ReadFile(buildEchoPluginFixture(t))
+	if err != nil {
+		t.Fatalf("read echoplugin fixture: %v", err)
+	}
+	pluginDir := filepath.Join(p.wasmDir, pluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin wasm dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "backend.wasm"), wasmBytes, 0o644); err != nil {
+		t.Fatalf("write plugin wasm: %v", err)
+	}
+
+	manifest := map[string]any{
+		"id":          pluginName,
+		"displayName": pluginName,
+		"version":     "1.0.0",
+		"backend": map[string]any{
+			"wasm":   "backend.wasm",
+			"routes": routes,
+		},
+	}
+	payload := map[string]any{
+		"name": pluginName, "version": "1.0.0", "manifest": manifest, "enabled": enabled,
+	}
+	resp := p.doPlugin(t, http.MethodPost, "/api/v1/admin/plugins", token, payload)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	var env envelope
+	decodeJSON(t, resp, &env)
+	data := assertDataMap(t, env)
+	id, _ := data["id"].(string)
+
+	plugins, err := p.pluginService.ListPlugins(p.env.ctx)
+	if err != nil {
+		t.Fatalf("list plugins: %v", err)
+	}
+	var found *plugindom.Plugin
+	for _, pl := range plugins {
+		if pl.Name == pluginName {
+			found = pl
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("installed plugin %q not found via ListPlugins", pluginName)
+	}
+
+	if found.Enabled {
+		if err := p.runtime.Load(p.env.ctx, *found); err != nil {
+			t.Fatalf("load plugin %q into runtime: %v", pluginName, err)
+		}
+		t.Cleanup(func() { p.runtime.Unload(context.Background(), pluginName) })
+	}
+
+	return id
+}
+
+func publicRoute(method, path string) map[string]any {
+	return map[string]any{"method": method, "path": path, "middlewares": []map[string]any{}}
+}
+
+func authnRoute(method, path string) map[string]any {
+	return map[string]any{
+		"method": method, "path": path,
+		"middlewares": []map[string]any{{"name": "authn"}},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Install -> real load -> serve a request
+// ---------------------------------------------------------------------------
+
+func TestE2EPluginRuntime_InstallAndLoad_ServesRequest(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-install", []map[string]any{
+		publicRoute(http.MethodGet, "/hello"),
+	}, true)
+
+	resp := p.doPlugin(t, http.MethodGet, "/api/v1/plugins/com.paca.rt-install/hello", "", nil)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+
+	var body map[string]string
+	decodeJSON(t, resp, &body)
+	if body["message"] != "hello from plugin" {
+		t.Errorf("unexpected plugin response: %v", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API calling
+// ---------------------------------------------------------------------------
+
+func TestE2EPluginRuntime_APICall_EchoesRequestBody(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-echo", []map[string]any{
+		publicRoute(http.MethodPost, "/echo"),
+	}, true)
+
+	payload := map[string]any{"hello": "world", "n": float64(42)}
+	resp := p.doPlugin(t, http.MethodPost, "/api/v1/plugins/com.paca.rt-echo/echo", "", payload)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+
+	var echoed map[string]any
+	decodeJSON(t, resp, &echoed)
+	if echoed["hello"] != "world" || echoed["n"] != float64(42) {
+		t.Errorf("expected echoed body to match request, got %v", echoed)
+	}
+}
+
+func TestE2EPluginRuntime_APICall_CallerIdentityPropagates(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+	adminToken := p.issueAdminToken(t)
+
+	p.installAndLoad(t, adminToken, "com.paca.rt-whoami", []map[string]any{
+		authnRoute(http.MethodGet, "/whoami"),
+	}, true)
+
+	userToken := p.issueUserToken(t, "plugin-rt-whoami-user")
+	resp := p.doPlugin(t, http.MethodGet, "/api/v1/plugins/com.paca.rt-whoami/whoami", userToken, nil)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+
+	var who map[string]string
+	decodeJSON(t, resp, &who)
+	if who["caller_role"] != "USER" {
+		t.Errorf("expected caller_role USER, got %v", who)
+	}
+	if who["user_id"] == "" {
+		t.Errorf("expected non-empty user_id, got %v", who)
+	}
+}
+
+func TestE2EPluginRuntime_APICall_AuthnRoute_RequiresToken(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-authn", []map[string]any{
+		authnRoute(http.MethodGet, "/whoami"),
+	}, true)
+
+	resp := p.doPlugin(t, http.MethodGet, "/api/v1/plugins/com.paca.rt-authn/whoami", "", nil)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusUnauthorized)
+}
+
+func TestE2EPluginRuntime_APICall_UnmatchedPath_PluginReturns404(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-nomatch", []map[string]any{
+		publicRoute(http.MethodGet, "/hello"),
+	}, true)
+
+	resp := p.doPlugin(t, http.MethodGet, "/api/v1/plugins/com.paca.rt-nomatch/does-not-exist", "", nil)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// Other cases: disabled / nonexistent plugin
+// ---------------------------------------------------------------------------
+
+func TestE2EPluginRuntime_DisabledPlugin_Returns404(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-disabled", []map[string]any{
+		publicRoute(http.MethodGet, "/hello"),
+	}, false) // enabled=false: never loaded into the runtime, same as production
+
+	resp := p.doPlugin(t, http.MethodGet, "/api/v1/plugins/com.paca.rt-disabled/hello", "", nil)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusNotFound)
+	assertErrorCode(t, resp, "PLUGIN_NOT_FOUND")
+}
+
+func TestE2EPluginRuntime_NonexistentPlugin_Returns404(t *testing.T) {
+	p := newPluginRuntimeE2EEnv(t, pluginrt.DefaultResourceLimits())
+
+	resp := p.doPlugin(t, http.MethodGet, "/api/v1/plugins/com.paca.does-not-exist/hello", "", nil)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusNotFound)
+	assertErrorCode(t, resp, "PLUGIN_NOT_FOUND")
+}
+
+// ---------------------------------------------------------------------------
+// Large request body
+// ---------------------------------------------------------------------------
+
+// TestE2EPluginRuntime_OversizedBody_Returns413AndStaysHealthy proves the
+// HTTP-edge defense end to end: a body over the configured limit is rejected
+// with 413 before it ever reaches the plugin, and the plugin keeps serving
+// normal requests afterward.
+func TestE2EPluginRuntime_OversizedBody_Returns413AndStaysHealthy(t *testing.T) {
+	limits := pluginrt.DefaultResourceLimits()
+	limits.MaxRequestBodyBytes = 1024
+	p := newPluginRuntimeE2EEnv(t, limits)
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-oversized", []map[string]any{
+		publicRoute(http.MethodPost, "/echo"),
+	}, true)
+
+	oversized := make([]byte, 4096)
+	resp := p.doRawBody(t, http.MethodPost, "/api/v1/plugins/com.paca.rt-oversized/echo", "", oversized)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusRequestEntityTooLarge)
+	assertErrorCode(t, resp, "PAYLOAD_TOO_LARGE")
+
+	// The plugin must still serve a normal request right after.
+	resp2 := p.doPlugin(t, http.MethodPost, "/api/v1/plugins/com.paca.rt-oversized/echo", "", map[string]any{"ok": true})
+	defer func() { _ = resp2.Body.Close() }()
+	assertStatus(t, resp2, http.StatusOK)
+}
+
+// TestE2EPluginRuntime_AllocatorRecovery_AfterOversizedWrite reproduces the
+// originally reported bug end to end: a request large enough to exceed the
+// plugin module's actual WASM memory (not just the HTTP-level cap, which is
+// disabled here) makes the host's write fail inside Runtime.HandleRequest.
+// Before the fix, that failure was returned without ever resetting the
+// plugin's bump allocator, permanently poisoning the instance -- every
+// request after, even a tiny one, failed the same way. This test fails
+// against the pre-fix runtime.go and passes against the fix.
+func TestE2EPluginRuntime_AllocatorRecovery_AfterOversizedWrite(t *testing.T) {
+	limits := pluginrt.ResourceLimits{
+		MaxCallDuration: 5 * time.Second,
+		// The echoplugin's actual WASM memory is ~7.25 MiB (116 pages) once
+		// loaded. 200 pages (12.5 MiB) is comfortably above that so the
+		// module still loads, while leaving room for a request that
+		// exceeds the module's real memory without exceeding this ceiling.
+		MaxMemoryPages:      200,
+		MaxRequestBodyBytes: 0, // disabled: this test targets the deeper wazero-level bounds check, not the HTTP-edge cap
+	}
+	p := newPluginRuntimeE2EEnv(t, limits)
+	token := p.issueAdminToken(t)
+
+	p.installAndLoad(t, token, "com.paca.rt-recovery", []map[string]any{
+		publicRoute(http.MethodPost, "/echo"),
+	}, true)
+
+	// 20 MiB comfortably exceeds both the module's actual ~7.25 MiB memory
+	// and the configured 12.5 MiB ceiling, so wazero's own bounds check
+	// rejects the write regardless of which limit is binding.
+	huge := make([]byte, 20*1024*1024)
+	resp := p.doRawBody(t, http.MethodPost, "/api/v1/plugins/com.paca.rt-recovery/echo", "", huge)
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected the oversized write to fail, got 200")
+	}
+
+	for i := 0; i < 3; i++ {
+		resp := p.doPlugin(t, http.MethodPost, "/api/v1/plugins/com.paca.rt-recovery/echo", "", map[string]any{"attempt": i})
+		status := resp.StatusCode
+		_ = resp.Body.Close()
+		if status != http.StatusOK {
+			t.Fatalf("request %d after the oversized write failed (instance still poisoned): got %d", i, status)
+		}
+	}
+}

--- a/services/api/test/e2e/testdata/echoplugin/main.go
+++ b/services/api/test/e2e/testdata/echoplugin/main.go
@@ -1,0 +1,145 @@
+// Command echoplugin is a small WASI-reactor fixture used by the plugin
+// runtime E2E tests to exercise a real wazero-loaded module through the full
+// HTTP stack, instead of mocking the runtime.
+//
+// It serves a handful of hardcoded routes (matched on the incoming request's
+// method+path) so tests can verify request/response plumbing end to end:
+//
+//	GET  .../hello   -> 200 {"message":"hello from plugin"}
+//	GET  .../whoami  -> 200 {"caller_id":..,"user_id":..,"caller_role":..,"project_id":..}
+//	POST .../echo    -> 200, body echoed back unchanged
+//	anything else    -> 404 {"error":"not found"}
+//
+// Its malloc export reuses the same intentionally unsafe bump-allocator
+// shape as services/api/internal/platform/plugin/testdata/poisonplugin: it
+// advances its cursor with no bounds check, so a request larger than the
+// module's actual memory still "succeeds" at the allocator level before the
+// host's write fails. That lets the large-request E2E tests reproduce the
+// allocator-poisoning bug (and its fix) through the real HTTP path, not just
+// at the Runtime unit-test layer.
+//
+// Rebuild after editing with:
+//
+//	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o ../echo.wasm .
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"unsafe"
+)
+
+// arena is the plugin's entire "heap". Real plugin SDKs size this much
+// larger; it's kept small here so tests can deliberately exceed it without
+// needing a multi-hundred-MB request.
+var arena [4 * 1024 * 1024]byte
+
+var offset uint32
+
+func arenaBase() uint32 {
+	return uint32(uintptr(unsafe.Pointer(&arena[0])))
+}
+
+// malloc returns the current cursor and advances it by size with no check
+// against the arena's actual capacity. See the package doc above.
+//
+//go:wasmexport malloc
+func malloc(size uint32) uint32 {
+	ptr := arenaBase() + offset
+	offset += size
+	return ptr
+}
+
+// ResetAllocator restores the cursor, mirroring the per-call reset a real
+// plugin SDK performs so its arena can be reused by the next request.
+//
+//go:wasmexport ResetAllocator
+func resetAllocator() {
+	offset = 0
+}
+
+func bytesAt(ptr, length uint32) []byte {
+	if length == 0 {
+		return nil
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), int(length))
+}
+
+// hostRequest mirrors the JSON shape the host writes -- see
+// internal/platform/plugin/runtime.go's HTTPRequest struct.
+type hostRequest struct {
+	Method     string            `json:"method"`
+	Path       string            `json:"path"`
+	ProjectID  string            `json:"project_id"`
+	CallerID   string            `json:"caller_id"`
+	UserID     string            `json:"user_id"`
+	CallerRole string            `json:"caller_role"`
+	Headers    map[string]string `json:"headers"`
+	Body       []byte            `json:"body"`
+}
+
+// hostResponse mirrors the JSON shape the host expects back -- see the
+// pluginResp struct in plugin_handler.go's ProxyRequest.
+type hostResponse struct {
+	Status  int               `json:"status"`
+	Headers map[string]string `json:"headers"`
+	Body    []byte            `json:"body"`
+}
+
+// HandleRequest ignores allocator failures by construction: it is only ever
+// invoked after the host has already written a valid, in-bounds request
+// payload, so reading reqPtr/reqLen here is always safe. The allocator's
+// unsafe behavior only matters for the *next* call's malloc, not this one.
+//
+//go:wasmexport HandleRequest
+func handleRequest(reqPtr uint32, reqLen uint32) uint64 {
+	var req hostRequest
+	_ = json.Unmarshal(bytesAt(reqPtr, reqLen), &req)
+
+	resp := route(req)
+
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		respBytes = []byte(`{"status":500,"body":null}`)
+	}
+
+	respPtr := malloc(uint32(len(respBytes)))
+	copy(bytesAt(respPtr, uint32(len(respBytes))), respBytes)
+	return (uint64(respPtr) << 32) | uint64(len(respBytes))
+}
+
+// route matches on the last path segment rather than the whole path: the
+// host passes the sub-path captured by its "/plugins/{pluginId}/*" wildcard,
+// which arrives without a leading slash (e.g. "hello", not "/hello").
+// Trimming defensively handles either convention.
+func route(req hostRequest) hostResponse {
+	path := strings.TrimPrefix(req.Path, "/")
+
+	switch {
+	case path == "hello" && req.Method == "GET":
+		body, _ := json.Marshal(map[string]string{"message": "hello from plugin"})
+		return hostResponse{Status: 200, Headers: jsonHeaders(), Body: body}
+
+	case path == "whoami" && req.Method == "GET":
+		body, _ := json.Marshal(map[string]string{
+			"caller_id":   req.CallerID,
+			"user_id":     req.UserID,
+			"caller_role": req.CallerRole,
+			"project_id":  req.ProjectID,
+		})
+		return hostResponse{Status: 200, Headers: jsonHeaders(), Body: body}
+
+	case path == "echo" && req.Method == "POST":
+		return hostResponse{Status: 200, Headers: jsonHeaders(), Body: req.Body}
+
+	default:
+		body, _ := json.Marshal(map[string]string{"error": "not found"})
+		return hostResponse{Status: 404, Headers: jsonHeaders(), Body: body}
+	}
+}
+
+func jsonHeaders() map[string]string {
+	return map[string]string{"Content-Type": "application/json"}
+}
+
+func main() {}


### PR DESCRIPTION
## Summary

Fixes a bug where a single oversized request to a plugin route could permanently "poison" that plugin instance for every request after it, and adds defenses + tests so it can't recur.

- **Root cause**: plugin allocators are bump allocators with no bounds checking — they advance their cursor unconditionally. An oversized request payload pushes the cursor past the end of the module's linear memory; the host's write then fails, but the allocator cursor is left corrupted, so every later call computes addresses from that corrupted cursor and fails too.
- **`runtime.go`**:
  - Adds a `MaxRequestBodyBytes` resource limit (`DefaultResourceLimits` sets it to 10 MiB) and a `Runtime.MaxRequestBodyBytes()` accessor so transport code can enforce it.
  - `HandleRequest` rejects oversized payloads before writing to memory, and now always resets the plugin's allocator via `defer` on every exit path (not just after a successful call), so a rejected or failed call can no longer leave an instance poisoned.
  - The per-instance lock now covers the full write → call → read → reset cycle (previously released mid-sequence), preventing concurrent `malloc` calls from racing on the same bump-allocator cursor.
  - `EmitEvent` is refactored into a new `dispatchEvent` helper with the same lock+defer-reset treatment, for consistency with `HandleRequest`.
- **HTTP layer (`plugin_handler.go`)**: `ProxyRequest` wraps the request body in `http.MaxBytesReader` using the runtime's configured limit, and maps `http.MaxBytesError` to a new `CodePayloadTooLarge` error code, surfaced as `413 Request Entity Too Large`.
- **Tests**:
  - New unit tests (`runtime_test.go`) run against a real wazero module — a "poison plugin" fixture (`testdata/poisonplugin`) reproducing the bump-allocator-with-no-bounds-check shape — instead of mocks.
  - New end-to-end tests (`test/e2e/plugin_runtime_test.go`) exercise the full HTTP stack with a new "echo plugin" fixture (`test/e2e/testdata/echoplugin`).
  - `plugin_handler_test.go` extended to cover the new size-limit/413 behavior.
- **Docs**: `backend-plugin-system.md` documents the 10 MB request body limit and the allocator-reset guarantee.

## Test plan

- [x] `go test ./internal/platform/plugin/... -run TestHandleRequest -v` — all 3 new unit tests pass
- [x] `PACA_E2E=1 go test ./test/e2e/... -run TestE2EPluginRuntime -v` (requires Docker) — all 9 e2e cases pass, including oversized-body rejection and post-rejection recovery
- [x] `go test ./internal/transport/http/handler/... -run TestProxyRequest_OversizedBody_Returns413` — passes