### PR TITLE
fix: persist agent replies dropped

### DIFF
--- a/.github/workflows/ai-agent-pr-ci.yml
+++ b/.github/workflows/ai-agent-pr-ci.yml
@@ -118,3 +118,48 @@ jobs:
           tags: paca-ai-agent-ci:pr
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # 4. E2E tests — real OpenHands agent-server sandbox + a fake in-process
+  #    LLM server. Regression coverage for the agent-reply-never-persisted
+  #    bug (https://github.com/Paca-AI/paca/issues/211, #214).
+  # ---------------------------------------------------------------------------
+  test-e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: [lint, test]
+
+    defaults:
+      run:
+        working-directory: services/ai-agent
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: "services/ai-agent/pyproject.toml"
+
+      - name: Install dev dependencies
+        env:
+          VIRTUAL_ENV: ""
+        run: |
+          uv venv
+          uv pip install --group dev -e .
+
+      - name: Pull agent-server sandbox image
+        # Reported as its own step for clearer timing in the Actions UI —
+        # this pulls several GB on a cold cache.
+        run: docker pull ghcr.io/openhands/agent-server:latest-python
+
+      - name: Run E2E tests
+        env:
+          PACA_E2E: "1"
+        run: uv run pytest tests/e2e -v --tb=short

--- a/services/ai-agent/pyproject.toml
+++ b/services/ai-agent/pyproject.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 description = "Paca AI Agent Service"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi>=0.115.0",
+    "fastapi>=0.138.0",
     "uvicorn[standard]>=0.30.0",
-    "openhands-sdk>=1.23.0",
-    "openhands-tools>=1.23.0",
+    "openhands-sdk>=1.29.0",
+    "openhands-tools>=1.29.0",
     "docker>=7.0.0",
     "redis[hiredis]>=5.0.0",
     "asyncpg>=0.29.0",
     "httpx>=0.27.0",
     "pydantic>=2.13.0",
     "pydantic-settings>=2.14.2",
-    "python-multipart>=0.0.9",
-    "cryptography>=48.0.1",
+    "python-multipart>=0.0.32",
+    "cryptography>=49.0.0",
 ]
 
 [build-system]
@@ -27,11 +27,11 @@ packages = ["src"]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0.0",
+    "pytest>=9.1.1",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=5.0.0",
     "httpx>=0.27.0",
-    "ruff>=0.9.0",
+    "ruff>=0.15.18",
 ]
 
 [tool.ruff]

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -180,6 +180,36 @@ class _AtomicCounter:
             return v
 
 
+class _TurnState:
+    """Tracks whether _make_token_callback already persisted the agent's
+    reply for the in-flight turn.
+
+    openhands.sdk.conversation.impl.RemoteConversation accepts a
+    token_callbacks kwarg but never wires it to anything — Conversation()
+    always builds a RemoteConversation here since docker_sandbox() always
+    yields a RemoteWorkspace, so on_token is never actually invoked.
+    _make_event_callback consults this flag to fall back to persisting the
+    SDK's own MessageEvent instead, so the reply is never silently dropped.
+    See https://github.com/Paca-AI/paca/issues/211 and #214.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._token_persisted = False
+
+    def mark_token_persisted(self) -> None:
+        with self._lock:
+            self._token_persisted = True
+
+    def consume(self) -> bool:
+        """Return True if the token callback persisted this turn, clearing
+        the flag for the next one."""
+        with self._lock:
+            was_persisted = self._token_persisted
+            self._token_persisted = False
+            return was_persisted
+
+
 # ─── Event callback ───────────────────────────────────────────────────────────
 
 
@@ -187,13 +217,15 @@ def _make_event_callback(
     trigger: TriggerMessage,
     loop: asyncio.AbstractEventLoop,
     counter: _AtomicCounter,
+    turn_state: _TurnState,
 ):
     """Return a synchronous callback invoked by the OpenHands SDK on each complete event.
 
-    Agent MessageEvents are skipped here because _make_token_callback captures
-    the LLM's text output directly from the streaming response, which gives
-    cleaner content without SDK wrapper fields.  All other events (actions,
-    observations, system messages) are saved normally.
+    Agent MessageEvents are normally skipped here in favor of
+    _make_token_callback, which captures the LLM's text output directly from
+    the streaming response for cleaner content without SDK wrapper fields —
+    when on_token actually gets invoked (see _TurnState). All other events
+    (actions, observations, system messages) are saved normally.
     """
 
     def callback(event) -> None:
@@ -203,15 +235,19 @@ def _make_event_callback(
         # Events the frontend never renders — skip to avoid wasting event_index
         # slots and polluting the paginated events list.
         if event_type in {
-            "StreamingDeltaEvent",  # streaming chunks (handled by token_callbacks)
+            "StreamingDeltaEvent",  # raw streaming chunks — only the final message matters
             "ConversationStateUpdateEvent",  # internal iteration bookkeeping
             "SystemPromptEvent",  # system prompt echo — not shown to user
             "ConversationErrorEvent",  # SDK error signal — surfaced via conversation status
         }:
             return
-        # Agent text responses are captured by token_callbacks with richer
-        # streaming data; skip them here to avoid duplicate DB rows.
-        if event_type == "MessageEvent" and event_source == "agent":
+        # Agent text responses are normally captured by token_callbacks with
+        # richer streaming data; skip them here to avoid duplicate DB rows —
+        # unless the token callback never actually persisted this turn (it
+        # never fires at all for RemoteConversation — see _TurnState), in
+        # which case fall through and persist this event instead of silently
+        # dropping the reply.
+        if event_type == "MessageEvent" and event_source == "agent" and turn_state.consume():
             return
 
         event_index = counter.next()
@@ -262,6 +298,7 @@ def _make_token_callback(
     trigger: TriggerMessage,
     loop: asyncio.AbstractEventLoop,
     counter: _AtomicCounter,
+    turn_state: _TurnState,
 ):
     """Return a token callback that accumulates streaming LLM chunks into complete
     messages and persists each finished message as a MessageEvent.
@@ -331,6 +368,7 @@ def _make_token_callback(
                     future = asyncio.run_coroutine_threadsafe(_persist(), loop)
                     try:
                         future.result(timeout=10)
+                        turn_state.mark_token_persisted()
                     except Exception as exc:
                         logger.warning(
                             "Token callback persist failed for conversation %s: %s",
@@ -358,6 +396,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
     """Execute a single agent conversation end-to-end."""
     loop = asyncio.get_event_loop()
     counter = _AtomicCounter()
+    turn_state = _TurnState()
     stop_event = threading.Event()
     logger.info("Starting conversation %s (agent=%s)", trigger.conversation_id, trigger.agent_id)
     await conversation_repository.update_conversation_status(trigger.conversation_id, "running")
@@ -478,8 +517,8 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 conversation = Conversation(
                     agent=agent,
                     workspace=workspace,
-                    callbacks=[_make_event_callback(trigger, loop, counter)],
-                    token_callbacks=[_make_token_callback(trigger, loop, counter)],
+                    callbacks=[_make_event_callback(trigger, loop, counter, turn_state)],
+                    token_callbacks=[_make_token_callback(trigger, loop, counter, turn_state)],
                     max_iteration_per_run=agent_config.max_iterations,
                     visualizer=_QuietVisualizer(),
                 )

--- a/services/ai-agent/tests/e2e/fake_llm_server.py
+++ b/services/ai-agent/tests/e2e/fake_llm_server.py
@@ -1,0 +1,251 @@
+"""Minimal OpenAI-compatible chat-completions server for e2e tests.
+
+No model weights, no network egress — just enough of the API surface for
+litellm's openai/-prefixed client (running inside the real OpenHands
+agent-server sandbox container) to get a usable response.
+
+Each server instance is driven by a `script`: a list of ScriptedReply,
+returned in order on successive /v1/chat/completions calls (the last entry
+repeats once exhausted). Use text_reply()/tool_call_reply()/error_reply() to
+build one, e.g. a tool-call-then-final-answer flow:
+
+    FakeOpenAIServer(script=[
+        tool_call_reply("terminal", {"command": "echo hi"}),
+        text_reply("Done!"),
+    ])
+
+Binds to 0.0.0.0 so containers on the host's Docker bridge network can reach
+it via the bridge gateway IP (see _bridge_gateway_ip in the e2e tests).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+REPLY_TEXT = "Hello! This is a canned reply from the fake LLM server."
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    name: str
+    arguments: dict
+    call_id: str = "call_fake_1"
+
+
+@dataclass(frozen=True)
+class ScriptedReply:
+    """One scripted LLM turn. Exactly one of content / tool_call / error_status is set."""
+
+    content: str | None = None
+    tool_call: ToolCall | None = None
+    error_status: int | None = None
+
+
+def text_reply(content: str = REPLY_TEXT) -> ScriptedReply:
+    return ScriptedReply(content=content)
+
+
+def tool_call_reply(name: str, arguments: dict, call_id: str = "call_fake_1") -> ScriptedReply:
+    return ScriptedReply(tool_call=ToolCall(name=name, arguments=arguments, call_id=call_id))
+
+
+def error_reply(status: int = 500) -> ScriptedReply:
+    return ScriptedReply(error_status=status)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: FakeOpenAIServer
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass  # silence default request logging to stderr
+
+    def do_GET(self) -> None:
+        if self.path.startswith(("/v1/models", "/health")):
+            models = {"object": "list", "data": [{"id": "fake-model", "object": "model"}]}
+            self._send_json(200, models)
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if not self.path.startswith("/v1/chat/completions"):
+            self._send_json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length) if length else b"{}"
+        try:
+            payload = json.loads(body or b"{}")
+        except json.JSONDecodeError:
+            payload = {}
+
+        reply = self.server.next_reply()
+        if reply.error_status is not None:
+            self._send_json(reply.error_status, {"error": {"message": "fake upstream failure"}})
+        elif payload.get("stream"):
+            self._send_streaming_reply(reply)
+        else:
+            self._send_non_streaming_reply(reply)
+
+    def _send_streaming_reply(self, reply: ScriptedReply) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        base = {
+            "id": "fake-chunk",
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": "fake-model",
+        }
+        chunks = (
+            self._tool_call_chunks(base, reply.tool_call)
+            if reply.tool_call is not None
+            else self._text_chunks(base, reply.content or "")
+        )
+        for chunk in chunks:
+            self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+        self.wfile.write(b"data: [DONE]\n\n")
+
+    def _text_chunks(self, base: dict, content: str) -> list[dict]:
+        return [
+            {
+                **base,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                **base,
+                "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}],
+            },
+            {**base, "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+        ]
+
+    def _tool_call_chunks(self, base: dict, tool_call: ToolCall) -> list[dict]:
+        return [
+            {
+                **base,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": tool_call.call_id,
+                                    "type": "function",
+                                    "function": {"name": tool_call.name, "arguments": ""},
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                **base,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {"arguments": json.dumps(tool_call.arguments)},
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {**base, "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}]},
+        ]
+
+    def _send_non_streaming_reply(self, reply: ScriptedReply) -> None:
+        if reply.tool_call is not None:
+            message = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": reply.tool_call.call_id,
+                        "type": "function",
+                        "function": {
+                            "name": reply.tool_call.name,
+                            "arguments": json.dumps(reply.tool_call.arguments),
+                        },
+                    }
+                ],
+            }
+            finish_reason = "tool_calls"
+        else:
+            message = {"role": "assistant", "content": reply.content}
+            finish_reason = "stop"
+        self._send_json(
+            200,
+            {
+                "id": "fake-completion",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": "fake-model",
+                "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    def _send_json(self, status: int, body: dict) -> None:
+        data = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class FakeOpenAIServer(ThreadingHTTPServer):
+    """Runs _Handler on a background thread for the lifetime of a test."""
+
+    def __init__(
+        self,
+        script: list[ScriptedReply] | None = None,
+        host: str = "0.0.0.0",
+        port: int = 0,
+    ) -> None:
+        super().__init__((host, port), _Handler)
+        self._script = script or [text_reply()]
+        self._call_index = 0
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self.serve_forever, daemon=True)
+
+    def next_reply(self) -> ScriptedReply:
+        with self._lock:
+            reply = self._script[min(self._call_index, len(self._script) - 1)]
+            self._call_index += 1
+            return reply
+
+    @property
+    def call_count(self) -> int:
+        with self._lock:
+            return self._call_index
+
+    @property
+    def port(self) -> int:
+        return self.server_address[1]
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self.shutdown()
+        self.server_close()
+        self._thread.join(timeout=5)

--- a/services/ai-agent/tests/e2e/test_run_conversation_e2e.py
+++ b/services/ai-agent/tests/e2e/test_run_conversation_e2e.py
@@ -1,0 +1,223 @@
+"""End-to-end regression tests for the AI agent's conversation pipeline.
+
+Drives the real executor.run_conversation() against a REAL OpenHands
+agent-server sandbox container (the same image used in production) and a
+fake, scriptable OpenAI-compatible LLM server — only the Postgres/Valkey
+persistence calls are mocked. This exercises what a pure unit test can't:
+that openhands-sdk's RemoteConversation really does deliver events through
+the `callbacks` channel, since `token_callbacks` is never invoked for remote
+workspaces (confirmed by reading
+openhands.sdk.conversation.impl.remote_conversation — RemoteConversation
+accepts the kwarg but never wires it to anything).
+
+The first test is regression coverage for
+https://github.com/Paca-AI/paca/issues/211 and #214: before the fix, every
+agent reply was silently dropped — for every LLM provider, not just
+custom/self-hosted ones — because the event callback unconditionally skipped
+the agent's MessageEvent, trusting a token-streaming path that
+openhands-sdk >=1.29 never actually invokes for RemoteConversation. The
+other tests cover scenarios that were never exercised end-to-end before:
+a multi-step tool-call flow, and the LLM-failure path.
+
+Requires Docker and pulls ghcr.io/openhands/agent-server on first run.
+Run with: PACA_E2E=1 pytest tests/e2e -v
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import docker
+import pytest
+
+from src.agent import executor
+from src.core import streams as stream_store
+from src.core.streams import TriggerMessage
+from src.models.agent import AgentConfig
+from src.repositories import conversation_repository
+
+from .fake_llm_server import (
+    FakeOpenAIServer,
+    ScriptedReply,
+    error_reply,
+    text_reply,
+    tool_call_reply,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PACA_E2E") != "1",
+    reason="set PACA_E2E=1 to run e2e tests (requires Docker; pulls the agent-server image)",
+)
+
+
+@pytest.fixture(scope="module")
+def docker_client():
+    from src.config import settings
+
+    try:
+        client = docker.DockerClient(base_url=f"unix://{settings.docker_socket}")
+        client.ping()
+    except Exception as exc:
+        pytest.skip(f"Docker daemon not reachable: {exc}")
+    yield client
+    client.close()
+
+
+def _bridge_gateway_ip(client: docker.DockerClient) -> str:
+    """IP the sandbox container can use to reach a server bound to the host's
+    0.0.0.0 — the container can't reach the host via "localhost"."""
+    network = client.networks.get("bridge")
+    return network.attrs["IPAM"]["Config"][0]["Gateway"]
+
+
+@pytest.fixture
+def make_fake_llm(docker_client):
+    """Factory fixture: make_fake_llm(script=[...]) -> base_url string.
+
+    Starts a FakeOpenAIServer scripted with the given replies and tears it
+    down at the end of the test. Call multiple times for multiple servers.
+    """
+    servers: list[FakeOpenAIServer] = []
+
+    def _make(script: list[ScriptedReply] | None = None) -> str:
+        server = FakeOpenAIServer(script=script)
+        server.start()
+        servers.append(server)
+        return f"http://{_bridge_gateway_ip(docker_client)}:{server.port}/v1"
+
+    yield _make
+    for server in servers:
+        server.stop()
+
+
+@dataclass
+class MockedPersistence:
+    insert_event: AsyncMock
+    update_status: AsyncMock
+    publish_realtime: AsyncMock
+
+
+@pytest.fixture
+def persistence(monkeypatch) -> MockedPersistence:
+    mocks = MockedPersistence(
+        insert_event=AsyncMock(), update_status=AsyncMock(), publish_realtime=AsyncMock()
+    )
+    monkeypatch.setattr(conversation_repository, "insert_conversation_event", mocks.insert_event)
+    monkeypatch.setattr(conversation_repository, "update_conversation_status", mocks.update_status)
+    monkeypatch.setattr(stream_store, "publish_event", AsyncMock())
+    monkeypatch.setattr(stream_store, "publish_realtime", mocks.publish_realtime)
+    return mocks
+
+
+def _agent_config(
+    base_url: str, *, max_iterations: int = 3, can_clone_repos: bool = False
+) -> AgentConfig:
+    return AgentConfig(
+        agent_id="e2e-test-agent",
+        project_id="e2e-test-project",
+        system_prompt="You are a helpful assistant.",
+        task_trigger_prompt="",
+        doc_comment_trigger_prompt="",
+        chat_trigger_prompt="",
+        description_write_trigger_prompt="",
+        llm_provider="openai",
+        llm_model="fake-model",
+        llm_api_key_secret_ref="sk-fake",
+        llm_base_url=base_url,
+        max_iterations=max_iterations,
+        can_clone_repos=can_clone_repos,
+    )
+
+
+def _trigger(*, repo_plugin_ids: list[str] | None = None) -> TriggerMessage:
+    return TriggerMessage(
+        stream_id="1-1",
+        trigger_type="agent.chat_message",
+        conversation_id="e2e-test-conversation",
+        agent_id="e2e-test-agent",
+        project_id="e2e-test-project",
+        task_id=None,
+        comment_id=None,
+        chat_session_id=None,
+        message="Say hello",
+        actor_member_id="tester",
+        repo_plugin_ids=repo_plugin_ids or [],
+    )
+
+
+def _persisted_events(insert_event: AsyncMock) -> list[dict]:
+    return [call.kwargs for call in insert_event.call_args_list]
+
+
+async def test_agent_reply_is_persisted_through_real_sandbox(make_fake_llm, persistence):
+    base_url = make_fake_llm()
+
+    await executor.run_conversation(_trigger(), _agent_config(base_url))
+
+    persisted = _persisted_events(persistence.insert_event)
+    agent_messages = [
+        p for p in persisted if p["event_type"] == "MessageEvent" and p["event_source"] == "agent"
+    ]
+    assert agent_messages, "the agent's reply was never persisted (see issues #211, #214)"
+    assert "Hello! This is a canned reply" in agent_messages[0]["payload"]
+
+    persistence.update_status.assert_any_call("e2e-test-conversation", "finished")
+
+
+async def test_agent_tool_call_then_reply_persists_full_flow(make_fake_llm, persistence):
+    """A tool call followed by a final text reply spans two agent.step()
+    iterations. Confirms the action, its observation, AND the final reply
+    all persist — i.e. _TurnState correctly resets between turns in the
+    real pipeline, not just in the isolated unit test."""
+    base_url = make_fake_llm(
+        script=[
+            tool_call_reply("terminal", {"command": "echo hello-from-e2e"}),
+            text_reply("Done! I ran the command."),
+        ]
+    )
+    agent_config = _agent_config(base_url, max_iterations=5, can_clone_repos=True)
+    trigger = _trigger(repo_plugin_ids=["fake-plugin-id"])
+
+    await executor.run_conversation(trigger, agent_config)
+
+    persisted = _persisted_events(persistence.insert_event)
+    event_kinds = [(p["event_type"], p["event_source"]) for p in persisted]
+
+    assert ("ActionEvent", "agent") in event_kinds, f"tool call never persisted: {event_kinds}"
+    assert ("ObservationEvent", "environment") in event_kinds, (
+        f"tool result never persisted: {event_kinds}"
+    )
+
+    agent_messages = [
+        p for p in persisted if p["event_type"] == "MessageEvent" and p["event_source"] == "agent"
+    ]
+    assert agent_messages, "the agent's final reply was never persisted"
+    assert "Done! I ran the command." in agent_messages[-1]["payload"]
+
+    persistence.update_status.assert_any_call("e2e-test-conversation", "finished")
+
+
+async def test_llm_failure_marks_conversation_failed(make_fake_llm, persistence):
+    """Previously-untested path: when the LLM call itself fails (not just
+    the reply-persistence bug), the conversation must end up "failed" and
+    the frontend must be notified, instead of silently hanging."""
+    base_url = make_fake_llm(script=[error_reply(500)])
+
+    await executor.run_conversation(_trigger(), _agent_config(base_url))
+
+    persistence.update_status.assert_any_call("e2e-test-conversation", "failed")
+    failed_events = [
+        call
+        for call in persistence.publish_realtime.call_args_list
+        if call.kwargs.get("event_type") == "agent.conversation.failed"
+    ]
+    assert failed_events, "agent.conversation.failed was never published"
+
+    agent_messages = [
+        p
+        for p in _persisted_events(persistence.insert_event)
+        if p["event_type"] == "MessageEvent" and p["event_source"] == "agent"
+    ]
+    assert not agent_messages, "no reply should have been persisted when the LLM call failed"

--- a/services/ai-agent/tests/test_executor.py
+++ b/services/ai-agent/tests/test_executor.py
@@ -1,6 +1,22 @@
 """Tests for executor helpers."""
 
-from src.agent.executor import _build_project_context_suffix
+import asyncio
+import json
+import threading
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.agent.executor import (
+    _AtomicCounter,
+    _build_project_context_suffix,
+    _make_event_callback,
+    _make_token_callback,
+    _TurnState,
+)
+from src.core import streams as stream_store
+from src.core.streams import TriggerMessage
+from src.repositories import conversation_repository
 
 
 def test_project_id_appears_in_suffix():
@@ -20,3 +36,146 @@ def test_suffix_discourages_list_projects_call():
 
 def test_different_project_ids_produce_different_suffixes():
     assert _build_project_context_suffix("proj-1") != _build_project_context_suffix("proj-2")
+
+
+def test_turn_state_defaults_to_not_persisted():
+    """The event callback should fall back to persisting the raw MessageEvent
+    when the token callback never fired for this turn — which is always, for
+    RemoteConversation (see _TurnState's docstring in executor.py)."""
+    state = _TurnState()
+    assert state.consume() is False
+
+
+def test_turn_state_consume_reflects_token_persist():
+    state = _TurnState()
+    state.mark_token_persisted()
+    assert state.consume() is True
+
+
+def test_turn_state_consume_clears_flag_for_next_turn():
+    state = _TurnState()
+    state.mark_token_persisted()
+    assert state.consume() is True
+    # A second turn with no streaming output must not inherit the previous
+    # turn's flag — otherwise its reply would be silently dropped too.
+    assert state.consume() is False
+
+
+# ─── _make_event_callback / _make_token_callback integration ─────────────────
+#
+# These exercise the real closures together rather than just _TurnState in
+# isolation. They run a real asyncio loop on a background thread because the
+# callbacks call asyncio.run_coroutine_threadsafe(...).result(...) — exactly
+# how they're driven in production (the SDK invokes them synchronously from
+# the executor thread, while the main event loop runs separately).
+
+
+@pytest.fixture
+def bg_loop():
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+
+@pytest.fixture
+def mock_persistence(monkeypatch):
+    insert_mock = AsyncMock()
+    monkeypatch.setattr(conversation_repository, "insert_conversation_event", insert_mock)
+    monkeypatch.setattr(stream_store, "publish_event", AsyncMock())
+    monkeypatch.setattr(stream_store, "publish_realtime", AsyncMock())
+    return insert_mock
+
+
+class MessageEvent:
+    """Stand-in for openhands.sdk.event.MessageEvent — the callback only
+    relies on the class name, `.source`, and `.model_dump_json()`."""
+
+    def __init__(self, source: str = "agent") -> None:
+        self.source = source
+
+    def model_dump_json(self) -> str:
+        return json.dumps({"source": self.source})
+
+
+class _FakeChoice:
+    def __init__(self, content: str = "", finish_reason: str | None = None) -> None:
+        self.delta = type("Delta", (), {"content": content, "reasoning_content": ""})()
+        self.finish_reason = finish_reason
+
+
+class _FakeStreamChunk:
+    def __init__(self, *choices: _FakeChoice) -> None:
+        self.choices = choices
+
+
+def _trigger(conversation_id: str = "conv-1") -> TriggerMessage:
+    return TriggerMessage(
+        stream_id="1-1",
+        trigger_type="chat_message",
+        conversation_id=conversation_id,
+        agent_id="agent-1",
+        project_id="proj-1",
+        task_id=None,
+        comment_id=None,
+        chat_session_id=None,
+        message="hi",
+        actor_member_id="member-1",
+        repo_plugin_ids=[],
+    )
+
+
+def test_event_callback_persists_agent_reply_when_token_callback_never_fires(
+    bg_loop, mock_persistence
+):
+    """Mirrors production under openhands-sdk's RemoteConversation: on_token
+    is never invoked at all (token_callbacks isn't wired through for remote
+    workspaces — see openhands.sdk.conversation.impl.remote_conversation).
+    The event callback must persist the agent's reply itself rather than
+    silently dropping it."""
+    trigger = _trigger()
+    turn_state = _TurnState()
+    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), turn_state)
+
+    # on_token is intentionally never called here.
+    event_callback(MessageEvent(source="agent"))
+
+    mock_persistence.assert_awaited_once()
+    kwargs = mock_persistence.call_args.kwargs
+    assert kwargs["event_type"] == "MessageEvent"
+    assert kwargs["event_source"] == "agent"
+    assert kwargs["conversation_id"] == "conv-1"
+
+
+def test_event_callback_skips_duplicate_when_token_callback_already_persisted(
+    bg_loop, mock_persistence
+):
+    """When the token callback *does* manage to flush a finished message,
+    the event callback must not also persist the SDK's own MessageEvent —
+    that would duplicate the reply in the conversation."""
+    trigger = _trigger()
+    turn_state = _TurnState()
+    on_token = _make_token_callback(trigger, bg_loop, _AtomicCounter(), turn_state)
+    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), turn_state)
+
+    on_token(_FakeStreamChunk(_FakeChoice(content="Hello", finish_reason="stop")))
+    mock_persistence.assert_awaited_once()
+    mock_persistence.reset_mock()
+
+    event_callback(MessageEvent(source="agent"))
+    mock_persistence.assert_not_awaited()
+
+
+def test_event_callback_still_skips_non_message_noise_events(bg_loop, mock_persistence):
+    """Unrelated to the fallback logic: internal bookkeeping events must
+    still be skipped regardless of turn_state."""
+    trigger = _trigger()
+    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), _TurnState())
+
+    noise = type("ConversationStateUpdateEvent", (), {"source": "agent"})()
+    event_callback(noise)
+
+    mock_persistence.assert_not_awaited()

--- a/services/ai-agent/uv.lock
+++ b/services/ai-agent/uv.lock
@@ -2,9 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -182,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.105.2"
+version = "0.111.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -194,22 +197,22 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/8a/9afc7305a2ce4b52b30e137f83cd2a6a90b918b3997073db11bb5a1de55a/anthropic-0.111.0.tar.gz", hash = "sha256:39cbda0ac17a6d423e5bf609811bd69b26eddf6299d7a468126e05bc711ce826", size = 934001, upload-time = "2026-06-18T17:31:44.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/bb/09e82a81885d787f350fb55ca9df865b63140dd28b3b5b3104c4ae261657/anthropic-0.111.0-py3-none-any.whl", hash = "sha256:c14edb36ed80da9099acbd26b5cec810d76606c31f32a0d56a4cf9d4fa9e25ae", size = 929774, upload-time = "2026-06-18T17:31:43.116Z" },
 ]
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -294,15 +297,15 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
@@ -364,15 +367,15 @@ wheels = [
 
 [[package]]
 name = "browser-use-sdk"
-version = "3.8.0"
+version = "3.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/42/feefdbba5463ec269e4e30d5b4e692caddd28a3d3f287af05dce4defc6d9/browser_use_sdk-3.8.0.tar.gz", hash = "sha256:b172b582c973d665b6947ad9ca916ee041341d0b3764f426403faf4eacdb8c62", size = 214936, upload-time = "2026-06-01T16:59:52.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/5b/9f52925c3dc1bc651a67031c3d456ce39731fbca870be55b3fedd5555498/browser_use_sdk-3.8.4.tar.gz", hash = "sha256:9dbabc8971e676c8c454b877ba87142a7cebc39c2b4c2888ff16ad3bed1412f6", size = 203882, upload-time = "2026-06-10T11:18:37.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/31/c0b16134d0c2c29604f3b81d2f08a997119af1ef57ac71cba4648a6cf6ac/browser_use_sdk-3.8.0-py3-none-any.whl", hash = "sha256:b7f73799583d7cc4e9d7f1f2cd495437899c202511efdd795899d13616b76447", size = 64690, upload-time = "2026-06-01T16:59:51.025Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3e/67206e2526e73ad4e4064009d6216000fa5e09381681a11104b868592f30/browser_use_sdk-3.8.4-py3-none-any.whl", hash = "sha256:55f1fd41f6753529ace4b583377b5bf12d61bf85f32abf8bd458e8dd331efa83", size = 64702, upload-time = "2026-06-10T11:18:36.201Z" },
 ]
 
 [[package]]
@@ -438,11 +441,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -607,144 +610,126 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.14.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/91/0a7c28934e50d8ac9a7b117712d176f2953c3170bccced5eaacfa3e96175/coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f", size = 924398, upload-time = "2026-06-22T23:10:25.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
-    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
-    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
-    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
-    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
-    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
-    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
-    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
-    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
-    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
-    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
-    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
-    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
-    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b0/8a911f6ffe6974dac4df95b468ab9a2899d0e59f0f99a489afeec39f00bc/coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24", size = 220672, upload-time = "2026-06-22T23:08:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/0fc0cb52538783dbbae0934b834f5a58fd5354380ee6cad4a07b15dc845d/coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665", size = 221035, upload-time = "2026-06-22T23:08:28.372Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/421ccfbb48335ac49e93301478cf5d623b0c2bf1c0cadd8e2b2fc6c0c710/coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a", size = 252540, upload-time = "2026-06-22T23:08:30.226Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c2/05b8c890097c61a7f4406b35396b997a635200ded0339eda83dfbe526c5f/coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727", size = 255274, upload-time = "2026-06-22T23:08:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/b6d9efe447f8ba3c3c854195f326bd64c54b907d936cd2fdebf8767ec72e/coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977", size = 256389, upload-time = "2026-06-22T23:08:33.843Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/f26e50acc429e608bc534ac06f0a3c169019c798178ec5e9de3dbc0df9c9/coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c", size = 258648, upload-time = "2026-06-22T23:08:35.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a2/01c1fabf816c8e1dae197e258edf878a3d3ddc86fbda34b76e5794277d8f/coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf", size = 252949, upload-time = "2026-06-22T23:08:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/941166dd79c31fd44a13063780ae8d552eee0089a0a0930b9bdb7df554ed/coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f", size = 254310, upload-time = "2026-06-22T23:08:39.174Z" },
+    { url = "https://files.pythonhosted.org/packages/10/31/80b1fd028201a961033ce95be3cd1e39e521b3762e6b4a1ac1616cb291e7/coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205", size = 252453, upload-time = "2026-06-22T23:08:40.84Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/c3d9addd94c4b524f3f4af0232075f5fe7170ce99a1386edff803e5934db/coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c", size = 256522, upload-time = "2026-06-22T23:08:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/14/e5a0575f73795af3a7a9ae13dadf812e17d32422896839987dc3f86947e1/coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef", size = 252023, upload-time = "2026-06-22T23:08:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9b/9652ee531937ce3b8a63a8896885b2b4a2d56adc30e53c9540c666286d88/coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd", size = 253893, upload-time = "2026-06-22T23:08:46.113Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/05/42678841c8c38e4b08bdfc48269f5a16dfbf5806000fe6a89b4cece3c691/coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35", size = 222734, upload-time = "2026-06-22T23:08:47.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/87/07a4fcee55177a25f1b52331a8e92cf4f2c53b1a9c75ce2981fd59c684ad/coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d", size = 223266, upload-time = "2026-06-22T23:08:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/34/2b8b66a989282ea7b370beb49f50bab29470dc30bb0b03935b6b802782f7/coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336", size = 222655, upload-time = "2026-06-22T23:08:51.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/83/7fefbf5df23ed2b7f489907564a7b34b9b07098128e12e0fdfa92626e456/coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c", size = 220699, upload-time = "2026-06-22T23:08:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/38c3653ff6d56d704b29241362387ca824e38e15b76fdcb7096538195790/coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a", size = 221068, upload-time = "2026-06-22T23:08:55.571Z" },
+    { url = "https://files.pythonhosted.org/packages/20/86/4f5c45d51c5cd10a128933f0fd235393c9146abbfd2ce2dfa68b3267ead3/coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027", size = 252060, upload-time = "2026-06-22T23:08:57.464Z" },
+    { url = "https://files.pythonhosted.org/packages/82/50/dfce42eff2cecabcd5a9bbad5489449c87db3415f408d23ffee417ce01f6/coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73", size = 254657, upload-time = "2026-06-22T23:08:59.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d2/639ceb1bc8038fd0d66768278d5dc22df3391918b8278c2a21aa2602a531/coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9", size = 255892, upload-time = "2026-06-22T23:09:01.291Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/96/002094a10e113512500dc1e10430a449417e17b0f90f7d496bcb820208b7/coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de", size = 258026, upload-time = "2026-06-22T23:09:03.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ec/286a5d2fad9c4bee59bd724feeb7d5bf8303c6c9200b51d1dd945a9c72b0/coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd", size = 252285, upload-time = "2026-06-22T23:09:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7d/a17753a0b12dd48d0d50f5fab079ad99d3be1eac790494d89f3a417ca0b9/coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5", size = 254023, upload-time = "2026-06-22T23:09:06.513Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/a76c6ceba6a2c313f905310abf2701d534cada22d372db11731831e9e209/coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb", size = 251989, upload-time = "2026-06-22T23:09:08.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/39/353013a75fec0fb49f7553519f9d52b4441e902e5178c93f38eb6c07cedb/coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f", size = 256144, upload-time = "2026-06-22T23:09:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0e/613878555d734def11c5b20a2701a15cb3781b9e9ea749da27c5f436e928/coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498", size = 251808, upload-time = "2026-06-22T23:09:12.057Z" },
+    { url = "https://files.pythonhosted.org/packages/af/76/359c058c9cfdcf1e8b107663881225b03b364a320017eda24a2a66e55102/coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0", size = 253579, upload-time = "2026-06-22T23:09:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d9/4ba2f060933a30ebe363cef9f67a365b0a317e580c0d5d9169d56a73ef1c/coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37", size = 222741, upload-time = "2026-06-22T23:09:15.636Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e8/196ebc25d8f34c06d43a6e9c8513c9266ef8dbf3b5672beb1a00cf5e29fa/coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994", size = 223283, upload-time = "2026-06-22T23:09:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/51d2aac6417523a286f10fb25f09eb9518a84df9f1151e93ff6871f34849/coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150", size = 222678, upload-time = "2026-06-22T23:09:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/14e3b97facbfa1304dd19e676e26599ad359f04714bed32f7f1c5a88efdc/coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc", size = 220741, upload-time = "2026-06-22T23:09:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7", size = 221068, upload-time = "2026-06-22T23:09:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f0/3f8421b20d9c4fcd39be9a8ca3c3fda8bc204b44efbd09fede153afd3e2f/coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce", size = 252117, upload-time = "2026-06-22T23:09:25.458Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5", size = 254622, upload-time = "2026-06-22T23:09:27.523Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/ec6de51ae7493b92a1cf74d1b763121c29636759167e2a593ba4db5881e4/coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a", size = 255968, upload-time = "2026-06-22T23:09:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/05/c8bfc77823f42b4664fb25842f13b567022f6f84a4c83c8ecbb16734b7cb/coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501", size = 258284, upload-time = "2026-06-22T23:09:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/15/1d1b242027124a32b26ef01f82018b8c4ef34ef174aa6aeba7b1eeef48e8/coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e", size = 252143, upload-time = "2026-06-22T23:09:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b6/d2a9842fd2a5d7d27f1ac851c043a734a494ad75402c5331db3da79ed691/coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3", size = 253976, upload-time = "2026-06-22T23:09:35.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/30/e1600ddf7e226db5558bb5323d2186fff00f505c4b764643ec89ce5d8175/coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5", size = 251942, upload-time = "2026-06-22T23:09:37.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2c/9159de64f9dd648e324328d588a44cfab1e331eb5259ce1141afe2a92dfb/coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845", size = 256220, upload-time = "2026-06-22T23:09:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/91/67/b7f536cc2c124f48e91b22fbb741d2261f4e3d310faf6f76007f47566e5d/coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027", size = 251756, upload-time = "2026-06-22T23:09:41.056Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f3718038e2d4860c715a55428377ca7f6c75872caf98cabd982e1d76967d/coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b", size = 253413, upload-time = "2026-06-22T23:09:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a5/91f11efeef89b3cc9b30461128db15b0511ef813ab889a7b7ab636b3a497/coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965", size = 222946, upload-time = "2026-06-22T23:09:45.261Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fd/98ac9f524d9ec378de831c034dbdeb544ca7ef7d2d9c9996daf232a037fd/coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3", size = 223436, upload-time = "2026-06-22T23:09:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/7cd612d650a772a0ae80144443406bf61981c896c3d57c9e6e79fb2cdbd1/coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92", size = 222861, upload-time = "2026-06-22T23:09:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/55/57/017353fab573779c0d00448e47d102edd36c792f7b6f233a4d89a7a08384/coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949", size = 221474, upload-time = "2026-06-22T23:09:51.417Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/90cf1f1a5c468a9c1b7ba2716e0e205293ad9b02f5f573a6de4318b15ba1/coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891", size = 221738, upload-time = "2026-06-22T23:09:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/4df964fa539f8399fd7679c09c472d73744de334686fd3f01e3a2465ce4e/coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388", size = 263101, upload-time = "2026-06-22T23:09:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/e5d33b2576ae3bf2be2058cd1cae57774b61e400f2c3c58f3783dc2ffb4a/coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784", size = 265225, upload-time = "2026-06-22T23:09:57.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/e52419afe391a39ba27fdefaf0737d8e34bf03faef6ab3b3006545bbd0d0/coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed", size = 267643, upload-time = "2026-06-22T23:09:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7a/f2625d8d5006b6b20fba5afaef00b24a763fe96476ea798a3076cbc1f84e/coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5", size = 268762, upload-time = "2026-06-22T23:10:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bf/908024006bba57127354d74e938954b9c3cd765cc2e0412dc9c37b415cda/coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26", size = 262208, upload-time = "2026-06-22T23:10:03.954Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a0/d4f9296441b909817442fdb26bd77a698f08272ec683a7394b00eb2e47a0/coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889", size = 265096, upload-time = "2026-06-22T23:10:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/da/4ae4f3f4e477b56a4ce1e5c48a35eff38a94b50130ce5bdc897024741cfc/coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d", size = 262699, upload-time = "2026-06-22T23:10:07.973Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/6927148073ff32856d78baa77b4ddc07a9be7e90020f9db0661c4ca523a1/coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e", size = 266433, upload-time = "2026-06-22T23:10:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/774f658dbe9c4c3f5daa86a87e0459ac3832e4e3cc67affe078547f727b9/coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7", size = 261547, upload-time = "2026-06-22T23:10:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/a0c18c0376c43cbf973f43ef6ca20019c950597180e6396232f7b6a27102/coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635", size = 263859, upload-time = "2026-06-22T23:10:14.492Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ac/43a3d0f460af524b131a6191805bc5d18b806ab4e828fbf82e8c8c3af446/coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc", size = 223250, upload-time = "2026-06-22T23:10:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5f/d5e5c56b0712e96ce8f69fe7dbf229ff938b437bc50862743c8a0d2cea84/coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda", size = 224082, upload-time = "2026-06-22T23:10:19.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/35/947cbd5be1d3bcbbdc43d6791de8a56c6501903311d42915ae06a82815f0/coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f", size = 223400, upload-time = "2026-06-22T23:10:21.24Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "48.0.1"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
-    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
-    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
-    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
-    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
-    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
 name = "cyclopts"
-version = "4.16.1"
+version = "4.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -752,9 +737,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/07/bf61d13de86d96a4c46aff00c9ca0eced44bcc8c3e16280605c1253e5720/cyclopts-4.16.1.tar.gz", hash = "sha256:8aa47bf92a5fb33abca5af05e576eecdb0d2f79893ad29238046df78370fc4a8", size = 181196, upload-time = "2026-05-25T15:29:08.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/e7/4b3048094559b86a800e0f0de7faf8e6d8213727cf31553ec58453f25abc/cyclopts-4.19.0.tar.gz", hash = "sha256:c7532803ab8560d4de8600769793c3de4b2dc8c3b23ec707b989d84d9bae6ff4", size = 189274, upload-time = "2026-06-22T23:58:54.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/8d/7f362c2fb8ef4decd2160bc24d4292c6ca658cc6d9a161b89ca5122bbdbf/cyclopts-4.16.1-py3-none-any.whl", hash = "sha256:617795392c4113a2c2cc7af716f20244900e87f23daa05442d1268d81472a592", size = 219020, upload-time = "2026-05-25T15:29:09.646Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e8/b84c32f35a19107b55b8ceed260de9469206464da26bd0b979db470782c3/cyclopts-4.19.0-py3-none-any.whl", hash = "sha256:a8c11adb45afae25db310122950c7639c70b56e2ce341e5b29848bf3a8ecc1d4", size = 228005, upload-time = "2026-06-22T23:58:52.495Z" },
 ]
 
 [[package]]
@@ -850,15 +835,15 @@ wheels = [
 
 [[package]]
 name = "fakeredis"
-version = "2.36.0"
+version = "2.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "redis" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/26/9cf5174d2e42c24761f87d76160f959e7dbea1cf35b2c81c9cfcd7c74ad9/fakeredis-2.36.0.tar.gz", hash = "sha256:66d00953c9bfd3e345266ded342a2e54c611417344f43ad1467cb68f30bc8354", size = 209484, upload-time = "2026-05-29T19:14:27.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ed/86ed74d8829c3bc565025c1c9efaf8518c9165fbf8c9cc2c026c8ed21bd9/fakeredis-2.36.2.tar.gz", hash = "sha256:c37a0b307fae3f27ec7c19e59519e57b8c52782e00303df9075361b5ba441be6", size = 213336, upload-time = "2026-06-17T13:25:38.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/5a/6ea14103f9254f0bef31d323e8fe1f57bc0151f7a4b287889217752e9879/fakeredis-2.36.0-py3-none-any.whl", hash = "sha256:43536ed9eb7af34a31226ee4e52c8471d1c3cc522ba2852a9985d3291e71287b", size = 138102, upload-time = "2026-05-29T19:14:25.974Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/e6e40f93031adbf654d34e542bd396e9f3bc1c6209b40c920d58c9e1317a/fakeredis-2.36.2-py3-none-any.whl", hash = "sha256:84cbb9c74ca8946c0d2499daadf3a5d0bfe3cfbac71e3398316d1a1eab3421c4", size = 141039, upload-time = "2026-06-17T13:25:36.638Z" },
 ]
 
 [package.optional-dependencies]
@@ -868,7 +853,7 @@ lua = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -877,26 +862,26 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
 name = "fastmcp"
-version = "3.4.0"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/24/519739e98daf92ebc64580e9d3320649bf9a1612c029a913dd88c3474d73/fastmcp-3.4.0.tar.gz", hash = "sha256:29055fb6816f4862c615aabaf0112ae8feb8b469740db13403a0ce5b799ec1dc", size = 28754939, upload-time = "2026-06-03T02:32:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/72/9f9bbfc3a8d26870dbdbbd633cd1c6f42b8d3bec379426c760676d936e86/fastmcp-3.4.0-py3-none-any.whl", hash = "sha256:34523083d6149400a0655a8aa769eb34f85b1ce6dac6d66efb07503ebbe5f44b", size = 8017, upload-time = "2026-06-03T02:32:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.0"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -906,9 +891,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/4da6078c2d6aa0a38a8b1ae0271e1ed400f9e2cd1b3b46e6453fb1fe2b75/fastmcp_slim-3.4.0.tar.gz", hash = "sha256:faa0ccf16e85ec4b9f79c006fed3546b866d7e6dba3f60cd32cd98e84753a496", size = 575895, upload-time = "2026-06-03T02:32:18.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/66/cc283d4efd3faf325c26f51cfb43a118270ea732e70dda509f49d80ea625/fastmcp_slim-3.4.0-py3-none-any.whl", hash = "sha256:17cd0a1535972d3748d8c2416f0826dfc86c18df7a6cbc38602373277d44baa6", size = 748849, upload-time = "2026-06-03T02:32:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
 ]
 
 [package.optional-dependencies]
@@ -919,6 +904,7 @@ client = [
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 server = [
     { name = "authlib" },
@@ -937,6 +923,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -986,11 +973,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.1"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
@@ -1084,11 +1071,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.4.0"
+version = "2026.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [[package]]
@@ -1131,15 +1118,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.53.0"
+version = "2.55.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
 ]
 
 [package.optional-dependencies]
@@ -1208,16 +1195,16 @@ wheels = [
 
 [[package]]
 name = "griffelib"
-version = "2.0.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
 name = "groq"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1227,50 +1214,50 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/84/d99c4894d32ed52bf2763127804343d9323dce22beb61d42aebc7d9c5f4d/groq-1.4.0.tar.gz", hash = "sha256:09b1ed51408c6969a11ef1a4dfe44d42ec975b5f1510e5de3f3dab56e22dffc6", size = 158123, upload-time = "2026-05-28T03:11:47.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/3a/31c54e35d694ba9c263939ecae0874c78fc51f22b9fb13d2dab50edf6e3c/groq-1.5.0.tar.gz", hash = "sha256:8648388f8668629490bb0eab11252b4cc43316149fda9c6343e9a9577fe7df88", size = 158239, upload-time = "2026-06-21T22:57:30.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/5b/28cfd8937be95c0814fd9458710a8a257fb8424a39e291b7bbd494476108/groq-1.4.0-py3-none-any.whl", hash = "sha256:99a3bcd57c71538f69cf11c75cdae91598983d2681b9a14008636a018c4b6d17", size = 143699, upload-time = "2026-05-28T03:11:46.23Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c3/cac2aee75198c0382a2e6070619a798de2288e01850abb6e999746bb92e3/groq-1.5.0-py3-none-any.whl", hash = "sha256:a927fd75b4a60cb066c408cb4f9647536caf74e241ea75bc57d1810501b8203f", size = 143690, upload-time = "2026-06-21T22:57:29.213Z" },
 ]
 
 [[package]]
 name = "grpcio"
-version = "1.81.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272, upload-time = "2026-06-01T05:56:22.827Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/d5/896a3aaf07068d707d88b282a04914b872db4d32d3c7e6d88e43a3b911fa/grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c", size = 6053538, upload-time = "2026-06-01T05:54:58.965Z" },
-    { url = "https://files.pythonhosted.org/packages/68/6a/7e3eafa4727cd405ff917605ed2949e2af162f233f5cbdd773723a5fea7d/grpcio-1.81.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8bb1789c94322a13336a2b6c58d9c14d68f8628b6e24205a799c69f5bf8516ce", size = 12053447, upload-time = "2026-06-01T05:55:01.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/79/a4302aa82428de48a922421f522b027a1a727ab4d0926368454aa953d36d/grpcio-1.81.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e4d053900a0d24b75d7521139a3872150301b3d6bde3bed5e12318fb25791e4d", size = 6595872, upload-time = "2026-06-01T05:55:04.946Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/1f/7ff2850eaefbecf99af3f624dbb28dd1ad6c5fd4c1d8c26909ed6482673b/grpcio-1.81.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:db217c2e52931719f9937bd12082cd4d7b495b35803d5760686975c285924bf8", size = 7303857, upload-time = "2026-06-01T05:55:07.205Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/98/1f3896a9baae1f2aedf4e99c55291d6fa1f30ad9603d63bc18bda967b53e/grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22", size = 6809676, upload-time = "2026-06-01T05:55:09.513Z" },
-    { url = "https://files.pythonhosted.org/packages/34/8b/3441983718095208c5d797fd3239882e97ea89a629f41c8df94b4eef4df9/grpcio-1.81.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:275144b0115353339dbb8a6f28a9cf8997b5bf40e37f8f66ac0b0ea57e95b43f", size = 7412654, upload-time = "2026-06-01T05:55:12.777Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/98/1eddf07df6e4fe85cf67502a793f7b05468b2dca3d1ef35b972cf5d54468/grpcio-1.81.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5192857589f223e5a98ff0e31f6e551b19040e647d17bfe10116c8a2ce3b8696", size = 8408026, upload-time = "2026-06-01T05:55:15.514Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/73/3860341e6a1f5347be6ab35c6c0e1e3a8eb59d010388207fd561dcf01a88/grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb", size = 7849498, upload-time = "2026-06-01T05:55:18.078Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3f/0ea06bd85c701966aa3f8f37314f2ed83520d2b7590f42d643d445d8bc8b/grpcio-1.81.0-cp312-cp312-win32.whl", hash = "sha256:98c6240f563178fc5877bd50e6ff274463e53e1472128f4110742450739659fa", size = 4184161, upload-time = "2026-06-01T05:55:20.127Z" },
-    { url = "https://files.pythonhosted.org/packages/39/e3/a7c387406827a86f99ad7838b995bf9b4a182ffe2d2c439ed2873efec952/grpcio-1.81.0-cp312-cp312-win_amd64.whl", hash = "sha256:87e33b7afcfb3585121b5f007d2c52b8c534104d18f556e840d35193ca2a9141", size = 4929958, upload-time = "2026-06-01T05:55:22.736Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/29/779ee53c931d0fd55c1d459fde43e485172caa3ac87cbd43d003a13a0185/grpcio-1.81.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:62bbe463c9f0f2ff24e31bd25f8dd8b4bae78900e315915a3195a0ef1471a855", size = 6054973, upload-time = "2026-06-01T05:55:25.043Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b6/7211807926b5a17f8d9a5d47c739a163d6812fefe3e4714e81cf92945ed7/grpcio-1.81.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43c121e135ae44d1559b430db2b2dfad7421cbbe40e1deba506c7dc62b439719", size = 12048662, upload-time = "2026-06-01T05:55:28.453Z" },
-    { url = "https://files.pythonhosted.org/packages/64/89/b1b93ef6b34bd20bbaf707fa99133bc9cc302139d5ec6f77a165c7169796/grpcio-1.81.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f345de40ef2e65f63645d53d251824e6070e07804827c5b00ec2e44555f9f901", size = 6599116, upload-time = "2026-06-01T05:55:31.185Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/bc/c89f9b9d1c22895715356a1e009554dae66319e97826bb4d30bcda7d29e8/grpcio-1.81.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8c0855a350886f713b9e458e2a10d208009dcaa849f574e39cd6067db1fe1279", size = 7307591, upload-time = "2026-06-01T05:55:33.463Z" },
-    { url = "https://files.pythonhosted.org/packages/65/4a/1df2a4cb4a1386e066ab7e4175e34bb884b35ccb60d3621c09c84af6aabb/grpcio-1.81.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a524cd530900bd24511fcb7f2ed144da4ea37711c4b094475d0bceca7a93a170", size = 6811797, upload-time = "2026-06-01T05:55:36.731Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/dc/fa189d20601a1be25b08850cfb733879bbb1047b62a8feec3a60e3e1a87b/grpcio-1.81.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e7746ba3e6efc9e2b748eff59470a2b8684d5a9ec607c6580bcaa5be175820bc", size = 7415131, upload-time = "2026-06-01T05:55:39.451Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/a3/5625c48cb48d23c6631b3e5294f88e4c751f22a52591ae78859fab96dca1/grpcio-1.81.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:aaaa4f7f2057d795952e4eacf3f342be8b5b156992f6ac85023c8b98794ebd47", size = 8408398, upload-time = "2026-06-01T05:55:42.219Z" },
-    { url = "https://files.pythonhosted.org/packages/75/34/0f8202c6809a46c2b4d69125ef3667c40b1c211f8e19930e5fa1f1197039/grpcio-1.81.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0fba53cb96004b2b7fb758b46b2288cb49d0b658316a4e73f3ef67230616ee65", size = 7844481, upload-time = "2026-06-01T05:55:44.849Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/95/c3366b5b5edf4c4adc90f2e29ca16e57965a8e56dc8d2ee89565ba1905bb/grpcio-1.81.0-cp313-cp313-win32.whl", hash = "sha256:c197e2ef75a442528072b29e9755da299110e8610e8bcbb59a6b4cf55384f005", size = 4182777, upload-time = "2026-06-01T05:55:47.459Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/a7/932f2f748511a32e641a2aba0d30dded3ed6e8bc330e0924e4d5d86853e6/grpcio-1.81.0-cp313-cp313-win_amd64.whl", hash = "sha256:194eddfacc84d80f50512e9fd4ee851d5f2499f18f299c95aa8fb4748f0537e0", size = 4928085, upload-time = "2026-06-01T05:55:50.158Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/1d/28b231333857deb840bc3d182ae087510170ea6d68f21393aeb0fe499530/grpcio-1.81.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:a9351055f52660b58f3d4890ea66188b5134399f82b11aa0c55bd4b99eff5390", size = 6055712, upload-time = "2026-06-01T05:55:52.889Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/b8/999c14f9dff0fc47549d2e827cba1343ddc18e1d1bf0d06d2cf628eecbd9/grpcio-1.81.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:300f3337b6425fd16ead9a4f9b2ac25801acb64aa5bc0b99eb69901645b2b1d2", size = 12057189, upload-time = "2026-06-01T05:55:55.952Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/3d/1fbde079572562af65351151d840525a13879eb7b481d35b55cd64c6127a/grpcio-1.81.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:97bbd623f7ded558fd4f7cb5a4f600c4d4de65c5dd364c83a5b14b2a10a2d3b5", size = 6608136, upload-time = "2026-06-01T05:55:59.069Z" },
-    { url = "https://files.pythonhosted.org/packages/32/89/1f17cb6882abfd8e5a303a25d5d1665abef5a8c499a96198c65a651d1b85/grpcio-1.81.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ff83d889e3ebf6341c8c7864ad8031591ad5ca61599072fc511644d1eb962d2b", size = 7307045, upload-time = "2026-06-01T05:56:02.376Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5a/f98e91b2e755652e637ea2144318b0229b290062199f761b445fe1fa6015/grpcio-1.81.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4fe218c5a35e1d87a5a26544237f1fa41dfd9cbd3c856b0810a30061f8b0aaf", size = 6812794, upload-time = "2026-06-01T05:56:05.777Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0c/77892d715ac41e7ec0ace2a50080ffb64e189188056f607a66fe0014d1ee/grpcio-1.81.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b8b025b6af43ee0ad4a70307025d77bcab5adde7c4597786010d802c203e9fc5", size = 7422767, upload-time = "2026-06-01T05:56:08.524Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/b8/aa04590c6564714d94954515f15a236e59d4b9b3ad01e615f1b706d7792d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3d4e0ce5a40a998cf608c8ba60ecfe18fdf364a9aa193ae4ac3faeecd0e86757", size = 8408551, upload-time = "2026-06-01T05:56:11.283Z" },
-    { url = "https://files.pythonhosted.org/packages/43/3d/4f4a3450a1973568910c6909cb74abbf2126f68aefae5976962f9f7ad50d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe", size = 7846468, upload-time = "2026-06-01T05:56:14.536Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f4/5827fd248221ad3b44161c23ce9b5f4ee405b04fc6da5fd402a9aa87a84a/grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664", size = 4264427, upload-time = "2026-06-01T05:56:17.192Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/127dc2b246096ad50ef7c8d9b7b31d757787aeb796368bcdd4454e4204c4/grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b", size = 5070848, upload-time = "2026-06-01T05:56:19.735Z" },
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
 ]
 
 [[package]]
@@ -1284,34 +1271,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.5.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
-    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
-    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
-    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
-    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
-    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
-    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
-    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
 ]
 
 [[package]]
@@ -1470,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.17.0"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1484,9 +1471,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/65/9826515abb600b5722bcf53f8b4a2fb58340b1f8bfcaee19f83561c13a44/huggingface_hub-1.17.0.tar.gz", hash = "sha256:fad842b6763ef70ebc3919665b1b9273645203185400a7d6c5eddc2323cc3435", size = 797082, upload-time = "2026-05-28T15:12:13.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/7e/fad82ad491b226e832d2da90a1a59f36acd4526cda8c726f639834754aa4/huggingface_hub-1.20.1.tar.gz", hash = "sha256:9f6d63bfbeab2d2a8357200a9bc4f18cd2c8bfac9579f792f5922e77bf6471d0", size = 859910, upload-time = "2026-06-18T22:06:53.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/28/d7cef5e477b855c25d415b8f57e5bc7347c7a90cad3acf1725d0c92ca294/huggingface_hub-1.17.0-py3-none-any.whl", hash = "sha256:3b8156d23118e87f6a587648bfbc04f04a12a757ccb4ed298b35c4ae638bf24c", size = 671546, upload-time = "2026-05-28T15:12:11.441Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/ff8516e74b459da3dce9567540c39f2d305ee7a2655109f6802873ff1588/huggingface_hub-1.20.1-py3-none-any.whl", hash = "sha256:274448a45c1ba6f112fe2fb168ead05574c654faa156904157a84085cfae14bd", size = 719837, upload-time = "2026-06-18T22:06:51.486Z" },
 ]
 
 [[package]]
@@ -1660,23 +1647,23 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.7.0"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/2f590052b55cbdd0ace470ee7ee1f685f6882051be93a9374891005623e2/joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4", size = 232967, upload-time = "2026-06-02T09:59:34.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/83/b6b62a66a06ce872d9429a5eb5ee20b2002fd9c331b953c94381c1f7c9f9/joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224", size = 70387, upload-time = "2026-06-02T09:59:33.264Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]
 name = "json-repair"
-version = "0.60.1"
+version = "0.61.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a6/d69888cb4ffde30e80db1e6c32caaadd2f984a80067d5ea72c2cb3f61c3f/json_repair-0.60.1.tar.gz", hash = "sha256:841661cdd2df507c9a4e189097f38ca6bc372e06d4b4e36d72e590f68176c290", size = 49451, upload-time = "2026-06-03T17:28:44.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/c0/1cb689126eacd166fd5a78370f095c7d3a250808dabeda129300e5280110/json_repair-0.61.0.tar.gz", hash = "sha256:48759cc6c3052814c797d1d56787d9e1d451603a8760a55d619e97d2f49353d6", size = 50055, upload-time = "2026-06-16T12:18:33.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/1f/2a2b5eea8ef5762a86ad3f8fddddaaba2c0d76dd44e644b9158900868bec/json_repair-0.60.1-py3-none-any.whl", hash = "sha256:ba6ff974f2a8bef2f7768144a7f03f870a816443f03da27a49cdd0ec31a78049", size = 48045, upload-time = "2026-06-03T17:28:43.038Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b9/e996902245d5e12e55b0b2e667d3e83a4636dec3692e405e5b8ea0868263/json_repair-0.61.0-py3-none-any.whl", hash = "sha256:ee9fe5f95fcb2713d72d4495b67b794b62ff2cd24d6dba3bfb3173d9f7ab0f7d", size = 48490, upload-time = "2026-06-16T12:18:31.883Z" },
 ]
 
 [[package]]
@@ -1749,16 +1736,16 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.58.0"
+version = "0.58.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/4e/daccd4fd72ad3f17b8fb97f69403774d6c510b5d513521b454fdaedb0561/libtmux-0.58.0.tar.gz", hash = "sha256:abbe330bec2c45687a4bf417ee436373b37046afe123ba547495ee0448e1145a", size = 522080, upload-time = "2026-05-23T16:03:38.566Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/58/346776e0491ede33e1554a4bff9b545dbe9f3164e45abac483195938a1cf/libtmux-0.58.1.tar.gz", hash = "sha256:a294dd585aa419d4ecce36f3e55df656693743c97a0b5b5bb1e5fea31ada2482", size = 519541, upload-time = "2026-06-17T00:03:31.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/d5/1cee7c13865d0d55ddb54709aaf85e0dc645e2998ce85ffce2c36d3bf08d/libtmux-0.58.0-py3-none-any.whl", hash = "sha256:1aec9875983a8eb121a8de7be7dffa6b97d9754c013ce960944d058764e47ec3", size = 113680, upload-time = "2026-05-23T16:03:37.049Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/e44ada32edfe947c40d4dfc596a6f5355400a16d08be06016bd754375e41/libtmux-0.58.1-py3-none-any.whl", hash = "sha256:ab0f47d03a59d674962bc23e36e188fcfa4a82b0f270d474afab519e3076839b", size = 113653, upload-time = "2026-06-17T00:03:30.48Z" },
 ]
 
 [[package]]
 name = "litellm"
-version = "1.87.0"
+version = "1.89.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1774,9 +1761,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/0d/ccdf682ccfd7f18bf0e179c39d85616b8f8ef05a798588285310412db13d/litellm-1.87.0.tar.gz", hash = "sha256:cafc1882cb0cbab8374c41180af86e4a067796e4524e15f59e99f6e689cd1bd8", size = 15453755, upload-time = "2026-06-02T03:53:29.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/20/88a372fa7e50fc2c33458c6eef94a79afcf7bdfa43610079531b82b484a3/litellm-1.87.0-py3-none-any.whl", hash = "sha256:fbbba7e47ae29b55f878fe1acc80effb92761bc168f6236bd81a0cb6e147d855", size = 17103948, upload-time = "2026-06-02T03:53:25.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f1/34d174ff1d84e459b30f971606ac9cb7078ad24cd7661e9786b25adf7def/litellm-1.89.3-py3-none-any.whl", hash = "sha256:414ef5aee504b2b3eb1b219d39f1c11902db399cbdbc06e5fb550c15d731abeb", size = 15495226, upload-time = "2026-06-20T22:42:23.156Z" },
 ]
 
 [[package]]
@@ -1809,88 +1796,73 @@ wheels = [
 
 [[package]]
 name = "lmnr-claude-code-proxy"
-version = "0.1.21"
+version = "0.1.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c8/697a70901c32022ff3270e5d39d09c60edc86f9b95b0371acbaba95faffa/lmnr_claude_code_proxy-0.1.21.tar.gz", hash = "sha256:897cb3c87a0a0f9c9d681f178416407202eec16575573589ab42a1a4241e9346", size = 61105, upload-time = "2026-04-22T16:20:17.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/e8/b3987e4e286052f4ccaf4408fe5404d14e4c0f65841118ccc5c97de60d77/lmnr_claude_code_proxy-0.1.23.tar.gz", hash = "sha256:6d8fa044c2f5774a6b70de9025a91c13c74361d4349ae528b4b4fcca48219a13", size = 60777, upload-time = "2026-06-17T22:02:48.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/4d/583e1574534aaeac7fc21e2ab5c8391c62744980eaf596593cf48d154d97/lmnr_claude_code_proxy-0.1.21-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6e5286020412aca3d8a9613cce9526b40099436a0f5afc4fe06cc8229f08c456", size = 1372699, upload-time = "2026-04-22T16:22:25.556Z" },
-    { url = "https://files.pythonhosted.org/packages/63/7d/2ecfad1e2ab8a61af79459c4ccd6af8988bc52a2910189af115d01f88969/lmnr_claude_code_proxy-0.1.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8921cc4d3a5cfc7f47f43b26790f70835ab94311ca03410aac4f10d41e1f3b04", size = 1313653, upload-time = "2026-04-22T16:21:02.605Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/a6cbed39e3438d6dfbe8e2b8ee5b6cfd5f61a0090cf7ad0369d6619278bb/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e855b3a52bd540c534abf8b87823855088bfb6068170dce43aea65b3b8d30642", size = 1358223, upload-time = "2026-04-22T16:20:18.195Z" },
-    { url = "https://files.pythonhosted.org/packages/53/55/18fb708d5daee9de8b439d8f7c419775b9ac9e88747a5b442ebac90c9964/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:815693c1e45aca834cd24b6a7e435d88d59a4dcd50bad2b55b1b89b179231c72", size = 1191660, upload-time = "2026-04-22T16:20:34.831Z" },
-    { url = "https://files.pythonhosted.org/packages/57/44/7f3df158b6421578b12a4c1c7d0b862d1c21f3364ab1e87c13a76a62b3a5/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:296432de34ff54543c702720215e5db4fdd2db97a2a84f9cb257c55b3a20f3c3", size = 1361646, upload-time = "2026-04-22T16:20:33.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/45/bcab851ddf317099def6c5ae7be52e758529a47bfddcbb81cd3abbd01aa5/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04455e30b8451d0b2f316ca6580806b65f3a246eafd8351fa5f8169f7800fa95", size = 1276576, upload-time = "2026-04-22T16:20:31.939Z" },
-    { url = "https://files.pythonhosted.org/packages/83/84/bc5799bc88f123ddd105edeabecfe247b2a967dadc6a158c0f406e89dee6/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64b245d6fcc97a851d23a3f66191076c6a729a599b9f597f59779beece6025a5", size = 1503868, upload-time = "2026-04-22T16:21:49.791Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f6/8e7bed52697a7ac43ac71deff08c667b54df8e4ec654bde4bd805abfb245/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:39f181d84a00ee6bd6fe90fe3ce4b10e600ccd1a71a0ff26693defcb9fd9c6eb", size = 1471162, upload-time = "2026-04-22T16:22:47.643Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f7/540674d61f2117fc2c4bcc8ac89d31a5334fd8e68a0032ffe6109e30ef83/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1a9b6dea12972f723536f1239976993ac74dd8a3e015c2b3c04a799422e6f6b4", size = 1646664, upload-time = "2026-04-22T16:20:03.48Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/b5/869f3d1effab5ace022a51206030d716dabda8f331abc2422f55449bc6ad/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:91e499ac1b45836541a6dcc13e433409ba6c97a6881677abbb42225769924167", size = 1466278, upload-time = "2026-04-22T16:21:04.047Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c2/f3f0a36e1df6c8b1c9a093135b192985e0d172680da0a388074e8b7579f3/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:058a2cbf9be7c27cc98d155b6c01e5070834f3a748da89fdf0aaaf1878ca1a15", size = 1526212, upload-time = "2026-04-22T16:21:30.771Z" },
-    { url = "https://files.pythonhosted.org/packages/29/41/9c54ddc3e7670824477dcdca4468d8db7e2467f7bc76a98ddd8ee369a6a1/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a7035d9015ff03d42920c1d47a82cd182d256c3b80cac82f6d36cc5594983386", size = 1720244, upload-time = "2026-04-22T16:22:45.163Z" },
-    { url = "https://files.pythonhosted.org/packages/70/7b/b394ffc305084b7c16ed46211909ec17c34af6570286ccb4eec2e836fca0/lmnr_claude_code_proxy-0.1.21-cp312-cp312-win32.whl", hash = "sha256:0ec8296341ee28560623653cd9cbc9fe0cce213abbb7be1b76696a60cf8bc4d3", size = 1079244, upload-time = "2026-04-22T16:22:06.429Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ed/8d9d5dbfb84e505d3046b54ed79cbcd53adcb6ae79584f88f6c0604cca7d/lmnr_claude_code_proxy-0.1.21-cp312-cp312-win_amd64.whl", hash = "sha256:d29c00ce28af31855d7ba72a1a037c5f9f37148d2d08643f38a0e76cf195680e", size = 1323469, upload-time = "2026-04-22T16:20:07.286Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/32/66cab9f287768eeb28ebcad36f8d61d0b1ebe5dc200230c1af42956ba711/lmnr_claude_code_proxy-0.1.21-cp312-cp312-win_arm64.whl", hash = "sha256:da87d2da2b94057c69837fea8897878fbc564efc3740a9e7cd0faee9817786ff", size = 1239719, upload-time = "2026-04-22T16:21:45.134Z" },
-    { url = "https://files.pythonhosted.org/packages/39/52/4db4343b811972181cb2c5531791b508c37f1509ef0115cb06cd18c5e6b8/lmnr_claude_code_proxy-0.1.21-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:79ec94a3ec0e2b2abea9a7b04ce6a2899cc466722807cbb32279941c35b1dfe1", size = 1374685, upload-time = "2026-04-22T16:20:15.995Z" },
-    { url = "https://files.pythonhosted.org/packages/22/91/815d0f4b1d5d79e57930af3c3294768274afcb814f9d5a5bf064a54cf958/lmnr_claude_code_proxy-0.1.21-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f2d4e54cd47a6d02dc518f4016de5db345fea3056ec168d2bd0e260613433db1", size = 1314118, upload-time = "2026-04-22T16:19:56.344Z" },
-    { url = "https://files.pythonhosted.org/packages/97/d3/ddef5f5f20594ce2477472bd7b3d86fce5648a73fff72a89fdbed9483957/lmnr_claude_code_proxy-0.1.21-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ea907116ea2cf310cc11de658d06d863521a1d295ff9c9471a936e7ee3621d0a", size = 1358327, upload-time = "2026-04-22T16:20:39.071Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/91/21b4f403983103768009964aa34e0a1aa3f39b464b24cc5faa22ccbc0ec4/lmnr_claude_code_proxy-0.1.21-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c89c504dd3cbcc26037f92c98dbfafd9d6de283ec16224873dac3002410c9823", size = 1191962, upload-time = "2026-04-22T16:22:49.238Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6c/59b52cb4c3f383870c44398e964c4dc25dd1e515e601f6019402d920f1bd/lmnr_claude_code_proxy-0.1.21-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30429aae486a979419c216546b5f4476c8b81eb7801d4d5a4d260d867941dc9a", size = 1361671, upload-time = "2026-04-22T16:20:10.418Z" },
-    { url = "https://files.pythonhosted.org/packages/94/5e/8a908d2fe3023763690bc0ef6097e070dfce54fb89af79eca2ea8bbe17ea/lmnr_claude_code_proxy-0.1.21-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:72075c8fe15f9646b3ae14ec3b8a19a12ba9f382c607f655f988167f11f62400", size = 1276646, upload-time = "2026-04-22T16:20:29.216Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/72/d26911c0cfe3c4f30e1d759d2e7e6979cc9fa4a8b24f8918064173e3b910/lmnr_claude_code_proxy-0.1.21-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac82208af0ac2b67b973ce32814c07b32ab366d0786f9ec7bb8607a2703ddb0c", size = 1503955, upload-time = "2026-04-22T16:21:25.91Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/fd/caf91d3d888b137803a38ab9c866fd0b287354f78d1f77428d75d9ee1df7/lmnr_claude_code_proxy-0.1.21-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:df0118493744a07ea295756f1cb832bdb61607480f80b59cbd381ab6cb87208e", size = 1471232, upload-time = "2026-04-22T16:21:58.272Z" },
-    { url = "https://files.pythonhosted.org/packages/43/db/d4b931f0138af86b50ad1073ac34db21246d7a9e65cc6892499ae5410383/lmnr_claude_code_proxy-0.1.21-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:08b2db0aafb9da288e28be351cc1d4e91d5d530aef3a10ae5514d0b7639c692b", size = 1646914, upload-time = "2026-04-22T16:20:05.668Z" },
-    { url = "https://files.pythonhosted.org/packages/11/24/66e4caa7457183a122cbce6ea4066a9dd914ad1b2a2eba754d0f425d3ed5/lmnr_claude_code_proxy-0.1.21-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:622a73ac12c126a1fd4cd29bed0daf2ed0eec8bbcc109b508694a230301ef21f", size = 1466321, upload-time = "2026-04-22T16:20:50.067Z" },
-    { url = "https://files.pythonhosted.org/packages/04/47/648ab32a7fe64310a16655df4381e2a11db77b095f31548f794f81184813/lmnr_claude_code_proxy-0.1.21-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6d3f553d1013ede7d4f7fdbe8715a77ad931f9b5c24bcd53c901b7ec6be2b508", size = 1526180, upload-time = "2026-04-22T16:22:00.014Z" },
-    { url = "https://files.pythonhosted.org/packages/63/5e/ebf5cc8fbaf471a52f3c2d0d9134c21cb404d57994a082b2a08ae03ad2a3/lmnr_claude_code_proxy-0.1.21-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e158158a3b85cf8db708df429c2a3444453fec5408da6ac701d85c032fbcac5f", size = 1720394, upload-time = "2026-04-22T16:22:16.178Z" },
-    { url = "https://files.pythonhosted.org/packages/33/1b/a3c551cc44e60e24d5bb0444f8a95a9f6b0c5b0f35586a63a4c1042ad345/lmnr_claude_code_proxy-0.1.21-cp313-cp313-win32.whl", hash = "sha256:3e7b6ccb05bb994f38fc8a9cb27e169a0e1fb659e89f8cca3d46af37db0493a4", size = 1079406, upload-time = "2026-04-22T16:20:46.505Z" },
-    { url = "https://files.pythonhosted.org/packages/af/d6/382c0690e94a44a5414ba64810c8c13fef0829dbe461439cf180318a90b6/lmnr_claude_code_proxy-0.1.21-cp313-cp313-win_amd64.whl", hash = "sha256:5e1fcaf93cff83557e147ad04e2e8928719761c1ef0cdae8e687cd90ca652d8a", size = 1323521, upload-time = "2026-04-22T16:21:51.476Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/2c/ea58cea29168a8495b12a5d0f9e0d6269083d47c2517fc3b379520f8be9f/lmnr_claude_code_proxy-0.1.21-cp313-cp313-win_arm64.whl", hash = "sha256:65bff5e15288b273019413fdc711bbd9e0cdbbe9a678f16ac044c19f2c443765", size = 1240859, upload-time = "2026-04-22T16:22:01.612Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/59/b7ca350da44bda8756af9d24293a807e54a0904b3a2438f9bd31e5a63fa0/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f372791e240608b53db5db4fae581a7edd4fa22636898a9f6d649a0d5ccdd159", size = 1372869, upload-time = "2026-04-22T16:20:19.621Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2a/090156381d2b5ec4426377784d7aff32f029829aa4fd44d913f6360db35a/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73c9ce9fc15ebbc9c0e59b0d80e928814de4cdc359245ebb9b279896913fcfe8", size = 1313902, upload-time = "2026-04-22T16:20:13.014Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0b/f0c6a19b8c61db8182d44922a3ac2cbbcdb9223e28df04f44fb4ea23a284/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:44b3b5c0c9f4c32e481214dd1d3ff39c8596d5c7c1e031e33e8ff29371d4d372", size = 1358539, upload-time = "2026-04-22T16:19:50.411Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/65/047d219a1abae86ca06adc863feb26f4996beaede32858612bae2f7325d8/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32f253bc7be435636d16eafc2cc218b7ab0a3c56ed67f2a0fae917742accdc50", size = 1191697, upload-time = "2026-04-22T16:21:19.482Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/59/8516e80c5e042d992284a3480bea948d2ecc8eaaac17a47c0ea661fa15d4/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:18c9c0c0ce756f7473ec7e396c43c572e7166d6a246c23347de800bf1f236986", size = 1361736, upload-time = "2026-04-22T16:20:59.39Z" },
-    { url = "https://files.pythonhosted.org/packages/89/9f/6225c3842c13d9667ae6f510b03da407b4851e2dd896c438233ebb27cb38/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ceeb2318ea5682c69b1ff72daabcac4a2fbc07a78794cd1d55acc26edbf9403b", size = 1276804, upload-time = "2026-04-22T16:22:50.871Z" },
-    { url = "https://files.pythonhosted.org/packages/31/41/f2904249c0339a025bc4852054e4b22749079ba3b6edab8062a7a1abb659/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb1b3429a5fe48faf016898c82c33661923d301a7fd61a30a37f71769ee7b336", size = 1504077, upload-time = "2026-04-22T16:22:30.445Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/4a/b99684fad6d0a9cf08fa46c40dd7ff09e5756110812549924a30e75e6ce9/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:ecc2ce42767658fa253acd47946704f1053dfb986d3c99bff85596e95bc1ec80", size = 1471510, upload-time = "2026-04-22T16:21:14.295Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/22/7346b8377e47ebd33e6820348d1fe9b2d54d3ef12acdf9568d6788f88f74/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:37d10e1c924dcf4e1ed61a24943c1cbf374b97315d7b8623a7432e4cfec8c948", size = 1646674, upload-time = "2026-04-22T16:22:12.961Z" },
-    { url = "https://files.pythonhosted.org/packages/30/67/b2c9926dc0cc3fec3e4f3d21422829828089017d929ea244917852393b63/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:81df9f336f12f4ca6920ef02617aa5d9722c7680a4378e4b88255afe7c2c201b", size = 1466256, upload-time = "2026-04-22T16:20:44.351Z" },
-    { url = "https://files.pythonhosted.org/packages/29/87/d670907853b3cf55f16f8860b155a3e0f292cb91bd0ce1dc0f07222c66a1/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1c87a2cb6e1673753d7477774304ccf13debc217869ebebb893e4ff112ae89a2", size = 1526454, upload-time = "2026-04-22T16:21:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/41/c7/57f01bd9095132f84b57ec0b4b4bc2242764f1816f00a5002b542f0022db/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0722476427bf5a61a50386d294dfd1576afa20ed2794b11bfce4f7c59b4dab54", size = 1720509, upload-time = "2026-04-22T16:22:04.857Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/bd/d2dcd3ea62ad820d86130fefe593f29c8a13e76b1f2c1898297d46da2666/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-win32.whl", hash = "sha256:bd9f06b2d99f02ffbfd85a5b756fc8467338379c38130b8c1ed6285d1b8a349a", size = 1079417, upload-time = "2026-04-22T16:22:14.619Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/1b/94a953b475f87f8b0e77e9b727ff7d9f0d72b7178fbe1c6dcec829d02618/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-win_amd64.whl", hash = "sha256:fe9b33e5ed4314a11ddab5ccbe24276a3007e134fe74d1d06e2bacb3614c1374", size = 1319032, upload-time = "2026-04-22T16:20:26.397Z" },
-    { url = "https://files.pythonhosted.org/packages/12/cf/6cf6a232624c4e437237836185db57c6368f5c6503486741d0232b54d407/lmnr_claude_code_proxy-0.1.21-cp313-cp313t-win_arm64.whl", hash = "sha256:d1b67147d30c71297fd36cf754e18526dc20d0cc90d1cab006b30d185c3b97fc", size = 1239776, upload-time = "2026-04-22T16:20:24.404Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/62/0782f0428fe4cba25255d3ec73bb83ab190f5aa52f47cac2777e103439ea/lmnr_claude_code_proxy-0.1.21-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4c84e44439d20c417be69db641ba8bed4ddc39c1ca86f4bb696d0955a7a7de2c", size = 1374862, upload-time = "2026-04-22T16:20:56.379Z" },
-    { url = "https://files.pythonhosted.org/packages/12/39/033d8576e9e34f8ca2b7b29e8744e142b185b249accc2472da0491e1f14b/lmnr_claude_code_proxy-0.1.21-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:666c796e5b6b056dae0c06eab03bb1bf6a837bbcd552de70932cde28405fbf94", size = 1314152, upload-time = "2026-04-22T16:22:21.5Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/7d/f007d1da60ad42511680d75a3e01ef4cc32db95d7344d8d1d67380f54f03/lmnr_claude_code_proxy-0.1.21-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e5873f593fd7b17c79875b79aff8cf5b461849d0cc6871cccc0a53abdc289e46", size = 1358520, upload-time = "2026-04-22T16:21:22.803Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/b0/783ebbadb49f2650d1f4e31da877626eeb08f063baf3889e589be4f0cfba/lmnr_claude_code_proxy-0.1.21-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b037b944c112a18399c83ab566cb410b5afaa899d7f63fe648644f8ac0736db", size = 1191925, upload-time = "2026-04-22T16:22:07.922Z" },
-    { url = "https://files.pythonhosted.org/packages/20/3b/a120fe21b472f90c6b4f887cd037c5382b4bdd502b6da9a928362b7ffa19/lmnr_claude_code_proxy-0.1.21-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb6f2eb6f1cc5c04c972024475c0b0af3b64f96567905290ad599fd671f7d789", size = 1361680, upload-time = "2026-04-22T16:19:53.061Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/d3/87b6b42e3913ef2c8ebd720783aca13f5b12728d0731cfa8cee1d3442ea9/lmnr_claude_code_proxy-0.1.21-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:85bc58578c325435b6fa1dfc180fd247805564f3cff32b4d922a5811b38c9ac0", size = 1277021, upload-time = "2026-04-22T16:20:42.625Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0f/c6530e867a0b7e8c9f4b143ab99d3e1856b3cebe7966d12f2ff9b72be0e6/lmnr_claude_code_proxy-0.1.21-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98ec0589e7bd3607ab9c34d4e4805760794c4a3e1956de2ba7d491da90ad38af", size = 1504147, upload-time = "2026-04-22T16:20:14.336Z" },
-    { url = "https://files.pythonhosted.org/packages/77/59/039cc53eba7f65e9431ea19f57fe42e867322f5e853f47beea73f167250b/lmnr_claude_code_proxy-0.1.21-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b0d0bd832775a6193dbe877d1cc2fd1155528c467d15f5515da5c6c6248a8298", size = 1471404, upload-time = "2026-04-22T16:22:41.359Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/36/cc4406315282c89973dc9fac86b76c253a782baffa083ab4179312b3a99e/lmnr_claude_code_proxy-0.1.21-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20594371cd0951a617ef8ed41cc05b27906c1f9e1bf4a9b2b60b88a05fcaf59d", size = 1646874, upload-time = "2026-04-22T16:22:31.883Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/11/1fe8df928f1ca7d895985aeac4a96e61b16dab5b52376c8761fdfa0ac6ae/lmnr_claude_code_proxy-0.1.21-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:3612e944db84891146b5ab7dd84b508646813cca9726dc94c4e12a8b7b246c34", size = 1466245, upload-time = "2026-04-22T16:22:03.248Z" },
-    { url = "https://files.pythonhosted.org/packages/06/4b/3811489282ffb5fed8cebd04a3f0fa8a63257b028cbe5c6ed727730457f2/lmnr_claude_code_proxy-0.1.21-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ace38e919f8ff655a154b6b4c93b6e712dcebc89e4013f7219e7c815c1b8e7b3", size = 1526319, upload-time = "2026-04-22T16:21:32.322Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bd/cf519add658fc34bfb86c92345fe63380305ad18c90328a194e36162c55d/lmnr_claude_code_proxy-0.1.21-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7a7a259ef790ef3e41850263f76ddb6de14e475ef3678802fefcdef8ffd653cb", size = 1720474, upload-time = "2026-04-22T16:20:51.473Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e1/872ea51ebfd66e5ff8c42845b1bf3e0969a7b3a7732c20844c740a5e0560/lmnr_claude_code_proxy-0.1.21-cp314-cp314-win32.whl", hash = "sha256:0719ceaa6f9e1a1e153063025f63cdf38b672f015c52a9fe8cc9ea2a4c51364b", size = 1079460, upload-time = "2026-04-22T16:22:17.697Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/94/85e960e3333b64267ade93261503d14f846fc72a3de88e3859cf9bea562d/lmnr_claude_code_proxy-0.1.21-cp314-cp314-win_amd64.whl", hash = "sha256:48f5560bd0747134db92b8015ab1c8d9d15eb2510dc978f4899591e3bccc1892", size = 1323746, upload-time = "2026-04-22T16:21:05.481Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/4e/4ae5e2b14c498713fd710d17d5dce9c0a631c52e12917cf6a6834251c607/lmnr_claude_code_proxy-0.1.21-cp314-cp314-win_arm64.whl", hash = "sha256:c6f74206ca6e2446718892810b084cbd677e2ecedfdb41ca51702a7155791bd1", size = 1240880, upload-time = "2026-04-22T16:21:46.709Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/6e/78c575900c18a0981d29fc71362328c6f433f3621f645cb17a96d2497aae/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:392231238c496317e1e22e3c44e40835c72b9e5524d2d731ac9e4ffbb6add484", size = 1374718, upload-time = "2026-04-22T16:22:36.709Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/73/5b066817351d96d6d07c3a9fb4e61800b38d4bf7239d7f7dd85acfd8639c/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e9be49928b394c3bc4681ac75154b60831253ec8db9b48f4a38451aff8092dd2", size = 1313913, upload-time = "2026-04-22T16:21:28.876Z" },
-    { url = "https://files.pythonhosted.org/packages/43/24/ca0b28b475c51939139e5f2d5251c2c48b3fc597ab46bdba45d596df6c26/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e6363961ff887464567e6b5a7e9f6628fb54855732386ab0f3fc9766a8de428d", size = 1358620, upload-time = "2026-04-22T16:22:33.446Z" },
-    { url = "https://files.pythonhosted.org/packages/68/db/26d9660a7c4e579d614a0bcf1d540a28da98b1f7d4c1a119f21c501d070e/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:efeaf3b9ca5f348194ef3d7e8d20bb7e2f459283989af8670bd5b09920762cbb", size = 1191745, upload-time = "2026-04-22T16:20:30.542Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/40/91209e046b174c34b9864511e8d27b32c0a9fc2b394390e6d90c4e3dedad/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db2288f0d9d065da7c378c2ba0ebfcefdb81ae0cc2da1f557e85be6953c9ff6a", size = 1361841, upload-time = "2026-04-22T16:21:01.164Z" },
-    { url = "https://files.pythonhosted.org/packages/18/e7/ee60526d49a45f10230604c1100907312cf259151c3cbdb786b254bc2bdf/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:09e0f770d4510d50eb9bdcc82e9ca67962b953a82e7362a28768f03e5cf459c2", size = 1276919, upload-time = "2026-04-22T16:21:11.377Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/70/8ac4988bf29e14568983cc8223f38b6fced2b6e4178c9820fc3fd97ea81b/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ab0938cc5b32ab421f42f0911128ab0911a36f40d53efaab4fa271042d892c1", size = 1504098, upload-time = "2026-04-22T16:21:27.396Z" },
-    { url = "https://files.pythonhosted.org/packages/62/34/5b298df809696c3bf013b711c9247de2b26bb73fff2cb2199efed8cf64ab/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d45052aef43e8113af2a7cc9c4c3b3d43913bc491d63b104c53c4222b5bdd43b", size = 1471349, upload-time = "2026-04-22T16:22:38.343Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/1e/ffc70dc5553e2eec1d2008ec07c995468e412140e11fb4909a8566ce23ea/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dde9baf97f087eea72e917db45bf05d008b1085b8bbde55c9b7b7ed726fd69c8", size = 1646898, upload-time = "2026-04-22T16:21:37.352Z" },
-    { url = "https://files.pythonhosted.org/packages/43/78/03b122c96fcebb30a7a3b37d18801926f0e6f57ee66bc1c70ff3f52a8a7d/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:42f546a3f81c0643318874ab6538ca204d7c88726e5c1c4128a71c3d8210717c", size = 1466261, upload-time = "2026-04-22T16:21:54.875Z" },
-    { url = "https://files.pythonhosted.org/packages/27/56/121495d793dba0f236714af9ae535144d057ec698576b65211094a857ea1/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:daa92abad72c589adfa341338b98fedddc208c0aa49d49c780259356b1b88dbd", size = 1526465, upload-time = "2026-04-22T16:20:47.969Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/05/7bf480dcddb7fe55a54c39ef6cf30707de80c48ed15073319f1990c52866/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2dfaefbe63483a86e34e7b6644a6b4685556a58813782f3a2fbfec81fbf5ff44", size = 1720603, upload-time = "2026-04-22T16:21:12.837Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c1/a6364a4b886285da7fe2734c0b428930b2ff645cb6698ef2623182cb9e59/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-win32.whl", hash = "sha256:c8d9b9bf2ef086a9d64c38d956a3f595333791333c564c942c1edaf60766d398", size = 1079452, upload-time = "2026-04-22T16:22:52.754Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/0f/74324a321b21cce7540040c2a5f4f176e221863c051ea3fc363262498197/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-win_amd64.whl", hash = "sha256:6540b70b04dfff16c03973b29dda1b90a3e691bd719ca33e09f9b34ec8f77379", size = 1319172, upload-time = "2026-04-22T16:22:35.02Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/70/b4ef57172983a4e0146fde7cf15413ea3418cadf9b003d546992c6c29f16/lmnr_claude_code_proxy-0.1.21-cp314-cp314t-win_arm64.whl", hash = "sha256:a2696b79cbec43bbe79ba3fbac9e12a90c17e9373f06a18d1eacef533a9a48bf", size = 1240776, upload-time = "2026-04-22T16:20:57.683Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/56/a58d7d129b5d04de7086f168f6f8f38f140ec6bc57da11d9e0565612b136/lmnr_claude_code_proxy-0.1.23-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f05a1978c707ba5df0be531dd2cac0da8117c86c6172d84cb4f5180c8123fc49", size = 1372073, upload-time = "2026-06-17T22:04:43.739Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/de/58a11459ad5f4274b8e87c7c52386e3ed0e31806400a4c25bc418db2a7a2/lmnr_claude_code_proxy-0.1.23-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1304486204ddc39a3f5639153df6ae4ee53152ea83063b0ce3331360f05ee026", size = 1305975, upload-time = "2026-06-17T22:05:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/29ecaff001a7904bcc4f43c5eec537b8525816ec5f0ed4fac9122544478a/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a3769f25f3341ae04885f3b8668fd48214b8eb9b72faa97b9d7dbc9095c8a40d", size = 1355954, upload-time = "2026-06-17T22:02:45.19Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/c82f3b7e6672642bbfcab008294f324b979ec17fe8c4dd1caa2ac932011d/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c64fcdd623ceec9f41cf0cd6761409a1c0add4e85409de294faf0647f5eb86", size = 1189115, upload-time = "2026-06-17T22:04:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/09/84/6d49fdefdef24e37997cd9da6a7b3b1e0933fec7d6b9b357394e3a6bddcd/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c372c3678aa21d422644bef5955a68b4b53cafb40a0c0804b09eab418443fb8", size = 1357661, upload-time = "2026-06-17T22:04:45.369Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/89/293fc625963d8adb61828edeeb348ee5eab8d9707f63771f2035d83cd16b/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bcd83941a84b89fc2f5dac40b10b7736a5602766f33afcd554545b0bf770fdc2", size = 1274822, upload-time = "2026-06-17T22:04:02.448Z" },
+    { url = "https://files.pythonhosted.org/packages/26/82/59b3f0e580519d07c0f9176ac9a47fca25e0d539284f9355d503d1139126/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44b270a4c40daf3b11a5d96694357c4ff99842e82c514281b2910eae4a5d653a", size = 1501770, upload-time = "2026-06-17T22:03:33.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/25/7d11adf65f6ccbb22929a5d842e3707a1f98ea5bf041f842c72d1a957b25/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e8ef14e4b592cfd27d057b47a25e9f62e6d900a95ed244c4acb3316b76f6034f", size = 1469005, upload-time = "2026-06-17T22:03:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/81/84/9f4de95e2789b59e2f4a5c65c4f7745743a85553bc7b97444aecf09edea6/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a77258d487989bf23ec6807e21cd2c334e9e457e9f854875a0c253cb04260387", size = 1648912, upload-time = "2026-06-17T22:04:59.001Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a5/c48aaa153629db2818849638b28166239a06ce351ea805576e369a10397c/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:2d6c4bf49bd060146577022d2f45a9921ce5604289d7f52db357fd3d5aeac838", size = 1463928, upload-time = "2026-06-17T22:03:36.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/8bb6cb1c11a1474361ae52610965f3ac3f8ac52d3d5d0e83da60989efdc5/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8b43a95fdf053fc4ebc0723363d9f88aa5060078733f9df6b3e991235c473a96", size = 1526261, upload-time = "2026-06-17T22:04:26.804Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/e761878f5ff53a5d9de5c5b8b8420d7b9f8473c0cafb34f3d94255016e9b/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9e7a58160b8c327e9fddbba828c86bb1084967519a160ae4f64d0ae01d65730b", size = 1720713, upload-time = "2026-06-17T22:03:01.577Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/25ac768a6e3a8e6e14b0571e6f6e5526a2c557337ee8a63dd640e2673fdc/lmnr_claude_code_proxy-0.1.23-cp312-cp312-win32.whl", hash = "sha256:d7ac385abe119b21aaf8ab1c1aee7f9dcdd8a03a3a00aad331f3326b6aac075c", size = 1077961, upload-time = "2026-06-17T22:03:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/5e/17f625ff97eae59ad6cd4f1e82c687dc291b7d8e50fc9d87300d5101b12b/lmnr_claude_code_proxy-0.1.23-cp312-cp312-win_amd64.whl", hash = "sha256:53c6d47ad2bea70dda75a642a3d8fa7b4fbb68c718958d37a5f994ff6f98d210", size = 1314902, upload-time = "2026-06-17T22:04:33.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/21/3441b032c060165d4f6eab6c4a89abdab7c369e1c42a6d3d66d61ea79d7c/lmnr_claude_code_proxy-0.1.23-cp312-cp312-win_arm64.whl", hash = "sha256:7192a72122633ce7d92e2ae4d3df53854c2aa3dddccf4f8c5155d0dfe3e574ab", size = 1240245, upload-time = "2026-06-17T22:03:55.958Z" },
+    { url = "https://files.pythonhosted.org/packages/44/59/321fae11909c8f77e63d8b5e6e6472d32e2faa4c60359aa274ba091e31dd/lmnr_claude_code_proxy-0.1.23-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:d2b41beaf87b99e12943dfd4c28343b9fbf7771582ac68bb8dbb847eeb7b7446", size = 1372277, upload-time = "2026-06-17T22:04:42.05Z" },
+    { url = "https://files.pythonhosted.org/packages/58/00/9639c5cf92d0327953fd5936073e5de34f0c40fe4c68b44a448604d7dbaf/lmnr_claude_code_proxy-0.1.23-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5e67485c946f716e6f4c7522c67ecb0a7925f3ed15a0d40bafd4632409c1acc6", size = 1306203, upload-time = "2026-06-17T22:03:13.048Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/76/9416596c4b770ec6ff03da27a4860e70775900760da4306e094cf1bf15e0/lmnr_claude_code_proxy-0.1.23-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7b883a547e444a095f93eebbc42ed0d27e84346d986251097b7cb62fc2a0a492", size = 1356090, upload-time = "2026-06-17T22:03:29.889Z" },
+    { url = "https://files.pythonhosted.org/packages/13/45/c0ca2384f487a068db2bf4d0d6ce77789846f83d27b97829ae7b01d2ccec/lmnr_claude_code_proxy-0.1.23-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6d7fe54463ff075d557dc1941d7d271bc79e2663e2a90ab1ff45594804b6958c", size = 1189148, upload-time = "2026-06-17T22:03:37.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e7/f5d5fb442c590652f1564d155a36ebe400382d2ab7b2e1e1a1f2d0186f06/lmnr_claude_code_proxy-0.1.23-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a44d51db3002164ea5795721e3d8d8927f7981a89ffe1ae9359b6b69ebe02836", size = 1357838, upload-time = "2026-06-17T22:03:52.874Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5d/fd440f8b98dcfe6bcddeaa3a5ffde99b649c3b486c6640fd0ad4ce3e8562/lmnr_claude_code_proxy-0.1.23-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b59f21e7baa11212e61a300736fca7c2a724950811f1301e605c7d08c886fd5", size = 1274980, upload-time = "2026-06-17T22:04:57.258Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/75/45502d4ae61de9c8a721e5e2f1d9b34259dc9b1978df03d8620a686ff304/lmnr_claude_code_proxy-0.1.23-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fd8e1bfeef82802c8a74533a6d27e7c7912c7db68358ca67976f1635311503f", size = 1501883, upload-time = "2026-06-17T22:04:30.086Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/82127dd73bd3d628712f5e294921d6d7c3b002579500de5af5bf40f5902d/lmnr_claude_code_proxy-0.1.23-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5ace97624a755d5c79fcbf9d0ab6564ac17a9d1dc361747fcfa299a3a004249", size = 1469004, upload-time = "2026-06-17T22:04:06.798Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c1/bb85500e75db15155e3683d80d2d19aaa0533f725594957842228e323447/lmnr_claude_code_proxy-0.1.23-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97bd9997af125df8f2a0fb72ac135c0c0fe89ae67f497ac5da51b45ac142f5a4", size = 1649011, upload-time = "2026-06-17T22:02:32.727Z" },
+    { url = "https://files.pythonhosted.org/packages/00/66/9a034445b0b57d6c4c795fb310c29adeaedbc04a788e274868bcbe7d891a/lmnr_claude_code_proxy-0.1.23-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b4288560b0076ba68d6103065043d5258594eed4d1fe59631a74e20c6cddf9c2", size = 1464105, upload-time = "2026-06-17T22:03:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/35/c89a0fe198c12f0bc65ce4379707177b2faf41290470cf2428e6fad4fe44/lmnr_claude_code_proxy-0.1.23-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f82487d932680337e3335573a8d582cfd02cee5bc95a4e28cb4befa38b658a27", size = 1526339, upload-time = "2026-06-17T22:04:50.522Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/46/931f751ac8dc44606e160ac662fd15e0e59690e3abf09eeb227794863450/lmnr_claude_code_proxy-0.1.23-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:92233f1c19971678225ac884d26b77cbbe9e90ec0a154752f8feee9ffa3f21c2", size = 1720748, upload-time = "2026-06-17T22:04:34.882Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/55/8088592a7ed8a04f557fd18880654841eb0662562f82e25406e32f9d88d7/lmnr_claude_code_proxy-0.1.23-cp313-cp313-win32.whl", hash = "sha256:a99809eea013706b24b260a2f095551d2b82ddd6e0655e0b0ff2a5d468fdfbea", size = 1077961, upload-time = "2026-06-17T22:05:12.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/78/4c1a3b20cfb2cd97bcbfcd62c55f8a32b8f29afc5cdf4eaa7645aea4c8ac/lmnr_claude_code_proxy-0.1.23-cp313-cp313-win_amd64.whl", hash = "sha256:e747afab3475d07f0c8941e7d1bbb27d2e88284afef03b7824fc40175adb047c", size = 1314968, upload-time = "2026-06-17T22:03:03.277Z" },
+    { url = "https://files.pythonhosted.org/packages/76/cc/15eb95c79fcfb4a2cb98b32b7cfae69abd2b86060787b6d533d0aa1cd178/lmnr_claude_code_proxy-0.1.23-cp313-cp313-win_arm64.whl", hash = "sha256:8646625c70cd2730799e6d3266cf42af86c47101e7eae7254e2c6b482c4db05f", size = 1240246, upload-time = "2026-06-17T22:03:39.025Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6e/f8513ed88064583b8f44d6dffbb6ef7528d81fb186fcc3a1cadac7e09f53/lmnr_claude_code_proxy-0.1.23-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:5f90acf340a618cfa445bcff29b0c942f231368fcaaca590755ca47960437373", size = 1372823, upload-time = "2026-06-17T22:03:20.438Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/28/551ff91b35d6f6ce116318a79ca804ff44f6cc74242b83208c478b5b7c29/lmnr_claude_code_proxy-0.1.23-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:21fdef811f3f06fc507ffd795bca64a21b525faa7f3f6e2f33856910d0f96192", size = 1307323, upload-time = "2026-06-17T22:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/22/42/a4b8a5329bfa66552595d12947b3b3980ee539601f2dfd51b55ff31698fc/lmnr_claude_code_proxy-0.1.23-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:207f6d423467909a130308d2c33eba05b25232e6934c9c23b928b24037d51f3b", size = 1356956, upload-time = "2026-06-17T22:05:04.258Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ca/caf0a939bc9f82a5214f674b7a1b38f116ade2ea3413be74a8a9b30f10b4/lmnr_claude_code_proxy-0.1.23-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:48479d6205854919139c748cac2407a39061eca363ce00a2664e05623933cada", size = 1189574, upload-time = "2026-06-17T22:03:18.92Z" },
+    { url = "https://files.pythonhosted.org/packages/20/65/38cf2e7c1d860b78a1f5d3bc597e56ed6d8856f7668e319f8e47752bb0cd/lmnr_claude_code_proxy-0.1.23-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6704d8e779950f643c901d1c298428ed06eb331f6e86dd95758fd89ebb17f9cb", size = 1358548, upload-time = "2026-06-17T22:03:11.546Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fd/05fd0e7f39bc2e8cbe5719096063d5cf83e14d413c56819ffba9200f176e/lmnr_claude_code_proxy-0.1.23-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6bfb54627cf1a400e18e4c51a7bcb312da1bac701ef56059c82f094d5edf75c7", size = 1275271, upload-time = "2026-06-17T22:02:52.02Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fd/0b6bd1042f5bb4e9f1c8dfbb3d52ce61bd368c1c27253d40f9b59b675967/lmnr_claude_code_proxy-0.1.23-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:724ac0371eef99c034762521e580a986fc2b012ffc8c650dd8d66f1765d9a102", size = 1502443, upload-time = "2026-06-17T22:02:41.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/00/4627ed09698195f40e4dd0b68a164b7e19100254f1214726564b3baf1e5f/lmnr_claude_code_proxy-0.1.23-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cff0ef6dbe34324bada6d538a8dd71bae07184715f6e9ba8408ab85bf251b1ab", size = 1469727, upload-time = "2026-06-17T22:02:43.628Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a4/07ff40343e1e5138dcb80444851b9cc57d1841a994ad3e1f201210211eb0/lmnr_claude_code_proxy-0.1.23-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:962aafb103e435461a66c3ca0a77bfddb7d2bde5abe56922f418076472eb27cc", size = 1649632, upload-time = "2026-06-17T22:05:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f1/14a8faca377ea57ce5f2006bd143f9a868d05c3b513d540409f6fdc97193/lmnr_claude_code_proxy-0.1.23-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d575823c9002c55e67a4e8277ff0477739f84b419e3356a974a3dbedbda90b63", size = 1464784, upload-time = "2026-06-17T22:05:10.356Z" },
+    { url = "https://files.pythonhosted.org/packages/12/31/88f5b24c9b52e1422715e269f0b9934c92505f0b9d5de83e04411ffe588d/lmnr_claude_code_proxy-0.1.23-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a3a3ec1b6b015d8fb6fb373cedb55bfc90c1187333456eb9e6a4a8124b23ee1d", size = 1527192, upload-time = "2026-06-17T22:03:25.017Z" },
+    { url = "https://files.pythonhosted.org/packages/19/77/61158228ec90355ace8bbbb3f5e2275bacd97498ef578d1f24b078741932/lmnr_claude_code_proxy-0.1.23-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68fdb6a26d30977b5d4e7ce4a117b2a427a16b1cc0d075f4cecd1839da12975a", size = 1721447, upload-time = "2026-06-17T22:04:14.027Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/7e/2969a5ac79928e1dccedb781832a544a3891f0f5be4574dbda0159df7c0a/lmnr_claude_code_proxy-0.1.23-cp314-cp314-win32.whl", hash = "sha256:e9d9d94f552a1ae8e7f871b8af2440653b614ba818054c60080d457a6fefd07a", size = 1078355, upload-time = "2026-06-17T22:03:17.45Z" },
+    { url = "https://files.pythonhosted.org/packages/68/99/fe83be0ad3bee2a390a6422bd92839ab401fd03aca924991ddaf9e752cbe/lmnr_claude_code_proxy-0.1.23-cp314-cp314-win_amd64.whl", hash = "sha256:29e19c7fb7d14e6df820a6c2e4a8ee62f13974fc23d966086a75f1d3d90bc68a", size = 1315522, upload-time = "2026-06-17T22:04:36.575Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fb/7e3f2e5373e531752bc0b4505be4a37923cfbd5460817506ece9039136cc/lmnr_claude_code_proxy-0.1.23-cp314-cp314-win_arm64.whl", hash = "sha256:f06ff39da6c5bdedd7daadd4b33337aacc33b51ed57aa6a6a4f035de243ab59e", size = 1240665, upload-time = "2026-06-17T22:02:50.578Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/30/9d9790a8203a54d1b9f43db4810d621fd851a3d5088bdd96591e28d5c727/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:0ca8b8badb3bf137fc58cf3e98542869d983691b91d431508c1f92d8c7b1267c", size = 1372641, upload-time = "2026-06-17T22:04:48.717Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/abbed7f695e0a10150e6ca9570356238382fc7b6eb988b9a4ab81a2a9e87/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9cccd9219743a8539ab9711fe01e84eb91d95388b19a3bfaa0d215cc946d7bf2", size = 1307497, upload-time = "2026-06-17T22:02:56.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c5/eb2e76745e07cbe46c5d8e837bb17a4d8c31a8f26c8f8c31029ec1faf66d/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e5bf63f3f99f011200a6efcc3312a8a2c72cf4a7457580056654df71ef4cd87b", size = 1356927, upload-time = "2026-06-17T22:03:00.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/3c/0f3d717c91d4ef293eb1f645dd37250f15d82d4061114826ae69d9a7a3fb/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7164c71707717a6e242ef5fe0ddeb33095a69e8566a80bb979f4d81037e4dcf2", size = 1189389, upload-time = "2026-06-17T22:03:46.59Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2c/707eaa0cc90128d18ada797a614cfc40bd4b4e07fe1bd717457c7f5a3f8c/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50a9659f4e06cdf783740cef04811e09017e091993da2d26aafef6e0cc1526a9", size = 1358507, upload-time = "2026-06-17T22:03:23.51Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/24/ae2cd75561654686107e2641c14fbe944bd42021234aa855f135d123cf63/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e140b8e9c0b56e63ef86e8ccda0faf6fa9e171c3d0efa11467afd35853770daf", size = 1275218, upload-time = "2026-06-17T22:04:00.966Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c5/623997a2019d64d8ddc8ea5fe6a7544bfbfad9328f9a81d72116239ed403/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8d636068b2b141f210dcadf433f86dc69f810245771f95f647c1a57d2a37dd9", size = 1502448, upload-time = "2026-06-17T22:04:03.956Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a1/98b5298d8d3be52352a106ab1ed79a0a4252360ce596eca2bb0bc1b5341f/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1b04bca678761d37e60508494b8c04c3368bf23bd6569a4d215e93ca5daac89a", size = 1469656, upload-time = "2026-06-17T22:02:29.77Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2f/6b4c94b2bfa6ae63b86c16353fceae0851749a74a7ac683f305af8fe37a3/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5853e6fa123af8611c53b3fcac86231a6944d0861fe7808cdc2281c8168d66bd", size = 1649626, upload-time = "2026-06-17T22:04:21.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/41/bb46a3d930ff8ff6906a4e0dd2f092d7bc56a42b731033c020255ec0636f/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4a42afb4bc589f0d1d6947b88d8a33e3c44029620212d143320875a3d997331a", size = 1464487, upload-time = "2026-06-17T22:04:23.465Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fd/9c7364ce20cd5fe4654956737d3f668ef6bb6df9b48486a9193d98f5c0d6/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:cffbd2436215675119b94de508d20a87c49e0bcf9de7b2dba1974f1af35f0bfc", size = 1527165, upload-time = "2026-06-17T22:04:47.083Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/91/40923b314a3fcdb22ea7d88d61591ae1a3bd019095be037d6a99b2da4def/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5bb8df798ad59b5ba096a7ce1c9a1a08fab5fcb9a6701b3e304bac6a060f109c", size = 1721297, upload-time = "2026-06-17T22:04:52.235Z" },
+    { url = "https://files.pythonhosted.org/packages/10/94/8462ccd92c014bbc99f4ac678216fcceea574e75fb53853425396a77db11/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-win32.whl", hash = "sha256:88c39ab3a86fcafcad48297bda0f91bd1b2d0e4d9dbf4ac2a94e7ecace3f6165", size = 1078371, upload-time = "2026-06-17T22:03:51.414Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4d/b5f97fb3da3a2983a72f8f06301c232c8104a3250a41f6ec9fb23edb04d8/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-win_amd64.whl", hash = "sha256:0147eecb2704a39eceaf01a23768be1de49c3f2f909d5ad5e5ad5a1c8a4b8d94", size = 1315510, upload-time = "2026-06-17T22:03:06.523Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d6/401e965d569efe66befd2402c138a6c0edd8bca100a53df753c81835d4d2/lmnr_claude_code_proxy-0.1.23-cp314-cp314t-win_arm64.whl", hash = "sha256:18147e58da5c3cd2901adfbbdf0851c5aef4a0feb0fed66732f4f0ef64549531", size = 1240645, upload-time = "2026-06-17T22:02:53.54Z" },
 ]
 
 [[package]]
@@ -2115,7 +2087,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2133,9 +2105,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
 ]
 
 [[package]]
@@ -2279,7 +2251,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.41.0"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2291,9 +2263,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
 ]
 
 [[package]]
@@ -2310,7 +2282,7 @@ wheels = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.24.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2331,14 +2303,14 @@ dependencies = [
     { name = "tree-sitter-bash" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/e5/5d70635041b4c9f701c2846d21dba251c4969f5d0903459cd144996b3c06/openhands_sdk-1.24.0.tar.gz", hash = "sha256:df15f8330ca93614e8c35832891b0ef93b8cffd3bedcfd67b1413b8c3457a275", size = 479868, upload-time = "2026-05-27T17:38:53.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/d7/03c75453aa50e016e10989bb11e6fe5015db659c3d6d541a38aa60ec7920/openhands_sdk-1.29.0.tar.gz", hash = "sha256:2b38dec04858535ff78fdc961ffc44cee338aca6947c0ddb70c6926e5ac883af", size = 588347, upload-time = "2026-06-18T16:10:58.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/20/dff83b90b66a12d068ca325cebd06e6fdbd2d704346147cf87264730bda3/openhands_sdk-1.24.0-py3-none-any.whl", hash = "sha256:c588cc33632d7de9905a9f0e6ecbc427a25c9bfd125046f0c17df9896565c225", size = 589706, upload-time = "2026-05-27T17:38:57.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/faacecdc314f1deb85f7f123147c4522a77200c8b744496269b830dded36/openhands_sdk-1.29.0-py3-none-any.whl", hash = "sha256:ae9f4ec0b1fd86e3fd4c74682a9ee477614e790457ed06c675ad6caf9eef5194", size = 710013, upload-time = "2026-06-18T16:10:59.683Z" },
 ]
 
 [[package]]
 name = "openhands-tools"
-version = "1.24.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "binaryornot" },
@@ -2352,9 +2324,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/e2/802c1e385bfcbed75cf2dc19fd3cf3d14e5d844586df1ed0ad2510093244/openhands_tools-1.24.0.tar.gz", hash = "sha256:09eb4261b4ba8b859badb5c6f282bfc2339e452bfee4807f246a7684614a74cd", size = 134580, upload-time = "2026-05-27T17:38:55.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/31/95c9575bca5124dec2e603b32ebf15363b6a3e70f7d8becfa1e025c1df5e/openhands_tools-1.29.0.tar.gz", hash = "sha256:3427966f5cb21cc64932dde73173772ccf384ba25f4f599501d540b3f2dd7d01", size = 144895, upload-time = "2026-06-18T16:10:54.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/3b/e85602752d03c29401b1af9d8eb3c4a437e2ce5da8b859f2684d6dc3556c/openhands_tools-1.24.0-py3-none-any.whl", hash = "sha256:58c529fd91b9e30d05290ad0a81fde1c0a75be1a04bcaa34461f90ed507b94a1", size = 178313, upload-time = "2026-05-27T17:38:51.146Z" },
+    { url = "https://files.pythonhosted.org/packages/05/49/0375502eb628d5df7e4dab08bfedcdbd5caec8c81d6dc2176ead1c7f9423/openhands_tools-1.29.0-py3-none-any.whl", hash = "sha256:bb50b62a1929958e4fd8991fd8dbd6b8269c87da74286a925c066d0ac3dd915f", size = 190143, upload-time = "2026-06-18T16:10:55.842Z" },
 ]
 
 [[package]]
@@ -2579,15 +2551,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "cryptography", specifier = ">=49.0.0" },
     { name = "docker", specifier = ">=7.0.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi", specifier = ">=0.138.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "openhands-sdk", specifier = ">=1.23.0" },
-    { name = "openhands-tools", specifier = ">=1.23.0" },
+    { name = "openhands-sdk", specifier = ">=1.29.0" },
+    { name = "openhands-tools", specifier = ">=1.29.0" },
     { name = "pydantic", specifier = ">=2.13.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
-    { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
@@ -2595,10 +2567,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "ruff", specifier = ">=0.9.0" },
+    { name = "ruff", specifier = ">=0.15.18" },
 ]
 
 [[package]]
@@ -2729,7 +2701,7 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.17.0"
+version = "7.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -2737,9 +2709,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/53/9abb7c2ec8acfcafd488a379f5937d248bf290f9fe8c0a2edc023063b7e9/posthog-7.17.0.tar.gz", hash = "sha256:25bcd488a2b2359b0ae969ffcba75ecb5fd0287ad3f32fffe645659d543dbf17", size = 229049, upload-time = "2026-06-03T15:14:41.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/33/b44963d075a5793cf1bb00cec36ef57b65a699eb9edb54de42ff19c33d7a/posthog-7.20.2.tar.gz", hash = "sha256:3c95f1571230db4e839618500b058d68f5f8abadf1eaabbad5b359f971988ea5", size = 255598, upload-time = "2026-06-22T15:36:46.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/fe/49358d2a9ebde6538ace96785e5b59c4df302ab0b72fef6010625cb77c06/posthog-7.17.0-py3-none-any.whl", hash = "sha256:b2735701effba2f8f4ccf58b0b49fbaaf7d4d0544fb6d6b7547cd7ccde5d4f43", size = 267430, upload-time = "2026-06-03T15:14:39.432Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a2/f4c9ab53769bc2c76063f275b38eee2789cde802f975981ec1b2d31bfa5f/posthog-7.20.2-py3-none-any.whl", hash = "sha256:9f55d28937ba908262b44bda7a8b8f2cc8d87dafccc8b53ffc5d014ee4d9c514", size = 296886, upload-time = "2026-06-22T15:36:44.404Z" },
 ]
 
 [[package]]
@@ -3092,7 +3064,7 @@ crypto = [
 
 [[package]]
 name = "pyobjc"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3257,133 +3229,133 @@ dependencies = [
     { name = "pyobjc-framework-vision", marker = "platform_release >= '17.0'" },
     { name = "pyobjc-framework-webkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/09/68336c2ed662cecc8dc71e3bdcde2666430f3eb981cbd86661e7aa260cab/pyobjc-12.2.tar.gz", hash = "sha256:7074dcb0999e611e456b12cf94b7289cf6327094359b2c21c5ae593048b909bf", size = 11841, upload-time = "2026-05-30T12:28:53.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/ef/b4e64fe87051e72608ed4134072e832e9eae28d97e9c9bb0870f01a18ac5/pyobjc-12.2.1.tar.gz", hash = "sha256:0b2cf49d24213e7604620c31863e7b4e42770c4442c10e59b18ad951cd200cd3", size = 12148, upload-time = "2026-06-19T16:19:38.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/25/f988de6a2028550fbd79f386938c4d99ac0f6b7652ad212cd8b74654924c/pyobjc-12.2-py3-none-any.whl", hash = "sha256:f3b0d4cdb7d0be242a37ff27c9f0b3ef182fe8ebdbac6ae0c40ef87539fe7d77", size = 4225, upload-time = "2026-05-30T09:44:22.344Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a2/3878e4783c65eeb72a1c06de1f880ef573b9677198a3142ff5082c0810ac/pyobjc-12.2.1-py3-none-any.whl", hash = "sha256:edbbf9e2e249cd2fa660422c7d72e9fe5be1438deab38c64238b26f4c9db9421", size = 4262, upload-time = "2026-06-19T12:50:03.55Z" },
 ]
 
 [[package]]
 name = "pyobjc-core"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/e8/a6cc12669211e7c9b29e8f26bf2159e67c7a73555dc229018abf46d8167a/pyobjc_core-12.2.tar.gz", hash = "sha256:51d7de4cfa32f508c6a7aac31f131b12d5e196a8dcf588e6e8d7e6337224f66d", size = 1062064, upload-time = "2026-05-30T12:29:55.417Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/be/4771f4fd786f0e1a2bd6d8931a72a5f3929b7bb1b28a1fe6ca8a08371c55/pyobjc_core-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7677ed758a367bbbb5589d6f5276fb360a45c89168276c26162f61840b0fa03d", size = 6421145, upload-time = "2026-05-30T10:17:41.992Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ed/6e62d038992bc7ef9091d95ec97c3c221686fe52a993a6501e961c757613/pyobjc_core-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9287c7c46d6ae8676b4c6c0389a8f4b5381f42ae53a47151900c08b157e5a992", size = 6428611, upload-time = "2026-05-30T10:21:33.83Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/0b/d492110202f4d1050a5e590620ebd1e730cf89f9880a26cf18205e0f5800/pyobjc_core-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:515ecf2afe168301feb66a7230d700584ce2e4b8a0ac178e19450b8898384139", size = 6677992, upload-time = "2026-05-30T10:44:13.039Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b2/ecfbd0c80e7688ed6f3db23414758443c69c3a9d318f2036e26530ede955/pyobjc_core-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a51352e478785cd7fce1604b9902125a286139caea0759cb340e59d75b594992", size = 6421372, upload-time = "2026-05-30T10:47:27.907Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/89/ecd5cb62573fba9a95f8bdb838a9860a360907104a0724af6611d3b20512/pyobjc_core-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3137b2d14f9f2154fb5b1c092c38d15e164f68ab190c18335d76e4e7e1583f79", size = 6676789, upload-time = "2026-05-30T10:59:33.811Z" },
-    { url = "https://files.pythonhosted.org/packages/74/24/5091d156b19df0f657127f42b08eada11c9b9cc5df49fedb91bb354d9821/pyobjc_core-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1e4216f2ec962dc13cf7f31b9bc3a7190337a0f401e7dc9de6b2d8c08b9dbb7a", size = 6476112, upload-time = "2026-05-30T11:21:46.914Z" },
-    { url = "https://files.pythonhosted.org/packages/77/e2/ee91ea8a0ad28e759f351ed8654027c34fc62ad5e207672522025a6a3fc2/pyobjc_core-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ac952bac8057dd0b97ee7b311c39f97cad7430b7cfbd67ca0a30135a7d17d2ab", size = 6718365, upload-time = "2026-05-30T11:51:47.35Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/88/300ad283bed0c971c52dcac6f70113e138169d4ce6d856ddd03d16081e51/pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b", size = 6433347, upload-time = "2026-06-19T16:04:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/b9b0ddffae66996b8779f1f7958adc9f21c13a0448cd3be8d7fe589b5b0f/pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2", size = 6436004, upload-time = "2026-06-19T16:04:53.257Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/bd309ede07784c6e5fac4b440c90a5f72a66da7859ed303a9392fe8a5f3f/pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071", size = 6687044, upload-time = "2026-06-19T16:04:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8a/cfa4f56939d554dbb342ec6e5226a441e2f552bc2002a0ddf7705bb11bef/pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a", size = 6429289, upload-time = "2026-06-19T16:05:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/42/74/446c89bc18103aaa4a00d1fb85ff8acace9a0dc3f362d9678ebf7571e275/pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7", size = 6690181, upload-time = "2026-06-19T16:05:06.201Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/0121ee4c616af07ad2de8cd1a286f6978dc9a227eb58b7c2e875cb68a1df/pyobjc_core-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:047c226eeb58a2993ace5e8904e71cc9426ee20d064c617f8fbf32717d37093e", size = 6487078, upload-time = "2026-06-19T16:05:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a8/cb9fcc150f97d0bf22a2028f88b24cc35949beb1bcc7b8bc5c17d4401677/pyobjc_core-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1188613805336270279570467e4455b74cb6c0f60913ac74c917ee1c37cfaecb", size = 6733064, upload-time = "2026-06-19T16:05:14.313Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-accessibility"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/31/ddc59bea6388a37461e919f25d2120bd93df0b30f552c606fab2804c52c3/pyobjc_framework_accessibility-12.2.tar.gz", hash = "sha256:86f82cc21db65c73c72ae93b7536381f1e12a1c89d4c554a216217dacdf60bb3", size = 34357, upload-time = "2026-05-30T12:29:58.741Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/4b/b0a0f0183b359a07663ed31a3f790986cf880bda909b623fead15cb2afbd/pyobjc_framework_accessibility-12.2.1.tar.gz", hash = "sha256:1e0ad06b5b6ae623f443d15c11780f97908d5c41fdb79532e96c6a4a76066fd8", size = 34377, upload-time = "2026-06-19T16:19:40.592Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/6c/dc7cf2eca4239e69942d68ab16b5708707975548a197f081c8fdc3445262/pyobjc_framework_accessibility-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4c2e2965bf539e356ccb92aa3ea4e9fc764629e5fa7d5a9c52387970ee021038", size = 11545, upload-time = "2026-05-30T11:51:53.936Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/1d/d13365b48fc989b5217ef94facec719f7c7ab2878e573462cf822095cb3b/pyobjc_framework_accessibility-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e60d910261d018770722ad0987291e94229e09aef0e919073c87a30cf677686d", size = 11564, upload-time = "2026-05-30T11:51:55.545Z" },
-    { url = "https://files.pythonhosted.org/packages/28/22/2f3ebe592655f5106a072cf1f1fe331f7c9ba06b24ac8e3dcdc9e9294d03/pyobjc_framework_accessibility-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:535a3e2ccb36e707dd72ed54f7f1772ef41526cebe6fe52acc081d45a10ede15", size = 11732, upload-time = "2026-05-30T11:51:57.41Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/68/898391808390d55e38d97ba9bf975e5cd9f64692c051d290ee8f366269cf/pyobjc_framework_accessibility-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a6b1bcadaee86389775288a2f44658fa6a5b150ecb8bd3ff694ed9a0c2a62e7d", size = 11626, upload-time = "2026-05-30T11:51:59.164Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/1e/070f0260e49efdf2e96b805efc6a5b03f7f0e7d85f9f07aaa6c8660c7869/pyobjc_framework_accessibility-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3c52e73046cc32830ddc494d10ce76292c13f8f16b1e8dd96af3e9a972755e23", size = 11809, upload-time = "2026-05-30T11:52:01.081Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b2/8fdcf94b5f25b6b8410ab3ae5106b6edadbc6131ce133cc8be76f4f7a8b3/pyobjc_framework_accessibility-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:4a998d5fa8bfa43de83554187cee3ef3db2c2b144d5799eac5852266c1d1fa7c", size = 11615, upload-time = "2026-05-30T11:52:02.811Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3d/a4908231fbf37ff60cafd7c66cc080ba1c3265090810e2a416ecf5dc8444/pyobjc_framework_accessibility-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:76495fbe29ad10051cfd66d1f9e54283a82b22e70b0a25ee6481f8f7e0de5b9d", size = 11805, upload-time = "2026-05-30T11:52:04.54Z" },
+    { url = "https://files.pythonhosted.org/packages/43/22/28a3096e9bb6332d851a7bb4191d6591088165a8465d3540e82a7f3fd9fe/pyobjc_framework_accessibility-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a906f4d6447a6394f10fc7d77cfb755815fb07cdb97c9e3018bd7c528600df3f", size = 11570, upload-time = "2026-06-19T16:05:17.802Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/0630c4c67f262d3d018aee43d185d8e58a8aa32a34222be3177fe9a8c21a/pyobjc_framework_accessibility-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6814e863cc1a29e62d9ec97f7a9535598e46748b9d734cf0b903d190fe0e224", size = 11586, upload-time = "2026-06-19T16:05:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c4/6966cd83fb01c183d778799de67100761f7ffe9b7de34b543c4b5034c7a0/pyobjc_framework_accessibility-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5213d57f9b1d6a7b452af78f904e3eed1b4372e9a850e772cf275177038c8512", size = 11756, upload-time = "2026-06-19T16:05:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2a/6f0e49d8a76891f1416e9ee8ca8e89fdc353a2770c6651512803d6de4ccf/pyobjc_framework_accessibility-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cd6d0740f72f99bea723b3ea0b3fc9c8a4bb15965ecaeca6b534dd5c5c766048", size = 11650, upload-time = "2026-06-19T16:05:20.388Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/ba2f8ad4a4d2b29c35b6370ffdac9dbe1f39552b1c9d8174940814d40b0f/pyobjc_framework_accessibility-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:327885b50b9d7a46844c063330ee8e6d76d1e68916e9eb92a8ad00657baee014", size = 11832, upload-time = "2026-06-19T16:05:21.142Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c7/924357300836590c51614c6fe51a684818a973d88fe07c79088bab802f73/pyobjc_framework_accessibility-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6b229742dc42a337b32314563bb6d2ff8aafdb1ff1c951e86db5918412351437", size = 11640, upload-time = "2026-06-19T16:05:21.966Z" },
+    { url = "https://files.pythonhosted.org/packages/80/27/9eafd7a630657accd3ead893418d5aed203883ec6b2bd85294ae64ceadb8/pyobjc_framework_accessibility-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:97d564e2c7e7b12aaa2acfaa1a22c50b6606d0198f4beb1a641b46f50d2ee8d3", size = 11829, upload-time = "2026-06-19T16:05:22.966Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-accounts"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/ec/aea64ed95dda48f2c1a049c638be39822f731e79ef9fb4202dd2b3d87b86/pyobjc_framework_accounts-12.2.tar.gz", hash = "sha256:823b61e3ed964efde365e6c83b605692f72cb7f7e0782dafea674f2de8e3f8ed", size = 16208, upload-time = "2026-05-30T12:30:00.949Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/14/6086edbaeb0f48ac1b915d38d11a36efd8de918277da86abc2058a50baad/pyobjc_framework_accounts-12.2.1.tar.gz", hash = "sha256:6e6d603e10182238cd77596380262a38cbb0a9141d1eca6bf522b2213c6d6751", size = 16209, upload-time = "2026-06-19T16:19:41.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/fa/61661645bdc59e6aa9c92791731d688c76b84260362849f8c768e48558ea/pyobjc_framework_accounts-12.2-py2.py3-none-any.whl", hash = "sha256:a1638b7758e6371f59e7ea9f912922530062ce9640a0f1d1e66a0702bff7f8e3", size = 5104, upload-time = "2026-05-30T11:52:05.957Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2b/f8138fa91af3ada0bae01dc5430f0f3a79daeabfd36e02ac165423f67041/pyobjc_framework_accounts-12.2.1-py2.py3-none-any.whl", hash = "sha256:b86cba0f2a9219a1c57aba6c0f0973f7a06f10bf9ccd39b74fdb567f9b34a041", size = 5133, upload-time = "2026-06-19T16:05:23.786Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-addressbook"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/03/76bd426954723343854c2f4da82bbcd61048eccce31c00381dbfb7677c85/pyobjc_framework_addressbook-12.2.tar.gz", hash = "sha256:5f763983c1c32e70f7b742e35a025530be4bf6742ff4ac98f71ab0bfeb5cf9bd", size = 47681, upload-time = "2026-05-30T12:30:04.791Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/20/70dad64d397f9ba513a314ad4d1e1f7e4903c21caee98dfab2f7a39aaedb/pyobjc_framework_addressbook-12.2.1.tar.gz", hash = "sha256:bb113fd5bcae93da00d67bf870704d2cfb73da49c4a281249d8a5abf9809aa91", size = 47685, upload-time = "2026-06-19T16:19:42.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/f0/0eefbd03448706f71580ea82254cb72a0aff70d6df6fc49e2e6ad915fa56/pyobjc_framework_addressbook-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9cdafcbad3d9e145a32390dd026bf27da3be1aadf337c3d56c08ee4a791755a6", size = 12805, upload-time = "2026-05-30T11:52:11.851Z" },
-    { url = "https://files.pythonhosted.org/packages/81/bc/d3afc72e56b2e49580ada60dff250669f2b80ee1e2c59bdd3e577f32d0cd/pyobjc_framework_addressbook-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37dbd5a712c2ff71ec80cc5a86d96c98b1d5e26eb2c7bc4d251f84eb1a3c8893", size = 12826, upload-time = "2026-05-30T11:52:13.667Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a6/9d0a9433e3b76ee9e6d728d463377d1833389450315a6122342e4d42c5c1/pyobjc_framework_addressbook-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:899b19c7c2c4a8ee7020a20022a8c64daf86dccd163da03a41bbd585565d18ed", size = 12981, upload-time = "2026-05-30T11:52:15.771Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/2d/4bbd5dc76233c3c1ad4529536b3c47fd7c20faaa88a915f509baaea1050c/pyobjc_framework_addressbook-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6ea77ba8de1ffa9a05836081bd36ec3828cadc0215f1fcd64446b80228e69775", size = 12886, upload-time = "2026-05-30T11:52:17.742Z" },
-    { url = "https://files.pythonhosted.org/packages/95/79/f76414b5643f3828fa8e03c6f2cb91307c27785f930a02a37ca0299e522a/pyobjc_framework_addressbook-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:76839a5441cdbecf3b0984d83385a80e926f38234f98063af297b646fe9dc658", size = 13043, upload-time = "2026-05-30T11:52:19.566Z" },
-    { url = "https://files.pythonhosted.org/packages/95/dc/9d748ad57fde50831b59704c13f82cf658869d6f8de428455f127a49324b/pyobjc_framework_addressbook-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:155f285e181a8b4c72dcc559a044c8a2c2af5271ab5926356ad67daa5a0600ca", size = 12877, upload-time = "2026-05-30T11:52:21.45Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/20/c03dc03da793fbdbf3bf381979c1301b66642cdc43a42ac768715283c2f1/pyobjc_framework_addressbook-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b0b3c2e00500d4ee3ebb62df367473cc8c92b1ece7b4ad65384e1ac56d6a7c68", size = 13042, upload-time = "2026-05-30T11:52:23.251Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/01/83d10cdd6bcec2b63ded8dc5dd1036fd0dc8b8bb2f3a00b2c57ea785c32e/pyobjc_framework_addressbook-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1bd586c3aa24345cc9e1cf31a8860cda1298cb92a70fe73b05bdf31cb69edcb2", size = 12835, upload-time = "2026-06-19T16:05:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/50/64/909d16cbf2efcd95807da7b9966d6de35225cad192444a93eb07c1c8de3e/pyobjc_framework_addressbook-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca9a94a3d27cf9b9ae22ac8fc48bfce392757b283419ac38567eeac73b6f8ffc", size = 12853, upload-time = "2026-06-19T16:05:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b7/ac71ac95e5d1bae7aa4ec67e444683780274b826b0e6cad3d57252b29f1f/pyobjc_framework_addressbook-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:32a21916f38dff86226c37e0478dd86e8e5fa070403f8ca27dedf5b48f30a059", size = 13010, upload-time = "2026-06-19T16:05:28.426Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b4/dd48553aa1daf16768ae3fc8cb168e4b01c29ac4b99be36679e7f0639d5e/pyobjc_framework_addressbook-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:687c1752dd0a3b649444839453c51c3f7ad9b540f04ad6d5e68d94678700d524", size = 12911, upload-time = "2026-06-19T16:05:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/13/34d930ad908a3d9fca0096ab57a231993a0d090038627b5926f09b66a204/pyobjc_framework_addressbook-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6578aaa8015b4e2db6139081efef3ff1c87b9d8b7a2b2ffbd99964b2f0f232e6", size = 13075, upload-time = "2026-06-19T16:05:30.665Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0a/b718c14bae7522cd65e2a4afc23c7e3016a8dd1883b75e6aa93ea86d46af/pyobjc_framework_addressbook-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:73e3b8c88f839a00648b9ce5a35ef184bdd78075ecebeb5e8d6210cf07d7c8fd", size = 12901, upload-time = "2026-06-19T16:05:31.665Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/7e83e806be5f788251c9c93a8c54f3e71f0014d2a48ec66070b47771bf98/pyobjc_framework_addressbook-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1adc06442fea100f8524282891d8358d621b8906bad30cbd61552e5edf92dcb7", size = 13066, upload-time = "2026-06-19T16:05:32.605Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-adservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/05/fb43d284efe7e48b43abe2507f79b91a4c9ebce4f76c552fc228b647c0b9/pyobjc_framework_adservices-12.2.tar.gz", hash = "sha256:77a3cf0acdf5e83c29c26be60a63e35a31ad5076ac60188a52268fe53de7cee0", size = 12249, upload-time = "2026-05-30T12:30:06.574Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/de/6e9fa436a7aacaebe664c918dabfad14a19aa0f6ccaf24384d0c0b55b6f0/pyobjc_framework_adservices-12.2.1.tar.gz", hash = "sha256:6668fbef1b383c5cafae8479f4a8b53e824bd4d568611a53a3075e8c6dc4e39a", size = 12269, upload-time = "2026-06-19T16:19:43.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/2b/230ad0f52e7f960a560afbae80dacdfc831a01a3507989e1ee41755ab793/pyobjc_framework_adservices-12.2-py2.py3-none-any.whl", hash = "sha256:7c1b1f78689f66fa724c23fd20dac56e8ea3190e868d9859d08294a58e26cb33", size = 3485, upload-time = "2026-05-30T11:52:24.532Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/43/c8d1a8be6faf0b3c60b28f8dbc31198ccbb72acdf0eb42fa8effbc9eaccd/pyobjc_framework_adservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:631eaa86145179631624788ac1ee485fc79c2f9de347ab7d0cb3ea3413cd0cb1", size = 3510, upload-time = "2026-06-19T16:05:33.49Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-adsupport"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/6d/6041af76d08da1ddae42804dfff3b5fb0fb27c2da8eb7a1a04ece4532e46/pyobjc_framework_adsupport-12.2.tar.gz", hash = "sha256:fe8e730c102a6579fe905b20e497423a080fd1f6a75eabf7356d2394467f64a4", size = 12112, upload-time = "2026-05-30T12:30:08.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/53/d73eafbc080b7eed68917f6a62758dafca80c7a6ac98ef35660185f8ea89/pyobjc_framework_adsupport-12.2.1.tar.gz", hash = "sha256:c659ac447b1bb3b1a54add100d72932cfd50482384a97c22926d281c9d97a6c0", size = 12098, upload-time = "2026-06-19T16:19:43.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/b7/956f2d841a8709ab7cae6726dcd953a54650768f9b78cf9821fb732c6cca/pyobjc_framework_adsupport-12.2-py2.py3-none-any.whl", hash = "sha256:39ca7e3c336c32c5d9d5780eba7606f4d53034bb53bc7b55c8a5a2e430ad7c66", size = 3402, upload-time = "2026-05-30T11:52:25.922Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e309b2c03498b2d0848382aabea2b068f314c40dc58f1e3dbd5bedbddaf/pyobjc_framework_adsupport-12.2.1-py2.py3-none-any.whl", hash = "sha256:46a18c775a12565efbe46fbd0258ed63aa74002773362ff7d5e5be525013b221", size = 3424, upload-time = "2026-06-19T16:05:34.492Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-applescriptkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/e8/1af0305da68a6923d269806f6f60b900e473b3ac03279a8614d71e224592/pyobjc_framework_applescriptkit-12.2.tar.gz", hash = "sha256:1e1f91966b42f902d954a570a2aab8a4e24af465833525863e30c8a5b47ee4f1", size = 11690, upload-time = "2026-05-30T12:30:09.765Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/04/187611b7f3e51532b45df08c3b22edd53f163f337a88d7c03c4dc904e2ed/pyobjc_framework_applescriptkit-12.2.1.tar.gz", hash = "sha256:fa3a55933ec090aebc695f3575a5afe8a2d37015162cd30e6c00948748d08f83", size = 11668, upload-time = "2026-06-19T16:19:44.68Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/2b/3abd0d61208205b5617590e6c9cc35f744a41a2bdb81b5e18eba7810b9ae/pyobjc_framework_applescriptkit-12.2-py2.py3-none-any.whl", hash = "sha256:4b2a2f02e159c3c13834c3a605c1445563592f41d57ef6cdca2bd39e6409270d", size = 4352, upload-time = "2026-05-30T11:52:27.452Z" },
+    { url = "https://files.pythonhosted.org/packages/84/82/f83a29b54c8fbf5a7a6cc53676767968fa970fa902b599ae92ecf4208fd1/pyobjc_framework_applescriptkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:db6a0aae4d9421068ed8a0838c509e3a7858813975dde40c40ef1dcc15328d1d", size = 4381, upload-time = "2026-06-19T16:05:35.356Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-applescriptobjc"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/bc/4bcbb2fdae7a4526432619ec9a15fb7ee8ef22358be422e7b3c23c280f6f/pyobjc_framework_applescriptobjc-12.2.tar.gz", hash = "sha256:118abccae98c0af67e7c850058e4651748256eba52da382a2cd58e0e7c74418e", size = 11787, upload-time = "2026-05-30T12:30:11.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/b8/67273037f4f10334d9660001bf12f5cc8b483f9cf9c8df91aa39701bcce4/pyobjc_framework_applescriptobjc-12.2.1.tar.gz", hash = "sha256:c60b751a6c20148f23eb1d556aa36612c7e39b14e0bd87abaea53744ff8eabc9", size = 11777, upload-time = "2026-06-19T16:19:45.417Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/a8/bb375c57509a1553e5ee51758caad3f946a98180577680b33a509f65bd9f/pyobjc_framework_applescriptobjc-12.2-py2.py3-none-any.whl", hash = "sha256:0a3019b16959dd8bef9fb581894901e89e027fa0b8b21b8515deda13a3cd9b34", size = 4452, upload-time = "2026-05-30T11:52:28.996Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8f/d66814f05748297c1c281d3b2f4a96600d4a3de87c65b6abf6a92151cac0/pyobjc_framework_applescriptobjc-12.2.1-py2.py3-none-any.whl", hash = "sha256:59a3f7668b1f88707c06ae1cd263856ac29c2bf1650a9dbfa21288e0baebe298", size = 4479, upload-time = "2026-06-19T16:05:36.364Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-applicationservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3391,122 +3363,122 @@ dependencies = [
     { name = "pyobjc-framework-coretext" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/ab/1776ac62687cb3d81e59517ca55970f26efa5a96bbf3ebcea57afcdd6b06/pyobjc_framework_applicationservices-12.2.tar.gz", hash = "sha256:4f6c4027405f709872e5b098f3cd86961bdf262fb80679a548725a02171bb0cf", size = 109325, upload-time = "2026-05-30T12:30:18.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e4/0c7c5a48f88ab7510365559facf060f7c059dd4d5e39571d07d96a2b84a8/pyobjc_framework_applicationservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36a03ae7168657379e3ad96397f3ebb15e6c617b96901a919c7610ce2de0007a", size = 32736, upload-time = "2026-05-30T11:52:38.386Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/28/8c85ef2dff09fb4c6adf2161bf1d32ff81dca497863682ba46107e38bbb9/pyobjc_framework_applicationservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7119c75ad2c0e21b0bd44865641944e691e80abce0d5805fa344730238b16b15", size = 32754, upload-time = "2026-05-30T11:52:41.299Z" },
-    { url = "https://files.pythonhosted.org/packages/61/ee/4be28e61319055092d3a963514c2fb4daba86785d4044f073a4135273bb0/pyobjc_framework_applicationservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0492c478b175005f38c887523f895382a9ed47c0810ab786c6712d3fda245832", size = 33017, upload-time = "2026-05-30T11:52:44.534Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/60/43c4e2697971bb9ec7766d6fe00861ef2055f3fa7d733c407676fcd5cbac/pyobjc_framework_applicationservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d157ace1d768665f180cf9711fb31ddb29006e5df545e7e3ebf2be5054c6170d", size = 32896, upload-time = "2026-05-30T11:52:47.456Z" },
-    { url = "https://files.pythonhosted.org/packages/03/12/4f0662012b77b9c15afb6c52fa92e069d2a6793dcfcd9864bfef4c7d3c4b/pyobjc_framework_applicationservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9be6f6866f532fca35f7d62f27f43df6a95c8b195030d44b9d68ed63ecb1e1f0", size = 33135, upload-time = "2026-05-30T11:52:50.587Z" },
-    { url = "https://files.pythonhosted.org/packages/36/9d/91c93ad58e6b52035da745c2ddcbb32018a03091d9f139e077f53089a002/pyobjc_framework_applicationservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:01afa4ef373edc58cd3fa55f5fe5d7db5dda22b8e6ff65f743a509180149dab7", size = 32888, upload-time = "2026-05-30T11:52:53.487Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f5/c25b153ea0be05a749915bc45b4f9d85e7d84d2fbafc81efe68cae29540e/pyobjc_framework_applicationservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8e14e97fc6bbedc95479f7b408f00e3b4aaaafafc23f9e2a955210beca15b474", size = 33128, upload-time = "2026-05-30T11:52:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/89/39a7462006afbc06c69029fe4181b7359a9da25ae7864ef75f9d3ffb9272/pyobjc_framework_applicationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f519ced13888d03410cd7da1f08fc56ee2944099e607216cef7ca26ecfdef61b", size = 32764, upload-time = "2026-06-19T16:05:39.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/8e928d5e3025529ed92c6eb5fd88a5e6e485cc6df945c541f29b4af7f2c6/pyobjc_framework_applicationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8749290f796e6cca341d443769b79329dde5d157bcc4413c1f7fdb68ea4a8e48", size = 32782, upload-time = "2026-06-19T16:05:40.284Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a5/c7b5a31777fe2ce7c07b9c16941ff4fbf0a150bf755164d96228d32ccb4f/pyobjc_framework_applicationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9ee11677fbd6a0987234814c7dde88ffd11242e8c1f76952e6654ea07f2370ac", size = 33048, upload-time = "2026-06-19T16:05:41.308Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/47/cd2bd76b862686c0aa78568ed9dff175764353c209a3096c72d6e2a9b151/pyobjc_framework_applicationservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a1c0ee536cb8bd7f5a811165ec323a9207b1e8dad9534fe2081f767fb90b0411", size = 32921, upload-time = "2026-06-19T16:05:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6989a96f8501aa3a16513d08b2c4c78ca906a10b6a4e5a33c4c59fd1bea9/pyobjc_framework_applicationservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0d55dd5be19e4a1363662bc8b48894d45714d07f0ee3958665fc9ea7df0f61b7", size = 33163, upload-time = "2026-06-19T16:05:43.256Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/41/66f2bcd12454a85f0479393f5825021332ee84b49583c7954cd20310cab5/pyobjc_framework_applicationservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e91c84238b2f68f608473854bcabb8770f15ad837e7561d217f24a1e482e42be", size = 32915, upload-time = "2026-06-19T16:05:44.151Z" },
+    { url = "https://files.pythonhosted.org/packages/81/cf/04b6b1eb181fa3071e9743bab7551f5d2ec3f650ac74bab790f21717ba51/pyobjc_framework_applicationservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:09bfa27765d4c74155323fd8185b7aba6d639ce06c0a9f00ee2d9e7dce3d7800", size = 33158, upload-time = "2026-06-19T16:05:45.017Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-apptrackingtransparency"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/08/28b67c30aae6b1d870aac62ef63e7f518f3507a5c8c34378ca2cd89d2f7d/pyobjc_framework_apptrackingtransparency-12.2.tar.gz", hash = "sha256:7887b9c574c8a4edafbf8e34649a77ea91aab93dcf92b22e272ab01341d9e404", size = 12778, upload-time = "2026-05-30T12:30:20.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/c3/2f6b30c7010b32450769d679c30393a148d0b1531b31f1c0d3a600fc999b/pyobjc_framework_apptrackingtransparency-12.2.1.tar.gz", hash = "sha256:3eff48469eb07e4637408f410ce2690711f5c3de2fbfaa8844daa718ed3479f7", size = 12795, upload-time = "2026-06-19T16:19:47.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/65/1a2b950fb8c7c98ee6ab894e5466094039846ff10986ceb04d4c29ce3118/pyobjc_framework_apptrackingtransparency-12.2-py2.py3-none-any.whl", hash = "sha256:f0b51c30dc8c32882aa88e891ec13e52a0b339a3bb52ab7eed162a9640b76b4a", size = 3905, upload-time = "2026-05-30T11:52:57.929Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/2d/a78781f57f2c28155a60eb5ef255d50a7d34b036d16e395cdbc27c2c02da/pyobjc_framework_apptrackingtransparency-12.2.1-py2.py3-none-any.whl", hash = "sha256:29fb3e38e124932eb566a8427dc0db759eba63396cf530862b081432316ff863", size = 3930, upload-time = "2026-06-19T16:05:45.898Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-arkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/27/94cce926f3a8d95050bcfa14b1fe4e6d45ff86b93f3aa53f336a9eb3e5b6/pyobjc_framework_arkit-12.2.tar.gz", hash = "sha256:48f7241f07c03a5caad05b8998ee23210f9fd2395be69b635fdcd41d11329cf3", size = 40141, upload-time = "2026-05-30T12:30:23.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/be/db21fafd315dc479925d79bd144f132cb38fb37583212753db8252b765d8/pyobjc_framework_arkit-12.2.1.tar.gz", hash = "sha256:ed4f67b1594a427b66ab751657ce6183a93a07ba32d3ba3bbefd7e0b4f6bf64d", size = 40145, upload-time = "2026-06-19T16:19:47.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/cf/7fc4248af3c7ef766137ffa831dbe999efeaef48df108e62d35099aa6b5e/pyobjc_framework_arkit-12.2-py2.py3-none-any.whl", hash = "sha256:6a8065f5e49c6efddfa9250f14845b5a5fc0cada5444a87d1f96fcf72ac71f19", size = 8305, upload-time = "2026-05-30T11:52:59.499Z" },
+    { url = "https://files.pythonhosted.org/packages/53/34/439b5e0505a369ab741daf65dee78a58e9110df79bf2fe20883b0c93666b/pyobjc_framework_arkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:2834c497fe9f6cbfcdfdcb0202945b7ad36708438afbc71c77186ce3fb972366", size = 8328, upload-time = "2026-06-19T16:05:47.05Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-audiovideobridging"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/cb/4e941fbd2e199b92accbee50839a7841dee74d63d6b199c0d37e7df0e40c/pyobjc_framework_audiovideobridging-12.2.tar.gz", hash = "sha256:7019abd29ab7b232618a5ab7135670e6f1e15744167b8d4f841133893914ebf5", size = 44219, upload-time = "2026-05-30T12:30:27.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/6b/cacbe1a5f8e72c76f546689b551853e9312a00a612e8a2087e75f0dc1e3a/pyobjc_framework_audiovideobridging-12.2.1.tar.gz", hash = "sha256:7b6890ebfb1d346988dad7ff20182373c5c15026b1f9a50f64f654b4ff255e76", size = 44241, upload-time = "2026-06-19T16:19:48.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/82/41160cab1bf637d7b5f7a048dd79d78a72971b2be7556d9071cbac47e51c/pyobjc_framework_audiovideobridging-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7d97571f76a0da68a30b2cf717b4b200d26dfcbad73a040c3c86b4b0ef341c3a", size = 11060, upload-time = "2026-05-30T11:53:05.296Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/d0/146911872702f1e2e25fd3274d29e796ace042d863f076947344158ffbca/pyobjc_framework_audiovideobridging-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7b07278a182e177f0e6417d8252df6ad6b885e17d6b7d09965d35510983bf9c6", size = 11074, upload-time = "2026-05-30T11:53:07.266Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/48/3f73eba1e79e0eea83fe8504f64fe62688178c51ea6ec4b1f90aabeeaf3c/pyobjc_framework_audiovideobridging-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46e962bda54b81fa0e84bd58ccd0284ee680689891c04b869542bdcbb7c3870e", size = 11249, upload-time = "2026-05-30T11:53:09.207Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/75/2aa2210ee0892a2076c58918f9ee53f5c9f62fd5f9b70b4a2e5a56384a1a/pyobjc_framework_audiovideobridging-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d439e659e732b5da958543a2979a7c518374aa2fa2009dccc5bc823043e0f647", size = 11132, upload-time = "2026-05-30T11:53:10.755Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/11/5ce0c697668f3df9aa56c748180e52e0cf93c63cac9622f981751e882ed9/pyobjc_framework_audiovideobridging-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f11f209a1fe86c82ffe0e9dcb5ac22a1c1ccc5ea1133e2dbd43d93218969b4a3", size = 11311, upload-time = "2026-05-30T11:53:12.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/f1e8ec87cfcded57e1ad86d2a6e369cb39ba5bcb64878813dbf2acda9d0b/pyobjc_framework_audiovideobridging-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:98986494aee8c8e70b92757fd3e159ca1a9bbe049062a481ff11bd60ec6ee0b0", size = 11131, upload-time = "2026-05-30T11:53:14.193Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ec/8cd87e9f4b74cf52332269dca22bd34c9db94ec50c6f1f240eef43ace4eb/pyobjc_framework_audiovideobridging-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b85588556c9987e64f458eb7beb99773f7b854a804ffe025c492f8eb04f996a6", size = 11309, upload-time = "2026-05-30T11:53:15.883Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/18/aa7624312ec1aff0243232c75e8f911441c64c417be5a2fd904b89e705a2/pyobjc_framework_audiovideobridging-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8a96bac7a308bed774a5332069ea013e999fa269d58ea67b67ef31dfde705186", size = 11085, upload-time = "2026-06-19T16:05:49.743Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/5221bb910b6d4d91bc0653eafa111fe125ca181da7254b4d1bd5e09dea5a/pyobjc_framework_audiovideobridging-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ceebe03b803be2684412050afc9e661d1e9fc7857ca34f27beff3a11b2cad773", size = 11098, upload-time = "2026-06-19T16:05:50.524Z" },
+    { url = "https://files.pythonhosted.org/packages/39/87/9fbd555fb110f3210a39405c604de75561f68e5cf8e1daeddf4101905f5a/pyobjc_framework_audiovideobridging-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:271d3a0a46cc13437b27c790bc7a5fd9dba8f445a743c243de2b41cc2b396aef", size = 11268, upload-time = "2026-06-19T16:05:51.378Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a2/35db7aed073c8d403b965668c66fa4c84c9557ceb248def2fda7276699d4/pyobjc_framework_audiovideobridging-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ce46d2afc7cc5dacea90dc671c1981d8366239d0aa83f06c0bd7ccb5e8218f19", size = 11156, upload-time = "2026-06-19T16:05:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/49/b7e4728e86dbaca3134cc630876b82c0b1955232015e156e0477ba3e499d/pyobjc_framework_audiovideobridging-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:622afa4c3a12878746d10994ef7536d6c81fba75123b3969613ff23da771e36c", size = 11334, upload-time = "2026-06-19T16:05:53.181Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/3e3b00ed974a7351d9972273c515b65ce0ec0dc677d1f4956ed6cd4eca7d/pyobjc_framework_audiovideobridging-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9770aad1e6f915fd162ff2f867c21114b134a0341d1ceed7fa067d3b02d47c38", size = 11156, upload-time = "2026-06-19T16:05:53.978Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/71/a32171ea36e8c890dff834f6529912f281062d3f50b73c356e416663101f/pyobjc_framework_audiovideobridging-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:81fbcaff1304d1aac41a5a661736d7f8ddd31b3b1352bc1fe471906956997b38", size = 11327, upload-time = "2026-06-19T16:05:54.917Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-authenticationservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/a6/973aca6e96097cf2121027b09720d6e564d381c8f024ae0ebb67939d184b/pyobjc_framework_authenticationservices-12.2.tar.gz", hash = "sha256:c99c11082d5ac6c454d729142709552b10e385d99e34d8e631bedca1886c8b78", size = 75719, upload-time = "2026-05-30T12:30:32.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/1f/fa7506fb8df1c30f7a1fddc9812705494421b2064391106dc00cac948ce8/pyobjc_framework_authenticationservices-12.2.1.tar.gz", hash = "sha256:da70cd842a41276e6f9958b1d3e227a3de452e696c56f8e2b439add45e578665", size = 75693, upload-time = "2026-06-19T16:19:49.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/c9/6f1a312a3d5705ae3bd20660b19b1fb1fa8e8b8bd80d5df1c6e6f7fb7df1/pyobjc_framework_authenticationservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:011e44ad3a42e3f27381f733931677106189c3979841ff8f2b097b1fc1ab6cf1", size = 21360, upload-time = "2026-05-30T11:53:23.218Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ef/4cd4e3648d0187aa06de7146eb7597a2ace07fe5007dab0d99d5565c1175/pyobjc_framework_authenticationservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:98e3b27b9033bb21e12efe89700d0d4cc1b72a90a98ded4d19c3af7edcf8eb50", size = 21376, upload-time = "2026-05-30T11:53:25.564Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ba/b1b41b65dcd3ee357fc3716e5f241ead2da57c9a8984b6a7b8c71f160d3e/pyobjc_framework_authenticationservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0a0e966a24d0c1b9a8c6c94751c05e2cd4f4a47a06ec53822aa626677f52959b", size = 21620, upload-time = "2026-05-30T11:53:27.891Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/95/bfec54f879d12fb78a035923f9d26e08d7d16fd03a8f3c9d2ca56223525b/pyobjc_framework_authenticationservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:62b4fd6303ff3476637d006b4dfef0814f6e163693901f6e66b4d2102f9febf7", size = 21377, upload-time = "2026-05-30T11:53:30.272Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/e5/f52075b41a5e89fe9b5b472ce0d22975081ee3b6ccd141ff9f6394157864/pyobjc_framework_authenticationservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b9efe881067d2201fbaae49fcf8df6c032e571f43921c262719f2c37c03b9d63", size = 21651, upload-time = "2026-05-30T11:53:32.539Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/09/623d86fa7a7cafda9b441e2fe1660b431172fc7a209f7bc0992f36737f2e/pyobjc_framework_authenticationservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d081e3b816db301582cb516a252ac83ec0c686ea00b5011c12e42d73fa871dd5", size = 21376, upload-time = "2026-05-30T11:53:35.031Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d4/16086f609041d5894450f2cbd64521439a16608b2d063cf368afda2537f8/pyobjc_framework_authenticationservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:bab948aaec62be6351712c32c56647e678add6313d07c7cac3277c222ead5e65", size = 21659, upload-time = "2026-05-30T11:53:37.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/85/5019b9a1768b0b9e002029e036d7028312d5704ea48a18bb39e24d22c0dc/pyobjc_framework_authenticationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2f78923734fb477ec4de4a2bea243ae418b33675c2ee62bf12ae333b31dad8", size = 21388, upload-time = "2026-06-19T16:05:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c1/98c8ec590df7d76f394b90e6bffacdaadcf30555e34b2955ac3348316845/pyobjc_framework_authenticationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a3ec1ff47578c7163718aed572fb5d4902f2e33df0b178b01c00797b75802225", size = 21399, upload-time = "2026-06-19T16:05:58.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ee/6775170a378c836767c785b2b99294926c9ddd7f9d38a599e5cef52fe6d1/pyobjc_framework_authenticationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:19194a7266ed75d9d083cf7e8b3d8ac3b241ae259d8c6cd3b4f68bda70751522", size = 21645, upload-time = "2026-06-19T16:05:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/fe/bc580ed2693cfaae762989d90b9d7186b7b53f7c5b5deae94b77f52df0a6/pyobjc_framework_authenticationservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b5b5f66e21df6bf856406dbc984c6400f23b43aef4f22603c7685bf074dc749a", size = 21400, upload-time = "2026-06-19T16:06:00.367Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/02/c5e0b7e5aacfc527ce788d5dd3b836f0a8660fe1bf3af85a5ab7e47f2eed/pyobjc_framework_authenticationservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:90e7c3595fabaf1f905473a553f33572d3bb7d53decc323c18df0a7a2e6c4660", size = 21678, upload-time = "2026-06-19T16:06:01.274Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c0/2824fa1036adb44090d1131e9699d9bfb849f5662a084b579e8a2370ed0f/pyobjc_framework_authenticationservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d431787ad7a9718ab7468411e279ab56e59967744dad6b998be623e3fe9df0dc", size = 21401, upload-time = "2026-06-19T16:06:02.088Z" },
+    { url = "https://files.pythonhosted.org/packages/28/85/ca5af44bbd71fab51bab17c18aa39b258cdb5c5eb22db4bfaefc297bfcb9/pyobjc_framework_authenticationservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fd0592d7257eeb47cf398f4a579a617e977a5b949440a60a34f130c0d811d071", size = 21685, upload-time = "2026-06-19T16:06:02.978Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-automaticassessmentconfiguration"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/6c/1bb82a3487454624071fe1ba5d75e005dfd82770d1472a1cbb78e4508316/pyobjc_framework_automaticassessmentconfiguration-12.2.tar.gz", hash = "sha256:dbd96b6085cc9da3f5115d418b2e052a5807a8964e49422c0d7bf7196499f78c", size = 24753, upload-time = "2026-05-30T12:30:34.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d1/1124aaf5aa1a35126836c623e30eb7ea47c9e64e758f7c3156aa61dbffbd/pyobjc_framework_automaticassessmentconfiguration-12.2.1.tar.gz", hash = "sha256:6888ec9846d04cb7983525d9a134b838044d9857182fe5404224c3071f4cc64f", size = 24775, upload-time = "2026-06-19T16:19:50.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/3b/0c5344819de9ef7267fff2c773649b5d3c988207edcb74cc4399795dac3b/pyobjc_framework_automaticassessmentconfiguration-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:79076241d12df1c60d52ff9ef554f201eb010ab3d9d244ea5d015b628ef2b735", size = 9358, upload-time = "2026-05-30T11:53:42.562Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/d9/7b56f64006c83a65b38e7b58d0a2d3d499f8633d066617c5c0e1ac338970/pyobjc_framework_automaticassessmentconfiguration-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a045df9bf1224d30727db4af8ceabc2f227356e494e93db69b4abc058b4e4edf", size = 9368, upload-time = "2026-05-30T11:53:44.189Z" },
-    { url = "https://files.pythonhosted.org/packages/98/82/1846574b7a414d29f0d81344be71a25f4d18ec5e02ad1fcf1db7c2af68c4/pyobjc_framework_automaticassessmentconfiguration-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:052e81f7a83ddb45ce5c4aeb01dc57f3cc42a5496e6117eb4174d195a2c45752", size = 9522, upload-time = "2026-05-30T11:53:45.772Z" },
-    { url = "https://files.pythonhosted.org/packages/78/80/05090a15011ad969ac8ee5565a77980b4cc35dfdfa8bd69b0ac714ffd4f2/pyobjc_framework_automaticassessmentconfiguration-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3157826b9a7325433635cec279724c995f93dc09a64a46acc7ec26b25b9cd7c4", size = 9418, upload-time = "2026-05-30T11:53:47.32Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/bb/c84d56a921110a5f1bc2ae6d09af79eabdead30b1992a86f683a9c6f12d9/pyobjc_framework_automaticassessmentconfiguration-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c9c5f31eb76405d74e0cdac56d8a6bc1cf2785a3a1121c91e49e852de7bbbe45", size = 9568, upload-time = "2026-05-30T11:53:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/11/dc4e0ff6a968e28354f1d5267e60b4ddd9026e9feb2f86ed9ad113d1e525/pyobjc_framework_automaticassessmentconfiguration-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d7c8bd3537ebe74153c9d9eb1d883be44788d1116757265b7108e3dbaf48b19b", size = 9425, upload-time = "2026-05-30T11:53:50.467Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ce/4d931993b0dafcc776d685a5566eafc8111684c9d3762cd01d420f7a23f9/pyobjc_framework_automaticassessmentconfiguration-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:793954d0a7b2d28fd21c509a897dbd78fa42433cf5f00c09091c143023659775", size = 9570, upload-time = "2026-05-30T11:53:52.047Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/2e284b1b296745e899d1e920c163d3e0d1a7b1111b8735e3b2f9cb57e5d7/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:742f022d3a43478e6d322ea1d2d608080263de75456b5bae7a465a9f463089bf", size = 9382, upload-time = "2026-06-19T16:06:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/61e92054653173c358b17579058e7e5037679a43d0962fa0296070a0f2aa/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c4c233d052d699cf6db479dd8ac0a741fe920e192adc716121c8f4ff3f0ce864", size = 9393, upload-time = "2026-06-19T16:06:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a5/a5bfc8caa00251b2b1abc22d3a5ef28f4e40c14fad9a8ea1c4817d568495/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:90942b9e126b67f151f0965ca84e00795724a96971195e910137dff2c6c0a20b", size = 9547, upload-time = "2026-06-19T16:06:07.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/8e/61b26f0be555d71142533c18e21e28d5cc7929b8451f42753fe43c12ba79/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d1117a6d3481c8e5ec9f984d201c356598e116daaa0a5db6341c7f52a30e0d4e", size = 9440, upload-time = "2026-06-19T16:06:08.048Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/35c209314ceb17601e01a39e3e47a574ca7a3e536b39a4923aafe2a25941/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa564494b074a5020e27b307d73cf695cc9256284996304d9e5d22cf8efb9629", size = 9592, upload-time = "2026-06-19T16:06:08.824Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f0/ef2aa598ea223ad2ea2b295f0e16299d4e1bddac81768a6b6b1d2afcafbd/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5fea5ebc25b053b979536f1b40d19ad9ea80457f47e3df475709b5ab8cf9d7bc", size = 9449, upload-time = "2026-06-19T16:06:10.138Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/49fee458fba33c76e9db0fa602b694cd893a10e43332c749fe69ff9c0b5f/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:170a62e3635f1ddec3e1ec82694ed7330f3ac659ac7ffefc4cee4770d3cc3242", size = 9597, upload-time = "2026-06-19T16:06:10.998Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-automator"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/3f/65daacfdd38b6936cebae9c27f25b5bcb97e4de813488caaa066c80013a7/pyobjc_framework_automator-12.2.tar.gz", hash = "sha256:bf38231f0ad38115473e853e6419c5d0511f4fe6dd904ea380160da91cf27bea", size = 188951, upload-time = "2026-05-30T12:30:46.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/2f/6669c037108799e2319894f21e0067c3119c2a185b18ca70aaf645309199/pyobjc_framework_automator-12.2.1.tar.gz", hash = "sha256:6ea468966d911292d73f52672603eee50bb4a3d651094f63de25dd6d5818d347", size = 188942, upload-time = "2026-06-19T16:19:51.099Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/2b/7423f651934d5cdf44e8cc8b3a544530de173906766bb005c110ef91abbc/pyobjc_framework_automator-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e91a72760b9e23af2e7d2848deba25e76d05d8104f7aef85cc9d955aba4bf8f3", size = 10035, upload-time = "2026-05-30T11:53:56.937Z" },
-    { url = "https://files.pythonhosted.org/packages/16/56/1749bf5de1f138f68bfd498b639a480e06ac9b108c5e50a68cdf58379175/pyobjc_framework_automator-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:949f2d403d4d6d753122fa8ece9f9fd417b8b4afe6b65f64879259a03ca6f59e", size = 10056, upload-time = "2026-05-30T11:53:58.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/2f/de880591ffa058c8456157f5d618d5950ab8788b7f1e8f81d62ab8afe0d7/pyobjc_framework_automator-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:038ece9097bc9441554d48dac051bf445ed5496d4ced03962c5dca2ea46cfd29", size = 10201, upload-time = "2026-05-30T11:54:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/40/6db933f50cbeec6c5665c38d5442d9ed0cea59981d6295e0cb4a25d04331/pyobjc_framework_automator-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:349b7d02f898bf16edbadf5212758d5bac89440de9bd00edfd28c302bef8bf1e", size = 10100, upload-time = "2026-05-30T11:54:02.072Z" },
-    { url = "https://files.pythonhosted.org/packages/69/1b/ecc8113beb74c41a26336485030d127ebf6232c22c7e6e14ba9e99903b7a/pyobjc_framework_automator-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b62fa84bdf975e7c74973b37de491846fd7373eafdf5ec048d52a66b1cc24e8b", size = 10245, upload-time = "2026-05-30T11:54:03.664Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d1/ec4ff07ee7f1ea0f3b74b1f4d91113adb79e6a77a78b00f145cf92e35b83/pyobjc_framework_automator-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c1e1f2f64a6aa9b5d4d30db3794957d7d9d51a3d3e8c3563d0362ad10add5e83", size = 10091, upload-time = "2026-05-30T11:54:05.308Z" },
-    { url = "https://files.pythonhosted.org/packages/29/df/462ce3c16015fb1927c0b3b7a6f1a6f070ec7a4d5b0f0f270d0dbdddf6d7/pyobjc_framework_automator-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:86e9dfa9290909e999cd86686a4f7cf8f437a6c218d03dc244fea7b84cbd80b8", size = 10241, upload-time = "2026-05-30T11:54:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3c/296fbea8ecdfb45944eeb427328d729280b1dd1a811563a40d8baa0b6fdf/pyobjc_framework_automator-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:275dad426c9cee7b683fa5f800e2779b565d1a1e75cb82bb79ad2289ed802f56", size = 10060, upload-time = "2026-06-19T16:06:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/4dfeec84201af81949f7edf670bffe7e88ce022402cab7f62a8ed2234b06/pyobjc_framework_automator-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b74cc160c2f751885d70b6db4d02506468ee4b149672ce06cace88484d8fa769", size = 10076, upload-time = "2026-06-19T16:06:14.725Z" },
+    { url = "https://files.pythonhosted.org/packages/96/62/349e5b92592094e7fe50fbd46e87fc1b5d1f9e09adb48a7e67d3afe4f721/pyobjc_framework_automator-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c41866f4068789acf653416e61ed914279f0d83e12f62b3d5c7eea658df8dbb2", size = 10220, upload-time = "2026-06-19T16:06:15.914Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f8/7452651974e5c7f7c20b03d25b046ca3883ba649cd26f396ab3fa1c3312a/pyobjc_framework_automator-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c6c203c6468df9d958a2e2c5283518b862e87cf1b5db867471ccbb8d0cb9dd0", size = 10124, upload-time = "2026-06-19T16:06:16.732Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ce/de1866c4e99e45e282a53259a266f10f6f70a606c2ea3c8bca19a8b62f49/pyobjc_framework_automator-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc742dc85b078fcd40f4a6e68f4d712791245b2c64ade046c78661680cec57b1", size = 10266, upload-time = "2026-06-19T16:06:17.526Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e8/7d4d106e3da67c0235e4ebdcda4b2e4e7fdb4e5c784bff93c836a25bafeb/pyobjc_framework_automator-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:146fa43a474585ec27f7edb70513c1b75c4fae53b4f8bf971e7a45f1d37c093c", size = 10116, upload-time = "2026-06-19T16:06:18.53Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d7/39f36aa3137dd34902c1f496218e1398b80f7acc5222867aefb6859c7f0c/pyobjc_framework_automator-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3da3eac88bd2c1615040eefb6df7f98b8dc120eee08a27b86c5bfee5f295edc5", size = 10268, upload-time = "2026-06-19T16:06:19.388Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-avfoundation"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3515,78 +3487,78 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/d4/88d226694f8e598138fbc26808bb2d3a0637500691e42d15c64f3a8c1258/pyobjc_framework_avfoundation-12.2.tar.gz", hash = "sha256:d06443acf26f3f3e16e8a9bfad42db900af3b8c3ca34c5676343d2f8e001f56b", size = 410281, upload-time = "2026-05-30T12:31:11.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/26/7616f0bc8e4eaaba948cf5d220c8f55e0f54f617a2812392a82f19c30f39/pyobjc_framework_avfoundation-12.2.1.tar.gz", hash = "sha256:2735e4f1c345d2b533541577e292f3ad2f75d19200eff99f1a2db16d78b4f1a3", size = 410329, upload-time = "2026-06-19T16:19:52.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/0b/491ec7a65d9b6301a8a55a1607bb9079afc18946bb6c87944d51781b5e70/pyobjc_framework_avfoundation-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:593d2ec35f6799d9011f414247570457d8eaa68a1ce1381b4df2ab1daec509f5", size = 85570, upload-time = "2026-05-30T11:54:25.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f5/54bcdd1543663f7e90560adc2ea4daf2ed6bd7ab92f734816cec79cd2244/pyobjc_framework_avfoundation-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:67320d3c7cb0fe1caf019d29eea38e39ede81458e3f4c13c5483892dc66f3b3a", size = 85606, upload-time = "2026-05-30T11:54:32.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ef/f69dc23071b4b7f7a996dbeafee8afbd9be21fe2b651de2eab5d513d6622/pyobjc_framework_avfoundation-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4b45994d9230d2751590928d0421fb7d0b7e8988e52ec1d9ab3f1d57cb869a6b", size = 86054, upload-time = "2026-05-30T11:54:38.113Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/5c/7c2a89266936fc2a99f50810a459ce054035956b07d4d9cc33e9abc5b7aa/pyobjc_framework_avfoundation-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6f03f0122e4f0b2add93f02d92bd7274abf09979116382c74f79715d33e6461d", size = 85825, upload-time = "2026-05-30T11:54:45.189Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/a5/78c75eca36aca64941451a61aa532bfe5305f886fc6f21fd4f4414ea4960/pyobjc_framework_avfoundation-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d2535a7bc3e579bc7621066481791f53d1ac83c0bda16fedbbfa513271238b56", size = 86153, upload-time = "2026-05-30T11:54:51.264Z" },
-    { url = "https://files.pythonhosted.org/packages/33/5c/f872e9502fc96894474b9e0fbd9e36f6fe38052d7f186fca79f150862b8e/pyobjc_framework_avfoundation-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b43a0d1344a062dd983881398a75e5916c46c479b299ff89c14d298ab0a0f1f0", size = 85863, upload-time = "2026-05-30T11:54:57.353Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/2a/d477d3cd1f68cc14706835711f01b87c3063fb40002e79e3d798b6d6fc58/pyobjc_framework_avfoundation-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d60d7ee5935266907acb1a61c25a0d2750f9b1f4ffe4fa6c908440f003d1addf", size = 86205, upload-time = "2026-05-30T11:55:03.541Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bb/e427b2fd705e9dabbfa0ab89b863305788906e34064db2bb930f1c3ba216/pyobjc_framework_avfoundation-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f372800274df35f8d964cad0ad6da7636f1b6720e802e28e5a6bc1f16f16f135", size = 85578, upload-time = "2026-06-19T16:06:22.292Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f5/b38da31d9f95770d0f0f9b9724a898d240d6fb630796e04e9682384d086c/pyobjc_framework_avfoundation-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9291848b0f0f66031bd3af2549e1e0cdf43e4872b9c562bd29f0239c6ef2b75f", size = 85628, upload-time = "2026-06-19T16:06:23.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a4/f1bc5fc239015d8fb4414a83592d69b85b8bbdc68f2403c21dbcdcb8ce12/pyobjc_framework_avfoundation-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3e92a8502d389469b1307a6a2c386f20d2e77878c7e35e3e14120596b47eb205", size = 86077, upload-time = "2026-06-19T16:06:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a2/4a65d749d57dd16b034ee0935b7daa1228e8a735bf920e9eab9f4aaa9f1e/pyobjc_framework_avfoundation-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:043aedd86adbc0a3bfe8f76d1a1ce920539e47b5dd5d965358f93e0063c9a53d", size = 85836, upload-time = "2026-06-19T16:06:25.377Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/49/b9e8f51821a9e5a4a76bea7ab10c2dc1b51b8a141cf4bccbba022f2db19f/pyobjc_framework_avfoundation-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:50e2b65e5c3845eb8ad0d37868a7f040656fe69e6c03f4282670e7dc52ed7a4a", size = 86173, upload-time = "2026-06-19T16:06:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3d/eda090c53a98293d6ad78eb2a0639e9ab402c14555c2d9e3c311fc482051/pyobjc_framework_avfoundation-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f74e199c933df54020b972b985af5a5d2e63134278ea02dfd81923976500794", size = 85889, upload-time = "2026-06-19T16:06:27.517Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/88126080195ab3fc95b08562ce30f9f599bdabf282b3a4e57bd2c8c2595c/pyobjc_framework_avfoundation-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1ec2fdfe6eee51f12e7d933e0109ea8ad553acf4301c01f46b79d0a9d378d705", size = 86232, upload-time = "2026-06-19T16:06:28.535Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-avkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/5e/baee189b339f0249b35da67ff07004412abd4fbf74fbcb63b0208534991b/pyobjc_framework_avkit-12.2.tar.gz", hash = "sha256:e93667aa0d1283e692c6709b79212438e5fc7eb621371f573a7eccf3ecaa57ee", size = 33572, upload-time = "2026-05-30T12:31:14.31Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/8be6b94ad46e50f7f868b487b98ade01914809cf440d5ec892a16600d5c4/pyobjc_framework_avkit-12.2.1.tar.gz", hash = "sha256:9180734ba1ef34000ee0463727dbb73624cc4610a298447c8200aa8a7515e0b6", size = 33618, upload-time = "2026-06-19T16:19:53.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/5a/3d81fbe55c5a62568810b37530631f2c50ec957add1b8cce48f8d249e655/pyobjc_framework_avkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:357dc1cb2f4b0ae60d89788cba6495fdacd773330d47e6687acd2b09859efda7", size = 12350, upload-time = "2026-05-30T11:55:09.154Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/58/d1737715102c83c82789fd8f68c323ef4571de79d4bc619800287af5b6a4/pyobjc_framework_avkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9867e4eb5d84c88f962118cb22a74c594909dedd3d45eea85ead9450c397e76", size = 12365, upload-time = "2026-05-30T11:55:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f3/f5a8f8d154b023930534a77b2039729968d0ade2136fc1c1672b40f3500a/pyobjc_framework_avkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ad719d907340151ff5c3d9b067e8c152a8a23c6d18fc8256fdbc1431b40cf7d6", size = 12557, upload-time = "2026-05-30T11:55:12.539Z" },
-    { url = "https://files.pythonhosted.org/packages/06/f6/5b226e18592b5b89419221509d37caedbd1f44ab9781c6abf9e9649ef9ba/pyobjc_framework_avkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:df3918f5f9bd687a6a6604dade8461a948c15fb8d755eb1aba21819271e822ea", size = 12377, upload-time = "2026-05-30T11:55:14.41Z" },
-    { url = "https://files.pythonhosted.org/packages/81/61/f2b09c245299251307ca545a3160565893fd3f6350f11b8142efaf37e87b/pyobjc_framework_avkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbe7c41d928849aa8628a893fb06b7ddd77af5f2dad9ba22e5ab88545620d295", size = 12569, upload-time = "2026-05-30T11:55:16.229Z" },
-    { url = "https://files.pythonhosted.org/packages/de/26/deefd3fba2daf5a196fd5701159d2ffac4bf9ee13677254ae2ec1eaeee33/pyobjc_framework_avkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b8200fbc2744791dfb4985ca5b7387417ffed8c47b81547d36863bc177b6ea54", size = 12364, upload-time = "2026-05-30T11:55:17.822Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c1/58b2ffdad3dce58e1d71e3baf0b2759b7edbe17f85e4a0346de21d985cee/pyobjc_framework_avkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f089e1022690eed0bb2111e64dec71b1779885e5cc7fe745b7ca1f6df1545fde", size = 12563, upload-time = "2026-05-30T11:55:19.729Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/62/ef72553ed6ff62578f9618551f84d76be247082f9c0baabf8b8672f65f29/pyobjc_framework_avkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f8514a6ca882e55738bf5c2c8fd498b4920b3344481ca6747b32526fe99ac7c4", size = 12375, upload-time = "2026-06-19T16:06:31.682Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/18/9812526e8246048e8873ca243868ed1766e4e25335e33deff79c2802ae3b/pyobjc_framework_avkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7743cd8455031f2580188d6428411516bd927fef619b3764c1450379f030ea75", size = 12387, upload-time = "2026-06-19T16:06:32.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/da5f02922f7ea01e4e36cb62029c8ea4110520bb4a0edd3f5b3cf761cb29/pyobjc_framework_avkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9dce2ef4ecb2dd97fecdb25eccf2c1506b5406699e5cf50c3124dc231e6729c0", size = 12575, upload-time = "2026-06-19T16:06:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/86/6d8fcdd0a79bfc1486a9db2ff1548eb561561aa20ed11c0e8923a7945558/pyobjc_framework_avkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:eba6105589792316b40ce2b23f4957d0185130daf482c37708424b5e61a5a7bf", size = 12396, upload-time = "2026-06-19T16:06:34.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/28/81aaed729f87f904339f072dd89e5f79807bcfc1ceca0362fbbd1276fb4c/pyobjc_framework_avkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2424165d424359a2eaa4f593fe71864c2aa167efa476226fa0be2d07676be967", size = 12589, upload-time = "2026-06-19T16:06:35.11Z" },
+    { url = "https://files.pythonhosted.org/packages/40/15/82a1e4f9400894e09353f2f6a2faba85ea27d0b3e2bad9f6308ee1f62d44/pyobjc_framework_avkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3cf369d8a7afc4585a6abdc8f13fc7bc41da3cba36459fcd9cd3b7fa8f7968d9", size = 12386, upload-time = "2026-06-19T16:06:35.93Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/5a/620afa55572fd2302c6a3495a26c6ba6f781c4e0c559607348507b5aced8/pyobjc_framework_avkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fc3994a696f550393558dc974b7c8f72dd8ca43cf645e5c755f7d5ac167dc93d", size = 12584, upload-time = "2026-06-19T16:06:36.937Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-avrouting"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/5f/dcb7d6a4615c0f4b80492b0ba778f0b49aba6c6b4c3a727d0bf38696aa28/pyobjc_framework_avrouting-12.2.tar.gz", hash = "sha256:78affe0c4335ff47f186fed21965f8a381e46429c1a52794044cf2835b48dd4f", size = 20872, upload-time = "2026-05-30T12:31:16.386Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/74/75a7a33349407c3801fd014cfdfa6ceb3e8e83a020277d5e99eedb3a3728/pyobjc_framework_avrouting-12.2.1.tar.gz", hash = "sha256:8fd237f7a5c8d905f194fcdfeb6771e69c7106fc544c24e9725d952505f0fdc7", size = 20905, upload-time = "2026-06-19T16:19:54.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/65/b8053591a08574a7de17200a6d571193b3298ec86694b2c359126104696d/pyobjc_framework_avrouting-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7324cf41f517328a401b5e7f4a2c0ffd08ebdc32199d3058f4088ff8ea36faf7", size = 8472, upload-time = "2026-05-30T11:55:24.633Z" },
-    { url = "https://files.pythonhosted.org/packages/43/51/2a34dab903467a34377de5ddc111b33506eb297fa1103a433e00a4352c80/pyobjc_framework_avrouting-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:72a6408801282037ded8a852c5d266d0e99b637496ef3aee1ac179cdd89b8d76", size = 8496, upload-time = "2026-05-30T11:55:26.359Z" },
-    { url = "https://files.pythonhosted.org/packages/96/28/015dca6d3acabb21f3e93942aff5cb4420f82ded98e2761d13d932837f35/pyobjc_framework_avrouting-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:feee657352beaa05d98a00d5e744d1d7a95572baa2df34f55496ee70bfc74d35", size = 8649, upload-time = "2026-05-30T11:55:28.273Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c4/332d8a24c4bb5855eef4282d292763a3fe918d8630636e0dcf0e91c18115/pyobjc_framework_avrouting-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2e86f63fa45172d92ad653af5c9977d0b68e10b36441db0157a5485df8ca3430", size = 8550, upload-time = "2026-05-30T11:55:29.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d2/e1fb703d271cd37d9fbb9236deb6bca5fa39c11dfc3248aad68d9ebb66b8/pyobjc_framework_avrouting-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:15a2fe798b118ecdfc4c9b75057630f0fd019aac8e17b9272762e776511ab06f", size = 8710, upload-time = "2026-05-30T11:55:31.423Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/f0/3833ce715747b99867e0615f4f5990cf6466b2e04d5354b78ab66ad40c1b/pyobjc_framework_avrouting-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f862f47adf00f0ba38076949502025489f8c75a7782b393f7fb93cdfc016f27", size = 8538, upload-time = "2026-05-30T11:55:32.987Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/f3/e68ca2735ec81fb13dee5b7f3f4f16b0dbe95765ffa221762721ced7d658/pyobjc_framework_avrouting-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7374ea465ea07f70eca80896701bd216bea9f32a46e3b52db55fd34da287791c", size = 8706, upload-time = "2026-05-30T11:55:34.582Z" },
+    { url = "https://files.pythonhosted.org/packages/df/73/b54c6d24904c3a2eef50a12f3ec0d77d7e2d74567164e088a26b3aac629a/pyobjc_framework_avrouting-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e31a7399fc04d8cdc63f2cd26809dc670acfd6bed4674288df4622c18123a43", size = 8493, upload-time = "2026-06-19T16:06:40.129Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fd/69f18627456e0e9e5bb2838bd1c015c662fa351adb6162d03337a52eec81/pyobjc_framework_avrouting-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2678d7f058cde4156c6c78cc87d71636c432071d0eee10c0d4263a21e6ef23f3", size = 8509, upload-time = "2026-06-19T16:06:41.098Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/8d8122f40b14c69cdc6a86d5211998ecda10cd86bb3fa9c9f27c00c6c3f3/pyobjc_framework_avrouting-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00401319b0fc450af6ea673af2733543b5e4a4e85b53a8ba15e42106f77a645f", size = 8673, upload-time = "2026-06-19T16:06:41.925Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/1fe8aec1f8c37a331fe9ac7abff251d26b5211e941bec8f5d70ddb41d825/pyobjc_framework_avrouting-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:849822d569032704d68d28eb6395c8e7bffac6966c9212066f5939e1844df5bb", size = 8566, upload-time = "2026-06-19T16:06:42.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7c/1a31edec8cc1f6cfb41d4a70ebef488d04e5ea22facda4699bc05541ddd0/pyobjc_framework_avrouting-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58b73bb613e6c7dc26c76a6ae2ab759dd58207847c333d9b1d0fa384bd2fbd61", size = 8728, upload-time = "2026-06-19T16:06:43.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4904ad65742b3b751291478d89a83367433a01569966bc24941ca65909ee/pyobjc_framework_avrouting-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1e112761fdaf8fa4558d908aa70b71b2ac1c3d867dd87217eaec7b2c884ac792", size = 8557, upload-time = "2026-06-19T16:06:44.582Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6b/0d2392882edf18c6441c25b40e86a455a67a7710168c0f307bdc4128cb68/pyobjc_framework_avrouting-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:835f4c32a2ee715e1ce9b694e448279bad9c1912e23725323acb0f5d8b968716", size = 8726, upload-time = "2026-06-19T16:06:45.504Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-backgroundassets"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/3c/b344ae79feea1d4169c2e95684d9cd8b938391371b3db8f24abb98501c12/pyobjc_framework_backgroundassets-12.2.tar.gz", hash = "sha256:6df332f129cc025843f5ba6affe651bbf6499b6be35d781fbb12b52250adba9e", size = 29362, upload-time = "2026-05-30T12:31:19.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/92/2b680e44df5d3a81a2431acfbf6eb2e6fba93f1c382651a77040060d4a83/pyobjc_framework_backgroundassets-12.2.1.tar.gz", hash = "sha256:771fc7a45a10a4b4afb5465b1528958078f456629b63c36a7a43505f93acbaea", size = 29376, upload-time = "2026-06-19T16:19:55.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/45/bc0a2b94d221e5c094b8c90980f1dd89684f9124c7c63ca3f640081c4075/pyobjc_framework_backgroundassets-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7052f3eec8ce4db24f3c513455b470a6936776878d025e081501fffa9cf2181a", size = 10925, upload-time = "2026-05-30T11:55:39.608Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a9/b68ebcab2895a659cc18dcb9890aff8fb2f19f9f4e97dee2197de5608671/pyobjc_framework_backgroundassets-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f40f72349412f7fe9b55e083de77f1ade5c33de8be529633727c83689421a21", size = 10943, upload-time = "2026-05-30T11:55:41.4Z" },
-    { url = "https://files.pythonhosted.org/packages/68/31/5e8d83b4a2269a6b8ba98a342852c5fcd6715390396c5a088e9efa88d9f3/pyobjc_framework_backgroundassets-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1cdb5e2c45786a6a36dea60fddc90251c6482bb6d1c05b499258ecd2a6972d05", size = 11192, upload-time = "2026-05-30T11:55:43.007Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/59/1356179290082932330c18b05ef6b2b2ee8c9d2546e316d555925d67301c/pyobjc_framework_backgroundassets-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:79e68372eb311932bd59dbd98523b3ecf5b6c3490f074be734b41b88ae276ede", size = 10992, upload-time = "2026-05-30T11:55:44.549Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/0a/3e7dd4a6abba8dde3e0aebe54122bb35c8e32d55842b15632c0955b3d03b/pyobjc_framework_backgroundassets-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e7cc37f7cd15cbfd52c30764d31e8c983352fe9813976496d356acdd9e04b5b6", size = 11199, upload-time = "2026-05-30T11:55:46.283Z" },
-    { url = "https://files.pythonhosted.org/packages/22/96/609372b2cd4422d900ec39063ae9a033cda13d2efd57e02bd3cd10e1042f/pyobjc_framework_backgroundassets-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d327bf09dcc25a881f72f74e3d07adbf45e1188e5d1f7bbac8f1bb814af1de15", size = 10986, upload-time = "2026-05-30T11:55:47.827Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/72/00889013075612cda22866a3e0521091f2912854ffd18fef84dfba7fb114/pyobjc_framework_backgroundassets-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:028fb2d4adbfdaab9a531943b4019de531ae3a4a57415da6e4b059ded28b7743", size = 11194, upload-time = "2026-05-30T11:55:49.565Z" },
+    { url = "https://files.pythonhosted.org/packages/19/32/9a08bc3f2aa8eeb5d5be2801a5766a755856b079b3e7afbc1fe31d679dba/pyobjc_framework_backgroundassets-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dac0d3a65a95ea886598f381080c4efffc3acfabcca3e692550fbe615627db7e", size = 10942, upload-time = "2026-06-19T16:06:47.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/89/4e42e961fd771db5c4ba3243ea499926b8242c681671818dcb613f41add7/pyobjc_framework_backgroundassets-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bd07fcd0324ba4c6ba00c0eb3af6832f102e51895afd1933fe9c0c2efe9b9734", size = 10965, upload-time = "2026-06-19T16:06:48.669Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/c05a4e2433c1eb61773fb4f4ff46ef6dec4926af4aa98c8a6776bf3cb95f/pyobjc_framework_backgroundassets-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2730c6e01c16d9c42cc46b0c23d37b3ce9de70cd0a93a2f712f44a84bd786bb0", size = 11218, upload-time = "2026-06-19T16:06:49.531Z" },
+    { url = "https://files.pythonhosted.org/packages/11/36/0c38885fb8e03428c5d451453830f91386f7522087e4e4919bbfe9e1375a/pyobjc_framework_backgroundassets-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9b4cd5797eeaae395ab00da89a141396a3f8c29bed13481ca52cbd66eba07406", size = 11013, upload-time = "2026-06-19T16:06:50.321Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6a/aee1901a06775f0a8716005fcab6a6ebd38b66e8dcc3d864b7414b23326e/pyobjc_framework_backgroundassets-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e315f1e22c54603dfd7a924a916cee4975c444ed097e34c5e4f2667e50ddc471", size = 11218, upload-time = "2026-06-19T16:06:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d4/75270e3d290e6387b61ef780629daf5f40f5f5eef85049db0a91c4187196/pyobjc_framework_backgroundassets-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:16573c33421d45b7eb5354c7ce1d2e21141404c93d3500cf4702ab37e1372dee", size = 11009, upload-time = "2026-06-19T16:06:52.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/8a564b1bc0fe6d8a308eb7c7a72cf9fde0b0f7bf8461d4b1d7292bb7ff83/pyobjc_framework_backgroundassets-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b848dfe93b3afddae60c5bd9b6b899c51f89591faebe3e7788b37928aead2d5b", size = 11218, upload-time = "2026-06-19T16:06:52.845Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-browserenginekit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3595,97 +3567,97 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/57/b5529f648215f9abf7f7bb5f57737b75d2cb12936a28907258d6ce2846e8/pyobjc_framework_browserenginekit-12.2.tar.gz", hash = "sha256:f38924bc5e8ab80d1248b00554015b4a86ec3c3c17c779a3e43a0179671e4d69", size = 32610, upload-time = "2026-05-30T12:31:21.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/45/955a13e96d79e369754a99ad185b59edb721e95196a893f215f299bcb9bc/pyobjc_framework_browserenginekit-12.2.1.tar.gz", hash = "sha256:6e07b9582fb7e9b9a9ea40280d5815e4130cd0f9194fdc6bdd3a3bc07d6d2f85", size = 32607, upload-time = "2026-06-19T16:19:55.949Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/d2/cabd9d636204dc08935c9120db60d74a56304d9700e9ba5842d7adf3dfee/pyobjc_framework_browserenginekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a5590d2301c7c0bfeabca352fc3eaa3314d918cfcb1b35b264c53c9364cb1ee3", size = 11737, upload-time = "2026-05-30T11:55:55.066Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/c4/34535b9a061dc619a2f3910d15fde604210187cda07bba4c720fedc77d26/pyobjc_framework_browserenginekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e500aa3ad0c9ef5787bc72a42474d58f8b3355d16f8944dabbe5db2f15a4634d", size = 11760, upload-time = "2026-05-30T11:55:56.77Z" },
-    { url = "https://files.pythonhosted.org/packages/63/05/c0c40325e75fbcf70372b7bea10eb875b24ced3582f580205d5a58ef72e4/pyobjc_framework_browserenginekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:88b2b6d5cf7b1e91029e3f32fa950bbed2cf43228ef6a0869bde915caf841152", size = 11927, upload-time = "2026-05-30T11:55:58.441Z" },
-    { url = "https://files.pythonhosted.org/packages/72/c8/fee307a791f1315eecb4414429ba3b98f0571ca768ae5eb9cfea30c88087/pyobjc_framework_browserenginekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:87c2d039d7008ccc06b2bd8a4760d356a4d1f1cb267d680813919320e46e9202", size = 11809, upload-time = "2026-05-30T11:56:00.151Z" },
-    { url = "https://files.pythonhosted.org/packages/98/21/eeb8cd19ff856e77a96d06f51dbc7e8c0f885c71cd0673401100bfe41f07/pyobjc_framework_browserenginekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79400862fc7c7bae77bdee8af2fb526877229066b6cf137a3514de8e304eab2b", size = 11995, upload-time = "2026-05-30T11:56:01.874Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/20/c3f5ded954426f8e44d831e18a5993d859b08c7a4a713a8de6c0016461a5/pyobjc_framework_browserenginekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3e02e17a4c7d28eea31fa870c48908d354e8ae9d07dae0691070feef584df7c4", size = 11800, upload-time = "2026-05-30T11:56:03.688Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f7/c468f25c1e19828ce256065d5d40b03b4f65229e3995de922d7c1569c270/pyobjc_framework_browserenginekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3eabf92613a55e9adbb0e8933898622868e2ab10e1731dca25cb8885ac73f0d1", size = 11992, upload-time = "2026-05-30T11:56:05.413Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ff/f2ecf8207db7a91a7ae778d041cce343e847ee63fc5975fbe1d53d9b62a7/pyobjc_framework_browserenginekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a57b1e941107346d8b948201501654541ed40a361dac81c20c154d428b8a0c37", size = 11760, upload-time = "2026-06-19T16:06:55.761Z" },
+    { url = "https://files.pythonhosted.org/packages/18/98/ad604a0a16bce24d8297d4a651d6ad207137df507f59ff69271fad084bfa/pyobjc_framework_browserenginekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:eb7148c7f32c98d40046eb3338f7ceb1ab055edb122065a7b37cbc84865aa41a", size = 11782, upload-time = "2026-06-19T16:06:56.666Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c8/baae0dc88d8f52cfbdc5623e9ae718fc44c9d72b1c9edbd85a525fc47c6f/pyobjc_framework_browserenginekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:52b212f57572e5d3b31b2dafcbe6e1e47c4af025cb396aba90ac74101ae0e717", size = 11949, upload-time = "2026-06-19T16:06:57.487Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/e636a02bb9ee6b546054aa098ff8ff4d66e62413a91d31ac78e229b9717c/pyobjc_framework_browserenginekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0b55960a96fe709ba9362638e794a887afd8c66ebcd75ccb758b4bf87233a249", size = 11830, upload-time = "2026-06-19T16:06:58.255Z" },
+    { url = "https://files.pythonhosted.org/packages/64/df/d2a7a7fd5ab5d86dda2256c891ae96c722c53099f8875fd09a06eef74904/pyobjc_framework_browserenginekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2884addef8f1f987cc625f4f123dde6e8e3eaf58915bc2452aa4090c24388338", size = 12021, upload-time = "2026-06-19T16:06:59.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/dc/ce1b20bacc0dad78d864f0b350e97a38588d02403f629aed1616ca23b97e/pyobjc_framework_browserenginekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a20ca22bd18a0d773cd483499761690cf00a6241a5a3186dd407e52ce054a36d", size = 11824, upload-time = "2026-06-19T16:07:00.051Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2e/8f3a89bab39a61cca4f707f3b7f09b650b2a94040c438a29d621484669b9/pyobjc_framework_browserenginekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca3a58c7be5463c65566d2b41d18cf5b9f0a1f70f27540c1a108e74d2487f1e3", size = 12016, upload-time = "2026-06-19T16:07:01.071Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-businesschat"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/9ad0a1f52f5c670948a71eceb295b6273fa7b3422651f660f9eaac5c3078/pyobjc_framework_businesschat-12.2.tar.gz", hash = "sha256:77809904d62b18377e0764458044f30ba380f462f616cb69628431814afb6f14", size = 12403, upload-time = "2026-05-30T12:31:23.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/26/c92176248363ef510e991c7b537de7aaa4c66b232de1d6c7c527270d9911/pyobjc_framework_businesschat-12.2.1.tar.gz", hash = "sha256:2847c422d202fb8e1eb892c7151b2251b2880a5e6618b7affbdec2b5521a6072", size = 12409, upload-time = "2026-06-19T16:19:56.76Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/19/5b9e89bf4c62bfe4ab844027f75786d171aee623fb4ca0c4dc46e67ffd7a/pyobjc_framework_businesschat-12.2-py2.py3-none-any.whl", hash = "sha256:c96bceb6796f1fb82edafcda75d5abb59e165aa0f55a6e646638ab56d94ceaa3", size = 3477, upload-time = "2026-05-30T11:56:06.861Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/58/cbe465cb6fcd155af2de412982e59ee9cc354be1b477cb0441e089613f57/pyobjc_framework_businesschat-12.2.1-py2.py3-none-any.whl", hash = "sha256:61ef7e7fb1846a1731c7e7268e032ed6fd2e6df3de195c6c35d4df4c81e18801", size = 3501, upload-time = "2026-06-19T16:07:01.885Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-calendarstore"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ae/e6ab01011033d45501d96e388eff16185152ce2459174b13e22d90c721a1/pyobjc_framework_calendarstore-12.2.tar.gz", hash = "sha256:26fd412f9c4b9bf5243d44f87b03e24c80562012f6db4ec88c78cc2ffe63e7bd", size = 54421, upload-time = "2026-05-30T12:31:27.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/f7/65fe8ddcfd0e88442139b9dd737184aeb6f83d6748315061190ecd0987ad/pyobjc_framework_calendarstore-12.2.1.tar.gz", hash = "sha256:5659f2d59dd49423d3880295cd4b395a61c0b7aea8db654e63dab6dd32d28dee", size = 54448, upload-time = "2026-06-19T16:19:57.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/f7/356d958ef979f1dc7c01c0a94f0a0b0bf409919308b69e5eee750772f480/pyobjc_framework_calendarstore-12.2-py2.py3-none-any.whl", hash = "sha256:cc9b0cee139d0552d8b924aca13c8ea3a51caa0e2bbf57540d84f249decd3846", size = 5288, upload-time = "2026-05-30T11:56:08.493Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/30/f11d28e0d4bea633a5a99e185b5574a8a04a0944372d05bd0a28167f2156/pyobjc_framework_calendarstore-12.2.1-py2.py3-none-any.whl", hash = "sha256:d144a2e2b2566b2954f0e365bf7592ccd17cb459165805ed73c6ed8d0feb2ede", size = 5312, upload-time = "2026-06-19T16:07:03.099Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-callkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/63/f050271956d5742acde26d04ec6e602af9c39e6ac338c161cdd44b083016/pyobjc_framework_callkit-12.2.tar.gz", hash = "sha256:862c4e7475cfc2ee6c663f042fc4a025cbf07edb7608aa8556e64a0591e070fe", size = 32654, upload-time = "2026-05-30T12:31:30.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/0b/0cef47cd370e195c113125205e83443e23a1da838df7419ad9131539b266/pyobjc_framework_callkit-12.2.1.tar.gz", hash = "sha256:66dfbb864c6aa253ff90ac91cdc23dc7158dee8eb76b1764126f2eae59e771a8", size = 32653, upload-time = "2026-06-19T16:19:58.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/14/a5cfb8c7a909836236c9f42ed4ba0e0566994828989cce99d646fb6032f7/pyobjc_framework_callkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe8d63ef451eac946864614874b03a2e68a87389e8af611aab32ba61b0e10d2f", size = 11368, upload-time = "2026-05-30T11:56:13.932Z" },
-    { url = "https://files.pythonhosted.org/packages/87/7a/4ac154b5bef806a770de93ff5bd5cb67ac92ddb92ceef697222919a8dcfe/pyobjc_framework_callkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09f8e08298a46ceb53e50c1e17c5dd9e06ac2096f1bda2f956f2ba8693e91ca6", size = 11376, upload-time = "2026-05-30T11:56:15.663Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f3/72f5b9a00b7adea3cda7d911414c8deaf0bf37e0396c9c918147fa002005/pyobjc_framework_callkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b7242585de40273f82c084fe00a1658f34b0357695f008c8c468ef08c50cc2d4", size = 11590, upload-time = "2026-05-30T11:56:17.342Z" },
-    { url = "https://files.pythonhosted.org/packages/43/7f/5723741b95b838230f833a98dd9795d49810b3986534b88addf3b8779b05/pyobjc_framework_callkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1548f4318427d392ba25296d84449980317a96e92ff01ad4ed77b11b69a8a5ac", size = 11366, upload-time = "2026-05-30T11:56:19.095Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/b9/43d2a04cbafee3f6ba86bbebb1767ff7678adcc8b78880725a85b9d4cd4a/pyobjc_framework_callkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa198339cb30cacf7783fce03b37a1e800e8ab297466c2e70793383a1658a701", size = 11591, upload-time = "2026-05-30T11:56:20.81Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ad/78870edd229349f9b6473fbfbc2612662166834f62474d830d80c972e519/pyobjc_framework_callkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c35bb086c67dfdc9facf0f56c8b7b3c1fb2f0ee5e373cfe6dab7cd91daf7b426", size = 11368, upload-time = "2026-05-30T11:56:22.495Z" },
-    { url = "https://files.pythonhosted.org/packages/43/74/0d66c43c2cabf383e304615bcbfcc9038ec66f9e8b7bf7becc3733625e4f/pyobjc_framework_callkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e0658e53a50a4244335b840c45825845350b2d2e9269ead43d7beb1430062d18", size = 11593, upload-time = "2026-05-30T11:56:24.352Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6a/27a76b1153822a64624dffb9cf93e0f815e3e8d618e4c6e49101cb602645/pyobjc_framework_callkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e259627de99e751d2f05f39d135281a58f75a18d3c5ba9dda27c6bf88bc673a4", size = 11387, upload-time = "2026-06-19T16:07:05.784Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a5/c05d4ac28acdbd24c0eb80b73f6a2968943892a624a90289f7d46c07205d/pyobjc_framework_callkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:afeea8cf2d302994481ebc4e7889168138b2ba82892496866135ad666023e1ed", size = 11402, upload-time = "2026-06-19T16:07:06.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/2fe9ef2735187d4f587a7ae698de5eb34fdaa5cbdc1abb771b3c62d9e3b5/pyobjc_framework_callkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9cc081df5897d0253c4924ff6da6f7c5c03ab6bca07302c99eea6e26738050a4", size = 11616, upload-time = "2026-06-19T16:07:07.628Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5b/4be62a9902ac84c347c893583615227ea479dbf94edf6bad51c314ff94fb/pyobjc_framework_callkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3c0bea7ed9c38d1c5e4a5ebf01a99b93e3eb9cee83ed3de1c3386ce2294bde55", size = 11387, upload-time = "2026-06-19T16:07:08.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e6/a542b46d954429de9f84e164877abd4cba65441792b31a6f39a087c77993/pyobjc_framework_callkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b26b5ab9f54dcfd629458a85d53288595df40aac2c51df0493c9e03967f9cf29", size = 11616, upload-time = "2026-06-19T16:07:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9a/d85b65ff7708699141b4af62be7def5fd1cbc5f82b0ccb0f74642a7488a0/pyobjc_framework_callkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:40d424890b084261ffb8f17f68b815c4724e529d985b88281eb48c76a325c148", size = 11394, upload-time = "2026-06-19T16:07:10.044Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e4/08d9e342c89c3f96f0783edff6192fafd56f5cfabb23323bf35ccbae832d/pyobjc_framework_callkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:446f8c3bc014ebea37e191539971b1dc39f10a259db0e7d552e738249ae43252", size = 11620, upload-time = "2026-06-19T16:07:10.957Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-carbon"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/ee/91f41ac1e637b999ba80ee3d5d2ceafaef8d8709012dbb8d0a904136ad76/pyobjc_framework_carbon-12.2.tar.gz", hash = "sha256:965a291f5d5db032057e00666b5a6baed66c564451db66e005fd88be17ed8e27", size = 39741, upload-time = "2026-05-30T12:31:33.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/1f/c5df0b0f276542be355e56541af59ae77e98b22e5265d483601a2324c4e0/pyobjc_framework_carbon-12.2.1.tar.gz", hash = "sha256:a14ca4a45e697c2d187753bc851f3bb49d5bcf66d4ef1d2363fd9962417d8638", size = 39755, upload-time = "2026-06-19T16:19:59.099Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/6c/4600816c385ad52f748bf527c4ed15a15d51fb79770bb0a5d6642c4f49a3/pyobjc_framework_carbon-12.2-py2.py3-none-any.whl", hash = "sha256:2420af5872473b91080b8000a50ab2e5053611dc68c094e257b75939f3fddef4", size = 4624, upload-time = "2026-05-30T11:56:25.712Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/6ec19751ee486409164e94ca6bba29050c491467540cefed1398ac520c09/pyobjc_framework_carbon-12.2.1-py2.py3-none-any.whl", hash = "sha256:603cf2bced196dd90d6400bcbca32ab573166fc4058193bfbd7c1bd95cdefd4c", size = 4646, upload-time = "2026-06-19T16:07:11.76Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-cfnetwork"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/01/3976ae7dca6f2f35659c364c2e8454a678f730f96f50d41f8ff53cb00d8d/pyobjc_framework_cfnetwork-12.2.tar.gz", hash = "sha256:d50078305b840d1c4f9d47c7c7cb66508766189f9aec6683f4207fccd6d096ee", size = 47633, upload-time = "2026-05-30T12:31:37.914Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/96/189e013d494489e6468d9b0b81c4b0e2f338574e1a777b7a43a6b37573e6/pyobjc_framework_cfnetwork-12.2.1.tar.gz", hash = "sha256:cadc9f65a97c20cf839259229c34ecdb5b54a3ade816c43374a1eb25d3900925", size = 47652, upload-time = "2026-06-19T16:20:00.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/79/29d6ba7cd1931c35b0b6590162b6ee21cae36c5a3597fe14ac69c1ff098a/pyobjc_framework_cfnetwork-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a38c3044b4086b840c974a430db0ca4f02b28b5bb18933da56e5fd3291458667", size = 20127, upload-time = "2026-05-30T11:56:32.622Z" },
-    { url = "https://files.pythonhosted.org/packages/07/fe/f89406f7cadd648eccb03d2777860b748f04db3245fd4bc7b1355cb00cca/pyobjc_framework_cfnetwork-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b4c2eba6d1060b3e0e7d63bb67d2d14b46a7e51fa8ab2c2e7767cee266f548a", size = 20145, upload-time = "2026-05-30T11:56:34.838Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5d/3bb11f406df581059d65a7807dd986796aa388a33da1c816b37238c2b889/pyobjc_framework_cfnetwork-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f4d6db3702593b2a93cf9b793f3eaac6c0fa7d128a5abcf9f8b7a65079930e5c", size = 20449, upload-time = "2026-05-30T11:56:37.185Z" },
-    { url = "https://files.pythonhosted.org/packages/63/7d/74225d22d6b26d44f51add2e7a24ed26cd083d52daa165b8fcfe668cfe17/pyobjc_framework_cfnetwork-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:760e6dddbd91013c24161413cbb4e91f0161d20815473d66cf6eb1826d579306", size = 20190, upload-time = "2026-05-30T11:56:39.404Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/6a/a040b6e60aa9ecd4b9b4ae606891944562312bc02a067538b9eaf06ea855/pyobjc_framework_cfnetwork-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4f0b1b47b0f230e4f24382dce5500fb1d19350c867e440eb01f31c24308002aa", size = 20432, upload-time = "2026-05-30T11:56:41.585Z" },
-    { url = "https://files.pythonhosted.org/packages/56/56/b7ecf9e748b86ceb0fd7f7b78f989b76aee05044346f1a6281e1cd095694/pyobjc_framework_cfnetwork-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b695807bf77444a08fc944c50c6a1aa246abf502c3c507ca04815964f4407024", size = 20193, upload-time = "2026-05-30T11:56:43.808Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/52/5fbabf17e9ae99a8df2115c21f4ac69463ed91f6e5b0481484b9c6d5ad95/pyobjc_framework_cfnetwork-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5400c56807880e58bac7ce3d48e7b9c773eda8ae1774f361e2e1c5e4afcc990e", size = 20430, upload-time = "2026-05-30T11:56:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/77/15/227b45b0780c1a0bab0b1e7343a59871d393150661e7e28b9e980c959a71/pyobjc_framework_cfnetwork-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f9be16c691c6f1f58e91551c9e67069abcbf3d5e9a789b1b95b1f84620f0308f", size = 20155, upload-time = "2026-06-19T16:07:15.201Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/17/1565bbd61caedeba02f86871a9db0dc3e103e5c0cb2e4264089741e4dc79/pyobjc_framework_cfnetwork-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e8efd441705148fc715c18e57c30c68da001465d2c443decbc56bd4417a8725a", size = 20173, upload-time = "2026-06-19T16:07:16.147Z" },
+    { url = "https://files.pythonhosted.org/packages/64/92/1d1fe63cad93c423f85ae41471bc1992902a7c3a90b106b1907fd460061b/pyobjc_framework_cfnetwork-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d040fd88f3b8e60f7c35096b0901cb6f05c0c5a7f0c90af783fab5547bed3061", size = 20473, upload-time = "2026-06-19T16:07:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f6/4af038de8529f9d13ed896b25d9923005bfe70d3b29053b515d484f7c639/pyobjc_framework_cfnetwork-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d9a9399799d5889b0746860c1ebc569b813e3fe836d80d19080901a966094121", size = 20218, upload-time = "2026-06-19T16:07:18.089Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8f/642e3270ba88868cec357a00f5641d448159287c1df896b10315328b8ef9/pyobjc_framework_cfnetwork-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:828d104edb558be33667ce3fa9cc37a853839fadcb10bed7017709b0511d8801", size = 20454, upload-time = "2026-06-19T16:07:19.104Z" },
+    { url = "https://files.pythonhosted.org/packages/28/21/5a0e30a9fcce01796cd1539d277e912729766723384b509efb2428fbdf30/pyobjc_framework_cfnetwork-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:89725cfeeb24fb277be2944c81f2f6f9dedd4da25c4af26a3d7b4aadeb421734", size = 20218, upload-time = "2026-06-19T16:07:21.604Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/9edc4c12f9445d43e98d13812495098d9d342e9d9ab6e9b1d9aa57bd3d0b/pyobjc_framework_cfnetwork-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:eedf28c9e2b69607e646b775bf2149835bdafac9133847c561e00e0c87e0e9e9", size = 20459, upload-time = "2026-06-19T16:07:22.742Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-cinematic"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3694,33 +3666,33 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/dc/afc97af264e477fea0f95b54f13350119d69d6eeeb68a6698452295576ed/pyobjc_framework_cinematic-12.2.tar.gz", hash = "sha256:2bec1954c5241e5c8dbefcab6d5b300e62f76eb3907a177840357f9de8474d7a", size = 24960, upload-time = "2026-05-30T12:31:40.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/a942906b8753161e58b89e6d986dc24a435a8cbe6ab6ea80162d31b37895/pyobjc_framework_cinematic-12.2.1.tar.gz", hash = "sha256:cd251ded9393ff4a993a3689d4d3ce7ba3926e7f884f9cd333cf9610338ac28b", size = 24948, upload-time = "2026-06-19T16:20:01.374Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/b6/97ff3fa5efbd7b80d40ab5be590f92b7a7ed711ce01812bd0a0a3c0453d8/pyobjc_framework_cinematic-12.2-py2.py3-none-any.whl", hash = "sha256:8df478081b8248a32e91aa2981806e05c551bc6f9ec1286b5ca2d1c64e981f6a", size = 5101, upload-time = "2026-05-30T11:56:47.469Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e4/9a0d9725de7a31c08eb470b6ccd9c5f3628b972a6309b3214406ed9f74cd/pyobjc_framework_cinematic-12.2.1-py2.py3-none-any.whl", hash = "sha256:73720492fc29eee04cbbeae701dd21c5ddd56dc4e19e59b2af520b8f53a129a3", size = 5123, upload-time = "2026-06-19T16:07:23.663Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-classkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/35/40a13933e42581a127334faebba2d352a01d3baab02693b31ca4622073bc/pyobjc_framework_classkit-12.2.tar.gz", hash = "sha256:41ca16e92a844bed689b634707a07ebd38bf53e1a0793bcb1005347221889d7e", size = 28943, upload-time = "2026-05-30T12:31:42.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/33/d2933e1dcf122be5b785220713c80cf07a24d2e21bd429b39d723059f653/pyobjc_framework_classkit-12.2.1.tar.gz", hash = "sha256:2f14c6056486b274e487deabf2ce94ccf17db5df6cd332617592ff2d306d7b5c", size = 28972, upload-time = "2026-06-19T16:20:02.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/33/be5bf6a705893bc936b3bbc7f9da464b8c0911efbd787a9b2ed8e5a0d664/pyobjc_framework_classkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b54bba859c942e00a279e9a42897897b6789ab46270ae02b9826b789def898b", size = 8928, upload-time = "2026-05-30T11:56:52.582Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/54/bb0db5a07037e4745deb8f0176cf78b03e4176bcd965693998fec86f5b4e/pyobjc_framework_classkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:168c875649e7e43192ef2961569fdf2ac77f662a29417991a99dff5a44dd9881", size = 8940, upload-time = "2026-05-30T11:56:54.141Z" },
-    { url = "https://files.pythonhosted.org/packages/91/93/d6581548debc49ce93d94eb909d663ab1bbf15439f3febd5ba7cfda91481/pyobjc_framework_classkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b593774ad4809c896d735fe3c0d69664cc74d3abe56d1a5fee809a7c05646ea6", size = 9090, upload-time = "2026-05-30T11:56:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/17/78/7354e03126de7bd6a0919a73c4daf54e8e614b257e223caf3171b8ff03ca/pyobjc_framework_classkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f86e741cc43454de9560839e96800f2d0f9ab07f1e52416e82ccb343137d7e94", size = 9006, upload-time = "2026-05-30T11:56:57.601Z" },
-    { url = "https://files.pythonhosted.org/packages/03/6e/a20b725099ee4981facc259c06d674e84aafb86d6387c208f7cb595da5a3/pyobjc_framework_classkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d7de8bdafa98f64f69094d067cc2a5dabad62a7b861f4837c4e95d380af20df2", size = 9160, upload-time = "2026-05-30T11:56:59.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/b8352ce9ab8e178a7c4ad719573116a6f3a4b9e268a1704c65342f28ab32/pyobjc_framework_classkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:21325c21ca70c38ef8536bf80a25cabb575d7cff95afcabfb8824c180945ee45", size = 9002, upload-time = "2026-05-30T11:57:00.825Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/73/9a7247e52db4d236355f8db3f1e7f94231942f491433cf6e825bd86d0cbd/pyobjc_framework_classkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:566d622feb6c5c45a9a8b60dca97dc9941f8b88826f7f91138e81719041288e1", size = 9163, upload-time = "2026-05-30T11:57:02.487Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/62/2acd49bb925b8785a2051825bae02d7db2e92d7fa1573585ccdeb131e76c/pyobjc_framework_classkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f39c78209ad615bb1ef54a3b78b56438aa734bb01143d954ab29d9cee59ec34d", size = 8950, upload-time = "2026-06-19T16:07:26.848Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/2a/b7ff453762489443997a3d39d5b6e6865c736ed57db7be67cfab982106fc/pyobjc_framework_classkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b96d7b6416e954be53ac4fc1908bad22c6609d116dd50ef1f25f057bf8274625", size = 8964, upload-time = "2026-06-19T16:07:27.966Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1f/83661aec2aa68f7c571370230a0dcca12f2c1b6bf615ab96ffbde12c2ea6/pyobjc_framework_classkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d689fb7bcf0120963b0d4518399c2440a4bf95378e9841289835846008bebac2", size = 9111, upload-time = "2026-06-19T16:07:28.953Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9f/b5ad19a4570757500433263c135408160c500301bc9aa09fe5a2c5598659/pyobjc_framework_classkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ad7e412ab76fc061b0ac40d98bee454cb4e211ca4ac8d0615a42d2e585ff927e", size = 9029, upload-time = "2026-06-19T16:07:29.838Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3a/0919a7c440882763f333534c84cd6ff2c65e980e7e3039d55f87573d2e0c/pyobjc_framework_classkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0cf34015821023ea317bad59087c44bb63c3e8be14177904f7204bd1e53cf8a1", size = 9183, upload-time = "2026-06-19T16:07:30.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/8f9e45ebab8eacdcf2d69e355719b20f7b36e20fcd02948f59bf2857138b/pyobjc_framework_classkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5b65626323c4e8fd51b85b0474a4a2c10fc4eca097857406837ca1570310fb34", size = 9030, upload-time = "2026-06-19T16:07:31.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/99/9cc70a07b4f44c484d66fc800198043dffb65924b5d50ba2eac865e3c2c9/pyobjc_framework_classkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6a71f9152dc08502fb299d664afde0936682e60b4023a887fcec6eb485dbe91d", size = 9180, upload-time = "2026-06-19T16:07:33.292Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-cloudkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -3729,1092 +3701,1092 @@ dependencies = [
     { name = "pyobjc-framework-coredata" },
     { name = "pyobjc-framework-corelocation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/57/418b22c326c62f03341e7a974852c5a5bae4dfce1ec88a570e22f14c662d/pyobjc_framework_cloudkit-12.2.tar.gz", hash = "sha256:7849629cc7c726c1a3e16b3324d9fac57f72b938a66f10d480f52e381bef1223", size = 71957, upload-time = "2026-05-30T12:31:47.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/3a/ff99bc394e051086f7d63ade09460de85e2540cf823fb1cd759225f2c744/pyobjc_framework_cloudkit-12.2.1.tar.gz", hash = "sha256:7d3810347fe8de6171d8a4377916750b4ba3bfa874b5f8e5bd0ca6e62d2c4f43", size = 71962, upload-time = "2026-06-19T16:20:03.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/01/1ad78a6eebbbac6381aa1163028dfe74ccc4111444ecfc1954b4d02a53b1/pyobjc_framework_cloudkit-12.2-py2.py3-none-any.whl", hash = "sha256:1e00a6d02ac005a4dd31aa0aa5e22fdd3e05f8324f91a175dfae7fd45d85afd1", size = 11412, upload-time = "2026-05-30T11:57:04.221Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3e/093157f31d29e06bad916d12f6903bcae9c7708ff89fef5bb612cf305f44/pyobjc_framework_cloudkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:4badd0d3b9d78fab900415a2b0319579c5be3a30fa99e631a9065f3768076e35", size = 11437, upload-time = "2026-06-19T16:07:34.479Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-cocoa"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/cc/927169225e72bab9c9b44285656768fb75052a0bc85fdbca62740e1ca43c/pyobjc_framework_cocoa-12.2.tar.gz", hash = "sha256:20b392e2b7241caad0538dfde12143343e5dfe48f72e7df660a7548e635903dc", size = 3125555, upload-time = "2026-05-30T12:35:09.273Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/66/5a91f2eddfced4f26bc2df2bcebb7f5f10c5bf5666aff6fa00ded845af07/pyobjc_framework_cocoa-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:06cb92d97d1af9d1f459ae6cf1d1a7b824c12d3aff1b709885966acd6b7208c2", size = 388093, upload-time = "2026-05-30T11:58:14.921Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/3b/1af2be2bf5204bbcfc94de215d5f87d35348c9982d9b05f54ceefbc53b8f/pyobjc_framework_cocoa-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f0bbe0abedfb24b11ff6c71e26cdefb0df001c6482f95591fad40c2688c16498", size = 388154, upload-time = "2026-05-30T11:58:38.547Z" },
-    { url = "https://files.pythonhosted.org/packages/41/cb/c0435d64f1199210af36141b90aea2ae3344719f7313d4160b8b0dd527db/pyobjc_framework_cocoa-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46b6681e2b21b099ed095339c140f2c8137d6ac5658653166ee90722f9e3c621", size = 392245, upload-time = "2026-05-30T11:59:02.436Z" },
-    { url = "https://files.pythonhosted.org/packages/56/4b/df8e359e5e422e8f1430bde038aa64364e8c1d4542d7f6fcc4f8a97ec0b7/pyobjc_framework_cocoa-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:aecfd44908fa12a9291fb6ca2458ebbc611102de6784f2202a35fd5ed9f56c60", size = 388334, upload-time = "2026-05-30T11:59:25.861Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a2/68c0702cc9d6dbc7077edbd13ccc9aa30ac589d514f51ad6f5c3840e3bf1/pyobjc_framework_cocoa-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ef679740f541c52118149b558b757d1f11d9dcf30c2a23344b13a6af6a99a1ab", size = 392376, upload-time = "2026-05-30T11:59:50.031Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c3/e170672302e75cc1aa833546fb0d5a3bd4a126ede4124566d5a2e4a50cd6/pyobjc_framework_cocoa-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:290e544a8c2d0786a34a359d825eaad44ebaaa3b30cdd765b2755422ca39a0d2", size = 388566, upload-time = "2026-05-30T12:00:13.606Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/6b/78e98e4de11646e56cf98066f9f84b43c86adc8b273a660d85a6ceba7a31/pyobjc_framework_cocoa-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5a0bed77b0b56074cc2b4564aae3e6e9d5da5fdf93252f50b6dbced0f7fece3a", size = 392674, upload-time = "2026-05-30T12:00:37.572Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/cf/1b3b32b2f28f66cc053c3438ef4e6df36a1591945bf05e7399da18d74553/pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080", size = 388113, upload-time = "2026-06-19T16:07:38.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/46/68e8e4d926a2f70fed0437047bc3f9fe08af8fe620d94d80656ebc3cfa9b/pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f", size = 388183, upload-time = "2026-06-19T16:07:40.483Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f3/dfc9af4c9eb2e5389c860ad5ef252be9fe456db09f39d537555dc5057aa1/pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c", size = 392275, upload-time = "2026-06-19T16:07:42.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c8/b90baa8f3592eded79b4be98fb59d2b8dc16b62361e34292bd95806ebd9f/pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561", size = 388357, upload-time = "2026-06-19T16:07:43.364Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/64a94651b9294702d55e748d94de30e25bc59d0784526be7643f4467eccd/pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b", size = 392404, upload-time = "2026-06-19T16:07:44.955Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cc/26e8a7bf1f5e8caa38b7f80d486296f9fd3c97e71ad7e5444ef22e802758/pyobjc_framework_cocoa-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6023657b8d6cc049a21bd6b4752425f2f53c42f9f0b02d64c7608cc484bf103", size = 388589, upload-time = "2026-06-19T16:07:46.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/eedf743a303ea742b8e082afe3613fb4d6618bc1a48cf2568b004ce906f7/pyobjc_framework_cocoa-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c685ccd8e266a07cf912a2c5a13b1f2eff2a868a1aff163b4801b4687bd425e1", size = 392691, upload-time = "2026-06-19T16:07:47.477Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-collaboration"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/72/f84e5835a01f42a8b14c165490e24ba72839ed411a24bd7217f4d37c7d54/pyobjc_framework_collaboration-12.2.tar.gz", hash = "sha256:77707156f677c502fa973bbb3028ad1cea8557875e75f1a03f605678c881289a", size = 15069, upload-time = "2026-05-30T12:35:11.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/b0/9cd5d547543a87ab199a5dc6e4c489b01b825994b52b0d17d89abd7219c6/pyobjc_framework_collaboration-12.2.1.tar.gz", hash = "sha256:d293b191823cf8c5cc17e74279e640312961a9226da97e6258580d1b6085e1e4", size = 15065, upload-time = "2026-06-19T16:20:06.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/d8/a1eb9888ca7ee599bc484feb78c43453f8c154c986bdc0daff4948fe39c7/pyobjc_framework_collaboration-12.2-py2.py3-none-any.whl", hash = "sha256:219f8e5b1f0cc25dc48460ca909c09127eb80b3aa0262cb50139cd46c84b63d1", size = 4853, upload-time = "2026-05-30T12:00:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/65/bd/7803dd4c6c472a610cd83f7ad7136b61b8bb3dab803a35a6ca4ed0561688/pyobjc_framework_collaboration-12.2.1-py2.py3-none-any.whl", hash = "sha256:03404e679dc77314ea94029c8e54dae25424194b5f39751fb6fa0eca4af99fdf", size = 4880, upload-time = "2026-06-19T16:07:48.59Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-colorsync"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/7c/eefce8ea94a1817842b54a1d6d472ae184749ca6ad8d84386436b10ac757/pyobjc_framework_colorsync-12.2.tar.gz", hash = "sha256:b403820f3504b0e728f883575637c217a2043fafca5c0b315f03c88805d37958", size = 26911, upload-time = "2026-05-30T12:35:14.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/dd/8f292cc041fb2a836a3ee7432c3f64347a15b5b4d64278277e4954ba28e1/pyobjc_framework_colorsync-12.2.1.tar.gz", hash = "sha256:1e682586a319f49d3ee3c93e54a527a1ff93de06f653e77c0c4ff4d9671469f9", size = 26902, upload-time = "2026-06-19T16:20:07.213Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/c7/0562840adbfaa21c37ced637653e4ade70618e911a151974c53d25c8f5d9/pyobjc_framework_colorsync-12.2-py2.py3-none-any.whl", hash = "sha256:5d2ce9acd7ec28133facf0af900fc4a5d36971083811eb6da775be4b659f9b77", size = 6006, upload-time = "2026-05-30T12:00:40.915Z" },
+    { url = "https://files.pythonhosted.org/packages/46/99/9c1d4d010cf51b17aba298664ff2dac7818a3d568202d36b0587fd07fd5a/pyobjc_framework_colorsync-12.2.1-py2.py3-none-any.whl", hash = "sha256:0bafd1bfdf77687910e4a6f01c640ec47def060fb88e3abaddf4cd7e7d469e87", size = 6028, upload-time = "2026-06-19T16:07:49.817Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-compositorservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/da/0f975d3bb2efbcd305d76f9c8869b5918116731e739cf071630ac3e1f818/pyobjc_framework_compositorservices-12.2.tar.gz", hash = "sha256:2c1e940959270aeded95b573ed57c9edd7d3da0ccd45fb5be262c93cc62e2704", size = 24919, upload-time = "2026-05-30T12:35:16.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f3/2136460770ff0b32e64282eed79c37a07c1dfa9df761f2679462391d4ada/pyobjc_framework_compositorservices-12.2.1.tar.gz", hash = "sha256:683b765077ce3bf9b680bfce23124ace85208738ff3c14768e1ca80fd78c1565", size = 24941, upload-time = "2026-06-19T16:20:08.032Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/86/f172e0a687dec40e7809e1efdffeb666c8d369cb73c7e50cb6f84d0b49cf/pyobjc_framework_compositorservices-12.2-py2.py3-none-any.whl", hash = "sha256:486f5e70250892122ba90f2923dc955a3622c4a047536ee3a0b15bd3568cd171", size = 5972, upload-time = "2026-05-30T12:00:42.699Z" },
+    { url = "https://files.pythonhosted.org/packages/af/0a/2e3177c354db49ffe137410431baed816fca9101bee9da808a5e5cbab9e9/pyobjc_framework_compositorservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:1c1cc5ca97e060afe2125b338651d5143f8f6b40e17748116dedc334449773d0", size = 5995, upload-time = "2026-06-19T16:07:50.803Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-contacts"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fd/b1569ca626fef30123f0fa5d3cb6126e171cea0900434e4b629f15c5f403/pyobjc_framework_contacts-12.2.tar.gz", hash = "sha256:117989ffed4f41d0bbf7e81dde8154a31995d2adf1fe898c2917bc6e9c1dc122", size = 48703, upload-time = "2026-05-30T12:35:20.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e2/a9c33480e4f6de3f20e2d2668ea05520061b8eae31e8461b09940c01f2dc/pyobjc_framework_contacts-12.2.1.tar.gz", hash = "sha256:b009f1e85d672e659c30cefbba02a1825b4ca2b604e65826445fb8620159725e", size = 48701, upload-time = "2026-06-19T16:20:08.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/03/2a6cd96ffa4d3d11216808d877913ee4a527adbfed56660ec7b577c568c8/pyobjc_framework_contacts-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:50a4b3b1ba1a27691dce40db61deff1b6e52889e063076411bcf797dd958d299", size = 12152, upload-time = "2026-05-30T12:00:48.331Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/79/609e55416da80222dbce2ca761f70ced7e45c85244f7b66e8713eb26dae8/pyobjc_framework_contacts-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1ee92445cb2c5168df0b25bb6d897b1389d55571eb6bba229431c1d933940a7a", size = 12164, upload-time = "2026-05-30T12:00:50.096Z" },
-    { url = "https://files.pythonhosted.org/packages/18/36/701eff1da16bb3d89dc28d0db6acf5604650dad6b722cbcba2ad9c8a6233/pyobjc_framework_contacts-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:91748bc3a42723d088f7ded819cf0155868b9bca16ed8cd753695bc71710f45d", size = 12325, upload-time = "2026-05-30T12:00:51.734Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/f3/1c272535422ab8642ce251accceef3ab29695742be5f1e658a41b0027a99/pyobjc_framework_contacts-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:63abb417bf2d3565dfc79cd8febdb2499040ec44900a972c7aeba02120bc27f1", size = 12237, upload-time = "2026-05-30T12:00:53.552Z" },
-    { url = "https://files.pythonhosted.org/packages/02/98/59a842bb85f1524996eb884a62d8e4303c28b0c480aaf221a95c0f480040/pyobjc_framework_contacts-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4cd0d97c47a4c6a6822fd213612a0b9a48a6f37f76f9b19bfa922b58a5ef061c", size = 12393, upload-time = "2026-05-30T12:00:55.355Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/dd/244f231b713ceda4873cac2f57e2c05ac77d6dbb37066223509b8042f3fc/pyobjc_framework_contacts-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:37d4e0b512de0586f90b306a4cc4ddc0752edf7ae8caad11317516da7d17d63a", size = 12231, upload-time = "2026-05-30T12:00:57.042Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/1e/870fbb8b096150a89159aec4d23f1ce0fa4ca0ffb532c5b4575a2234bb4a/pyobjc_framework_contacts-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8d50405ecf31ab5370f9ad5fe4aa4d69e0bca5c8fff0991671bb88f65ebdf3c0", size = 12392, upload-time = "2026-05-30T12:00:58.798Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c1/c4435f4dfb8ef0038a9556d2472cd259322f73627c21f94f3e233bd73587/pyobjc_framework_contacts-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9e31c635d1a8ed48d0e3332120d0eafa6a5d40b30fe4832aaa700fa03fe14c8d", size = 12172, upload-time = "2026-06-19T16:07:53.999Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0a/9a518f0ebecd5e27493230de7f5dc746b7abdf0ae3f192a14abc7c23cd15/pyobjc_framework_contacts-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:93facd1772971b6d88243fa28781498ab5f479c0fe286f8c03870f93c515b517", size = 12186, upload-time = "2026-06-19T16:07:54.774Z" },
+    { url = "https://files.pythonhosted.org/packages/73/74/57cbdbe46884d890e8321a9ea3cb85a163def2e0100bc38e14b41cdcde35/pyobjc_framework_contacts-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d0f73ff7f92986b5920155e9cb16bc74cf049e166e6bc2a7df1621135b4e6d79", size = 12351, upload-time = "2026-06-19T16:07:55.543Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a6/3fc0bc4c50fdf5005501c276613d39c09a35e236f8d5c8f344ae914895eb/pyobjc_framework_contacts-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:31d0906bce2e5c348a1453ac390d9e255ce547ca763e93875ea3582deba69070", size = 12259, upload-time = "2026-06-19T16:07:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4b/31ca64f27d6d9fd1ee2efed4bc979abefc21c743d6b7eab1257c2de2d359/pyobjc_framework_contacts-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:85ec30abb7b27655c715e3b2e01ed6229e24b7f14f235e6c04fb77afedad3983", size = 12415, upload-time = "2026-06-19T16:07:57.705Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/51/9b4ec4d4c5a316a2fd3fe6d70c10080e82a4af95e8ffc229f1d04285b60e/pyobjc_framework_contacts-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d21bce70f97cb4b5da7cfb35da64897ce69f96ffbecacfe64364ce220b74d075", size = 12257, upload-time = "2026-06-19T16:07:58.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c7/9215dab638d28aaa2af87b66324b954f53dd78060e0387f9300710332e4e/pyobjc_framework_contacts-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:536a46a5a55040142a2cba108ac48045f6da266a042f2fa0ec2bf4b7f8bc1e34", size = 12413, upload-time = "2026-06-19T16:07:59.544Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-contactsui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-contacts" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/e1/8f51114ec751ad746cd0aaefcb130f5dd3b09537a326425b4c8f47fc1345/pyobjc_framework_contactsui-12.2.tar.gz", hash = "sha256:ca1ab431b8838240877d8c8c1776d58c7eae9f9a7b193b0cc761162f6baf58bb", size = 19347, upload-time = "2026-05-30T12:35:22.591Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/22/a01e677c4e44c3e03850c7765b4cc20e3b8fbad53ee92300eddd77dc8627/pyobjc_framework_contactsui-12.2.1.tar.gz", hash = "sha256:6ddfaf3d3f159bc4bb8ccd65414e94b4b6539a5588e84efb01838b19e3b1ba0b", size = 19329, upload-time = "2026-06-19T16:20:09.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/b1/e95a20c1a090db78be1ab46b0d36e808dcfe8c759627359bd30c7830ffb5/pyobjc_framework_contactsui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:22aa70253b9c1087f5a1af645c87792096cba494d5a34edd964a2d8a4ad1cb1b", size = 7895, upload-time = "2026-05-30T12:01:03.734Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/e9/e4433cf42edaf26aaec04a4c059733b98ad9c0982a5e72da192309fbe391/pyobjc_framework_contactsui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8ac61436333c416fada5053c9d8b1879f82efa9bd96fbd5027da6ffcde0728b4", size = 7903, upload-time = "2026-05-30T12:01:05.63Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c2/cc3c32d9811798adf6404b8204731f855714869dd0e0476b6b4d6302ef42/pyobjc_framework_contactsui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2c7a4f5e89a22eafc056a52caa07e96f35b82a628b42a9c47d0720634ee01099", size = 8051, upload-time = "2026-05-30T12:01:07.166Z" },
-    { url = "https://files.pythonhosted.org/packages/49/b0/e65fb4c42eaa394e568aa7585baebe765a10076c868c552dc4eded593441/pyobjc_framework_contactsui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:91e82a66a34fe939274f4f6867e157adb608e0aa52b9dcbff7c0a199871195ac", size = 7961, upload-time = "2026-05-30T12:01:09.008Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/6d/f922216e36b461d9ddb348beaa300a21df6189ba85718be34bb230d0ad66/pyobjc_framework_contactsui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:583c884823816c0c890e070fc738522dd0c2081eb3663db1c64647ee1e76002c", size = 8114, upload-time = "2026-05-30T12:01:10.512Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/5c/163409abc851ea4b79097d1d08033c8ee1ca01df21093b74fc16bdbd8d0d/pyobjc_framework_contactsui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:eacd68ff0b2dcbeca2ba272799aba34bd2d966d3289a00aa8e4684b2870b96af", size = 7965, upload-time = "2026-05-30T12:01:12.191Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/eb/29970ba97be46f444e24c7e669f9fa87e6f2429d089bdedb4487bf3f7879/pyobjc_framework_contactsui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:993702a013f381d763be9b2bb45a363439562dbfe6238846c76c798305e3afb5", size = 8111, upload-time = "2026-05-30T12:01:13.649Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1a/bbcf4c5a21ff5aeb93cec6f629fd9e4fc7806fa03d11711346449b0147ea/pyobjc_framework_contactsui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1a447f3143759dc545a0a8caf23b3f6b5d4a27d50451046093a01f478a81bd8b", size = 7913, upload-time = "2026-06-19T16:08:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/05/16/617d8075fe65d3b27b5140da604531bb343f55eaa676ab88208d9c4e2ffa/pyobjc_framework_contactsui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1cbdefbc77830205ca9e63360cad08562d7b97789a792e98ab2108c018f10768", size = 7926, upload-time = "2026-06-19T16:08:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2d/15210bf2f5b5b57b436231c7789239cdbfeca4ad82a0b2f41d1a55256a81/pyobjc_framework_contactsui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:78452b5171a32d206a13d46ab7fdae60d87dd49802f531ced8646e6c71c25c57", size = 8073, upload-time = "2026-06-19T16:08:03.778Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/f0be6434e55627f843c253791d3fbeaae4badc03c07a2ad1cb06b4e698db/pyobjc_framework_contactsui-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:61d2a2df53a8bbdeadc552684a556c6ff7d4537c73333aa5629274eda2b99508", size = 7983, upload-time = "2026-06-19T16:08:04.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/eb/647e6261abb93b15515627f618f88c03b412c59bd1b1ed608906743567ab/pyobjc_framework_contactsui-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:81684620b41bedcef5423ea84337acd2e874c7ab7c2328b2f4f8d5df70daaffd", size = 8135, upload-time = "2026-06-19T16:08:05.586Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e4/5e11e387a598fe670e0f0db1eb73d84f096bb2c5ce12f576477651649b36/pyobjc_framework_contactsui-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3ecfb26a90b0b99231f433775ecda78bc461833e80212f8aa7f4f5d33dd1fe40", size = 7983, upload-time = "2026-06-19T16:08:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d9/fd4086be33ea326205847d2991e94e1e6b236183d69bd66cfacc3957d603/pyobjc_framework_contactsui-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:26acfebc03d264ff938da39ef33dbd1e09ab2c422245d146f14aafca78189894", size = 8127, upload-time = "2026-06-19T16:08:07.735Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreaudio"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d0/6e4adb375b81c06fbf28d758ea60281cf78f5675a68f7f3613d5ca28aa71/pyobjc_framework_coreaudio-12.2.tar.gz", hash = "sha256:1990be9a9311869b551e6a997ee84bee12ea38fc978d5fa7fc0119caff2f9ba5", size = 78669, upload-time = "2026-05-30T12:35:28.189Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/df/f1d402bb7b437374f942bb19410a955a74291867c77a920d9c13887d9e48/pyobjc_framework_coreaudio-12.2.1.tar.gz", hash = "sha256:7dfbf1851523aed453af43a628e057d8950d6e020574aa497a2e4f559b6383c8", size = 78690, upload-time = "2026-06-19T16:20:10.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/11/b2c641e4aaf79ff664c081ea09a79366c60406b36e80bece6faec83bf7a5/pyobjc_framework_coreaudio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:038293a480ec3afc902541ece05404fffdb915f0a6ad60fc81156beeb256cc5f", size = 35395, upload-time = "2026-05-30T12:01:22.951Z" },
-    { url = "https://files.pythonhosted.org/packages/14/3a/d2905ed8f0bfd74d7284e4018e11bf22f027e3ce7921a3298322d2273b4b/pyobjc_framework_coreaudio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:505564f35227b6bf3bcfcc950edeae81628724202eb2a49f4bf213be39589521", size = 35423, upload-time = "2026-05-30T12:01:25.959Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/33/cf17a929f444bca49a88f4c059868eda4ecf94ab7ab89e4d47b943d5a824/pyobjc_framework_coreaudio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1640bf44b001c960ae7ae84a43382141711bfbee439c88dea3872c64556e0308", size = 38179, upload-time = "2026-05-30T12:01:29.23Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e8/6fa5951c9c2f87fa7c973fe179d53245f49e0878221305e01eb0444a218b/pyobjc_framework_coreaudio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:27ef90a6414bbb156a8f2ea22afff5af080fc7fcfb570f215739c1ca136544e1", size = 36672, upload-time = "2026-05-30T12:01:32.506Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/ef/227b913bca61d3cf1c7be13b3fc8b60eb4895a6dd6a2371540f75cd1c2e2/pyobjc_framework_coreaudio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3fa7e25e6b90dab26bc9f94ad058e0346424604daa103d03ebbb6c2636772c1a", size = 38281, upload-time = "2026-05-30T12:01:35.743Z" },
-    { url = "https://files.pythonhosted.org/packages/68/de/d4c9de8311c73db5de4f75de88ac049990574c1f3dc7f2fe60879b84f482/pyobjc_framework_coreaudio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:4aba12b357f4e429a5c8a1bf6ccb7b5902ee8726863744284e3f6ae9b76fbdbf", size = 36706, upload-time = "2026-05-30T12:01:38.854Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/77/84f082096c107dd15956ad4752105e794efbcee415db5595bb2a376a5f17/pyobjc_framework_coreaudio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7f8ebd42735ca954d457c87e815da632e2ccd3b55ea501cda488389dd1f37093", size = 38314, upload-time = "2026-05-30T12:01:42.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/1fc7a344ac15646fdf78c91af81028113c87375036e505082cf1f90bd657/pyobjc_framework_coreaudio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:41a0d8c3b3957f35f17370071aeef94e176d07c9e2130d0aeeb4b260117acd52", size = 35415, upload-time = "2026-06-19T16:08:11.329Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/71b2e3bd03f0404c89b432273d272dc5427185fd9ed828036730bfc9d057/pyobjc_framework_coreaudio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6fb46bc090edcaefeb70be2c179071e7a758e3375aebd3338b11773e371c3dce", size = 35445, upload-time = "2026-06-19T16:08:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5b/07dc0bf9f79d3b76effba3f0a754be6fda0947848939236820c8e70ac896/pyobjc_framework_coreaudio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d05e5fd58c1e5f48e7767b1f6182cf36ee9bff38568544d51f468b25ad90e334", size = 38205, upload-time = "2026-06-19T16:08:13.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a4/6495dd34b1ed7a0e8f6d672577da62a92b166a0bc2ded8e55e552cbe5ad2/pyobjc_framework_coreaudio-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:efb79709371f29139f44adc36bd6c32d5a3a0ff3ffd0c5f3f372275cef893b18", size = 36697, upload-time = "2026-06-19T16:08:14.407Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9e/9f0cba5b973a5c8041edb75cf0870f40324437721428b1baceb437553e3f/pyobjc_framework_coreaudio-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9c06b9d7ee3b2a76dd171de519f571d09bdebd85f40b5960d16f711395513cdd", size = 38300, upload-time = "2026-06-19T16:08:15.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/13/e8df283cdd73dec1b97033be04a89a05e17714c8e2229f2a2e5a44f377c7/pyobjc_framework_coreaudio-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:51be22e4fac73ba4b26ee34c457ac94f56218e4e9c1494f8f4e7dfe9dbb6a15f", size = 36723, upload-time = "2026-06-19T16:08:16.247Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b2/c76ddff169b45d7239468f44bf4af3ff431c014fbf0aa5dbbfcc099672f8/pyobjc_framework_coreaudio-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:18717e6e106556fd4ffd0bdf6a6dae796fc9100c6b373e664437604dd0b9e94d", size = 38333, upload-time = "2026-06-19T16:08:17.264Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreaudiokit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coreaudio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/d0/189f067979cd117cfb1464dac24bd64e1d4127b09366fbf17a9bec84984b/pyobjc_framework_coreaudiokit-12.2.tar.gz", hash = "sha256:cb743400fff2cc0ee5837d124c1665135559d8505d28996423ed4a609221614c", size = 20916, upload-time = "2026-05-30T12:35:30.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/82/622a58a3aff47cfdad8cc3bf1c6a3a0c4d73d1cc3c71d050ac1bc0a62c6a/pyobjc_framework_coreaudiokit-12.2.1.tar.gz", hash = "sha256:61a5b796f8296ca5cb4779ec19391ad3a37f35c0c689a401d6e8d41cbe936f08", size = 20941, upload-time = "2026-06-19T16:20:11.407Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/84/b9b3436b22c97d0c8fd56214d49c1f41f90787377aad6e9c8abd1984ffd0/pyobjc_framework_coreaudiokit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ca439517d0780dfa9d85175a6a1db29b89ec2c55d1cd8711ba6a6433f9d637d", size = 7272, upload-time = "2026-05-30T12:01:47.161Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/e4/d59c8bc9f0dc3c953887fa9b5be06ffb6b007e3fe931b4faebb533c10e1b/pyobjc_framework_coreaudiokit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1da5bdab7f4d3c3f6b420f3d57e28a05c620e71cd3310499d415db0bb1f65c7f", size = 7286, upload-time = "2026-05-30T12:01:48.762Z" },
-    { url = "https://files.pythonhosted.org/packages/06/69/e46f04648626f8c70cfb5e024fd52a3ab3c832e40039b7d125fe62d2a49c/pyobjc_framework_coreaudiokit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:baaa6b2c32fe2cd2d554f0503b773710f21e061ad544773c86d7df95ddd983ab", size = 7449, upload-time = "2026-05-30T12:01:50.363Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/cc/0a8102a256bfbda603b94856ccf4c840658956e3b469725559af132984b5/pyobjc_framework_coreaudiokit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bf135b76cb36ef940ef340cafe233882edce97391e591ad635c6c1fbaa60565f", size = 7352, upload-time = "2026-05-30T12:01:51.811Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c4/9a05f93a0efdb13b1edd0422d9b5508e334d13bcfecf59afae98665b2572/pyobjc_framework_coreaudiokit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:680800157ff8e1b3f8f3654fc9d1f92b3919aa550c4be2fc926859b87374e20f", size = 7508, upload-time = "2026-05-30T12:01:53.289Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/9f/97cc6d01cd4d31c76ede65ad85a63ef32171b5c40edaa56b6efe0a41efc2/pyobjc_framework_coreaudiokit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:42471d1aa5240df4596d0c236b3d037827be66f6b4faa86fba743d2016902160", size = 7347, upload-time = "2026-05-30T12:01:54.741Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/72/b333b5ea068ad7c4bee7c83259f95c8a703532049650c828da09039fb90d/pyobjc_framework_coreaudiokit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e06953ff761da08123cd18225d008f6b6c35f1809862d46bfe825f618409acc8", size = 7500, upload-time = "2026-05-30T12:01:56.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/8f/78a68b53ee2227dd22939f8d435b5dc6252228fbcf5bbf497fe0d6a6b3a6/pyobjc_framework_coreaudiokit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fbc5f8f3b46645b1051658be8b172c85ed700a649ba3c4bcf68a5b8d3c09ecee", size = 7300, upload-time = "2026-06-19T16:08:19.882Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/5018ea6e71c3f29ef63241a28b20f67cec9236776d17a23e2d628171a0f6/pyobjc_framework_coreaudiokit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f6f4a3b5fac21170cce2f7585117c3fcce873ead84b4fe7e294dc823bff242dc", size = 7311, upload-time = "2026-06-19T16:08:20.701Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fa/6ea54d77c2b557c568274ccf75306fff426b7e099a0cd0b7e2c9c28c6e78/pyobjc_framework_coreaudiokit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dbc7d4ef4d7af452ba45c14e5324c11865e170b3b15f35d9431c97431b208f58", size = 7467, upload-time = "2026-06-19T16:08:21.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f3/000526a108d242477175cc9cecf71ca951fe6807db7cb2bd27389814892a/pyobjc_framework_coreaudiokit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:90610d5af81a071db7508df7a0dcc06ca2a95602f11dd7205f591bc4690e134f", size = 7373, upload-time = "2026-06-19T16:08:22.582Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/49/bb846c6d2f34d168c24fb7c6968699ec267de0fce6d381fbc4ea6e6b9100/pyobjc_framework_coreaudiokit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f997becd046c41e2da1a4e9f67715a13344f8546364de973dede6bf47a85b798", size = 7530, upload-time = "2026-06-19T16:08:23.398Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e2/84bbd3322eb54a8c85c301ea64be7888b83038f3a83716b17e775af64e68/pyobjc_framework_coreaudiokit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:78673312ebc806c4c635ca5906dab7c109d8346f058159cc6efa2be879244aab", size = 7372, upload-time = "2026-06-19T16:08:24.217Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2e/53817ad60d89043c890b0e8252c99e8d772e7ccc8a938217a8a741114558/pyobjc_framework_coreaudiokit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:173b58fce17e83aee72adeebeb5cc5a994184cabd1d5c25a6e4ba9902ae3e6b6", size = 7525, upload-time = "2026-06-19T16:08:24.99Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-corebluetooth"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/df/bee7ba216f9fb513710aac1701b78c97b087b37fca8ec1806f8572e0bbb3/pyobjc_framework_corebluetooth-12.2.tar.gz", hash = "sha256:8b4e5ca99953c360c391a695b0782a5328fcecafd56fdf790ad709e932feb306", size = 37552, upload-time = "2026-05-30T12:35:33.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/91/c76f3c5e8e80c7047e43c4c05b3e6fda9a7cefad5aae85487007674c966c/pyobjc_framework_corebluetooth-12.2.1.tar.gz", hash = "sha256:7dbb285295097205bebbcb11f55161e5faa02111108fb7b17536176e31971eb0", size = 37568, upload-time = "2026-06-19T16:20:12.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/9a/99e61547e61b0e38cb13c67931f9ca9bbd1dc72c1ff78322c7c3af805e8b/pyobjc_framework_corebluetooth-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31da3686ea55e9f7f8fc321fe2fcdf23827acd24c91ae1798e47e1f3a8355ab7", size = 13191, upload-time = "2026-05-30T12:02:01.811Z" },
-    { url = "https://files.pythonhosted.org/packages/25/eb/04f0ea541e6df3b7a328fe63ed1f508898d84910be66ae0f4d08103ad5a1/pyobjc_framework_corebluetooth-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b43a21eb9388453c867ce82bf5d475cfce4fe2ceaea974474071f1cfd178f40f", size = 13205, upload-time = "2026-05-30T12:02:03.831Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/b7/502b1e5ff1feede7fbed1f28e1fd14604cf564e4a4f5d4f33c93a4706739/pyobjc_framework_corebluetooth-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:162623f74c85041bb8a2c9a8862cee6674531d603ad7a8d65a3efc81619f84c5", size = 13389, upload-time = "2026-05-30T12:02:05.647Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ef/a75bd6c17e012f7d73a8a2d94e324528a82dc06451b6019d910b1a993864/pyobjc_framework_corebluetooth-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8a3b35a1253de626d5efe705dda36a4f1fb8753e48aafdc4dbf99dc9c9526d86", size = 13196, upload-time = "2026-05-30T12:02:07.462Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d7/11a8a90463e6a3928274e65bd17acaa3f0bfbd9c19a68b93c61cbc4fa379/pyobjc_framework_corebluetooth-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bd0b9e7bc2fffcfa4843d7f103e1e927ce37817a70932d080378e1e29a073381", size = 13387, upload-time = "2026-05-30T12:02:09.431Z" },
-    { url = "https://files.pythonhosted.org/packages/10/d0/d5cc4ba6dbe21f6f4c90e8f0087254f1f742134580394b763025416ab7d2/pyobjc_framework_corebluetooth-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a2dd4bd8fde13b97a3339a42d6703c9c9b148663e2e23a184ffe2877c8e51470", size = 13192, upload-time = "2026-05-30T12:02:11.41Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a0/964b18affc8f6b582ed891f3b59413452fd95acce4adbf070a389b5197e4/pyobjc_framework_corebluetooth-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:42db087cd3a328abc620c76c7f708d7c2b451f3dbc0779983812a0c84320fe60", size = 13394, upload-time = "2026-05-30T12:02:13.443Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c4/7938016860850e28c001dc9b7c653352c43f7aebfffc6d3c5fd087281f22/pyobjc_framework_corebluetooth-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2f8d2ed65c0e98ba044b6a7fc2f9a290a5c579a28d33a57c642f8617ccbcca0f", size = 13217, upload-time = "2026-06-19T16:08:27.802Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/79/890a53ed45c1006eedcf60627b7d661c8696e5367723ceb25cc6a0216b30/pyobjc_framework_corebluetooth-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30a26eef36c250fc14e73335641e24f764b32b7e42bae945a5d8a1c2347040b5", size = 13235, upload-time = "2026-06-19T16:08:28.727Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7a/40ffc3be8e31b1eb1f8f5eb2a58ef832287fb1ea6b3c452dc8b25b9e064b/pyobjc_framework_corebluetooth-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:756933b9ce6160a986c8877ab667659fa2d8e15aff28d0981b5284fbdd1ea735", size = 13416, upload-time = "2026-06-19T16:08:29.643Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ff/6f3b0bb3110ec82dbedaea47de151bd688980f5aadc634ef0cd236fdbd16/pyobjc_framework_corebluetooth-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2a2e6d56f51e4ca3e3b9766ef34150a9a7ce5f0cf4f9ee879ec10923af58e97e", size = 13223, upload-time = "2026-06-19T16:08:30.672Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4c/4e12660569219e4a68186ae9709b85278d3ebaf8d2f8e1c826a7337f4f7a/pyobjc_framework_corebluetooth-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:50d7e4245dbdc8789dcc1f11fca2e633aa126a298b09db62f8216531fe107ee2", size = 13414, upload-time = "2026-06-19T16:08:31.679Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4c/976ae9bcce3615af806e3c314ea9caa3faacf11ec44f00b1a149559c6cb3/pyobjc_framework_corebluetooth-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c8d126c56b71c25218be186930a1b41739f83e931726a52e3298beeb170c5e5b", size = 13222, upload-time = "2026-06-19T16:08:32.481Z" },
+    { url = "https://files.pythonhosted.org/packages/99/be/44bb648a6b5c8aec79138bf562dab9eef414016ee31f37066bf81d809ae9/pyobjc_framework_corebluetooth-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:81023518feb75e9b2b676b28198955c51ae00548cf23c73c524c7101263b68db", size = 13424, upload-time = "2026-06-19T16:08:33.336Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coredata"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/e3eb3661c72ee1bd97eab9f6fc5121987f8f8f78f47d07418c1ef6f8fd1c/pyobjc_framework_coredata-12.2.tar.gz", hash = "sha256:1942049d656e264f47177c2fbd84314839bf55f61a825ae49f4fc7b0ebb078da", size = 143296, upload-time = "2026-05-30T12:35:43.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/cc/62113edb09c6f72922d800ad7dbd2b812e69f5933a245c59f2d33b214a47/pyobjc_framework_coredata-12.2.1.tar.gz", hash = "sha256:f357447b7955cfe5391dac4fe003b79ded307f4f00712dcfaec3d3ecfca30824", size = 143307, upload-time = "2026-06-19T16:20:13.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/54/ceac7d7f2c0a56ba8daa931c8ce44b9d050c9c2a46e20ad7bc75b18c27d2/pyobjc_framework_coredata-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32a28504e3fd2ba2f4da8019a5325010f21d1395062946f143ed9672cb6a244c", size = 16525, upload-time = "2026-05-30T12:02:19.832Z" },
-    { url = "https://files.pythonhosted.org/packages/26/44/0cec6323ea515dd5a8b5382f78e871f905aa295858716b53d4db8162d645/pyobjc_framework_coredata-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:36c1fa33a8221339983eef98c2bc9894813a51f650c30e92fbd3cd1e9f51921d", size = 16539, upload-time = "2026-05-30T12:02:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a7/844e5e193cd8a5ac4620f40fb40d1d039282e17cdc19e1f50addf36e415a/pyobjc_framework_coredata-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4ed76ef3c44a0f7f488ac445fe06878e90fedd55c6077841efbded1b125f33ea", size = 16694, upload-time = "2026-05-30T12:02:24.118Z" },
-    { url = "https://files.pythonhosted.org/packages/94/a8/5dd670a58f82fb4adc1b5b9634e66572d6331a7e849e02ac36265b4d2753/pyobjc_framework_coredata-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1c68b2fac8f9bf591296253f54742804eaa3c99844b487988e0090f51e69a645", size = 16597, upload-time = "2026-05-30T12:02:26.178Z" },
-    { url = "https://files.pythonhosted.org/packages/de/b5/bbd4e22732cce98979a2a7ba8798f52a91342036fbb89ea30df9f3ca1b34/pyobjc_framework_coredata-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1b48293e6d4f2dd2fc661e1aec65e71e2b4ec4fea9c61ae41eb265e61d4b89cc", size = 16756, upload-time = "2026-05-30T12:02:28.349Z" },
-    { url = "https://files.pythonhosted.org/packages/66/36/8592d816be70e5e64fcc02489f65d7fa55fb8ba7706e396a356d550a7d7b/pyobjc_framework_coredata-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1145c11f4d0eeb7ec51818318027cd0bef8e65400186463d6f4ea5102ec2f160", size = 16594, upload-time = "2026-05-30T12:02:30.298Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f7/96f9c101562f3f6f4b7bfb728be64eb10730d696a9c2e923df91b2156a48/pyobjc_framework_coredata-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:262a9cdaa31a38bdf9087c4f89b235b389d1c778ab554a881559c3e0640ce540", size = 16750, upload-time = "2026-05-30T12:02:32.612Z" },
+    { url = "https://files.pythonhosted.org/packages/32/17/87ef5c0edb220df910a4936ad23272f763065ee4817ad01107b19a8c78ff/pyobjc_framework_coredata-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:53093b9a500e82794b142bfe3c844414e46ccc2b2f9e1f5a998243646be59725", size = 16552, upload-time = "2026-06-19T16:08:36.178Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/90/6c0887e8cefd12b76e9c6104dd07a5251ff2d5fe47a27427b07754326d1e/pyobjc_framework_coredata-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a8353dbe4cb0cc6d5313d23e47ed6c00bfc5161c84777d1d3e21048522822feb", size = 16562, upload-time = "2026-06-19T16:08:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/60fa04f65640e76e2b49a2a2e297b54c0d980a2bd631c3e9b5c2d247e262/pyobjc_framework_coredata-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7be973a5f2f5646a64d4c25175ec7ca2584f3ccd2c8bea4c2abc702ca61884c5", size = 16722, upload-time = "2026-06-19T16:08:38.044Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f6/b58d1ee3a6c489e0a0429dcac32b283e6609cba5a8da3cc013cfb03b50db/pyobjc_framework_coredata-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e3f12941b0b83c66c3e7d9845bc14ed8d215c2975f55098deee56e22477b93e5", size = 16624, upload-time = "2026-06-19T16:08:39.068Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/6f/dcdf9ed284f7dc56f48667fb137d1080de371297dbc86103b99b5dda94db/pyobjc_framework_coredata-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:cb6c3b1f70301b2201e84b12adfac93c8f47c7678f35d56ae4f63100dc4e438a", size = 16782, upload-time = "2026-06-19T16:08:40.07Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8b/dafc41f03709426901f5981334ecbd9b315ea29616d64d8711502d8ed802/pyobjc_framework_coredata-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:698b5591c622b6ce451851fe393fe7e9a0a1148830659f500e577d06ea470781", size = 16621, upload-time = "2026-06-19T16:08:40.908Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/05ebf0eab33ccc7cc80b7b5e6da89a37efba99aaa0b2f78b5176906f7a9b/pyobjc_framework_coredata-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:dabebe6ac3cdda4563635c781b0ab5e65e4f04e76e636dade0996a58ea66b311", size = 16771, upload-time = "2026-06-19T16:08:42.185Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-corehaptics"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/c0/fa97c71176260bf0fb764809034e2ac4a6f3e47701d7526ff5844da8a1cf/pyobjc_framework_corehaptics-12.2.tar.gz", hash = "sha256:d55b39ea4d998dd50f980e8c1800df2558099b96a99f25813bed702ebc2bf43e", size = 24902, upload-time = "2026-05-30T12:35:45.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/1b/76c27ae0f86126802c7f82f21c67868467795810750d9d192006471aa965/pyobjc_framework_corehaptics-12.2.1.tar.gz", hash = "sha256:73ce1afcb0174add11fd6f05cc67d8a371802ce8e94ba9d4f65c7cee0f392b0f", size = 24886, upload-time = "2026-06-19T16:20:14.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/19/b4842ca6182d754360289384aa3b4adf3775a6c4ec30818c8b8c1c473792/pyobjc_framework_corehaptics-12.2-py2.py3-none-any.whl", hash = "sha256:c04c64212e7e7a0859b23b939a4375a349176317cb2b11553d388965d9a8fec8", size = 5413, upload-time = "2026-05-30T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/23e82eded054389a686377ebce9b6f82d4fed4c445b004bb8385c3188bb1/pyobjc_framework_corehaptics-12.2.1-py2.py3-none-any.whl", hash = "sha256:d19505e9e38136f50fc551ad0e1849afd1656dce068c82018ad669d01128f8c9", size = 5434, upload-time = "2026-06-19T16:08:43.061Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-corelocation"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/81/f074ac32e9af964ba873ac646ceac9d372057ff8d1db01d31e8f5586a1f6/pyobjc_framework_corelocation-12.2.tar.gz", hash = "sha256:1e0f389140707ece2bb4d08def421e25b792dcc2a34000dfb128dec2e685d725", size = 60306, upload-time = "2026-05-30T12:35:57.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/93/41d2ae5cf15a27ee1b51e167b538e50aa752597002878556ed49b3615573/pyobjc_framework_corelocation-12.2.1.tar.gz", hash = "sha256:10b3c206049b70cbab0f98b37bcd91ad97de5ab57041b18a60ab702629009a31", size = 60318, upload-time = "2026-06-19T16:20:14.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/43/65d5d913e2aff660c71cfe6acec29adb6e461dcce3443a18c2bae03e6d67/pyobjc_framework_corelocation-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4f556f56955e9b909fbb0ab510449c89802f2f9e287bad402d0cd1b5c4e73c4b", size = 12822, upload-time = "2026-05-30T12:02:39.922Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/af/a8cf57caa11c1ce96bb19855ff02fd17a7e7f1d1ba3a890369be1f731f72/pyobjc_framework_corelocation-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8b355dcc544a2ab525744b777431cb902c951fbbf2281350b86323eb64c4b409", size = 12843, upload-time = "2026-05-30T12:02:41.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f8/4d1aa9f9736efa013cb73022df9f58beca9639d922613be0f2be16e0c709/pyobjc_framework_corelocation-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7515eda941b03c4e4f1e6d596383d4788997a05e30ce210ae250326ca418f240", size = 12969, upload-time = "2026-05-30T12:02:43.671Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/e2/90e8bb8654bda885e6acc8f15be2544f1c7cdb58503389b970dca5ae5324/pyobjc_framework_corelocation-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a3b70cca208369e8c68afd8cbe865d25829c34b338309a61b3b354d3824055a2", size = 12822, upload-time = "2026-05-30T12:02:45.678Z" },
-    { url = "https://files.pythonhosted.org/packages/84/70/4e8ad2a3c4649af2f5f2f132d800a13e1743581d3871304e80d8dad32e67/pyobjc_framework_corelocation-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:54d47d7f8df4383a1e3d1201a80520068222fad373caffb8adbb134ef16b9b7d", size = 12971, upload-time = "2026-05-30T12:02:47.454Z" },
-    { url = "https://files.pythonhosted.org/packages/59/95/13c20405ab3f561e20c13d2b7bdc4d1b2deddf9f00476b50c74a9be705d3/pyobjc_framework_corelocation-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:472b95e1a6ec6f14545d1d523f03a688d60a32ad722a267a3f9539d7d38cc94f", size = 12809, upload-time = "2026-05-30T12:02:49.443Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/76/23c7147aeaaf7c85a6e3c140c560244de5feedc8f9834b5f65e526f05815/pyobjc_framework_corelocation-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0f24d4ecd314691d773b98276880864dc3899605b2d708c75532acaf9c517074", size = 12961, upload-time = "2026-05-30T12:02:51.232Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/4f6a89027995948270699c47a86583bfe586ac0c480cf8427fb708bf3a9c/pyobjc_framework_corelocation-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:683b6eb23db94ae6ca48e58089c4a9641fd90b1137e54c147ad56ed6db4bb570", size = 12857, upload-time = "2026-06-19T16:08:45.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/00/156e1d533f3167e638a8e649f02a422cd1f95270932fede56e6bcf46c878/pyobjc_framework_corelocation-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f336ab0f9289d1909bf86cdd798ac4308166f6e90eecf07452d21182b9a7cba", size = 12874, upload-time = "2026-06-19T16:08:46.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/7519b4f9d4feeebfb770ed563b756c5dd370d9f4fa302425f05829a7d2d6/pyobjc_framework_corelocation-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ca3b36828b4324c058ccc289b33cbdb7986bf879719d99a735c3abcd1ceb6ad1", size = 13004, upload-time = "2026-06-19T16:08:47.482Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/09/556f20c1178bd39ede1b18690211b36c13ad458692330474ef2e42b2202b/pyobjc_framework_corelocation-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:407336ce4e2c4d4d61b486cf64a4672a0048523b9412db8d3a1d1d5b3eaa53bf", size = 12852, upload-time = "2026-06-19T16:08:48.495Z" },
+    { url = "https://files.pythonhosted.org/packages/57/19/bad61b941acf3c7e1a3aa623f9bd71dab9cfa7a52df40f79fed4370c2ddc/pyobjc_framework_corelocation-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:80423af235cfc73a719451e326631e743662d9c03821d227647d9fdb596a6401", size = 13004, upload-time = "2026-06-19T16:08:49.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c3/e3b7c6982a053293995be2cb47bc6294f01db98892c3f155f08ec87f9922/pyobjc_framework_corelocation-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8e1a2e5cdf5175b01cdda52a8d7dd5daec0afe08a5a0c7a359c2a2f93b66109f", size = 12839, upload-time = "2026-06-19T16:08:50.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/bb/a3bf2bc14ad5f0b6586de6526a9677cf505654ac1dace6b7aae3935ef72f/pyobjc_framework_corelocation-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:304db40687dd383fc787b795be9e8825f33c4fabf58b9a7d5582377eef173311", size = 12993, upload-time = "2026-06-19T16:08:50.891Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremedia"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/63/9b25f9abb14e8faee219e72953c3cc4bed48b0de4b86f767f073fd2fdc35/pyobjc_framework_coremedia-12.2.tar.gz", hash = "sha256:95ed2063cc48d73f6eb06f4e603372515b5b009bd2d6e547f90bbe9e64217206", size = 98236, upload-time = "2026-05-30T12:36:10.943Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/79/f501d730a9c320e0b2b3916e95f57e66dd6736d210a1aa5b63eb6c43e605/pyobjc_framework_coremedia-12.2.1.tar.gz", hash = "sha256:71b45f7cd52bd997d836c15a0e1016db90815a219dc87fd20435a6f08b87df7b", size = 98252, upload-time = "2026-06-19T16:20:15.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/db/966cad806594831379785af07669e5f2c1784e88c775a381cbcba215cfa3/pyobjc_framework_coremedia-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2eaddb2f4e25d7b6f32d4b85b828cc89ce6ae5502d531c2913b90d93f85fc2ae", size = 29400, upload-time = "2026-05-30T12:02:59.537Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/00/412b4b98b6c6b266a73be2862453d98a6f7f95e911c216ad2117831d2b18/pyobjc_framework_coremedia-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e992147e7b0c8c435f1bb786c8c610511453cf54bdf6c6b4a17e05936bacc44b", size = 29412, upload-time = "2026-05-30T12:03:02.254Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/61/e3285f4b7a889a334ba06c6daef78f32e39de40ca7b061443e39e0faf42a/pyobjc_framework_coremedia-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d9586fb8ae22ab1a500e812e5c16dde09b3ea75613a8b5ed61d17cd9ba75c809", size = 29472, upload-time = "2026-05-30T12:03:04.911Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/6e/66ff680d04e1e16321aca36524ef3b442de89330edd06275b9e2303b6af9/pyobjc_framework_coremedia-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c1adf7b6fcfb4c88bc2150c6f0366c19774e46c6978ebcfb7c70d02753bc0183", size = 29454, upload-time = "2026-05-30T12:03:07.771Z" },
-    { url = "https://files.pythonhosted.org/packages/74/dd/e61aaf92b4b7074b4f2609cd1a9c485410e76549a7f68ff10394e95396da/pyobjc_framework_coremedia-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9b75c3228732d78dacfac7a39f52470606e949f07c940b45ba73588db41fe73c", size = 29500, upload-time = "2026-05-30T12:03:10.304Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/aa/b3b65aeeb52cb08fc151fc6102d3127bc308e7ebd078410ff6832001d562/pyobjc_framework_coremedia-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fff54b5907cd346daea1bf4d6554fd6da1d69ee9bf012774c3b4ec972f4257a6", size = 29485, upload-time = "2026-05-30T12:03:13.023Z" },
-    { url = "https://files.pythonhosted.org/packages/48/b4/5c25ce6eaefc509a90c8f6efbb0a2a27e223552d4551c32cca514bd84ee5/pyobjc_framework_coremedia-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ee5889c07f61d16f8d195a793a7f0ebf7f5c4eef4d1ef2fdbf5c823c74e242d0", size = 29541, upload-time = "2026-05-30T12:03:15.744Z" },
+    { url = "https://files.pythonhosted.org/packages/af/17/6bf365530573a6b7719b5a47efe6c38ac8c42f6b556babe419f5de48a84c/pyobjc_framework_coremedia-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fd0e25bc704dd91882bc29d682880c42f712b39bdfe3d3168780d24a9d9eaf26", size = 29419, upload-time = "2026-06-19T16:08:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2a/9e5beae2961c9d22ce16258f39edae69996ee0167dd4cfe4e771454086c1/pyobjc_framework_coremedia-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:45878f686ce8ea1735ce382b34ef3a5852cafe0ae2a27a49c08701f4c3ab830b", size = 29431, upload-time = "2026-06-19T16:08:54.41Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/51/00b7f012e55475502296cc8ef276b94ad7d4d10d97ce2e88bf9d87f9b664/pyobjc_framework_coremedia-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9f2b30ef288c9f2fa1599a1cc5868f8cd949c7138a7f15244c7a6884afcef273", size = 29491, upload-time = "2026-06-19T16:08:55.297Z" },
+    { url = "https://files.pythonhosted.org/packages/16/dc/7083e6781fcd843d210ec6d247d28c6e1032ea1c5655b9e1182d0a85f331/pyobjc_framework_coremedia-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:84e9fb3f7b6420fc3865a5812604c63546b5777f4999e0e0e830a9a0816e8743", size = 29468, upload-time = "2026-06-19T16:08:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/11/74/edb3ec87d2e5f962c75af990207e4df39b290f11b4f4c3cc446ee141e4e7/pyobjc_framework_coremedia-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:541d64d2fc7576054bdc3508a94f37671e81e5ca1582e16ebec2c0e05dd75412", size = 29519, upload-time = "2026-06-19T16:08:56.956Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0f/9176b6a7666e46273c0392c8f77bc812e006dc74a1c21263c4bdf385012f/pyobjc_framework_coremedia-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2a355770b66b4caf99560c11af44dfeca53066ece75807fc6a391a16369ccc72", size = 29502, upload-time = "2026-06-19T16:08:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/13e7d8d16528734690f83abd901cbc53dd6f7c1adbcb3a902166735c6c21/pyobjc_framework_coremedia-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5536453ba631227810a1141fb1761149244bd6d0e7cd4b12477be3b164f5bb11", size = 29555, upload-time = "2026-06-19T16:08:58.792Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremediaio"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/24/7c8b41310cb874bd308c875252ec6872198f19f3be27aacdafcd98a4b27e/pyobjc_framework_coremediaio-12.2.tar.gz", hash = "sha256:38f656ebe897262463277d4551fc6cca4ac766629476576f040b34e84c956506", size = 56592, upload-time = "2026-05-30T12:36:15.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/8b/60e73d8049e9c123ff237694acea8752e9e8143864bfea4bab0bebb55db4/pyobjc_framework_coremediaio-12.2.1.tar.gz", hash = "sha256:edfd070544857b8e1d2ae55ed7c7eac9f513b4cd7c03ee79615c7d524e362d62", size = 56604, upload-time = "2026-06-19T16:20:16.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/ab/0e0cc4faca5bdb958c5da765de9d10a43f65ab57c1d400e06497a94221c6/pyobjc_framework_coremediaio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2543d464db2b169571ec757241813c761abfe31033a533830f6e62d044a31edd", size = 17335, upload-time = "2026-05-30T12:03:22.155Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/4b/65ed6a4af11af67ee64b5fafbf12ef2d56dd38020e88d9b67aed2128703c/pyobjc_framework_coremediaio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95cfaa7b8a0c970cfacdc620991345a3b55ba641a8091a1467a94310fc11b279", size = 17306, upload-time = "2026-05-30T12:03:24.356Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6a/4b04551647534735d788919a8a62b5261b249654b6e427f27d12f7e5377f/pyobjc_framework_coremediaio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f03e5f735b99508706f9ccf5233eaae4c53399459b6c87670112dcf1c0cd791c", size = 17627, upload-time = "2026-05-30T12:03:26.42Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/af/e39b0afd12229c9fc21945307d80f27f2e8548171d04327e4b6c8a601220/pyobjc_framework_coremediaio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:057d63ce28a64589d4ad103c5e9b0ef1c23e45e63693314eb75de9aba78ae7ff", size = 17325, upload-time = "2026-05-30T12:03:28.423Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/22/f206988eab96acd7e7203b93109d93a2812dcdf320892657a8b5cdd27221/pyobjc_framework_coremediaio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03b68e48f0820f9aac4f2250ceed138c097fb806cdbbd064ccc463709e828b68", size = 17622, upload-time = "2026-05-30T12:03:30.479Z" },
-    { url = "https://files.pythonhosted.org/packages/12/2a/4afa7f2fb64b3903e0ec4eedf51130856aa768c73de9bfb90720d706d259/pyobjc_framework_coremediaio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6fe8353ca1165120f69f8bc0aabc4041cdeda9b6fc4f3bda4ded601680df3061", size = 17346, upload-time = "2026-05-30T12:03:32.506Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/07/f7006431545f928f02eb1779abdf8e042238740469f137d20d0f0501670d/pyobjc_framework_coremediaio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9ce96c501bd64fbeb52e23332b72633f8b1d2f9390f01c5e1787c8f711eb4646", size = 17628, upload-time = "2026-05-30T12:03:34.549Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f2/95c8d8ef684b377d70b65ccea9cc8bb583eff79690d77a390fd52f190120/pyobjc_framework_coremediaio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c60ecc49fa18a53c5bcf7f844554d5e24883d2b7d5537923dfe4e8512069a6a0", size = 17361, upload-time = "2026-06-19T16:09:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/85/ae2715fe1d788e166ef04d7080f09de5cf3a63fa83253bfde42027ccf089/pyobjc_framework_coremediaio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30cfc0e30b46d67668114d7d2bf0a66196928ad84db77d34a1615d3f1b661c46", size = 17324, upload-time = "2026-06-19T16:09:02.234Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/96f68d7d82978a568ffed99a8b42361343499af4e227a4f896351418462f/pyobjc_framework_coremediaio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1dc37de0633e2daff4ae14640cec68e1b2c2d3b11f866f36961704abdfdabc38", size = 17646, upload-time = "2026-06-19T16:09:03.158Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/9504851dac16bfd7dccd4ddd0e1aa74d6185861c405213f26fa30df45ac0/pyobjc_framework_coremediaio-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:599dfff52ef5a7886753fef44b1226d939b1f44c02d7a9790fe40e1f792b9b81", size = 17347, upload-time = "2026-06-19T16:09:04.037Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4e/acf08847ee0fec18ccc944682cba5dadf9c0c9f32e9abdea74dcf725cecd/pyobjc_framework_coremediaio-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ae6485b88b13953a6485dd3b9afe6a99b538e3fab3c72c590a943c5173348268", size = 17644, upload-time = "2026-06-19T16:09:04.943Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d4/0c08222049c302d52e65acc89c28118581609bd8a307b02619a862d4ecde/pyobjc_framework_coremediaio-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0cb44d84412d737f103cb06b5b400e376ba8869da0d31326e5d040861831342e", size = 17365, upload-time = "2026-06-19T16:09:05.792Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c0/6e6de289f2126978f462b506faf5df6f13329ad71f9a4d123da34fd06469/pyobjc_framework_coremediaio-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cb6043694fddba0889861e8321cba422fd3d90f0e95ad716826e67246d86bb96", size = 17649, upload-time = "2026-06-19T16:09:06.638Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremidi"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/ca/ccc156899161481cc2c22529645d590a6f570c0583567ab6ba4a0df71bbf/pyobjc_framework_coremidi-12.2.tar.gz", hash = "sha256:a00e1d906f1a1fca302c867406ed8e1e23651b1551ce1943e9495e7665b6b0d3", size = 63475, upload-time = "2026-05-30T12:36:19.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/77/c51599da17f742fdcaaa381a26daadc22c79739dcf7705f8faf29ca1692a/pyobjc_framework_coremidi-12.2.1.tar.gz", hash = "sha256:d9744001102f935646997136c3d7d0562088bafa1837e5ccc439b5c8ee9e032e", size = 63469, upload-time = "2026-06-19T16:20:17.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/d0/5c7de6a375f63dd3bf772be75661f0cf1ed1949acdd89f539a32537fb03b/pyobjc_framework_coremidi-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4d480a526fca15ea16bb9e7fc7e5a7107c6263c8f791efc673525928f45a3c30", size = 24556, upload-time = "2026-05-30T12:03:42.158Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a5/b87175347becf46c8ade3593da8fc660d46a5fbf2794f5d7fcb0ca4694b6/pyobjc_framework_coremidi-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86c7114af6e06650a84eeb781b90bfb3569304f36a40e38eb2e6113e72385444", size = 24584, upload-time = "2026-05-30T12:03:44.625Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d8/2953bc296baaed3a4207131d9b90797b6a12ebee204c92addc14b6c7ac8b/pyobjc_framework_coremidi-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ae8c2e5113fe8a4afa4ce9c5231a5bf8a2c25dccc909b80d0fdd9ca0996e6d1d", size = 24734, upload-time = "2026-05-30T12:03:47.053Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/17/098da114f1f628551a48570a077747505afeedc63c3e6639dd7d17421e1b/pyobjc_framework_coremidi-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2d962b3f77f60fe608b845b903845585d0a47aed6345192d5a22d3b1ed205f1a", size = 24626, upload-time = "2026-05-30T12:03:49.642Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d4/10a32149671d8813251ad1688fcac5c1d500fa40ea98c9f7581ad4fef18c/pyobjc_framework_coremidi-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ff07b6a479c2a273276f156e598c02c59c9c1cf4ba8b34c7e1e938df484388a0", size = 24791, upload-time = "2026-05-30T12:03:52.111Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/24/8f30c3f25775a2458d0cd4003ba72fec22f2b9de776f6c4553785b699749/pyobjc_framework_coremidi-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:cd719cbd917606fff46e5eb937c472f10986036d1f00c7af237742825ac67b81", size = 24614, upload-time = "2026-05-30T12:03:54.578Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/7a/3bd8616d43311564b7286926b2e071de3cf0db2711e3c59f9474de12533f/pyobjc_framework_coremidi-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2f7e8a895852b4c3cfcc20cee8a1bd63af7577e0fe79a2e79de87d4da8ee671a", size = 24779, upload-time = "2026-05-30T12:03:57Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/b6d415a946c0b48d555aa96b2e8b11f45965f1f21524d91a40821e60df14/pyobjc_framework_coremidi-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab57adc4104135ae0373781b055ceabd9ac45db48e171502fcce48317b5c8d51", size = 24581, upload-time = "2026-06-19T16:09:09.451Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f9/45acec2ddfaed67da0d1a9fedc954162b899ab4f8612593bbdfdc223345f/pyobjc_framework_coremidi-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b6596d9062221097164f8adb445530aca398f6abee0111178cefe37474ab8d2c", size = 24605, upload-time = "2026-06-19T16:09:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/05/557f0e27db08880e6f403b192dd5e99c6cc68717042b4f28208c6f80901e/pyobjc_framework_coremidi-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:25ad1c67e2e50b67d0569f832ae8531c2a9261a6740a1b88d311fda5211f6130", size = 24757, upload-time = "2026-06-19T16:09:11.436Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/17/3dabcfe3db51d1ad6b91f8b4b0a5dceaa38bea61d5434c75763c28aad936/pyobjc_framework_coremidi-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:05b0da253ee7ebd2bbcc40f2893cd6f78ac50c5da07d256faecc7ef0746fbb7f", size = 24646, upload-time = "2026-06-19T16:09:12.226Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/8624f3598d7539da94fd00a510d6c4273ca6c6a88c613d66fbae2f68bb96/pyobjc_framework_coremidi-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7e76daa635b57659efc30ebb9cffa6e86beacda76a690120183961fcc5cdfada", size = 24810, upload-time = "2026-06-19T16:09:13.648Z" },
+    { url = "https://files.pythonhosted.org/packages/69/26/e3bfb5666ae2c69d5bfdaa7115299f6a0004ac900d020ffb2bb52192c29a/pyobjc_framework_coremidi-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:98fdb11eff3ce6ebc5841b91fadbfcfb5d41dd49bc0f1b4b0f55918e5f6a9959", size = 24638, upload-time = "2026-06-19T16:09:14.704Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b7/887887cdff0e27274bfa1d7b7e99ffe4233ea85cacb3a7f5f00bc709512f/pyobjc_framework_coremidi-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7cc1e3ac498ddd3cb2424ae003fdb06911c9aaea2e5f4544b14497cb512812f9", size = 24799, upload-time = "2026-06-19T16:09:15.517Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreml"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/a5/ee39e19017348fcba998de71f4f425abf0563b693fcf5bf7f4b84232d538/pyobjc_framework_coreml-12.2.tar.gz", hash = "sha256:884f1f68c7a74c56d26858051da8a1e19848be97f2c4b06b32ae93e505109583", size = 49266, upload-time = "2026-05-30T12:36:23.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/1e/7d2db3e4468eb04cc92264be83113d86eea4f96302742437de695a445d6d/pyobjc_framework_coreml-12.2.1.tar.gz", hash = "sha256:ef3c2b6a160891b44173235603d10174929656b9c206d6f2f443fe2aa903c2cb", size = 49272, upload-time = "2026-06-19T16:20:18.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/55/8bf3985e5639d95a44ee6431ee00f1ee823a36f9d1d5a5fe5efb60427386/pyobjc_framework_coreml-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:011dc67f11144817c9cf728cb7ae3d520001c4e099f9efb6a4c9fec4c19e6413", size = 11950, upload-time = "2026-05-30T12:04:02.515Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/42/93b24114d5334d7a1a5031788947f14f487c0aec4529ccfd7f78611c69b9/pyobjc_framework_coreml-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:64b66797b9cc1b20d726476f78ee2e69540fad60676d5dbb120530fbd429d3c7", size = 11966, upload-time = "2026-05-30T12:04:04.368Z" },
-    { url = "https://files.pythonhosted.org/packages/08/da/ccec3d91d7a740156d720056002befda423f3960691e4290460910d352e3/pyobjc_framework_coreml-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:774a28259888c1bc247e8ed5ad14d7fc8baa975591c89669cd952e1756cd7d48", size = 12188, upload-time = "2026-05-30T12:04:06.09Z" },
-    { url = "https://files.pythonhosted.org/packages/99/27/577ae403c3d2dc6c49dc18e8b16d315c54fcf31cdbdc839523ea40af4777/pyobjc_framework_coreml-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0ab804c7fdeedaea8fd6e1ec832a23d57913b280d3cc40419adabb0032271160", size = 12009, upload-time = "2026-05-30T12:04:07.798Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4d/605604165c57a329141436b750a0ac48860f59d73a015ca1a8abeed316d5/pyobjc_framework_coreml-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f55eb83825308fd759e053dcb9844ae5106e371645e7dcdb0777f161d59f8280", size = 12184, upload-time = "2026-05-30T12:04:09.554Z" },
-    { url = "https://files.pythonhosted.org/packages/97/e8/048beb8ab0df464b493a9c376b830d8cc1c84123d2ea44e5e80e0bd6a60e/pyobjc_framework_coreml-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5ebf148cedb1ee9b5183003cdb64033e97c7f50b4d073684e0fb54e63761259", size = 12004, upload-time = "2026-05-30T12:04:11.184Z" },
-    { url = "https://files.pythonhosted.org/packages/de/9e/b20114d45562f0f35ef0feb9aad604aac28a587ad7942b8c121cb9e6a85b/pyobjc_framework_coreml-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:82dded9d153db057aae965539cb28b4dc43391e5e07f38ac60db83061a9453ca", size = 12182, upload-time = "2026-05-30T12:04:12.841Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d9/d639ecf7f5730482c0be4a9a0e340a06d48fecad0976ca708cdfb4b79429/pyobjc_framework_coreml-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ca06f106c8d0e2e818212e6cfe9270bd333983ffd086be7b474fc9df34cbc5cc", size = 11973, upload-time = "2026-06-19T16:09:18.357Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a1/7f361206e202e84cf5695a8d1dc25810e8f58c4b9d043d10c0030a04dafe/pyobjc_framework_coreml-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4c9299321ced92439c203342183fdaa47aa8f125b6ef831c55bcc91a69e196e9", size = 11986, upload-time = "2026-06-19T16:09:19.211Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c4/763f7e8e8c63f4be106046dbca0cce3f33535c07dc5b079734951686dbd7/pyobjc_framework_coreml-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1ff65a16661abcc7c2dfe90e87b821d596bc17d1fed44c3a7ba36bd60b002a99", size = 12213, upload-time = "2026-06-19T16:09:19.991Z" },
+    { url = "https://files.pythonhosted.org/packages/09/77/957af9b9afcb8de21cbc3e0b58f29c28bbfa6b560643e1de0fa259a39092/pyobjc_framework_coreml-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:554b423411890d26a03628bb43f848d45656980b4cd43e8f91f84b52347f0b66", size = 12028, upload-time = "2026-06-19T16:09:20.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4c/10bf963e3dabd5354e64697b7ae847586169c37638da645f3af33165231a/pyobjc_framework_coreml-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6e2d71048e80c27c7c0fdd01b9ec5d309c873cb2c4da64578f13d842298a9186", size = 12207, upload-time = "2026-06-19T16:09:21.612Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ce/2c00c20db21112955aecc3b673da804734201a62bd9ba53e4d47b90acb83/pyobjc_framework_coreml-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:52dbdd00da500253ed8b21193ee0a4ba5c45e155fbe0d64448ba2c6666552f36", size = 12029, upload-time = "2026-06-19T16:09:22.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/53/d0401ecbbab4729b0b5a9a4eb8dd1a9bd40455ddacbae8dbc2aedb332286/pyobjc_framework_coreml-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d1cda08f258e30f5c92925d377a35bf5cd4a244911a4fb2196505431d2462ed8", size = 12198, upload-time = "2026-06-19T16:09:23.3Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coremotion"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/38/90010239d5d6721d8670cbb0edb71c39a1abca0cf22cecbeba7cbd490de5/pyobjc_framework_coremotion-12.2.tar.gz", hash = "sha256:8a2a06809b78a72cad52f27aa830c883e19ca36b57f8418ccfaf29773c5dc5ac", size = 38055, upload-time = "2026-05-30T12:36:26.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d5/15d318ab0d12681ff5aa5c6799287480dff561e2b3a79d2befe1811b0453/pyobjc_framework_coremotion-12.2.1.tar.gz", hash = "sha256:21fd319d7313b9b03f062239f1c09e324969d5da0fe74842c92a2724381bf78e", size = 38049, upload-time = "2026-06-19T16:20:19.483Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/f9/4ef3ac3cb071cef44fafa2de17d3e482c9c519ae5c1cdf00e3a6aa86351f/pyobjc_framework_coremotion-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b987d542146d75c890c205bc8c125b546c7bc35afb14d5156ffdba16914bed7", size = 10428, upload-time = "2026-05-30T12:04:17.943Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/62/606ca7aa90686f1eeb48d9870409bb1132ade70afc185816f12f0bce8f30/pyobjc_framework_coremotion-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:554bd583a6c36c659e83102832b65e6829c9f4c5d7dfe30f76e4fc62ab2ae13a", size = 10449, upload-time = "2026-05-30T12:04:19.591Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/7b/b5a942442e0b716319c442dd7a8cc2232b682509034c832898bbb7ba3783/pyobjc_framework_coremotion-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:657fc69c6446878c0a6b5cc53f689f110a8c4bbf0d57ae87f1d19ebf7bfc2889", size = 10597, upload-time = "2026-05-30T12:04:21.265Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ef/dc1a28f9f1fe86dd2b8b84bd1273cb1dbbf9fcd150097002fccc679eb4a4/pyobjc_framework_coremotion-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f5d1d3b4921cb334a4951623c85d3d5a2e79d13262d244e5355e42ffc0fc09e8", size = 10514, upload-time = "2026-05-30T12:04:22.828Z" },
-    { url = "https://files.pythonhosted.org/packages/10/7d/b3b3300224f0c26381911d6d58214c0fc354d3fd75a4d2c214bf880784a5/pyobjc_framework_coremotion-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03968db63df5b5898973936545b9a800165ab33ff672823186407e2a6d0e179b", size = 10665, upload-time = "2026-05-30T12:04:25.173Z" },
-    { url = "https://files.pythonhosted.org/packages/24/3e/c1e7fbb6d32e2ec0d5777e7eff11a96bcb564c70ccd99dd7bf68dbde8ad2/pyobjc_framework_coremotion-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:681b01d4677fc9ca6b0ab6da876087198957141fbf0799b5892beb71fbada5e4", size = 10503, upload-time = "2026-05-30T12:04:26.835Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c9/a35d41cd83e9743fd26fe8fdc039b88fb8549c702524e97d94d0c864288c/pyobjc_framework_coremotion-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:55dc932bef0ffa3b23e7e07a4016f4fa36687204528187c17dcb19cc4d322456", size = 10662, upload-time = "2026-05-30T12:04:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/58/28/a83a7ca091022d8b3df7ba1af2ad98b683f9db5c9e393e200c308a30f87e/pyobjc_framework_coremotion-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:05388142cc892b95e40fb626748a4af0816b285bf33f1fb3b8a856b964581433", size = 10456, upload-time = "2026-06-19T16:09:26.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/3f8e52e418be615aeb170541f873af739e756aab7d3610d707bfceb48698/pyobjc_framework_coremotion-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d18a90639934e0d4379cc6e632095cda1287c03054be73d79cb3eb680909445a", size = 10470, upload-time = "2026-06-19T16:09:26.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0b/6c69a4eae1e6ef0de4afae1cbef99e45348b1dbc067648872da9a6903b44/pyobjc_framework_coremotion-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:848aa8c0d0af9beb909f28f7aa6555b62646ff34a73873f8820d330c3c3e5578", size = 10616, upload-time = "2026-06-19T16:09:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/64d30e500aa92ed5cf97f63ce742615eea312dd1d790959c5f609a4492a8/pyobjc_framework_coremotion-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0caa15ddd0a25ed2cff27b28918ec690e1031ad62db8af5c4b0ec1957448aa10", size = 10534, upload-time = "2026-06-19T16:09:28.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b3/73b5e6bd8319d506a8effe250349c346f7e429bbd55d44f84fbcdcf05959/pyobjc_framework_coremotion-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7596619951228890658833c6a7bbd50b7287b501feae31d774cf7e699e9f8f9e", size = 10687, upload-time = "2026-06-19T16:09:29.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d2/f84d404430b905c6630db22f6cc768940e602db7ac7f4297a429546290a0/pyobjc_framework_coremotion-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6ccbc65ed88f23f0824dac41a321558dedd8ddacb3b6c967d19801c5418a7811", size = 10523, upload-time = "2026-06-19T16:09:30.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b1/05c42f264e2d01d483ff80b936f99ebaaf195ae081b6369a597f2db82a74/pyobjc_framework_coremotion-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0acd45e02a10a8e7f3fc6b2829740c9c18fc4c2adddf263e117a97c46105222a", size = 10684, upload-time = "2026-06-19T16:09:31.189Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coreservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-fsevents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/3f/92b7df81848039fa9b3eaa0181d9969f42dd8a208e8ba8b8d4a648c2cd46/pyobjc_framework_coreservices-12.2.tar.gz", hash = "sha256:ea52c77e9a162b6823c3b364f391b4369d967365e5207a0d45cf6d0e37cec0e6", size = 399867, upload-time = "2026-05-30T12:36:50.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/dd/d87ebbb99b1c277a519e1b7e0fb5efaf2e68833322d9c1eca5ecd79ed8b9/pyobjc_framework_coreservices-12.2.1.tar.gz", hash = "sha256:b4f052acd7346afa6f5441d32a19faaf080c3441cfaafad40c9b9a485b664554", size = 399935, upload-time = "2026-06-19T16:20:20.469Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/61/59b4c1fdbf05bdfa19bed5cc46b271c37f486dea17df67812702b3551713/pyobjc_framework_coreservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a3f9593b672b52ff31674104bcdd6ce6bf9f4560ca61380f2b35c904f8d77d0", size = 30318, upload-time = "2026-05-30T12:04:37.083Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ae/ca8c1386df09bcd7175f5fa8c37cf09f458b72549843e5454b2562db7194/pyobjc_framework_coreservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c07effb4e1bff841eec4304b759fe3ef73301a7b2ae3e5e3e203efe6c45e2bde", size = 30332, upload-time = "2026-05-30T12:04:39.951Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5a/1413029dd792fec9e9c27c18c6a48fccaad3ec675698fc2db6eb46d5e51b/pyobjc_framework_coreservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fb713264a7151a92bb11e6125da06af343037b96f6f8021e7cc8f8ff42897744", size = 30342, upload-time = "2026-05-30T12:04:42.727Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/f0/fc6dbfca3199ccb719c7591b478cd077746a924589383cc27bc426b64245/pyobjc_framework_coreservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:183a75dc6edeaa73f6f49b857bd5a61e522abcb5d7df1a3bee169896d0cac181", size = 30358, upload-time = "2026-05-30T12:04:45.682Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/2f/e3e711b8fb916d183f9e81c0871bb718680fd36277073e1eb962e29db10f/pyobjc_framework_coreservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c2255f66669f8a70b3badae5d728abb323a042008c01b825333f6bcb1446e2c7", size = 30374, upload-time = "2026-05-30T12:04:48.474Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/32/ef39a7d4bd6fb67dd69e3680a3d27b7be0039055ced4027c7615a102617c/pyobjc_framework_coreservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:7c32519d13c882b2a8f844e4f4def32eec9bd3f29781bdff85750f80320709ee", size = 30387, upload-time = "2026-05-30T12:04:51.296Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/11/31ca4a107a68797b22daff1ba35d61e7b1bad951c17c1ca61c38059966ab/pyobjc_framework_coreservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b17f2743ac0fe1245b16bccc2abc2568d4b33f0655b8f805d4bf19754284363e", size = 30398, upload-time = "2026-05-30T12:04:54.255Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/46/21129f921528551b8aec853ebe9f21edad01bd7f4501743d0601b7ac7ccb/pyobjc_framework_coreservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cf31f1d6e477414b7c5bd831df5864744a558eec5b055155fe6929ef1070d371", size = 30342, upload-time = "2026-06-19T16:09:33.961Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ad/aa9aea470acd79e69cac8dc561844236db307d6e93ad0e0140beed646f4d/pyobjc_framework_coreservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b911d08cf4e9fab5fd0992dc525bec02cc925102a42b2bdd4b77dd6a7b8ce70d", size = 30359, upload-time = "2026-06-19T16:09:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0b/67db0cd511e487a847e6ddf1a9e78baf5db210b848e48f782ad15e302b1f/pyobjc_framework_coreservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aad43d280da1ba8f7a815de1935957f3f61b80eda15c5cac35cdf6a1b20f69ee", size = 30369, upload-time = "2026-06-19T16:09:35.701Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/197681804de3504b66971f99d140e3284a028b3393e68130df928410804d/pyobjc_framework_coreservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cbb369619aefb556f0a0d06fd667ebb2ac4235fb2bb453454dda1571801e259c", size = 30382, upload-time = "2026-06-19T16:09:36.718Z" },
+    { url = "https://files.pythonhosted.org/packages/91/36/b07713ead8fcafd7279d6893822374f99690982dc47f23fe3d3b3d5628ed/pyobjc_framework_coreservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:38fdc91789137af9e22a7bcea0ecdcb9d1d35ebb1c66c58af91973bf9727dcfc", size = 30402, upload-time = "2026-06-19T16:09:37.641Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/bd/c0b88cba4b0cda2390d299cbfe3352b81e7861b46a0a5cb4471081fb1796/pyobjc_framework_coreservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:628aa9ed4c1da2bc2d155b29609de2ac6197bbe41d7f8eb0a594fb2d5d6570dd", size = 30412, upload-time = "2026-06-19T16:09:38.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ce/222b2ec4cfc803e47fe170d04f89d50a397020ca7436582a2d880779174e/pyobjc_framework_coreservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d87eb0f15224925d860c8332cf579b998db850cf0d4f7a611872915bf9271bfc", size = 30423, upload-time = "2026-06-19T16:09:39.593Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-corespotlight"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/c7/ea47b22b51e9e0bc69dc4f70bf19d18c9282df5d1c11343138ee01f7022f/pyobjc_framework_corespotlight-12.2.tar.gz", hash = "sha256:6aefcef43d3d3bf3e7cbcffca053a7dad07c434aa11b117dbb39d5cf596ee829", size = 45678, upload-time = "2026-05-30T12:36:54.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/89479d419712deef7e245a8284edfebc418297a17e3066a990ae88c3bf3d/pyobjc_framework_corespotlight-12.2.1.tar.gz", hash = "sha256:85d6080ff2f3a02593650eeb799d667be66383e8cd947abfec5e8ef8fd10d18b", size = 45685, upload-time = "2026-06-19T16:20:21.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/3a/a48e6bbe5159a23f946745d395463593bc3eea35a7ae4135a59169b7ce66/pyobjc_framework_corespotlight-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e3d60d1dca50418143e7365b4535c25fe04c66af2f6304bcc4d06e288e783e91", size = 10003, upload-time = "2026-05-30T12:04:59.497Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/bf/79508c58d3f68ce8a564146dfa29ae661d9970f64f2f8615b6cba0b866a8/pyobjc_framework_corespotlight-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d35028c872a89c0450e067c021d64b29c013fe980617aa16e9d9778f566e167b", size = 10019, upload-time = "2026-05-30T12:05:01.117Z" },
-    { url = "https://files.pythonhosted.org/packages/94/46/15463f342139c8c9d95efa0aa434494c3782472fad1ae6e0436f624eb34b/pyobjc_framework_corespotlight-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c0d6b74f497e835f9de97aeacdab7a2c9a1544135dee1c9665b2074de44424a4", size = 10162, upload-time = "2026-05-30T12:05:02.737Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/94/4a9a50d83b026eb924f57399f741397ea999cc947367d78914ecb90ce51a/pyobjc_framework_corespotlight-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:884a7629a98703308b11a3b350899c89ad268aa278b005b289765a13172bb40e", size = 10081, upload-time = "2026-05-30T12:05:04.358Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/7d/a056a2d3ec4ea0e9db6ce74b99cd0c0037e5ddf7022f0b21a3f852957012/pyobjc_framework_corespotlight-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:70e9536e0992d0777ef24e6972788e72bc80290da89c03a84237b9ddb60e3510", size = 10219, upload-time = "2026-05-30T12:05:05.906Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/3f/0d7780799604d6d4a922491cfc6db8a12c77544e45228a13d1ef883ef3d4/pyobjc_framework_corespotlight-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e472ac4d16b0485980f0632b8cd650515de4a6b44958fd370b00490a1f1a1bac", size = 10077, upload-time = "2026-05-30T12:05:07.447Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/59/08223d893ed5b902cb36cd9bdf93668c72cc8e882a092776c99f6cc5e11c/pyobjc_framework_corespotlight-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:61b331e85d12f550797a8010aa2f1d369a2fcd21990adbf3675005dc9e2475e6", size = 10211, upload-time = "2026-05-30T12:05:09.017Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/20/d6d9d96b4dba80f4030f6a94a322ef8dc384cf26e7a64f63b44d046f3b3e/pyobjc_framework_corespotlight-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:09b40a5982ca77c4b7119cb69765de4f7f565721bd3bfc724cfa9703abf15dc3", size = 10030, upload-time = "2026-06-19T16:09:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0d/8390925cdd196a209ec2e11b0924060d6a0b12256084bf193107792e45ee/pyobjc_framework_corespotlight-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:76b6315e724f81d62af09673b78ae4e3370b58b8ed639a1a9d2dcb2621a044b2", size = 10043, upload-time = "2026-06-19T16:09:43.011Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2a/3b85888fefe9dd61c6c3ea264950b80ac17ff9a740cfffa4bf796e3174b1/pyobjc_framework_corespotlight-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3591127a7958299406f592027de570d5c8b6eb40a7a0667b912562a42007e67a", size = 10187, upload-time = "2026-06-19T16:09:43.829Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fb/783c1776f81a491065e42622c7d2a80982ba8e852c9bfc804e51e57b7c44/pyobjc_framework_corespotlight-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:154fe491f217eb0e107ba37403b1856263f288ed801b10ede193df427cf15c57", size = 10102, upload-time = "2026-06-19T16:09:45.324Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/0e/dd272a9d0b6202cc039584e2e50a887237a8a06a7575257e426cad517e96/pyobjc_framework_corespotlight-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0da2cb26b9449cfe7f629c4f241319b2eaf083643e63125bda38135943132b4d", size = 10245, upload-time = "2026-06-19T16:09:46.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7e/a51ca1c2499e1905cd2f094e8d3fa295bf64e638bd15c8c0b782e166dde8/pyobjc_framework_corespotlight-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:53e8ab09ee1e4a2c0e20daf43a782ca381379ec5ee30224c561c62a3acd59766", size = 10098, upload-time = "2026-06-19T16:09:47.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/94/43a3f32026ddf215ff798bb5cbb5f4f251ba8f9b31759a07f10009aa51a9/pyobjc_framework_corespotlight-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:98ba3d15bcb028bd44425f1910c29c92245b69218cd340e8e35eaef535d609a9", size = 10240, upload-time = "2026-06-19T16:09:47.969Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-coretext"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/b0/e7ef99240f853d4dddde82c9c0114cc525de7355661b2bf2d5e04cfb1582/pyobjc_framework_coretext-12.2.tar.gz", hash = "sha256:82def2c281347e0677866315675124c84c36e9bc21651d62870cfdcecb7da34e", size = 97343, upload-time = "2026-05-30T12:37:00.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/8a/52cef4b31d5a6d3c9c426759bd256229fbf6757efec1b7f1ba5c2d051621/pyobjc_framework_coretext-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c1845fbdb96f605c7146c478c5d562961d77aadba6cc40e166fade08e11a730f", size = 30091, upload-time = "2026-05-30T12:05:17.568Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/db/783ae8290da2edb57b479fc474c7d66a319f4fd5f1f32dd642af1fd962ec/pyobjc_framework_coretext-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09daa6b6befea7c0d673a037d02ed13bb4443ed65d8948329ba6c8a08e06c763", size = 30087, upload-time = "2026-05-30T12:05:20.422Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/58/6d0a37fed6eee8ed4c950f71cc98355e8ce8d3a38c19aba1bf7ff6ac5441/pyobjc_framework_coretext-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:867e6f56c1c7703f27a7328d42d37cd184151657a3026cf46c0de207cc90a46c", size = 30635, upload-time = "2026-05-30T12:05:23.59Z" },
-    { url = "https://files.pythonhosted.org/packages/26/22/3c6dbe97cb5b121b01f61d575bf202238b0cd6f39f22f15d94179461b677/pyobjc_framework_coretext-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:88b9e705d47a663f079f6ebbca54f5b57f305bb639d5a9d943231596653520d7", size = 30075, upload-time = "2026-05-30T12:05:26.195Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/28/ffd7807c835010839678c6a43b7aa66d956816becb035c2371b8d03325b6/pyobjc_framework_coretext-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dec9a67529615fbcc7c11a9a655e8d17a6095d94807e5df11e0bda55b37f0190", size = 30614, upload-time = "2026-05-30T12:05:28.997Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/49/8c56735a3758b6570e98a22861becf514057db33abe48f7bfd6e7f533b91/pyobjc_framework_coretext-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:639ba39b119f24198184abf878bc1633355fecb36f8eab57f32956252df30d40", size = 30080, upload-time = "2026-05-30T12:05:31.979Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0a/5c881e86eda55bd4c7d33e7e93a8ef3b327e06203bfe45e16b7f8af0a3e8/pyobjc_framework_coretext-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:06bcb4e7de281423c212a39b3dc9873f09d9fd69da0abe93d987a59761bf265a", size = 30641, upload-time = "2026-05-30T12:05:34.814Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/11/c1298c2ec3b0cd19a457a1fd0da47898f894a13df5516f80dc04d1a7a4d9/pyobjc_framework_coretext-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2ead13dfa4379a1566129d0e8a8ea778a2bcac9ac360a583360fd4f1ba39c6", size = 30123, upload-time = "2026-06-19T16:09:51.183Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8c/154e8f34923b24aade64a20eca2b759f8f67e109654308103080751f246f/pyobjc_framework_coretext-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5c5a3c6e2d905a17efb15572dad97ce582feeab5c3b92537015445e0e0bb46de", size = 30116, upload-time = "2026-06-19T16:09:52.219Z" },
+    { url = "https://files.pythonhosted.org/packages/01/61/f53458c8f7fe74008e342946eca1fa82b777b284d4e13d8bd2e3e5724cab/pyobjc_framework_coretext-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5c979058c77df8cd3dac5fd7db4c484f9886fbe09e2687bfaf269a856f631f78", size = 30659, upload-time = "2026-06-19T16:09:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d8/d1178bb1ba3bb7a0d7a55db460aa89f2a8b232ed7eaf76cb402923cacf2d/pyobjc_framework_coretext-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d0b3b0467a23dbc2a39d0839e7100cc98b429fb7d52a471bd65477f46bb4c9e5", size = 30100, upload-time = "2026-06-19T16:09:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c3/780d739909e6d8ddd9e8786fd19e8ea10ccfcc7275df987e349af0fb33b1/pyobjc_framework_coretext-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3d4a92fa657180cd0e900b98535da4f0f4d8c76a7077730a507e50d52d2853e3", size = 30642, upload-time = "2026-06-19T16:09:54.736Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/867197c6cf2396b33e95d6175d7fdc6f789314859fb107560ae9b19c7b14/pyobjc_framework_coretext-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:7a17034fd0a08cf58323b7234a385ce0ec355509d414df69e3f8f88df26de1fc", size = 30098, upload-time = "2026-06-19T16:09:55.679Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a3/f4e6d1a38cd4db8a1275eddb287f3cdc2c01c48f80b30e89cc58cfd92156/pyobjc_framework_coretext-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:28980144af75598654f6997b2bbb427885f4f5df90aa4d840f452ba5778ab155", size = 30669, upload-time = "2026-06-19T16:09:56.521Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-corewlan"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/82/0393b32be2551bbaf09211eff01f92c60f9c3f964d6ace23f14847d88550/pyobjc_framework_corewlan-12.2.tar.gz", hash = "sha256:e0d81a95f6923c3dea9b0ab34fb0b028f5838930a602b5aa4bf9546eb268be9d", size = 35525, upload-time = "2026-05-30T12:37:04.208Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/4c/1ff3c5042ee2e8344b47978458af62a81ccc49894039fcfdf81d3ced4ee9/pyobjc_framework_corewlan-12.2.1.tar.gz", hash = "sha256:9a7ae402a55710392570a736a2bbe15f372325f941fb7074e682f75e4866c3fe", size = 35515, upload-time = "2026-06-19T16:20:23.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/87/d2a10c53938c5fe13548ae8cf39c8d807774b99288d25993feca36b6cf15/pyobjc_framework_corewlan-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ded695a9b0e3f4df19325bff6ee6c1ca6f601b6838a1f94fcc02892408e81051", size = 9993, upload-time = "2026-05-30T12:05:39.816Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/31/95f9eea9b71b724a239ca7445f666ec29cef9df7cc9ae3cfa77e1b9c875b/pyobjc_framework_corewlan-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6b922017499d6921a760bf3d359b1705ef31b87a2c4cfe763452759f9dc5a91c", size = 10001, upload-time = "2026-05-30T12:05:41.401Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/07/461ecada55a3d164f095e6e103d1bf9011e00334d2e7ce973048a0050512/pyobjc_framework_corewlan-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3435e7c086ae69522354ec4fb74bcb3bbaefbc4b895680dffe6fef634430d533", size = 10154, upload-time = "2026-05-30T12:05:42.982Z" },
-    { url = "https://files.pythonhosted.org/packages/87/f4/4a6a649323b656cb4ec33453da378bf88b9feb12b61f086efe81efed5d5b/pyobjc_framework_corewlan-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:daac8e5a802e52aec0f1240430c785b1e20219b5fa9928d951e0d8d8f23debb5", size = 10044, upload-time = "2026-05-30T12:05:44.593Z" },
-    { url = "https://files.pythonhosted.org/packages/97/cf/6cc4473726dbcaba595a22ed707ec1dbc04b998d01b0a76088dcc3a7a216/pyobjc_framework_corewlan-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d4116421fac622b0376220ce8dcf2769bd865412a0172fcea4fc3799f741ff05", size = 10203, upload-time = "2026-05-30T12:05:46.181Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b8/b4751f8788bdaf029af09fec09ab352bde587465ede0c24fb73ce9531b1c/pyobjc_framework_corewlan-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:06e722024d349d421825ce2354846c13684777290cd00e525650e064e5a6db01", size = 10039, upload-time = "2026-05-30T12:05:47.861Z" },
-    { url = "https://files.pythonhosted.org/packages/45/70/7ca06f390a382a49545b7a5b4677cf62b81f3f9ffd19b6aff44ec0b43c40/pyobjc_framework_corewlan-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5d31f40aad614fd19d6a9117f9a66f07eafe7a592ddc60258e9bf3f09d2fe552", size = 10201, upload-time = "2026-05-30T12:05:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/7f8b6da97b41155cab6bbf3a6d611f9c0ad172fd790bc912cb76146a4557/pyobjc_framework_corewlan-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a7a980cd8eb5f879923afbe92bf088e585968b3cd3448b9f4a16d5158b59e6ec", size = 10014, upload-time = "2026-06-19T16:09:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ad/1624d1d8d238cd7aa34b29154cd3d2ab7176c25aa84cbec9b85256de339e/pyobjc_framework_corewlan-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6c9597a5d8b9c7c9b01c28fc6fc6ccc4ec7ea2de83296d5f3f950fbd9c39b448", size = 10026, upload-time = "2026-06-19T16:09:59.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a9/f595af68e8975cef88088d963837eb37fb70aa8d1d42f3e42a62cf6c5e59/pyobjc_framework_corewlan-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8d91fd2396ddf71c8df01e36fc9b49a87a63de77220b39eb858f955cc2ebd593", size = 10174, upload-time = "2026-06-19T16:10:00.679Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6b/35dbc6e121fcda3d86db0722136cd48a93acf58d1b4c8058879f9f300b68/pyobjc_framework_corewlan-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e4ac75fcb3a8533c6e65d21871aef8ac52db4e322d038bfc38183667bae6b8ec", size = 10066, upload-time = "2026-06-19T16:10:01.622Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/45/8688ff8141220b64242e03f0619512593d2c3858e7bd852fbad6b14ba3ec/pyobjc_framework_corewlan-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7be48cb7492740d33c3cdfd3e42e527ec2d8feb9ff67f082471e4b2db636e140", size = 10218, upload-time = "2026-06-19T16:10:02.404Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4e/6d8b1530e5735482dc0e9f0cdf0d9371160313ca9f25a16cecf79d885ddc/pyobjc_framework_corewlan-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ea678d0a91bc5db8a3b80cebf016631883e7e8b0b2ac8b9cdddc97adc7031fa5", size = 10063, upload-time = "2026-06-19T16:10:03.172Z" },
+    { url = "https://files.pythonhosted.org/packages/be/5e/de7068bdfde55839959479ec69b2188867b71979469a894c66a309fededc/pyobjc_framework_corewlan-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:85016f24b0a0e4ea538f74203e22371aecde961d8f849883096576245afb94c4", size = 10216, upload-time = "2026-06-19T16:10:04.575Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-cryptotokenkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/73/f77f0dca70fee8a1999700dc878eea1e558d7d2e5088d3bce59e425f23e5/pyobjc_framework_cryptotokenkit-12.2.tar.gz", hash = "sha256:bf070e95f82db3bf8dcb0d67d459df3810bd9dfec63a31982adefba146d9e777", size = 38281, upload-time = "2026-05-30T12:37:07.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/0f/697f89ccc2b4f6186b126d29d33def5d699ded72746c6c963aae2f8f4107/pyobjc_framework_cryptotokenkit-12.2.1.tar.gz", hash = "sha256:f5ad2a333ff4ba77d2ba901257836b13c1c93e62342dc092fe57dd67a97ceee7", size = 38273, upload-time = "2026-06-19T16:20:24.319Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/63/a20a4ab7148a732353fd335511c1252b6ffb312c4062570c2afc192b7749/pyobjc_framework_cryptotokenkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eed85a7bdc797abec1d57ea9af9a7e5cd30b428947a75cb33320290c7bf3ff70", size = 12694, upload-time = "2026-05-30T12:05:55.157Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/ad/deaada5bb4b9f1463d3cc8b2be809818a911edf3f6618053cf6ae5307e09/pyobjc_framework_cryptotokenkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:240f79011ed7750a441f9d07e971ae262551bae3e6a455f7dc2dc8641fbde6c7", size = 12713, upload-time = "2026-05-30T12:05:57.068Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c4/36dff9b7c73eccedc57ec8bf60948b9410a95eb27d7e94bfd4bd89586ba5/pyobjc_framework_cryptotokenkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eeaa4be6eb2cc48a73a2444d5db1ad9f7c383e23d15efab12272cc66c3fc11c3", size = 12898, upload-time = "2026-05-30T12:05:58.89Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/47/c5c5e9988faae629356f1fc0e57f80e26c095a9a015a21af0dcda129ae71/pyobjc_framework_cryptotokenkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2ac46a8f261c465baa48c59b66fa4b80747033f6d9a252f23f6b7f24f2f2c826", size = 12691, upload-time = "2026-05-30T12:06:00.764Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/7b/9c924053856ef2d02ede6bd67b6df5608651422ae80b6086235d93645a1b/pyobjc_framework_cryptotokenkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:60a0fbc1191d239436892e84d526a80de7c57d07a2d1d713c7c21baf55743ef2", size = 12898, upload-time = "2026-05-30T12:06:02.588Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/4e/851f5ef1b357c0c1b0e42964920732ebbb7f939907005fd6470382ecb81a/pyobjc_framework_cryptotokenkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:15cf74cb05bdfc592c600dbf8b0cd24d18662158af93da399ba55762ef367020", size = 12682, upload-time = "2026-05-30T12:06:04.382Z" },
-    { url = "https://files.pythonhosted.org/packages/28/89/4054e14864f22515a9ef9c879d5ccdc77a9ac480f34701dfb5561dd68d1c/pyobjc_framework_cryptotokenkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a0df6e75334f762402e18f949a4e8485c73361f9fbc94d4a0dc8351832687db7", size = 12884, upload-time = "2026-05-30T12:06:06.544Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/cbae3352cd1e68373e65b3cd110aadf3839d2b64c75e639f37b6b954b0c7/pyobjc_framework_cryptotokenkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bd2084fc176f32f5900a17da4d3b05c9563e43521c5df3c8563caef1ebb9f194", size = 12727, upload-time = "2026-06-19T16:10:07.62Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fe/211725952ed459efd0e29e40de11277e1102fd9280f6cf15270de939234f/pyobjc_framework_cryptotokenkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ad53981b7f6d0f8114579c7b93b46fd8ead341663df9ccd845f79633f66b4c79", size = 12740, upload-time = "2026-06-19T16:10:08.466Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/03/a30266392021c8f0f4b8ba64ee3839e051448397d413bcf8ec4e3ba314a2/pyobjc_framework_cryptotokenkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7177828df64d96737d523a5b2ec28d5d5b171dcc1045c486b1e460234519244f", size = 12926, upload-time = "2026-06-19T16:10:09.798Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/79/47e48de94096025f06650286c2ce77c8d360d07075dfc0b10e9b5f0eec76/pyobjc_framework_cryptotokenkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:91fe788acab20a8066f05062410193952cb249d0d0acbbe675f08caf6f4993f7", size = 12718, upload-time = "2026-06-19T16:10:10.79Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/31/41c61fc4f085e94084d19b831057eaec59a14513c02ec313cd0a75fe8b42/pyobjc_framework_cryptotokenkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b5db6a890938f049c977d6a62f4db167c80a3146f753e98e67796ce6a49c5809", size = 12920, upload-time = "2026-06-19T16:10:11.844Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c1/7f04f571f3ba8e240e13155179d021b0c38432189ef9b07e26d751951244/pyobjc_framework_cryptotokenkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2e4306ffe83327219910d72e3c2524d4a6e4a02d64f39bf7b31a3613903b5e70", size = 12705, upload-time = "2026-06-19T16:10:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/00/87/a2e5f0cc0407e13ae2468eb8b555ccc6e2cd2643e917300399f620899c4a/pyobjc_framework_cryptotokenkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8914647c0556f61a0330b8becf5e42a5c23107f8fbf6acb10f51c0d0b68f3e6f", size = 12916, upload-time = "2026-06-19T16:10:13.599Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-datadetection"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/fa/eb20c36de2d038e2c65629b600dc0642727ae68e96f3bc9a692cf0b7184f/pyobjc_framework_datadetection-12.2.tar.gz", hash = "sha256:5fe732751662f119c8435c608785e86edff1b2ee394fbb9f010b5613bb6703d2", size = 12676, upload-time = "2026-05-30T12:37:09.09Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/f2/8c2ab85d3dc8022450af30d58b225bfd3e01693f50d383c80e7a905bcd81/pyobjc_framework_datadetection-12.2.1.tar.gz", hash = "sha256:b1059f9bcfab5a96606dfdde663f41dd8c23a33f8bc8c00371d68796476981cc", size = 12679, upload-time = "2026-06-19T16:20:25.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/8c/080a4c6ecffe45a64db10912ecc8c777f4368f4c5ad859a584a73e7243e9/pyobjc_framework_datadetection-12.2-py2.py3-none-any.whl", hash = "sha256:23246bea4dce73c702e176ed2be1ba26afc48a627c713a91417716c3d5915ec0", size = 3522, upload-time = "2026-05-30T12:06:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/4eafd52ca2dedd34b564d7f4cc41da8ef8c071b3fb30e9e74faca1c77a3d/pyobjc_framework_datadetection-12.2.1-py2.py3-none-any.whl", hash = "sha256:c18b746a420e33d13689cbe64635249c492d3b58044089c5c8d6366b7bb46ed4", size = 3547, upload-time = "2026-06-19T16:10:14.839Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-devicecheck"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/ed/0c173fbee96920addd4f2d9ad0e69dfc22b8080c16f52f6d75acd459692c/pyobjc_framework_devicecheck-12.2.tar.gz", hash = "sha256:2750bdfc7fa11e02c88fc8d681dcf202ce2f52c4eaafc55f0afa38df1bc66369", size = 13324, upload-time = "2026-05-30T12:37:10.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/c6/9784a80bf3bbd45b4982d9349280938bf70a0b7e15bccc8302ebf324c379/pyobjc_framework_devicecheck-12.2.1.tar.gz", hash = "sha256:f67a745b89cd2f3e307cabee018a509aff0561e3f747eb4dbfe84498f7f2ca90", size = 13321, upload-time = "2026-06-19T16:20:26.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/58/8dbb51f3f462ce1d1a880f8fafc47980f56e0ad1b7472e2a500c81d6332f/pyobjc_framework_devicecheck-12.2-py2.py3-none-any.whl", hash = "sha256:77bbc267426dbdf80799d9a63ed17545c2c8332e765da8f5ce34f40be78e7776", size = 3684, upload-time = "2026-05-30T12:06:09.443Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d5/79ee42be90a01fb0c6ae80b96bdc28160ca0fb415595438f503efe2502c0/pyobjc_framework_devicecheck-12.2.1-py2.py3-none-any.whl", hash = "sha256:085c91137b1583bcd62787a2788adc7a51b24d8c61fb7848fb607ce3bc49553f", size = 3708, upload-time = "2026-06-19T16:10:15.92Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-devicediscoveryextension"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/aa/848457f81670d784c3a0b35887f7d16fd76bad805ec06be21f9c15012b9a/pyobjc_framework_devicediscoveryextension-12.2.tar.gz", hash = "sha256:2f3f21f9f2c0e0f714bd38076d7082c923650ce180a15aab77f271575b4eef04", size = 15744, upload-time = "2026-05-30T12:37:12.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/e5794d11e3e485c194f26563d04bcd4d729335ac221547e6d93109dd070c/pyobjc_framework_devicediscoveryextension-12.2.1.tar.gz", hash = "sha256:ccec236e790304c0bb880035b7f14738346c90d18cc4cb77b35169aa1035051e", size = 15767, upload-time = "2026-06-19T16:20:26.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/9a/eee0a7ed475068d2bc24f2fe6a8243da384a3d5c742f6b0c436322e0b592/pyobjc_framework_devicediscoveryextension-12.2-py2.py3-none-any.whl", hash = "sha256:d0f2187013cefb9dc3ff20abd8dd0260a257a6bd6cd661b4d5a364c877ee4ac7", size = 4322, upload-time = "2026-05-30T12:06:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/00/cf5ff4cb4a2c35b7e42e386dfaf7d7692410126c0643db29afa3b028c0a6/pyobjc_framework_devicediscoveryextension-12.2.1-py2.py3-none-any.whl", hash = "sha256:6e4dcee2810968bf1b076d3718ce037f65d770533534806866ad8391f9806bfb", size = 4346, upload-time = "2026-06-19T16:10:17.071Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-dictionaryservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-coreservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/f1/07b79048947dcd0ed0aa2582591a17990252a5649be725c094662ef9fbe5/pyobjc_framework_dictionaryservices-12.2.tar.gz", hash = "sha256:51e826c92fc04a0aa531bd04f092ca1edb6c470bce3f04c4eff84fbedb61d929", size = 10693, upload-time = "2026-05-30T12:37:14.263Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/2d/0c9cc7065a9d2d387be065ad3721b77876627541beee224bf86639c65f61/pyobjc_framework_dictionaryservices-12.2.1.tar.gz", hash = "sha256:631560760d58fe89af8332adee6dcaee35867cf13f4607f7b5c36e85fa4c1db9", size = 10712, upload-time = "2026-06-19T16:20:27.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/af/2b7cb4c630a0f9f0588a53a290d96898bb1fc8dcb2abf311c20e250d4924/pyobjc_framework_dictionaryservices-12.2-py2.py3-none-any.whl", hash = "sha256:9257ed93dad0b4bcf82c871bc587f994d7619e5916df3662cc2510fe8f85ed5c", size = 3931, upload-time = "2026-05-30T12:06:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/5a2edb46e216df811e73aa08c22f31aaa5209479a58941c1946bd0be92d7/pyobjc_framework_dictionaryservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:2b9d3d09fc085d913f670e3069b6a88d35b76a03a5f37ce8636b47382dbb028d", size = 3956, upload-time = "2026-06-19T16:10:18.12Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-discrecording"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/ae/ea8b74b528cb281555bea842abbaeed99db66e8270d9eec37a3b2f5a9bfa/pyobjc_framework_discrecording-12.2.tar.gz", hash = "sha256:0b1df1d250b892d1b48e1ce87c9c89e944c28a4bb708d43848f12ff2d69cc396", size = 61967, upload-time = "2026-05-30T12:37:18.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/ec/a7be70eb1c6700f446c68530e74bd71e9fde6ca2a5e76b237bae8fa980f1/pyobjc_framework_discrecording-12.2.1.tar.gz", hash = "sha256:2616daba51f50b8c6989d38d502ca98ed3ce53aee6b01c9457534267cbb1a4e2", size = 62013, upload-time = "2026-06-19T16:20:28.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/f6/629885ead33cf4425d9be95c9b6f0bfa95f20444d2017fe2d07508b6de87/pyobjc_framework_discrecording-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cd8b5260ae022ddd314fdfb92741cb6ed72e87206148a8b1018f064e4903852", size = 14565, upload-time = "2026-05-30T12:06:18.747Z" },
-    { url = "https://files.pythonhosted.org/packages/85/18/da0b7c2bf4d4cc9f6a3863ef635d72206cd6c3959ac27471db0c6b5969d8/pyobjc_framework_discrecording-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23e4012a55a51e5af9d5a9526697efc1a0d55a1234541c58a27b464c2fdd4e2e", size = 14567, upload-time = "2026-05-30T12:06:20.632Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/24/e9abce96b6f19979e9701dd1dada13ac0e344425e144ee2e684ae5e62bcd/pyobjc_framework_discrecording-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:067095747927b85baf7395d16c033be15db14a61c3fa8f6d2d6ce1b06ab36517", size = 14743, upload-time = "2026-05-30T12:06:22.564Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0f/c0a93c4cc41c16ec0e71800b24e75a54e0262b895340900dd01118276850/pyobjc_framework_discrecording-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:99ef86ec82079ae4c413433ad6efe5fc526a3307cb9317f1614cc0acb55cfbae", size = 14625, upload-time = "2026-05-30T12:06:24.513Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/50/27aa4acb61f8c6275c1f188b7ffadb5c47bed5fe47a26c18edddf954453a/pyobjc_framework_discrecording-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:457a08b5f3d685e8b3802aa1e3d78dcb425616a20a38d2dbaa7ba987311437ab", size = 14806, upload-time = "2026-05-30T12:06:26.434Z" },
-    { url = "https://files.pythonhosted.org/packages/81/14/3c27363911d8ab60441c9d09a5ea900a89db4da01fc1c087b5afc5c1d802/pyobjc_framework_discrecording-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dd4ca56fea006923bc9a581955b6f75e3f5989f76611a451d52dd3c029d1d72e", size = 14633, upload-time = "2026-05-30T12:06:28.443Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/e9/004c04389aa5d2e0cb64ba246d15e287b0294b0f63791f9b4a3cbd22937d/pyobjc_framework_discrecording-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:df4b4a6badb024dc56127614712e2666a186ec3efeafeccb6c2cc3b7f10db75e", size = 14804, upload-time = "2026-05-30T12:06:30.375Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/4260e1493cd661f900cc4966a055f82cc9fbba7e311fae5c42190106d258/pyobjc_framework_discrecording-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed929553896338cc0e5109c9b67c121dee2049e62735de94522795708d1b61e6", size = 14589, upload-time = "2026-06-19T16:10:21.373Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/207c9f94d956c40a19547456e8d301fbe21dbcc0df69944339960051623a/pyobjc_framework_discrecording-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f6a590c94c53d6d0975b54218cf018f9660f145fe686992d377fbd7b9861706", size = 14591, upload-time = "2026-06-19T16:10:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ea/e5b722dd0daa4bb7c015d41e6c3e6f7013cd757bf27e18134f7954ae72ce/pyobjc_framework_discrecording-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc5557015d2df515bfc75e96b287d1209b59afa2ce1a4566af32e9b8b49e2318", size = 14765, upload-time = "2026-06-19T16:10:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/87/e06f86a6ac77d0896ca2944ab7f7ac88ba26e26d9a71bbe64f4d55a6107c/pyobjc_framework_discrecording-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439fc5b5b930ae7246c06a053748cdd0962db377d1493dd9fbec130939ff4a19", size = 14655, upload-time = "2026-06-19T16:10:25.061Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/04f04fa4071d44d5caf367c8586266083097d541118d3c39a5ec44161604/pyobjc_framework_discrecording-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5e0ad242013ed977c12a69beaef66b7c8e3cf24af5f802261da8241205ef15cf", size = 14827, upload-time = "2026-06-19T16:10:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1d/709d072496482c9d568009e69f41c46818a16f4f18b42ffd50a89e48c53f/pyobjc_framework_discrecording-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:43bb79f284648b07187ce01b3e6b55b1271951b438eb99eea9fcf39c008a80c6", size = 14656, upload-time = "2026-06-19T16:10:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3a/8f96d7d0fb19411141f1c0e03ce1c2f2f9141b41ab31f299beb97d9b46e3/pyobjc_framework_discrecording-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:18a68340d2090a707620f82038d68edd800f5d7806d566605e80104d12068dd5", size = 14821, upload-time = "2026-06-19T16:10:27.57Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-discrecordingui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-discrecording" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/a6/3f94dfd9508f98aa5d152f8e56dbcdd8a0ddf2bbb9f7e180a5561772a839/pyobjc_framework_discrecordingui-12.2.tar.gz", hash = "sha256:932175c1c2df93673ffd87e4d5270bd03591548e26e39664d813b5e1b0c0a47b", size = 19543, upload-time = "2026-05-30T12:37:20.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/34/be343e4da6765228d1b6c6ac72a0c1c339ed8da931fa2701f28467c14aaa/pyobjc_framework_discrecordingui-12.2.1.tar.gz", hash = "sha256:1cf9e9e028c619f932ecf3ec0efc91227840bf6c6492c788cde91dc5c3744da6", size = 19538, upload-time = "2026-06-19T16:20:29.049Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/bc/3d75efba436c907629af9f17414f10bf105581e6e6803d20d0ab097a4b44/pyobjc_framework_discrecordingui-12.2-py2.py3-none-any.whl", hash = "sha256:4ae5d1ec84ff47cf041973c112024f7b3b7c6eb0d5cbd3cecc393998efa0f654", size = 4701, upload-time = "2026-05-30T12:06:31.841Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fa/5447695b7b646242b4f0e790b382c4432cc6e730152a19271896e4683a63/pyobjc_framework_discrecordingui-12.2.1-py2.py3-none-any.whl", hash = "sha256:a29bf02898481e6ee02a38ae932a35b9c6a4f68fe9c890504db18e94d15cfa45", size = 4723, upload-time = "2026-06-19T16:10:28.438Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-diskarbitration"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/f8/aff13f6577bae073682c7e413ce725e51a11e2262c82956b5664621caadf/pyobjc_framework_diskarbitration-12.2.tar.gz", hash = "sha256:b5ce6750cec175066ed6dc6ccc9548201642f246130c1a82d01690747028505d", size = 18162, upload-time = "2026-05-30T12:37:22.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/25/d6a3231f7d81903e6cd6dd9674ef798d45dba2cf301dfb2224277e89c62f/pyobjc_framework_diskarbitration-12.2.1.tar.gz", hash = "sha256:b79a44c8a7791109371bb6aa78ee970c7cf0ee6a6ecdaf92ae3b9dcc4f57f469", size = 18174, upload-time = "2026-06-19T16:20:29.842Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/c1/93db22bbc25358cf523e7a66a76de6fdfff4719ce60e86a87d368587520d/pyobjc_framework_diskarbitration-12.2-py2.py3-none-any.whl", hash = "sha256:9952012b50f8d87849ca74c56a8b6fcd9373e8b5aa4566f628165cd4a2458a25", size = 4889, upload-time = "2026-05-30T12:06:33.405Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7e/c95163c4850fcd59f4d761ed0e453c50ab782914df478f53d402dd424314/pyobjc_framework_diskarbitration-12.2.1-py2.py3-none-any.whl", hash = "sha256:8fdde0943ca7499a246294d678b4f01c3f7c7569da19b029eeb31e4e9f01519c", size = 4914, upload-time = "2026-06-19T16:10:29.349Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-dvdplayback"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/87/6a2aa2a54df1b18f9543a2c64baa290be6e59d98b31b46559ea47b49b5d9/pyobjc_framework_dvdplayback-12.2.tar.gz", hash = "sha256:2f504e578a809ae8544e50d9958bc2101fbb0a35921f370c810b575b70d8096e", size = 34810, upload-time = "2026-05-30T12:37:25.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/de/281c85dbcde3422af95cb6cf4607abde52612bcaa66850b8c1e630f25152/pyobjc_framework_dvdplayback-12.2.1.tar.gz", hash = "sha256:cc715bce5edceaec078e3b39141a660cb4ca2fbe0afdf133bd2c531c170e45a6", size = 34829, upload-time = "2026-06-19T16:20:30.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/70/c7cbd09f8a84f1fc904206f855688c76feb02aaae1ab4efb6f1858f0ec0b/pyobjc_framework_dvdplayback-12.2-py2.py3-none-any.whl", hash = "sha256:37d0b460e0783c78c3099a653ae1a7db8158b12e4da6ca91d513ec708514baa6", size = 8244, upload-time = "2026-05-30T12:06:34.978Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6c/ee10385cdd403471b205baf701890b5cb640a9dc357013d8a1801f1d5640/pyobjc_framework_dvdplayback-12.2.1-py2.py3-none-any.whl", hash = "sha256:56d737c2a1ffb1076d280b84906adc8091c055fcf6670367a902f38ea4877367", size = 8266, upload-time = "2026-06-19T16:10:30.25Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-eventkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/63/1acab761201e3ba2ddaa093470bb94373a11cee4f406587fb687e31062ab/pyobjc_framework_eventkit-12.2.tar.gz", hash = "sha256:c4e96235a1f0e43ea9699054c289369efb9d7645254a6169559c671b4ed21f86", size = 33759, upload-time = "2026-05-30T12:37:28.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/94/757c963beb0fb86891c3cd16db56d2e1cf746c24d8256023d6d7f4c83ef7/pyobjc_framework_eventkit-12.2.1.tar.gz", hash = "sha256:2528a61da2fed7d71933d7e5407414176cfcac2e03fdba4633633f0d646c75fa", size = 33775, upload-time = "2026-06-19T16:20:31.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/c0/257069ea9e34c3b0dc473f6ac9c03c95029e9b3c686875ae8f1c564eb0ac/pyobjc_framework_eventkit-12.2-py2.py3-none-any.whl", hash = "sha256:b56a736182365eff268b6a8c958a663d53432bac5befd3116570d3f1e4ec8b1a", size = 6924, upload-time = "2026-05-30T12:06:36.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/cf/504f2531b02010857df765ecebf41097fbd0bf1b803be47afec574199437/pyobjc_framework_eventkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:8efb71afaf9a97450ba701a6fee7de79e0cdefe6d71b5f6724e87b2fd68c5bd4", size = 6952, upload-time = "2026-06-19T16:10:31.307Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-exceptionhandling"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/77/2ecf87e8ddffb3c43e0c79bba7e1113436b45c3bc30ee76a82e94f5028ec/pyobjc_framework_exceptionhandling-12.2.tar.gz", hash = "sha256:c11ab2b122b6f2d1dc4625d163a2c5713df5ec3b0372394d3b6ed875a49397f5", size = 17168, upload-time = "2026-05-30T12:37:30.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/59/ef544e804de32c5e437b9936742ae2bfdb6873ee1b284609a70e98855220/pyobjc_framework_exceptionhandling-12.2.1.tar.gz", hash = "sha256:aef051e1afda09853289f66d4e6c1b58cd924656afc2a1bec05b15e22e20e5f1", size = 17174, upload-time = "2026-06-19T16:20:32.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/24/9ab5cba61d04445d36ef2bd52ff871056cedde22c3a2a4ff60f111d1f25b/pyobjc_framework_exceptionhandling-12.2-py2.py3-none-any.whl", hash = "sha256:14a76583bec99e18c5d0b0fd1db554d6f75b614f2912435836bc4abe6e1220c5", size = 7114, upload-time = "2026-05-30T12:06:38.383Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/f271631363bf830d520ed52bc0c5257cfcfe196859ab1b58720b023ae17d/pyobjc_framework_exceptionhandling-12.2.1-py2.py3-none-any.whl", hash = "sha256:b1d33ccb5ded605f2c92240c5719b64c45505f4c0dbc42b7d8595223b395540c", size = 7138, upload-time = "2026-06-19T16:10:32.352Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-executionpolicy"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/ad5d770d04c5cd057c20362724246d1a7407883854e065c86122bcfdc272/pyobjc_framework_executionpolicy-12.2.tar.gz", hash = "sha256:9b527b0deede8057a6482a6837ad8b3f6c3117232b8c9f97a3244991c9d0449f", size = 13040, upload-time = "2026-05-30T12:37:32.139Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9e/c6f4962416713ee46ae5104b08091d3c1ff49fdcb69bf1edc03d2285b7e2/pyobjc_framework_executionpolicy-12.2.1.tar.gz", hash = "sha256:898d38b19e805e12da317930474f49a9f944f7e2335a9dc9c1644ecdd079d12e", size = 13043, upload-time = "2026-06-19T16:20:32.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/25/4b8994d6bc1b4647546a89225770e68121dad788e26fb2eba458e028d6fa/pyobjc_framework_executionpolicy-12.2-py2.py3-none-any.whl", hash = "sha256:a8b6177182c1cf316696db76de23dd40b47e41e8eebbe6fa204492055c8f1f3b", size = 3774, upload-time = "2026-05-30T12:06:39.998Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a4/7557a818158c59ed531ce0abbe7bfa8071c8657734b376dcf08a1bd54fc3/pyobjc_framework_executionpolicy-12.2.1-py2.py3-none-any.whl", hash = "sha256:493340d7311f6294feb93327c75675fff24859ad9bb3b87c0ce8d339850c4c93", size = 3798, upload-time = "2026-06-19T16:10:33.329Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-extensionkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/37/d8578fa098ce7c4caf70bd02cc52ebae57dba3beeea260e27f10852ab738/pyobjc_framework_extensionkit-12.2.tar.gz", hash = "sha256:eb85b5ccea05f5bc41d5c134a2d199eae2a3bc4ee12cdddb94501272a45052e7", size = 19199, upload-time = "2026-05-30T12:37:34.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/f3/51d50e7af4958d597d924fab765725746ed164ff02e59928296574f6e2d2/pyobjc_framework_extensionkit-12.2.1.tar.gz", hash = "sha256:9b8dea5867436ecfeefc7edb4cd8358c8e7741d31693047f1321e15dfc533540", size = 19239, upload-time = "2026-06-19T16:20:33.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/2e/f5a6c1f22f4237085b047cc5a632a2bd1c637e716e68562ba89a899d2d1f/pyobjc_framework_extensionkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8596735e5ea62af326a13fe61cd815027896e8960d32f7ed18f8c55e2911bf35", size = 7931, upload-time = "2026-05-30T12:06:44.916Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/7f/21d173aed300819ff9e7ed9918c8817f6279c0c85687208fc5466e92efce/pyobjc_framework_extensionkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e81277815e9b7ad6adb8141be1ddc794cbb92acbcb8b582f0b929100c6528ffc", size = 7943, upload-time = "2026-05-30T12:06:46.384Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/cf/c75dc1b6a171743eb45ba4a28f51eeb3d348727d2b85c7af32609e18847c/pyobjc_framework_extensionkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7f480965e4c3d06f352116f9362ecfaee20337f16a832c3f39ec185ebfc87553", size = 8084, upload-time = "2026-05-30T12:06:48.235Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/41/acaf60a6fba4235d3d5079a5ca8a9b60b50cdc20408f3c5c8d3719f6a73e/pyobjc_framework_extensionkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e6b8b9ee143cba5ea27fb3afeb5beef58a33525f1d3374ea40b339079e853c2c", size = 8004, upload-time = "2026-05-30T12:06:49.713Z" },
-    { url = "https://files.pythonhosted.org/packages/53/34/cf0cb884f1d38f50da523e98aeffb5b5d09f81f129b5fbb7cf4d908d73aa/pyobjc_framework_extensionkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bf4744cd6d3722a76dc61c8a7ff356457fb903ac5ac2fe20f49cc6f18dd95074", size = 8142, upload-time = "2026-05-30T12:06:51.395Z" },
-    { url = "https://files.pythonhosted.org/packages/73/9b/4dd5a8d62b8f8617f62f541befc4cc7ac5f8391add198641f723e64aa0a8/pyobjc_framework_extensionkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0d29ad16d7abc03aec419a47a02cb7f1904345cfab2ea3831ba8f8ad58d494d7", size = 8003, upload-time = "2026-05-30T12:06:52.885Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/28/44c7d7c10ba9c395d5240652ef1dd82c02462d30f100a2876b46e5c83b77/pyobjc_framework_extensionkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b355d0689196bb5b3a62c73fb1a9abf4b68e5582cce2b1057f2a6a02a7177f8d", size = 8139, upload-time = "2026-05-30T12:06:54.705Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d2/f859740c55b569857a2f969a39177fcceb64d41fc345fe39c7d27d48d3cf/pyobjc_framework_extensionkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9279dbc7e75f28b9b6553d351e48475fbf3841f9a30f4b503fe03e18c0ccb074", size = 7955, upload-time = "2026-06-19T16:10:36.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/c4162af7b93d92b0d6806bdbcfd16cbf0f3e5d6ff17e80b5feea4e0a2429/pyobjc_framework_extensionkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e29f5860aa6acb53582c2742e477922067b959046c1998ed7fd962898fd78855", size = 7970, upload-time = "2026-06-19T16:10:37.038Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4c/472391557a3ff3f3e4fcfb683c34c7f3bf9abef7c8d0eff563cb11168cbb/pyobjc_framework_extensionkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b8dae4aa09e327a44b12c2e5c49250e3439fd98fd8eabd08ae97d4b71180aee2", size = 8108, upload-time = "2026-06-19T16:10:38.033Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bc/89c590272ea844576f17bf52f46de5d6d9be06236be1c79b754e2847baf9/pyobjc_framework_extensionkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cb00d24a9a3b2284f9f5bdd2b65ca1e25f5743012e728b751109d66f28efb3c5", size = 8036, upload-time = "2026-06-19T16:10:38.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/4165f128867f83d4992aa3c7841826c98ea2142e115d7866580be70df59d/pyobjc_framework_extensionkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1307a42439c28e55081e47729dc04ec1de33693fb13df38381914b849580fa51", size = 8169, upload-time = "2026-06-19T16:10:39.899Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3a/68002c7bf2a8b0392af0d777510c3e7b754294f1b8e24b615547cf11bdb9/pyobjc_framework_extensionkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3599ba37400750fbca5a3500c7ecdf19f0df30182c9e9e50a51c0c0e12ee5cb5", size = 8024, upload-time = "2026-06-19T16:10:40.82Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3e/005011c3f7a0bc53dc8ad34b4fdf429a472cd95696023f9f4a87f581f3d1/pyobjc_framework_extensionkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ee7853b036f2a7c52a35ec0d6b155c8c2a36ec6c5bf2e3a35318a8eee66f9564", size = 8165, upload-time = "2026-06-19T16:10:41.745Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-externalaccessory"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/fd/8eaf82d13c74834007c716a13a10e6c2dfc0edaf62248c4801ad951e924f/pyobjc_framework_externalaccessory-12.2.tar.gz", hash = "sha256:0df5c2db52220753e3c7673fa3051fdf5d2890b9972dc3e140edc3dc16c7cd4d", size = 21989, upload-time = "2026-05-30T12:37:36.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/e2/96f79a29c7bc6c229035dd8e92f4f73001affa8e642248cf7ab5bf03b2c8/pyobjc_framework_externalaccessory-12.2.1.tar.gz", hash = "sha256:49658d55b3401c03ef3523ab3b8e2ed082739e971a0070d81b16d06441ac8d03", size = 22011, upload-time = "2026-06-19T16:20:34.554Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/89/e8fb9e30707a4535be8290788a950e02a28cc9c34de273833c3aae7207c1/pyobjc_framework_externalaccessory-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:01ee6ed84a307a8071de27cda8bc8abba748e818509d622728ad2c5f8d334f09", size = 8922, upload-time = "2026-05-30T12:06:59.557Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/0b/bf64b437eb48e86078cd2e9303ff4f45f1ea43b2f0febdf2bd03f44708c3/pyobjc_framework_externalaccessory-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c04313f4b68982d9f9f23d208f234b44d80472000b9945392459eddc44a61121", size = 8942, upload-time = "2026-05-30T12:07:01.214Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/98/2588a2e1888d91f1059ad0c3d1939a213f23fb5bfe0130828808eed3393a/pyobjc_framework_externalaccessory-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e546bb0db0e6832a40ac4978a24117eb1f93c2f419f6f26d908fd4315f04bd8e", size = 9105, upload-time = "2026-05-30T12:07:02.797Z" },
-    { url = "https://files.pythonhosted.org/packages/16/5d/fb59ccf789d1a68048163f83ee3250ff0990fec759846ecca9c57dfe332a/pyobjc_framework_externalaccessory-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:55c985489251fae171a743a2d86f7d3011e8c5283e22aea803708d4fd2cd1c23", size = 8995, upload-time = "2026-05-30T12:07:04.42Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/53/a5831ff85fe3c16c38c210dc605961a26dbdabd8e27e996ace0a59c13f56/pyobjc_framework_externalaccessory-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1cc058e0a036d4c5c377272173029120f8950595688139d12f8e702e250dc479", size = 9179, upload-time = "2026-05-30T12:07:06.008Z" },
-    { url = "https://files.pythonhosted.org/packages/64/53/67748fab7d4e7e438db5d7fdce8e35f546654041868763cf26da99fb5ece/pyobjc_framework_externalaccessory-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:710b9da3f123a53c3b6618d920d07782462b68060c51f772caa490535db1880e", size = 8989, upload-time = "2026-05-30T12:07:07.662Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/a3/797b5d182fd3433996a87dd87097845062bbb738c4612ed0bd90c54473df/pyobjc_framework_externalaccessory-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:02e4c9fe185372906f4cbde8d16d5756e71c134e969618703e3449414774eac7", size = 9162, upload-time = "2026-05-30T12:07:09.217Z" },
+    { url = "https://files.pythonhosted.org/packages/42/29/cf69d3931127544a7a576a3c3fa4aede1808ef62ad3c77e3803414aefa68/pyobjc_framework_externalaccessory-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:47635ff739691b8446079b5018c71585dbf33c2d5eff6a34279efb0868caf432", size = 8951, upload-time = "2026-06-19T16:10:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/21/21/6cc05d60f54f317ab6f0c36d025951ec9ac15cb088b219d88add060051d7/pyobjc_framework_externalaccessory-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c61d2d3ee83d4c0fbe4ef427041fc911c0f168bc7f10f9b7ff9d502e1a9995c8", size = 8966, upload-time = "2026-06-19T16:10:45.619Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5b/c2799931e1c456cf2748c8c81ed9ac8218bc55cf838f4d71d0355f52153f/pyobjc_framework_externalaccessory-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7cdaae96e146ffb1def2b14a0890555e4147ec77924fca241fb2361f93a36b31", size = 9124, upload-time = "2026-06-19T16:10:46.455Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ee/088bed0b691c624e2dbe764f86408b4086748147d63149b08cd28a3eb31e/pyobjc_framework_externalaccessory-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f13955be8d9f6f2e5922600d2063f765fb070bb3b4a2f2c0ef8ec21024d39ece", size = 9019, upload-time = "2026-06-19T16:10:47.241Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/29/8396b3231315a8221a8077805ce57889522037b18e9e5a42a926a6270eaa/pyobjc_framework_externalaccessory-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:16a269b33442580121353739ae128fa0dddd5c59f59705ee57b836932b750ad7", size = 9201, upload-time = "2026-06-19T16:10:48.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/19/07379ed2cde32acd29d783e0d76fadc5277f6cb117af934a805004bcd8c1/pyobjc_framework_externalaccessory-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:505ae95af4e8abc67016d26d59d2521b94ba3e6948b849d2cd85069dec31d044", size = 9011, upload-time = "2026-06-19T16:10:48.815Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/1310bfe12885753fa3cc497581441f145cc4ff5efa97d8a16115939c6eeb/pyobjc_framework_externalaccessory-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d2d3a2dba827c5054832142faec0793ea50e3dd869aa33df54c777a9e03557eb", size = 9186, upload-time = "2026-06-19T16:10:49.601Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-fileprovider"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/a4/44d4f784ed0601800c80e06c53e892ccc39c2a5545bb1caa13b661fd6d83/pyobjc_framework_fileprovider-12.2.tar.gz", hash = "sha256:f9b146eab8a7f664f0e417310802bc2e31ad52b0f61951ce58e471a989ad4e71", size = 50565, upload-time = "2026-05-30T12:37:40.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/15/d161117076a478299804b40720c5f110b4540f77ddb1b55e76b18dcc3ea8/pyobjc_framework_fileprovider-12.2.1.tar.gz", hash = "sha256:fd94e8941de50b6bc94ab8fbbf0f4605eca0602e4bd48088b8d6c1162115b506", size = 50576, upload-time = "2026-06-19T16:20:35.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/cd/ec8d50d5b56f4edbf2d9622f495c99aad8842c7cbe9729089d695f8d3eda/pyobjc_framework_fileprovider-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:659790edec0edd536732f79d16a44bd7b4c3112b410d463615514753717a26d4", size = 21067, upload-time = "2026-05-30T12:07:16.232Z" },
-    { url = "https://files.pythonhosted.org/packages/57/b6/27766ae4419f64f654c7c0b1f9892a0f82baec01a298fabd45d4fef10dfa/pyobjc_framework_fileprovider-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5718203d129eaf32dbf454b2a7a5f312f2dba108a4b49fa0536702537f93c961", size = 21080, upload-time = "2026-05-30T12:07:18.475Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/48/bb7466f3a3d990868eccee96c6eb02155af2aabb08b705f90302789848c1/pyobjc_framework_fileprovider-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:78c6528c5d59881f88b2fe657fb48aa75b652b830ca18f58cabc1ece2f308ff6", size = 21360, upload-time = "2026-05-30T12:07:20.798Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e9/60b8fb83afe07e69b0eddf382f2847bf642cb70ee5bc38ebd703b1a73f01/pyobjc_framework_fileprovider-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:746dcf3149920fe858d4b0bb725175f6df5cbd30fd35ff73a10cef30521c6398", size = 21117, upload-time = "2026-05-30T12:07:22.963Z" },
-    { url = "https://files.pythonhosted.org/packages/97/ae/e4eaf9f79210ee04eff41af0e890b6f2b5c5ce7780a5f54d8de038136397/pyobjc_framework_fileprovider-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:950b1d249475ae9d4f3c2b96058be4be2cda511eb5590c3f3f2243b7c6f75de1", size = 21397, upload-time = "2026-05-30T12:07:25.32Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/9c/4a514f54b03981f9cf3585b0052f8017005f876fb395e6e3986e9ea49f2c/pyobjc_framework_fileprovider-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dca30fb647c7d22fa0de5d3c21ea6db01e2820ab9ffba4ae75cae53a6d4b750c", size = 21111, upload-time = "2026-05-30T12:07:27.832Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/00/de7f14ebb96afa2551384330b3e8f3a51cc4fc158b5fb49d7beefb24816d/pyobjc_framework_fileprovider-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f9002875073d1e0c74d760518bca5101743392515478eed570d67f28bdb6ba07", size = 21396, upload-time = "2026-05-30T12:07:30.111Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/79/d9b4d70c71f6828a6dd1393fcd2e956be2079203eebb33beab5880241df1/pyobjc_framework_fileprovider-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:772d963f342af3d2853e4b5a14788b0f72e3c25c457c301e27d8bcdefdbaca01", size = 21094, upload-time = "2026-06-19T16:10:52.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/89/fb75ac1019a89f5f10716d57af5a4a7fb5baa720278c688012f1acdc39ff/pyobjc_framework_fileprovider-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95f7de1b2a048ac0edd1e02479b13956704b49521fabbd8e94e59564999204b2", size = 21100, upload-time = "2026-06-19T16:10:54.037Z" },
+    { url = "https://files.pythonhosted.org/packages/19/56/4565504252898725ff960d8511318314d10f1c0c887031e30d0e19ac477d/pyobjc_framework_fileprovider-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fe700e447f54a6bca8fdd13a4c21bb93d26665cb4598b958e099d1aca870b109", size = 21385, upload-time = "2026-06-19T16:10:54.874Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/602bdd1faf969d2742af163aa182622ddfecf2ca481449aa7f24ec6bb684/pyobjc_framework_fileprovider-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3bb8b09153e836d3a6223868a55762e5db42830bf58394c1785a90f20c044cef", size = 21145, upload-time = "2026-06-19T16:10:55.75Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/49cb132b6e4fead0b89c2c4c05df9a87717c0a63c26e5c83b139dc3c2a5f/pyobjc_framework_fileprovider-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d62ac3e6dab2087831f9bbb778adb1def9362aacf630cebd2afba16debf1a151", size = 21421, upload-time = "2026-06-19T16:10:56.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1c/440acd08b10764b1adeb6fe21a1eb473e7b840d8727bfa0022a9ebee06a8/pyobjc_framework_fileprovider-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b3592ee88ee6b328a990ed6e70f51a5396ff92f26f25e9a5a706c139d91de546", size = 21128, upload-time = "2026-06-19T16:10:57.525Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/417701fd9cf53fdddd3ba062004413edc28ca8c3ca8df647187de0b733f8/pyobjc_framework_fileprovider-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a23ac3e9c43894d7fc88e375b1f48f7d8695cf7d0e036d1ecbfdec1596e13a27", size = 21422, upload-time = "2026-06-19T16:10:58.357Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-fileproviderui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-fileprovider" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/53/ce4fc44c62f813e6572426c0f66475f5a5e4804693001185faa80aa95af7/pyobjc_framework_fileproviderui-12.2.tar.gz", hash = "sha256:520974c2966057cd47206f8792d8066531551b3222c8a5824851cc19e9bba7f0", size = 12852, upload-time = "2026-05-30T12:37:41.84Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/4c/066d39b6d90f637fdb2d6ab8762ffb234b700e89e93cb7473729b49aa505/pyobjc_framework_fileproviderui-12.2.1.tar.gz", hash = "sha256:40d02bcb15e324af6c624c85f1d65d83f81f31dd72136b0e5ec87440dc0fba4c", size = 12863, upload-time = "2026-06-19T16:20:36.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/40/4514fc9cf9b9f20d2abe1dac66c4f94b8c20da9db7865ee9dec9dd6f3f65/pyobjc_framework_fileproviderui-12.2-py2.py3-none-any.whl", hash = "sha256:0874b16ea64d055f53d0c6ede6ba61b3dbe9d2b27a64db5c12b829391a510cb6", size = 3715, upload-time = "2026-05-30T12:07:31.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3c/a030778db1b6272a2ed420a4ebd00a9084df932580c039d48f7891cad100/pyobjc_framework_fileproviderui-12.2.1-py2.py3-none-any.whl", hash = "sha256:2ff2f939ece56f06eae58b9494743941e40500b042a0cf3a64dcf78179d3d79a", size = 3739, upload-time = "2026-06-19T16:10:59.201Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-findersync"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/8c/dc4e185d054d422f0b24417dd0a340923f7cd317e70879dcbb740bfdd01c/pyobjc_framework_findersync-12.2.tar.gz", hash = "sha256:e8c8dbfd0c1e9a055d5778c8f65a72bfaabfb8c30ff9ef635ea25ee2d607dd75", size = 14210, upload-time = "2026-05-30T12:37:43.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8d/344b385f233b5843f05e7b78bea125123e22bc4c3b0e1eb93d3e55d9664c/pyobjc_framework_findersync-12.2.1.tar.gz", hash = "sha256:be3d41c9b836a53f24473e064ade6bd9ac071cc483377547cb6603e5a0de5d90", size = 14303, upload-time = "2026-06-19T16:20:37.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/3f/cd17c17bd1e3baa57388d80c5343bceb02df455047a3cfb91498b32849cd/pyobjc_framework_findersync-12.2-py2.py3-none-any.whl", hash = "sha256:6f7a461df88f4fe0cd64c0ad326c77bf1a8f72afb1bdf1f42c1d7e02b7340dd4", size = 4887, upload-time = "2026-05-30T12:07:33.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/73/eb80247a8fb7edd8565370dd7029e3f2e1ec76cc8f78efa1093f73328747/pyobjc_framework_findersync-12.2.1-py2.py3-none-any.whl", hash = "sha256:5b91a226b72a4c83a7ab5bf7e59164d59185021a396bd5804712ba8a55949db0", size = 4914, upload-time = "2026-06-19T16:11:00.173Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-fsevents"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/cb/f3fa1c24c2f7b3fc086b5cd0d7ec8bed1d5524e2b77d6e7b5c86d05284d5/pyobjc_framework_fsevents-12.2.tar.gz", hash = "sha256:c6599daed508605916fa31b23866c20ccc12565b568f61a43b5626d9b8bb8778", size = 27156, upload-time = "2026-05-30T12:37:45.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/fc/b31d09b6b58e50c8bcd16acf251d397bafc454bff9160f0e2c922cc9cbe4/pyobjc_framework_fsevents-12.2.1.tar.gz", hash = "sha256:f78c98f68bc643794668a9484fc348ef3e98df359db7d8726cada35310af93b4", size = 27163, upload-time = "2026-06-19T16:20:38.372Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/cd/714e19b57f11c2f92e1b31787846f5ee806d84897f01e6d8d39ec51843a9/pyobjc_framework_fsevents-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3a96802c25cbdce74b5d02bbb00cc85747f8f745102d3d22ec9bb540c2e17ac6", size = 13130, upload-time = "2026-05-30T12:07:38.808Z" },
-    { url = "https://files.pythonhosted.org/packages/67/61/e5376e0c3a95b93a6f1a77f68ca7a454ffe892ff6c5f301f4b83231a26a4/pyobjc_framework_fsevents-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b4adc50338dc4f9f50f3525e2f070e2ab4b469976f9d4762e373505f82068831", size = 13131, upload-time = "2026-05-30T12:07:40.621Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/14/f0fc106e63187438c783f2b8480470d43fba311355343856bda91899248c/pyobjc_framework_fsevents-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a00440f1e79f6639ffd601bf973d6c7064d82174da8433999825c33617d9c053", size = 13496, upload-time = "2026-05-30T12:07:42.429Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/6d/7cb724925e45553698e674ef48830052e1f7433d2ac715f90efc1c000ff6/pyobjc_framework_fsevents-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:caa86498ea298a542664222b33f6db2b09b7d315e1b1cb702c4652edb1fdca92", size = 13032, upload-time = "2026-05-30T12:07:44.421Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c8/f049d4f2b39f254e91c79e8b9703a42ccf712ed1169d79ba0902fb4edd7d/pyobjc_framework_fsevents-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b8e479864e232d76945219bcf3af12983a127a282f57af50ef089dc1b5116787", size = 13487, upload-time = "2026-05-30T12:07:46.371Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/46/176656c8bb720981e1806ec2f3c4396fa3f6ac9625bf69bb2a558b78b1fa/pyobjc_framework_fsevents-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fe72e987dae3919e80e7c3641d74fee8fec2ca841268cdb855f903b0b9f6f681", size = 13034, upload-time = "2026-05-30T12:07:48.198Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0c/c3a1ea89db895fdd0ce10a4d2c4686ad8e404482b4d9c407ad44ad9d3b13/pyobjc_framework_fsevents-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7665f7e2944fa50727e818dfa45a2c6d1234bd64d352559c2d6f3946febcf707", size = 13516, upload-time = "2026-05-30T12:07:50.03Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f0/a9025139c69511600b653e4e3bed2b009e0c1d901405cd9d48c6eacfae93/pyobjc_framework_fsevents-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5e863d5b188b4a7bccdda0cc1993b451768ca7425dd866a90a79857d459a2052", size = 13156, upload-time = "2026-06-19T16:11:03.048Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c2/bacaa5063b1e4ec270885fc0a268708c7cdf32b78b129fe753dca5daf470/pyobjc_framework_fsevents-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11552274cdaa97ffa23aa1cb167a6cb03a4b0923330bb75e4757fdd38b61a796", size = 13160, upload-time = "2026-06-19T16:11:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/1c376dd0b434ab505565e239e90fcb77a40d888b9fd052dda85b1820a1e6/pyobjc_framework_fsevents-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11d13fc2b3bcaa2a746b1f28b95ce9fa9d9078a7da61d6cb4a2f6bc7c163f108", size = 13519, upload-time = "2026-06-19T16:11:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e4/a0d14951d97f1552201c28f644abaa3b77d221d717b5faeeecf69c7b0c6f/pyobjc_framework_fsevents-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c2b0df089a87971ea2bcc8ecf36696943a9358bb6704780308fc4b392375a8f1", size = 13057, upload-time = "2026-06-19T16:11:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/73/4e166b1c9e7e67e4462970a83bedcfa2d19aff1d0ee1b1db3bce91ccf9cc/pyobjc_framework_fsevents-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7b47592f5ff58553aa2d9365aa7bba89b4bff3f3f2059fb7e0c3811712814219", size = 13513, upload-time = "2026-06-19T16:11:06.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/38fa04fac209c1619ce8792a226bf2f0b50e6da52cd9135dd06e4f9ecc0a/pyobjc_framework_fsevents-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b198330738637152999ba90ea49a744ecfcb0d64b1176dfdb6aed90bcd4ab926", size = 13063, upload-time = "2026-06-19T16:11:07.456Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e5/7758ebdc963f2ae70f60e78d5e5b6b9e9a7046d45fcec056ce1ce3793ce2/pyobjc_framework_fsevents-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:81f19060ae21a378b6e6c20cdf0ca1955199af45f3c3423b83dae53d2abb8c4c", size = 13537, upload-time = "2026-06-19T16:11:08.459Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-fskit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/46/9f5162cfde0340792043ab60d1a039f442a67b001f7bfc981b6837a9b07d/pyobjc_framework_fskit-12.2.tar.gz", hash = "sha256:a1a7f9678c55fa947783caa24325c91727cc3045b877c6770262790c00da3952", size = 49558, upload-time = "2026-05-30T12:37:49.685Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/38/4d47e4c2ef4a0e474469a715e5244b8e8dde89edde12c94551c5ed3ff7b0/pyobjc_framework_fskit-12.2.1.tar.gz", hash = "sha256:2607cef80fabe2394b30e1e3c10dc942c709afdbe7baacd3f86112b38add942b", size = 49577, upload-time = "2026-06-19T16:20:39.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/8e/325d1664fb5aefa2d7c2b3c3efc047cb2ec0b59f5948d63079c00ec35016/pyobjc_framework_fskit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3098dd1bb05c1e59fac70695b93e42f068735d0111aabff844781918895eedf3", size = 20586, upload-time = "2026-05-30T12:07:56.916Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ce/6bec42dade6873cf440f62d18be277b342b326bdb0ee7835b5f79b2748dc/pyobjc_framework_fskit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fcc8db6cf9e9b0e731e056411976c184bb3861288da4e97dae91a3e3e8063ade", size = 20597, upload-time = "2026-05-30T12:07:59.189Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/ce/385a29b02bc81bb70169cc2a5d85b78d3af131a113acb2615d87f12c5f16/pyobjc_framework_fskit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1f3935499d00678da05b97a7baa46bdbecaef3fd61768fa5dd34bd3dd484ad55", size = 20826, upload-time = "2026-05-30T12:08:01.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/61/b2900135b0cbc46edbafffd9b2bc13482d9ad417b7a09876464a2be09f14/pyobjc_framework_fskit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844a2b9f7377cbab03a578f0ef354450cff86d1520cd4f9a326590776df914fa", size = 20632, upload-time = "2026-05-30T12:08:03.59Z" },
-    { url = "https://files.pythonhosted.org/packages/58/95/b926293d92e47ad6a5f6e8dd86b0e3625e9e5e0c8b478d954ee6b4553d92/pyobjc_framework_fskit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7504760f3ef0337375ab6ec91688903981e71c4f65f5791778b34c7b27b54aca", size = 20890, upload-time = "2026-05-30T12:08:05.832Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b7/968e71f283ec520c5d4d994b51849e2e409f0f1c8de1adf588a42354d0b0/pyobjc_framework_fskit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:47fda8a47bc4711ff697601b4dce606ed75cd460f3a52fe1d3214fbb79acc6d8", size = 20634, upload-time = "2026-05-30T12:08:08.032Z" },
-    { url = "https://files.pythonhosted.org/packages/17/fd/b0cb952a57c1b133aac064f566c7e4bb38485fcde5c710d7f8c48e902102/pyobjc_framework_fskit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c8f247c6b3b77edea91f70e9c125f7faa493807c5e6b1922842c0046bc83bf52", size = 20895, upload-time = "2026-05-30T12:08:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6c/c43923e868f915f152cf67bacda50d6e8c44053f0b3b108a5c9a2edcbcb9/pyobjc_framework_fskit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:27deb130e5c3dab34689724a2da275ad83c579bc29da63904e0d2438b4d24ff9", size = 20605, upload-time = "2026-06-19T16:11:11.454Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d3/1148d635a3861e5f10d4cb23097ac797b0adb490922663acfad86b24e1f6/pyobjc_framework_fskit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b6094592998da2b3f61fd6a6599064e722ed91ef8a53e27b0c0cd080575cbb75", size = 20620, upload-time = "2026-06-19T16:11:12.278Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fc/a9a70c58484674873d48343bec31996f913d06071dc4575d6cc0dcdaf93c/pyobjc_framework_fskit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:58f9c31ad24af40b7f37000c31c684a4be1c2057345a921cb0fe57b111d62063", size = 20848, upload-time = "2026-06-19T16:11:13.187Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0d/0936e7af5dfbaae8e1efc3aa9b2b8cca42ca2770991363216edf0e718cfb/pyobjc_framework_fskit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:375ac21b3c028d772bd37aa4fb669aca11f6bd9d6015526f172acd0ace3cc88e", size = 20653, upload-time = "2026-06-19T16:11:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/79/edecf1a9d9857ef8959aa3649572e29f990c864ecf4272712ae5d654b084/pyobjc_framework_fskit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5992fb9c6e0b2b25ed322299a5cba1b239fa198712aa1a6f4e5ba00060350b12", size = 20912, upload-time = "2026-06-19T16:11:14.931Z" },
+    { url = "https://files.pythonhosted.org/packages/18/b5/6b6522cc5ac39162514bcab45d1800fb8a0a915801921275ab67c9917ce6/pyobjc_framework_fskit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f8dd8367162fa1048321183725c4117a0aa6bc1a54be9e289d03f64ba77c1916", size = 20658, upload-time = "2026-06-19T16:11:15.998Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/dc/bba39ec334208768f81c7d88733b7c557a142f164e23da0ecbe7d7826db0/pyobjc_framework_fskit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f6f13449364bc465c9cc5d45c1280aeae9fec9f777d962a0604d456aec0bc6ba", size = 20917, upload-time = "2026-06-19T16:11:16.878Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamecenter"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/bf/71c09142969953637a524946c3609ddf472c0b4311d134223cc9c87dbf8f/pyobjc_framework_gamecenter-12.2.tar.gz", hash = "sha256:a1207696a547011094a4b8d2865a3a9018a622647a8a0371baf86a3e5959ef4f", size = 32153, upload-time = "2026-05-30T12:37:52.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5d/a2969d6cb14a9fe10a744a89daa2b671a4fb5dd25354e75511a65f7f8249/pyobjc_framework_gamecenter-12.2.1.tar.gz", hash = "sha256:70fff5b1c0ac9d622709b4deb8e0bdf47cfa43591f1438ce2c6099abd93bbfde", size = 32149, upload-time = "2026-06-19T16:20:40.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/6e/fbf225a5826cfe68c447dbb1937d9c652617f5191772af95abca932cd252/pyobjc_framework_gamecenter-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d777dd5f2a1e4849434cb56f82418b4ee781718710b36c68860a91d85dcd1f89", size = 18865, upload-time = "2026-05-30T12:08:16.687Z" },
-    { url = "https://files.pythonhosted.org/packages/41/77/2496866b618c96b3569da87385db6593688222f6fcaf733cc702abf0309f/pyobjc_framework_gamecenter-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c5ff47f68b0f5f138fb91f03e5cc46dd12f00d95f795ed5b88f8b99c52e54e2f", size = 18868, upload-time = "2026-05-30T12:08:18.814Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/d0/6ec40754993e4f6f0366d7a13e5a19b6745b7c7d6395f2be0b3b60d5688e/pyobjc_framework_gamecenter-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ee1890cc3e1266407d41475659b382067a08765bdbc62a0ae4eecec733491fec", size = 19153, upload-time = "2026-05-30T12:08:20.886Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/52/7b37cae6390244058278a9322166b1d65f2a723d081b3d57f9cb4e5e3aca/pyobjc_framework_gamecenter-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bec386091dc9ebad94939acd26d2877d8f3a6dcaefab8a8336bb384b8f3c8f4e", size = 18916, upload-time = "2026-05-30T12:08:23.115Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/86/89f7a17d40f0cfcf546f3be1ec9a3c4aee77e7e875cee569aed6082c96af/pyobjc_framework_gamecenter-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:81e9e4680f13061a59b2814fbb316c17ea6fd41333b1dcc368c5210a26ef466b", size = 19209, upload-time = "2026-05-30T12:08:25.328Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/33/2ce5abb83cc70f3504ee46e660d1bc3ecb5db6ebee64409493b29d3c7afa/pyobjc_framework_gamecenter-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:96dade30ae38e54bf58aa4b727f66dd3b2c5918b5855502c099b0eed441448c8", size = 18906, upload-time = "2026-05-30T12:08:27.458Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/bf/f4f28be2dbddc09afafd1869e1b09b5b65b692c7a3f81d36dfdafcab7a8b/pyobjc_framework_gamecenter-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:834171b3059e778365190dfef1e075ca897cfb0a11e4af9f8a59d3a96285f16c", size = 19193, upload-time = "2026-05-30T12:08:29.562Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a5/b9a70c5e9e6ea55ffe9c7de8f3378473a4773d476aa25fe20bc5f0420c7d/pyobjc_framework_gamecenter-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e144d257b9461f8195512fb4b1a1cfd4cc0d603583ea039af7127a951ea7ad76", size = 18886, upload-time = "2026-06-19T16:11:19.608Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a5/a09890c3585740684c1a28620ef31bceaa4b455dd1aea59c95a1e30e6bba/pyobjc_framework_gamecenter-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:618fd07d19d715f172338a0d906f5a9e3dff67d3913e47d9033c0e7e4a6f5e88", size = 18889, upload-time = "2026-06-19T16:11:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/43/1b87ab10c0ccac15fa3daeb2bb0d915cb36c605d7c1ac24cd4eeaa3ba59b/pyobjc_framework_gamecenter-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8929a2ca38c79debb975bcd4bb15b0a3bde93f367f90e05cc530badeeae82b54", size = 19172, upload-time = "2026-06-19T16:11:21.461Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/510426e4c61ee1e5a8435348a1cbba2074e23b42e51367acc62fbc2b3280/pyobjc_framework_gamecenter-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a4e8056403464b3ae14a8ecb8ad7024ad6d5672af9cc189436f709952f071e4d", size = 18940, upload-time = "2026-06-19T16:11:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ac/98cb3210fe91470c9401c0a9e8d5affeb2eb6d8a69364a8f86abf914c103/pyobjc_framework_gamecenter-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0e42fdbf26cde6d8e302d61a2f318de0d33c90060f2a8848722cf5ef0cb2f4c8", size = 19230, upload-time = "2026-06-19T16:11:23.325Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ae/10f18ce863f9d94813ab64859ba9481937713ae901da768c3869a75cdc9a/pyobjc_framework_gamecenter-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6dbe68dc2e7b7882ba82c295e913999d441caa9c23c868db3a28b351e20909c", size = 18933, upload-time = "2026-06-19T16:11:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ca/96ad6ebc2fd96f37915462c1852d47c2828156cdcb2ca8620e3afd797568/pyobjc_framework_gamecenter-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5f61afc1269cee0518b7104c05131a6a652cf19ee2dd97471335c4943e0aac34", size = 19217, upload-time = "2026-06-19T16:11:25.034Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamecontroller"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/4c/440ac9652cae2fc386702a39973008fe0fd18928f70b359728c1926f5350/pyobjc_framework_gamecontroller-12.2.tar.gz", hash = "sha256:130418999cb5e202c0775fc1587666c6b9fa1d9285341eb6cbd589ecbe758a64", size = 65272, upload-time = "2026-05-30T12:37:57.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/94/3f01f6a15b892402e9ec5dd5530e53ce7feab236c374236059ab10961ee7/pyobjc_framework_gamecontroller-12.2.1.tar.gz", hash = "sha256:d40667869da0ef5d9905b4b3c365e275f731758bc0b09f10f7dfba579b1ee7d0", size = 65320, upload-time = "2026-06-19T16:20:40.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/cf/13e069a6c302c7f12e8a2fdd4da0ec2e4673936db28cf129af238d0cfb9f/pyobjc_framework_gamecontroller-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76b488179bef3430eb91a5cd2961659af0d98893a577fe532e0c4af16b525a7d", size = 21503, upload-time = "2026-05-30T12:08:36.688Z" },
-    { url = "https://files.pythonhosted.org/packages/65/54/519b19e43bb3fcb8058c9cf780d324e7b3532a1b8a317ff1831615993206/pyobjc_framework_gamecontroller-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8a448b31594c68993da348c3f2f24c02323853905e999f930d7c5d0fa6b4468d", size = 21517, upload-time = "2026-05-30T12:08:39.214Z" },
-    { url = "https://files.pythonhosted.org/packages/da/f3/11be9f022e2cc30f1ff2509bdb8405005b707beee2a01b70798054c52cdd/pyobjc_framework_gamecontroller-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d5a5ea2c31f179c72dfbd1564aaca52fcce742c27f91e2c7af37ba1e4777c3fa", size = 21768, upload-time = "2026-05-30T12:08:41.309Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/33/73b0769f8d91ccc992c4fc53bdc7de7ea8e1e425769b5a09e2136bf14d30/pyobjc_framework_gamecontroller-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:77f7e1155f7789ff5d86b202a37eb731db7d37796d4870ec9830bc94850ea806", size = 21537, upload-time = "2026-05-30T12:08:43.615Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/01/7786c685582915f804f137509c0e0e6b40fe3c3de4419eac7c7e6969b3bb/pyobjc_framework_gamecontroller-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e79ab9d3133d0e104da33bda7207f293cf0b981230969b8d865fed831631681", size = 21836, upload-time = "2026-05-30T12:08:46.036Z" },
-    { url = "https://files.pythonhosted.org/packages/49/02/6d1347c85ddc14238683e0e76ed588d31463e447b2f754a66f8d168e9b2f/pyobjc_framework_gamecontroller-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:221c88cf75b91abb75e3bbdbd40eb962c467b9568bffea9decc09b3da26ee2c0", size = 21539, upload-time = "2026-05-30T12:08:48.536Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c1/91d0459b9811309b817b96a48ba0a1a233146a19946344797d3b83f5f593/pyobjc_framework_gamecontroller-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:821098a524459089c77b19c4d11a378378fb010732babbb9dab1ab11118b5149", size = 21827, upload-time = "2026-05-30T12:08:51.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/97/a55cac5ba675a43b280454a50e377fd9733629d0afcf0bde51c042dd20b2/pyobjc_framework_gamecontroller-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:68d074ef1fbe4feb258e622f58764e79accd006ee39e069f8c50252b0657dff0", size = 21527, upload-time = "2026-06-19T16:11:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c9/55faa145c569b45b1f82d0437e89e84c5d42bcf3b822429eccfdb89643b7/pyobjc_framework_gamecontroller-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94af74d0229d5ef06e71d2d005a56018930827435778c946cf28ee98914bd0fa", size = 21543, upload-time = "2026-06-19T16:11:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/01/29/115e4e4ce6d34095fdbc689c1963b6a8688beca380ca5db43b9be6ab3175/pyobjc_framework_gamecontroller-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bb5704a35e501b8902e6210f1f11c7d7f55954dd906847cd6da2390b7176d357", size = 21784, upload-time = "2026-06-19T16:11:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b5/c8e9c80af4bc992bf06d1578736060fbb9955a174528a570aa0ed4172d48/pyobjc_framework_gamecontroller-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3602c85180be0bc1bcade88f802848e4649850115ba180923c8211311be62430", size = 21559, upload-time = "2026-06-19T16:11:30.468Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/23/fcf75429dd30f4029ec296cc62e802fd98ec3aa965cffd09dc5f76730d8a/pyobjc_framework_gamecontroller-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6a53c426ea670e45027a599c50112af2c4d557ac74e53d553a0f78167f5d7aba", size = 21857, upload-time = "2026-06-19T16:11:31.243Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/b54d79a802da063dfa7621638f7a4c7beaffd849147fb82bfcf6483cfbef/pyobjc_framework_gamecontroller-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c78519ed3422c5dee9be57a48242b81b482d5339528c7f1362e86efa7231307d", size = 21560, upload-time = "2026-06-19T16:11:32.055Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/b349c94923e0f30ae4224078280662a76544630cc1bdb0f72a6eac93e208/pyobjc_framework_gamecontroller-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6a63603e317168ae229af7ae7e5ed38644f32732127bdbb6e698bf6e787deb3e", size = 21851, upload-time = "2026-06-19T16:11:32.952Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamekit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/e3/dfc67af937bdf98b92fc0f6518bd1ee17cf84025ded15bd64acb91f0db8f/pyobjc_framework_gamekit-12.2.tar.gz", hash = "sha256:d4f4f98539db6125d5fb249b845398a0534f8962e6db390822da808b91ece009", size = 82428, upload-time = "2026-05-30T12:38:03.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/f3/6a4ae01c6a8e0e5b74e818694139edf9ebd395bbe04d275fb5f5e73ac919/pyobjc_framework_gamekit-12.2.1.tar.gz", hash = "sha256:e5e90dfa0eba5215406710d636c08ee9aa4ba886d9e0bf11849247b161aef1da", size = 82427, upload-time = "2026-06-19T16:20:41.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/90/6c3f9d8892d1c1490a76625d05817ae98cad664a56fe67c260a4a13662e7/pyobjc_framework_gamekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5bffec60177b0e2e20c239dd70035903a1937b0f9a8174029aa87a858ff8eabc", size = 22563, upload-time = "2026-05-30T12:08:58.282Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/26/f1af94c102570afb8ed0e1461fcc752098d8ea12e88959cbc3cd25709005/pyobjc_framework_gamekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:06ac26311a602aa0674c21d6dbc3fb0a19e0d8cc385e2e80b689518c3737df8c", size = 22571, upload-time = "2026-05-30T12:09:00.597Z" },
-    { url = "https://files.pythonhosted.org/packages/74/da/4020429066e04b02c1e40662dd546bba30adfbbbb19a3b87a4007bfe0244/pyobjc_framework_gamekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d915b5a8e8073769f0c371aedbbce31152859ab6352f7488f815bd572e1a12da", size = 22864, upload-time = "2026-05-30T12:09:03.066Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/fc/bd02d01198a4119f55b078a34ad90e6627be258d6eb9c26b570a39ca5407/pyobjc_framework_gamekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c891baea8d3f6530dfc0f1e824228ffd05f7e65f0053dc39c4dd6e3e56307b9f", size = 22608, upload-time = "2026-05-30T12:09:05.559Z" },
-    { url = "https://files.pythonhosted.org/packages/69/95/aca261e802409b745c2a0bf57a1dda51a67c51ee19bdabde40d63978c23d/pyobjc_framework_gamekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e4c0ca676cf6979d0ad503362c4f90bc46e22ef886528778ca086906080c53ca", size = 22922, upload-time = "2026-05-30T12:09:08.061Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/38/3deae98b764d3379e3a3841fa4bfdf090934b396472ebbaee5e91a1230f0/pyobjc_framework_gamekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:af4251f67756f5ebb54c2e16aa3a6ca6242202f52bea0b5b04ddf2ad35aa5648", size = 22595, upload-time = "2026-05-30T12:09:10.243Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/25/8c3a7d542728294effb68e07b0494ae1773aa5984d248808d369e0bf8563/pyobjc_framework_gamekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:97ebf06d2140661ab01701a91534b7ff9387625ee61e372370894e3debb004ca", size = 22913, upload-time = "2026-05-30T12:09:12.757Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/88/5c93226453c925d22a102df0aef522aac0786168171e1d49b3a15f5bd5fa/pyobjc_framework_gamekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d29a5ee705be7eb0e0fe46bd319462f8bb2f08c8761d65f0e22957f35b6db72a", size = 22586, upload-time = "2026-06-19T16:11:35.828Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d3/467011b105702bfb1e1145bb20863f5c72c49b2ac8f206eb16ed2df76c87/pyobjc_framework_gamekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7fbfa5eeb6c97183aa65f88a8d904bffe79b56db2352dc03ac0a1104c8a6cc56", size = 22599, upload-time = "2026-06-19T16:11:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c4/4554e23d5115aa93d1d375c3e17a44c6363174e337754404ecc13d7dd367/pyobjc_framework_gamekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:21b5ca685cfcc64ed05f5dd7a07b6ee852a6bebe251980185e795cc7117fa949", size = 22886, upload-time = "2026-06-19T16:11:37.66Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/91/42aeffba8651ab0ac7e69016d8a27f11f441bb3282568a521a2de1ce8ef3/pyobjc_framework_gamekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a95830e02163542dba2a4573062b151e298932cdfeef2cf48cc2cc63fca97e7e", size = 22629, upload-time = "2026-06-19T16:11:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d9/b5682acbbdaeb87778aeff55ba1b365a94729f6d0ba36c75d9ed71cbc01a/pyobjc_framework_gamekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a4f7fc8e01c9d80edf3d7792f2c35c2eedf67246d12242eea2b480863b642708", size = 22939, upload-time = "2026-06-19T16:11:39.4Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cb/cf33218de97a97824dc7ccb71cf7d8b274d1cef58e2209a18301c010526e/pyobjc_framework_gamekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:239aadec9465eafba7be40293192b79ac572dd0f97c41f3b5c1a2574f85be22a", size = 22619, upload-time = "2026-06-19T16:11:40.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/53/b20606954747d99f9f7f86e2ea1cdb78419c087839b74bd47414fb47d623/pyobjc_framework_gamekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b1a9873076cb61f19e792b5a87adb852b21353f6dea675a34c03512de18ecae6", size = 22937, upload-time = "2026-06-19T16:11:41.498Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-gameplaykit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-spritekit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/72/df0abe840ebc9e62f8a04afefeb38997b7774ab2b68ceebe89a9dfb81b2d/pyobjc_framework_gameplaykit-12.2.tar.gz", hash = "sha256:27da2b7c4cdef038215246fc6c98e45e076f969ebb83d827095432a8213b57df", size = 50735, upload-time = "2026-05-30T12:38:06.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/fa/df67a7bd14b44808060dcf82da26492cd7365bd6759d9437a004fb761a32/pyobjc_framework_gameplaykit-12.2.1.tar.gz", hash = "sha256:6ef81407e241016853cfdc6e580503d2d75a452ab0028f5c83390f102685c853", size = 50742, upload-time = "2026-06-19T16:20:42.656Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/58/935593360dadbf4d266bb350bb950e024b800057bf25bc880b017f5ceadf/pyobjc_framework_gameplaykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:792b527bda8e5784db552f4366de4e01f747a1b40a2c5445ed95cc75a687784f", size = 13612, upload-time = "2026-05-30T12:09:18.299Z" },
-    { url = "https://files.pythonhosted.org/packages/68/47/58dbd455f2d3cd18598408a45b05580387e788104148993aa79b8f4749de/pyobjc_framework_gameplaykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:89a695937dff8a4a43ac9d389b5f3eb64ced06410e8fbeb6e04f1976ed7c8be5", size = 13624, upload-time = "2026-05-30T12:09:20.136Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/73/87d2d0f4b97942f1401fd8985e8d7b2191502ed210c945472da1e37a4d2a/pyobjc_framework_gameplaykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db270f78befada566106e3557bdc7281fe2f2759cf81e664e9a45ff2ce709c72", size = 13839, upload-time = "2026-05-30T12:09:22.044Z" },
-    { url = "https://files.pythonhosted.org/packages/12/90/a87ffcf7b241918b09cbfdfefe2ca2a990c8645594953e121933530b62ef/pyobjc_framework_gameplaykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:68482906120a563ec2830cc02e8548b98d6203893ff1e8164e2612bcc5837ffe", size = 13627, upload-time = "2026-05-30T12:09:23.891Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a8/8b031c9768c6f0c01d338b5adc3e5491be558865307af9a395c942053fc6/pyobjc_framework_gameplaykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:92856cd1752fa4e50fb9522790969d57ceb8fd5ae45c9f766bf3d6256d5ddd86", size = 13821, upload-time = "2026-05-30T12:09:25.689Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f1/5d137c44e4e4c8b130bf225f67a3fb36ca0fed410a120f0fa226977628cb/pyobjc_framework_gameplaykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c9e60138e7d2328085db96e1b4ae6100912c42fb8f8871d753f4b4ea4fe6d56c", size = 13621, upload-time = "2026-05-30T12:09:27.506Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/8b/8fab0ee194b93f8bbac39e0eca9b6e32562a1aab994d886a839bf4d75f7f/pyobjc_framework_gameplaykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:14cb763e39a8705cdb39a28ada1c9ef2c5bdd47440155d1fb16a49641810920e", size = 13819, upload-time = "2026-05-30T12:09:29.466Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/23/d64fe0c702ff3ee8644bcde26e2c7d9062b19b7d40a60134ba2b4b353b45/pyobjc_framework_gameplaykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e1ef41d991e29358a26c92916bcedf722568e50ee66eab3088d2e88b9d77d9e3", size = 13638, upload-time = "2026-06-19T16:11:44.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/27/4e0e8260e2f3b4a3e99ea756166c9d7b12a971d470376bf417aa4edea133/pyobjc_framework_gameplaykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b51b11e20066f10532c225262d05fa6711e49685f5ecd9519b6c12ef69efa68", size = 13646, upload-time = "2026-06-19T16:11:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/9f36ade305fcf88bc077924404df1f96ec61e6e6dae2cb7625abca1a077c/pyobjc_framework_gameplaykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:95b06ed97e4e636140c5d28f507a298974413b501599cdcd2bb80fbc8fb85ae1", size = 13863, upload-time = "2026-06-19T16:11:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b9/143bdf083c3c4cf52430518a97ae515aac2fbd50feacfbab1fe486c1bb9f/pyobjc_framework_gameplaykit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a29a178fe0a64eeb959e1bb719248f7e9e44704b2b0a2f03b4ec6d951750f64c", size = 13653, upload-time = "2026-06-19T16:11:47.085Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/44/e98e8f3f8c131ceed736267f9067835a54ac9dc1d0ffff37dd5634722d6a/pyobjc_framework_gameplaykit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9a4810ad39a1d6729ac164803513043dde33842c19e91c158e645379aab5f873", size = 13850, upload-time = "2026-06-19T16:11:47.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/74/a60cd84430487a8190a2e463d47f5ebdbe81901c58fe6042410b6ed062d8/pyobjc_framework_gameplaykit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f8af54bedd499db1daa54174c0badcb48162601ecb71bfd97c4f7fe77d3ce007", size = 13647, upload-time = "2026-06-19T16:11:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/70/64/ac578939f804b6b7419e7fe482c353959274db818c36291740f6ca78fd4f/pyobjc_framework_gameplaykit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:720523342cdd978704fd2fea21312f8256d837dd64af2a04c683fbd2daa48995", size = 13842, upload-time = "2026-06-19T16:11:49.652Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-gamesave"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/fb/aed9853de0ac26c768c1bfefd7c32443367e489d16f5b5563043019aecf7/pyobjc_framework_gamesave-12.2.tar.gz", hash = "sha256:e272a1ec2fc84f680226abc6a4e034534509cbd545cb937fbc76b3a95d7b9e44", size = 13245, upload-time = "2026-05-30T12:38:08.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/96/c4c604170d28f2a2cddb1217dd0d8340ef9435ab2cf1042d85b45a14c2ed/pyobjc_framework_gamesave-12.2.1.tar.gz", hash = "sha256:d317d37f2716194e61cc91e855d6054c3c2b7ceaa82aaeff9c688d9f2cc43a42", size = 13238, upload-time = "2026-06-19T16:20:43.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/da/570c14f8c63cda0a128084cfc53f729e9183987b4a5582cc5ce4b3dbc6b7/pyobjc_framework_gamesave-12.2-py2.py3-none-any.whl", hash = "sha256:766d6eede6e7f9ef1c43333127ce42fdfa9438e62ab94c9533d32d41eb79233a", size = 3729, upload-time = "2026-05-30T12:09:30.757Z" },
+    { url = "https://files.pythonhosted.org/packages/48/4c/8fb1226802cf960ceaac85bbe7bb85aeb949f9c9ae477ecd35876a63eceb/pyobjc_framework_gamesave-12.2.1-py2.py3-none-any.whl", hash = "sha256:5d632ea0b62ef55b1b0f62e8ab6b9800bc14ca78f5a1bb629c95b28376b82379", size = 3750, upload-time = "2026-06-19T16:11:50.468Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-healthkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/c8/fa1a309cabfa0d7190a6dc1f6194d349cdde0105b86683780190aa4e46ac/pyobjc_framework_healthkit-12.2.tar.gz", hash = "sha256:48bda5f86fff2da976c49d27c746cd190d62eebdfa6197305c3656c64a6fbf09", size = 116197, upload-time = "2026-05-30T12:38:16.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/a6/a7f9f6d525c19ff1b2533220058cc70ca5bf3976a6adbe2efaa66ff3a349/pyobjc_framework_healthkit-12.2.1.tar.gz", hash = "sha256:d0a8c956746e8705edbe76a046e8c17ab6d7ae2603d8436e4477d30573acb457", size = 116224, upload-time = "2026-06-19T16:20:44.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/07/e2738cd62bd458a903112c6b3aec3bdc56c5fd54a734da49e19c5ae808fe/pyobjc_framework_healthkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b08b6a12a85c50bcd24286e3477070a60a9e602a34e14f1d1952fdd58e3e51c6", size = 22044, upload-time = "2026-05-30T12:09:38.055Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/44/db40ed76d01e0a99820f56dd0792448dbc34d508d2235d9185ec0fbb3db8/pyobjc_framework_healthkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:489858fd2cf97747390d14bd5343448a9cf612383e96958fd70968d1d7e75d02", size = 22058, upload-time = "2026-05-30T12:09:40.434Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/88/839c556d8e8e75b65961e65b78f683113cca6637e1917c9c4c0e2f050249/pyobjc_framework_healthkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c8d43159c2c40641f9306407ef909b338325028846d04feaf2b26673d6b1bb4d", size = 22228, upload-time = "2026-05-30T12:09:42.738Z" },
-    { url = "https://files.pythonhosted.org/packages/38/39/82d7c9e65344b6d223ea15132471e3091e85a6f0fb6e4672a27f2290360e/pyobjc_framework_healthkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:94a42750ac0fc7f0e624f5541798dc9dba4e557569016333c058552f29f237ef", size = 22117, upload-time = "2026-05-30T12:09:44.846Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2d/ef8d426d61ce4b41bdaa288b39246e7015264d96023318955e30f135e4ad/pyobjc_framework_healthkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:61b255e761c606a11f5a889cd3f7e251ae730bffbdd492e742030cd381ed69dc", size = 22290, upload-time = "2026-05-30T12:09:47.123Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/bf/c74fdf554df43bd0a52c97737e902aafa54aa5c38850749549c7b7a35054/pyobjc_framework_healthkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:328ff39f3ca9a4153c57b4a0ca38f7a5c8f289021f204c7347b04021100c277a", size = 22108, upload-time = "2026-05-30T12:09:49.443Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/e2/aad8f382f66cf5bbeb5ae87b162771ba3015215ec26b3d13d72a8f7ca064/pyobjc_framework_healthkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6bc2c41c2e4c42485bcb07a583dfa575678b1f220ec8b8186504495941d81793", size = 22274, upload-time = "2026-05-30T12:09:51.803Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f1/09a7ffbe1dec87ca60cb63c93b81b3f8e6b168e4e24c0fb244809a71bdee/pyobjc_framework_healthkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2c945edc98952bd7d1abad876ed7e36c3442ea6e6c1ec6718ab7554b8a47fba1", size = 22070, upload-time = "2026-06-19T16:11:53.843Z" },
+    { url = "https://files.pythonhosted.org/packages/94/91/31d4365275ce87ce1a0069a25ba1bc33e0ad205eacfe251633dcebd92171/pyobjc_framework_healthkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0408b552eb98319d83a106b25944d645dbe9927dff0ce9c701c25d472672aa63", size = 22083, upload-time = "2026-06-19T16:11:54.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/213460cfcc6f8f549c942873ed984f6aaa584c01f7874f012fb073693575/pyobjc_framework_healthkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:15d6a4a80a85e29d38371e98f70656a6b378cadbd9430579b9c15a46b81a0a2d", size = 22251, upload-time = "2026-06-19T16:11:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/bc39d024ae5bd4ad51a4903e8aa8707d55f4707c5bb978233ed5e7caf8df/pyobjc_framework_healthkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d8a44d60387e7e2d54e1d7b613ef93e5701837799bfd962d8d7df08b060d43d7", size = 22135, upload-time = "2026-06-19T16:11:56.333Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7d/35d5265a5da088437c498b7edfd05ad4ea77140ed570844fe6f924d5e929/pyobjc_framework_healthkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e6fa59e078ca6c4df56eb987a2c6267ef094b5c6a4b386865535da6e3ac2f05", size = 22315, upload-time = "2026-06-19T16:11:57.218Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/90/bdb840292838021ecda74a9498276a159cc0b232dad21ae09c98495fbadf/pyobjc_framework_healthkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f2d2278f3966c7ddf1f828461f11a94373ac3f25a6d052254a2fb0761cf62ea4", size = 22130, upload-time = "2026-06-19T16:11:58.095Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/d971feb74d6faa189bbb9304745a85a823828a23cfb3a967b7d21c4cc886/pyobjc_framework_healthkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:849a6abf2c895db3dd160fcf31b63c229eabbff5cdacabebc0f63e8e49f3c7b9", size = 22300, upload-time = "2026-06-19T16:11:58.924Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-imagecapturecore"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/7b/fada6744e9409643f7ec948a9b8fd5632a8f935d2c1d53e8a9f443a613bb/pyobjc_framework_imagecapturecore-12.2.tar.gz", hash = "sha256:c2931ca0d40d6ffe159149e140d4d158d3f844f19b99dae35f57c34551434eea", size = 53438, upload-time = "2026-05-30T12:38:20.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/fb/792b0945e2fb9de91b388e56603f5e6548573511cb40555ca0047d7f798b/pyobjc_framework_imagecapturecore-12.2.1.tar.gz", hash = "sha256:c1568be8cc0fd06046f7e344634951b3c02af3ad4f8a35fe1e2fecd9547b7042", size = 53435, upload-time = "2026-06-19T16:20:45.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/26/ae619b47f178d4fbf3b3abe277e1e17000b2c396f02f8b09e9206473a6a7/pyobjc_framework_imagecapturecore-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed4af478ae05a0c6890bb9b89fdd02e44ce5e6602145d5796299df1b729db43a", size = 16039, upload-time = "2026-05-30T12:09:58.219Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/39/23ab07b2cef5e26b017723f061d5941416a107679f19f5327b6576cf5df0/pyobjc_framework_imagecapturecore-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:12514630d46621acaeae0b921ee7c9c9e4a2bf81a936690b767a6b745e899812", size = 16055, upload-time = "2026-05-30T12:10:00.367Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d3/fed9ab9b40538711e3aba6c7b92a38c5439427510dd318923237f2280dc4/pyobjc_framework_imagecapturecore-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56dbdee10d3d735fadfa15b3e7b9a11d3574493a4114fe9bf0eae86f55b43d2e", size = 16240, upload-time = "2026-05-30T12:10:02.684Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/4c/c35456724c11023080016a693bfd045263d57b493532bac08ca953c6d886/pyobjc_framework_imagecapturecore-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:daa65200664f6098ddf8f7525a83bcf77766fbbff98eba54226318cc624c0d2b", size = 16052, upload-time = "2026-05-30T12:10:04.856Z" },
-    { url = "https://files.pythonhosted.org/packages/86/94/fa7ab262c873fa598e97b3a514b65237fa7b179a70b537eec83dac18d4a7/pyobjc_framework_imagecapturecore-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8e072e4ec1f67608e932bcf08a37972c10e91f1dd1dc92a7ade7210553aaaae5", size = 16234, upload-time = "2026-05-30T12:10:06.758Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b5/126e7612bb1113dfcba7469c6a7a5440d41004f0c1a1fab688d5ad8a16ed/pyobjc_framework_imagecapturecore-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbefe336223ec5b3b18a211a6b65212da0cd5caa03124a9bef75e175ae913493", size = 16043, upload-time = "2026-05-30T12:10:08.913Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/5f/8cacbb42d183d47367a5aff499eb7c7f262bfc508ae10dd581d8a54a8568/pyobjc_framework_imagecapturecore-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:40488cbbb0ac35545a5f55c1e06327d43927db2cbd1e339cebbef10e4e12aba2", size = 16233, upload-time = "2026-05-30T12:10:10.913Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cb/f542c35ad49f9f1e33b6e3d43860be84da2a24298579b7f508dd1f0a7e2a/pyobjc_framework_imagecapturecore-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:34165b84443a98ce8b7f12c12603cfbebe09bacc06f33ae1ed3774b649d0cec7", size = 16064, upload-time = "2026-06-19T16:12:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7a/fc4bf6e0973ef553be039d5651e22ea5802f8095154f41310c1df1a9bb2d/pyobjc_framework_imagecapturecore-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f6882e96cf748096fce49adcddeb882090cb1adb9c6699d1b869866053365d9", size = 16081, upload-time = "2026-06-19T16:12:02.86Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/bb/a7d080589fe074ec317b4022603f60adbab4dd3f671dc16a7516157e16d5/pyobjc_framework_imagecapturecore-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b6339dd78448762e1c017698b32736b809048ae3b0e51d1c625c03f47e59de52", size = 16268, upload-time = "2026-06-19T16:12:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a5/c502525300c68887985ace05015c4d4a3fa2ba657bf13e6f4e404fda9918/pyobjc_framework_imagecapturecore-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f6ab44c9e3005b1a30de18af8aacd65b8f1a4117ea1017efc72157b3e53914e6", size = 16080, upload-time = "2026-06-19T16:12:04.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c8/d17b4a5bd73bdf388e55c6ae4c6c5467be95324bb114fffd826489c47a58/pyobjc_framework_imagecapturecore-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:900ccad9c3ab452017bd3a184ecc7a866d1a8fc599c2e704fa8b62d7f75539c2", size = 16260, upload-time = "2026-06-19T16:12:05.473Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3d/07f1ac5f135b2a88303a429cefb27102d8f5311b2446505b0dc32c37cec1/pyobjc_framework_imagecapturecore-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ca3bff1d31e453b182c7ff7e91e6cf14e6564ff772371a5d53956204f903278e", size = 16074, upload-time = "2026-06-19T16:12:06.358Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/b7cbd69f0fe6041368ca6b9f14f1a7de6b75520880d79ea10363745e9793/pyobjc_framework_imagecapturecore-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fb11ecc92fc4e1df467d662afa1a26c89c026daa44b270fe324045b9e38d5c6d", size = 16255, upload-time = "2026-06-19T16:12:07.253Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-inputmethodkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8d/b9ba4cf37ef153584df3098cbc19ba668aef8469f18af53ff464eed1bd96/pyobjc_framework_inputmethodkit-12.2.tar.gz", hash = "sha256:63ab93867f25a3f54fc55e98b6b0540d0d23bf6f91a0a475ff742e4221a75917", size = 26270, upload-time = "2026-05-30T12:38:22.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/2bb0c543cfb7a1d38f4750b8b54c57663ec7c54f07499a3218c2a16e3e54/pyobjc_framework_inputmethodkit-12.2.1.tar.gz", hash = "sha256:008d792827ea1b11a051f4871c99c720ca5430395078158f082846cab43b04e1", size = 26255, upload-time = "2026-06-19T16:20:46.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/ea/e1f7e0d5984a6396e02930864e4260346f63506bf202a5e39a2052bf3f1d/pyobjc_framework_inputmethodkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:877c3fff5142434a8c7a5c357b5d44b731ecb1572c8f3ae275d54868fa9d46ce", size = 9509, upload-time = "2026-05-30T12:10:16.115Z" },
-    { url = "https://files.pythonhosted.org/packages/49/88/e5fc011ab34970cc1c1cc56b866e2edac6d160d25aafad7e86b033826cbf/pyobjc_framework_inputmethodkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:160ba62082a30d76b9e4aec1a4d54c95152fe39217940fea597756ad49910dde", size = 9527, upload-time = "2026-05-30T12:10:17.693Z" },
-    { url = "https://files.pythonhosted.org/packages/43/68/3c2fc27aab9cf228ede204ad7c8d1fe5f4e714aa4e478fe943dde6417258/pyobjc_framework_inputmethodkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0b81fba64e92953ffc1788ec13c630a9d19447deacde34a7309c0eae6412d628", size = 9694, upload-time = "2026-05-30T12:10:19.292Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4f/b8b96ca3392c7157e3abcd67f804ff1bc653b8a1c8c054a7717454e7d5b8/pyobjc_framework_inputmethodkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ec6fe7374c080676b0a3d54906f542fdf49d685c45b7988e03a58530f54b4522", size = 9572, upload-time = "2026-05-30T12:10:21.366Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f4/b4a07352bb14549d58edaed5eca2b97653960891d85dcb499425110e1260/pyobjc_framework_inputmethodkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1ee16198c4ac8e9327ce3d98f91cfe085d05eddae958a4e7fb3fe24e63d8506c", size = 9748, upload-time = "2026-05-30T12:10:23.069Z" },
-    { url = "https://files.pythonhosted.org/packages/28/de/5a54161025361652ba6ec476b55f4b9e6d89bf576ed3592b4f176c6790ea/pyobjc_framework_inputmethodkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a32436b7a498fa54e7a1a75d812dc7e61391cd7ce27d5ead0dd23ff0f3fbf74b", size = 9577, upload-time = "2026-05-30T12:10:24.674Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/7f/8bd67197094b11037ea5512eac034b9ed1cfd509f2db2d5d2063089bd947/pyobjc_framework_inputmethodkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:155a5d6a770403a99dc9a359aed08f542a309f6e3b20e96115196e7e61585b32", size = 9740, upload-time = "2026-05-30T12:10:26.275Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/eef2b45c70f0ebcc54db74b866753d7a140982519b18f738e9b6c00d7730/pyobjc_framework_inputmethodkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5c979473f54fa344cefc91525b2f7caadb682da7f7cc93f2bf49ba730569f05c", size = 9532, upload-time = "2026-06-19T16:12:09.889Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9b/338f8abbb7fdfecb8a89cd7ecaac0a1853d4a7399c77054b0875b3195e29/pyobjc_framework_inputmethodkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2fb01dfa2c624beafc25c9520806eaf2cc3212c7180a6623a1436d84e84ad84d", size = 9554, upload-time = "2026-06-19T16:12:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/d65f3b8606d8f32ae125e434fdf7aeadc5de5ececfa0f543c7cfd1c65b65/pyobjc_framework_inputmethodkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8d02da4d81146258fae8f2571b47df41a912b0e1f84bb38384e1a4d858feaf28", size = 9715, upload-time = "2026-06-19T16:12:11.541Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/c57dd6e1e7acca699c9861801334337478368327ad7571dc4d63c5a4ead3/pyobjc_framework_inputmethodkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9b7754bcf52aa753cbb616eaab5834f13b8ef4bdd163c89ad2f921e8fc89c05a", size = 9599, upload-time = "2026-06-19T16:12:12.473Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/ce41a93ef757dbbb3537f2d9552a7fbef05cb928315e67d34f6b3667968b/pyobjc_framework_inputmethodkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:017c2b316fa6f4477b4395b21a276e2caef8a4c558411110271b267bdd1a2276", size = 9767, upload-time = "2026-06-19T16:12:13.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/13/9196e22ccfa58996547b0ebc1931e3c6aa9b1ec2425b05d859db4ff476ce/pyobjc_framework_inputmethodkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ea2503ebbae052622c2fada50f445766906757b4ddccde3c2e66993703fb0393", size = 9595, upload-time = "2026-06-19T16:12:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4c/f79bc867cf5b06c5fba04422b6a7a690ea8c0b9f8c88d5f04bf5818b516d/pyobjc_framework_inputmethodkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:05886f2ab68f06693cd5c5c6f8a99a37ddebcd5a085d98ebbfc8b001b31a122d", size = 9766, upload-time = "2026-06-19T16:12:15.066Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-installerplugins"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/31/4284cba4b8904d2b93738249bb888762115d06876b92d30b721dea91e014/pyobjc_framework_installerplugins-12.2.tar.gz", hash = "sha256:6de54ab966f5bb304f9f5036c41937675cfdf49c44f70a1078a87dee2520261a", size = 26005, upload-time = "2026-05-30T12:38:25.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/2e/23d4d49b755fc6e179956d745311115dbff6b43a505a8ad627a13a301082/pyobjc_framework_installerplugins-12.2.1.tar.gz", hash = "sha256:118ee84e6e7f6f7913ade58818bfd2c12e2078ff7f6090e4941df1e739c8685d", size = 25978, upload-time = "2026-06-19T16:20:47.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/08/9b8bb5f74df7d23d83ec5ab954301c91b8239091767df064aaff5b54c7a9/pyobjc_framework_installerplugins-12.2-py2.py3-none-any.whl", hash = "sha256:358ef2faefe1b9938c0563e95551ad685c4c2097a7b8bc46dbf394765eb00674", size = 4814, upload-time = "2026-05-30T12:10:27.678Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/7ae359b8f858d6caeb076d779ef1123ed2f1d287e5e9a7262f7355b25819/pyobjc_framework_installerplugins-12.2.1-py2.py3-none-any.whl", hash = "sha256:aef22bff292d3b8fb9cb655f868d041dcc76d3d6b47d3022557fe3f657c28c69", size = 4841, upload-time = "2026-06-19T16:12:15.946Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-instantmessage"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/20/2beaee41e71fcfe9bd3149277977aaef9510fae7d4ea3d70baecf2a978f3/pyobjc_framework_instantmessage-12.2.tar.gz", hash = "sha256:95a972697cc1c8c773d2e211815c7b4f3f11ad0aa114e46ec386d92f873d5533", size = 34017, upload-time = "2026-05-30T12:38:28.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/66/89688001f6b1a76a09876b4fbe02760994b783d031e05b3d7e039514748a/pyobjc_framework_instantmessage-12.2.1.tar.gz", hash = "sha256:80d31bca02459c6d2364605b51a8064d0fbe3e7dba085b5b8ac59ee98157710c", size = 34047, upload-time = "2026-06-19T16:20:47.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/63/68356d5150c203b6b027dc93048b7e81d53c58d5d437b60dce914f861496/pyobjc_framework_instantmessage-12.2-py2.py3-none-any.whl", hash = "sha256:2fe9367f736b68557bf0c57a7da2c6a854cbf46ace9f6c5b161131309dc6b262", size = 5436, upload-time = "2026-05-30T12:10:29.334Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0e/b042906e81eb1865b123ef529516af7b2a2bc28f5bfbfd7b0e0d40a9f1de/pyobjc_framework_instantmessage-12.2.1-py2.py3-none-any.whl", hash = "sha256:42c7be0357b1d4e808b40c7d212f5d807e1901a87e0cbb6a215bd0232f87374d", size = 5464, upload-time = "2026-06-19T16:12:16.821Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-intents"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/a1/2544e2b1e4fc794bc09b16651e967cbe11a17bf75f6d13c34a261e49a13f/pyobjc_framework_intents-12.2.tar.gz", hash = "sha256:441acf32738c8a4fa21458467ce451ce6880d0bac71b6e63e2e6634775f603b6", size = 187703, upload-time = "2026-05-30T12:38:40.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a9/107e313345eef0a2be05017227073678b65b58f77af14312ff6403999856/pyobjc_framework_intents-12.2.1.tar.gz", hash = "sha256:579a36b1c2dae423ecf8f7fc02fc8a2a3d079366a073903ba323d40adeeabc2a", size = 187763, upload-time = "2026-06-19T16:20:48.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/40/01d85f90d9654083afd8588969b9d29daa8173463695e27df73103a74a16/pyobjc_framework_intents-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0813154a7d37ead88ef741e971b0e053560dfeec524b989f3b60b119df2b5976", size = 35255, upload-time = "2026-05-30T12:10:39.031Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4b/74dc067c2475881c4c93a2f4d6f460733a963a3f687de9f413b1280e40d0/pyobjc_framework_intents-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1786dd54d1c570ca6be16383e653b897ad4c1b0c3df9be60ac5f8e0096d4a181", size = 35268, upload-time = "2026-05-30T12:10:42.054Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/8d/d6cb87fdc7df4bc81b61cb184d5fed3f55cc2cd30eed90033f434a32716e/pyobjc_framework_intents-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9d697dca29ce2c282dafc4db9c0a0f165802e8d056a68f809bee0521ca47ff24", size = 35512, upload-time = "2026-05-30T12:10:45.295Z" },
-    { url = "https://files.pythonhosted.org/packages/95/78/30348e2ec790164ae11df2f07de9464ba767d3a73a55875b3e904e847e20/pyobjc_framework_intents-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed30e7c0b26622621046ce20c318084288d144ccc513736dbca856b91c5227e8", size = 35283, upload-time = "2026-05-30T12:10:48.573Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/f3/028fe6f22c6556c9f5faf391e3ea058339fd4ed2106fb34a6ba5c160af77/pyobjc_framework_intents-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d6ae3f19f711a256b370435df0bad11c805ba5513208b5abdc61c30e7c75fd44", size = 35578, upload-time = "2026-05-30T12:10:51.729Z" },
-    { url = "https://files.pythonhosted.org/packages/60/ae/f0a94a60a788a25716f854018e415112b20b1b3db1a54897e0b3290cf761/pyobjc_framework_intents-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f07dbd2383f859ed18a390d5e02b28e7fbc89679246fc1c330ec56190e72db1b", size = 35293, upload-time = "2026-05-30T12:10:54.895Z" },
-    { url = "https://files.pythonhosted.org/packages/45/4b/149a16762f0b496e1b025d6d56ed0a6447b1229ad1195297e06220931328/pyobjc_framework_intents-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e5a9548175ff5d4630a6f2d800bbfe82e26bc4205358a7fb28429c5d40727bf5", size = 35580, upload-time = "2026-05-30T12:10:57.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/cd105a3a262e9048accde15734d84869ea6d2e1eae95a9f5c32dfcb9f2c1/pyobjc_framework_intents-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:440fb3b4f2ffe3184f3fc8ba0abba83a3a59ba63dad12a5bb2b6792eab8722eb", size = 35276, upload-time = "2026-06-19T16:12:19.958Z" },
+    { url = "https://files.pythonhosted.org/packages/28/22/4f3a7ca8f8fd8a646074f2e9fae8798d2c8e9378d8fa191085b2b1abaa27/pyobjc_framework_intents-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c21cf1db00b8c997d3e6cfde53ec135ddee5b03138cf184deb842dbc925c1286", size = 35293, upload-time = "2026-06-19T16:12:20.884Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/59efde70a85b826bd7328c2d77fd19163014b571f0dac1543c46a1fbd143/pyobjc_framework_intents-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:21ed7ca804106bb1a606c070a081d59dc93fb23bd570a802518a8ed36357c275", size = 35529, upload-time = "2026-06-19T16:12:21.746Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/29ec0832512c3db3d5708eaa4f5ab4419aea65f2e7e6b4aeaf4f413b6086/pyobjc_framework_intents-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8fcc3326ed27b800a5da3e8634cdddd6506efd0c73a95f5e624f3dc963516baf", size = 35308, upload-time = "2026-06-19T16:12:22.626Z" },
+    { url = "https://files.pythonhosted.org/packages/34/dd/272debdcd22abb68d5b9574aa9fb87da590a281eb663f2bcf7ef9f0c9327/pyobjc_framework_intents-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1b4dc0c62df523a3391dc43c754cc9a4cae7334342785c882be0fa76b2ea22c6", size = 35597, upload-time = "2026-06-19T16:12:23.62Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f0/2aaae2250c7346d0c946a404aa7a6901b9bc2394ce986f7094e2167f53a5/pyobjc_framework_intents-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bba9340e7ec61747a5545d4fe569d77a3c10e870d1ec06a9e17412c29a1fdd07", size = 35317, upload-time = "2026-06-19T16:12:24.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/9c/fe3f1cea21ada9707e184cfbc6e661c4833fe2a68c4bb4b37123e775d8fe/pyobjc_framework_intents-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:18a726d52b4a24f6a274c094b1abb5cd757d1f29946a8058c85a32bc0857dab0", size = 35599, upload-time = "2026-06-19T16:12:25.398Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-intentsui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-intents" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/10/cdd1d80716e9970f5190517daa613a2d16bfec532b3fc9bd8f987c00a178/pyobjc_framework_intentsui-12.2.tar.gz", hash = "sha256:46292de2f2e915ddff88a060639adb175e0b3b2452a45f00e440dc04acbe0e70", size = 20742, upload-time = "2026-05-30T12:38:42.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/31/1426d5ca5dba96d82dc08c6f287361eec9c3d8008295403b015843bf7b51/pyobjc_framework_intentsui-12.2.1.tar.gz", hash = "sha256:ec1a0fa3861911da7e43abfb6f783052644d62f587554e15a06303a648f9f361", size = 20768, upload-time = "2026-06-19T16:20:49.755Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/6b/06859a077829bcb895ac373cd1d3b268bb77bdfdd90d976c741c68bc0054/pyobjc_framework_intentsui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a92c40a66a27e70c4ee70838f43ae2c6f8ca6263699ed5e38ba25ebfef35f6c3", size = 9023, upload-time = "2026-05-30T12:11:04.153Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f9/10f8bafdd58f136cd373fa2b0b5bd869dd6f7576abee9135fbc51c10e549/pyobjc_framework_intentsui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:da18833b15f8f31ecc5d4769250de6883e1e117392840175ff33d002a8196f46", size = 9047, upload-time = "2026-05-30T12:11:05.908Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e9/6f1eb774981b665e87c08f21b3a4695d0d97dce1c2a9e7eb2ab1956605e4/pyobjc_framework_intentsui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:96b0b96147554a0e848a6804ad725abbb183b3d045481abf54d31d6a334a1a25", size = 9222, upload-time = "2026-05-30T12:11:07.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/66/c65ce9b1e5241caec467ac8d983787cdfe8fb500ad4342d95cbcd9011674/pyobjc_framework_intentsui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c369461ac245b084cfa4803e90a91f43838637a4cce4cb0d25e71cf02e8444b", size = 9095, upload-time = "2026-05-30T12:11:09.161Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6a/4d1eb10ba9cb2eeb30b22b2b10c274f76f25d0e2ea6b0d2a129d704e0645/pyobjc_framework_intentsui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1c78cd4e536590c15926d3ec2d2e0eb7ddaee9430424b30d5478ae12d3a53897", size = 9290, upload-time = "2026-05-30T12:11:10.799Z" },
-    { url = "https://files.pythonhosted.org/packages/12/8e/819ab1305d33e6c0d1342d5ebbd216f13fc5f682392d85162ad8fd9d283e/pyobjc_framework_intentsui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6a60e5f5277690479cad06df8a8e008f8f02e625bce2a24869770807576a78d5", size = 9089, upload-time = "2026-05-30T12:11:12.412Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/22/a674939ee5fdab2238452a9389d36e543ffef04432319057f357ed060a78/pyobjc_framework_intentsui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cad7677ef0ebe7e9fe83f07dea7e999f9fe067b3ff8e02520ddd3272ba19eabd", size = 9278, upload-time = "2026-05-30T12:11:14.014Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8e/6cb7c5e2a9cf64fd1bacdbe103dc0355f85fcebbcedafeacdca9ae3678c8/pyobjc_framework_intentsui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b8f92e0018ca0d720f339b589ead6b46443b95f844258eb4f0a215101a74eb1b", size = 9047, upload-time = "2026-06-19T16:12:28.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7b/06fa5e8a04202dc42ba0eb0887ee362016417074343602cd1ae97a811978/pyobjc_framework_intentsui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3200f217607900018605f8b25a75d1e5b2b6739e2244b25147a77d9278ff745c", size = 9064, upload-time = "2026-06-19T16:12:28.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/bf/6bd5674aecf4f745fc1bd4ce0c5d75e4b562e43d8cdd65856d1665d998c3/pyobjc_framework_intentsui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0af7ede17b56defe1c19426e5b5f2dd39d8215eeee30c6dcd1501dba609566d0", size = 9245, upload-time = "2026-06-19T16:12:29.777Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f3/05119d645544e385d2ce402c3219f2ea46ef3a09aa58687704f81c99fba8/pyobjc_framework_intentsui-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0d3088164f6028b0f8eda429345f3ad33c7b8c70ca8ed3d75d178bc62ccc96f0", size = 9118, upload-time = "2026-06-19T16:12:30.597Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e5/62c2e46ec1a8cea1aafa74f4262246e48eabf781312b58e79f0dfc354adc/pyobjc_framework_intentsui-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f91ef9f61f65dcbf08b5277cf947ce390393eaf4829800d6aa5132e49dde6888", size = 9313, upload-time = "2026-06-19T16:12:31.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/2b/3884fbd8920ab24401f9dbcfd381e285a3fab1314fb3464666090e862779/pyobjc_framework_intentsui-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8bccc0dfa36cf12ee4de87195d1caaa8ba15334658cb06c81c6da8bb44a2c9d7", size = 9113, upload-time = "2026-06-19T16:12:32.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e6/54039e403a04afd25456953ce6f1240cafe0f2972e199c93b629b4029e06/pyobjc_framework_intentsui-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:70d30672d1b7213ea7018b7bf53bb37000179429f83759a471dda456bb07bdce", size = 9306, upload-time = "2026-06-19T16:12:33.565Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-iobluetooth"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/d0/ea3057fb6977ab87c85db9e676d8ec77ce77d096680bacade1964ced17e5/pyobjc_framework_iobluetooth-12.2.tar.gz", hash = "sha256:7fd7265db0f467a471a015f5a32ee79fd8f42440888d16b4206bbb985ed7331d", size = 174868, upload-time = "2026-05-30T12:38:53.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/5c/acb79d6180b7dc243b82c129292fc2c9e1f695793165dd6e89f55a000a49/pyobjc_framework_iobluetooth-12.2.1.tar.gz", hash = "sha256:eb99c27187c68f984dee4e9ac620f5b210f11f821a2063b2fb9161359a1f1754", size = 174846, upload-time = "2026-06-19T16:20:50.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6e/cf25292e7c6336b189f9bf9cd99df59aab8e20de9028abb4d2d7bc3d4559/pyobjc_framework_iobluetooth-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b895e3c7665ac7d59f3356fc0c4471cf7c47146da65ee0b5cce327d3cafbdf70", size = 40541, upload-time = "2026-05-30T12:11:24.486Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/7c/6252a3f61bd674c770d37517433485653aeb5e24ff2f5df2a71b79cf9197/pyobjc_framework_iobluetooth-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bea83069a68476036c260e3c1f3f2a6cc919aa965ecd89c8821165daaf9886f", size = 40552, upload-time = "2026-05-30T12:11:28.065Z" },
-    { url = "https://files.pythonhosted.org/packages/df/88/4e49653cc0bf64a90b1aa10b89540cd8d6929a4e4ed79d5546b3bf6cc0f8/pyobjc_framework_iobluetooth-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2d058ea04a6924233701cb0c9312aea71174d38a37430494e725d17eb7933ae8", size = 40763, upload-time = "2026-05-30T12:11:31.474Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cc/9b09bc4022a05b00a187577caba8d46850c5a1d29112d3cf3826993080fb/pyobjc_framework_iobluetooth-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:63e089fb47feee2dd1f7de136ecf4a4985597b175cd210252fad7789dff5c537", size = 40542, upload-time = "2026-05-30T12:11:34.89Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/59/a0ff3b21a108a8fe1bdbb2bfd831a07d4be77d133500a3ba2a9aa2a2d186/pyobjc_framework_iobluetooth-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:98685dae5876da9d01dd531ef8f2f40c87d076dca2b79edf12dc5413492127e5", size = 40743, upload-time = "2026-05-30T12:11:38.293Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c3/9dd84d41a883329e6cf2912f945ad2c22e9d6bb5802895e57e9fac4123ae/pyobjc_framework_iobluetooth-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f0f848fdc184ab910ab00e395fb1fe3de9b89625e0dc19967560b796da73bfdc", size = 40531, upload-time = "2026-05-30T12:11:41.71Z" },
-    { url = "https://files.pythonhosted.org/packages/54/bc/bc8c028fbcb51a4b4a91224b3f0e40ef1385cc444764efdc4ba8f411cb16/pyobjc_framework_iobluetooth-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6715d29e3f1fb465144abf77a7372795aa18e61b77abf44e9605ac657895cb9b", size = 40741, upload-time = "2026-05-30T12:11:45.07Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a0/59dd27082e6b01ab5f181a465ac86ce62ab5353d477254d78472afa7c26c/pyobjc_framework_iobluetooth-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8ca12b1ef8533fbd63c44c68ad80afe7ca0446f056399305e9f51f573c406b42", size = 40560, upload-time = "2026-06-19T16:12:36.361Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/aa00b0c445d1a20d8b67d67348c8890d122c1d1e76a5735b8e14c28649cc/pyobjc_framework_iobluetooth-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d5e76af8d2f0ad9f0a25158c0aa6dafa2dc59c57135dd1d4f39aff89e898344", size = 40571, upload-time = "2026-06-19T16:12:37.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/be/8d058fb08b3ce438e9878ca27e6c91d4e89e7cca9de8eb281317ff3d022f/pyobjc_framework_iobluetooth-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fed3eb2ce6aec555f1e22d04d06d2212a1d475740eaa2b832244198e09b5ce11", size = 40787, upload-time = "2026-06-19T16:12:38.145Z" },
+    { url = "https://files.pythonhosted.org/packages/60/69/763ad564f5ef8bde212024bdbfc750c0e0a73ec1f2ff5562f155669ef5c7/pyobjc_framework_iobluetooth-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:18c9b901de39aeb79ce36bb4e550410ad5112917bf7f4198776c25c07099ce0c", size = 40564, upload-time = "2026-06-19T16:12:39.004Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c2/65cd8eff70014848f1584ecd6e534d12062e4543db16c963806797dd1540/pyobjc_framework_iobluetooth-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9dfa596bd8fc4d1648909c04b2856193e627dcb46ceecee9997085b99e395a8c", size = 40765, upload-time = "2026-06-19T16:12:39.807Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c0/d16c0daa3cf2214301614641e83a49aed33eacbcd9f30505bbd3552959aa/pyobjc_framework_iobluetooth-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:aeca5abfaca23d204d9a4a32b68aa854b1d2893cfc593f0c3dab69c106c8ec63", size = 40555, upload-time = "2026-06-19T16:12:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/14/9fa4e6f0a7d990c9d0216d77222595991d3f802627dd089e4277890d46d1/pyobjc_framework_iobluetooth-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c80d734d08e2fd5d4764e0039693792fe2a7799156c08501b6734357a11e6c5e", size = 40761, upload-time = "2026-06-19T16:12:41.856Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-iobluetoothui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-iobluetooth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/cd/0c14569b91e29bd0f64e2496c21b15e34e789f0ca07f5cf0149dec37ec72/pyobjc_framework_iobluetoothui-12.2.tar.gz", hash = "sha256:7902974cbc2ec50adc38dd961b03eae6a84f082812ed60a440db6f690b30b2d2", size = 17987, upload-time = "2026-05-30T12:38:55.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/79/99c3fce73768d0fbbb9c2fbb9dda092c828c8d15e9e5ba4dd802b719582e/pyobjc_framework_iobluetoothui-12.2.1.tar.gz", hash = "sha256:53bbfa9451c3c1bb55e91f063bb0539509e1e2b11887736967cc218b93695087", size = 18013, upload-time = "2026-06-19T16:20:51.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/a8/2ab7199c81c9f1541e20caa78cf44df5f05162665fcfd29f16e3a85fe822/pyobjc_framework_iobluetoothui-12.2-py2.py3-none-any.whl", hash = "sha256:60622518d2f70e82398c62edf5e4e72403ef9210312945d82f3151cb5e888ccb", size = 4043, upload-time = "2026-05-30T12:11:46.476Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ea/015e595050aecaea98cfd9cb62d93bd86408af7550efc405d9bc661a69c2/pyobjc_framework_iobluetoothui-12.2.1-py2.py3-none-any.whl", hash = "sha256:321160ac3181349054d29f7804b24944549fe442f4d6840f9123bbcd48f62aee", size = 4066, upload-time = "2026-06-19T16:12:42.682Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-iosurface"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/3d/744c44cdd66f273e1ca731343e7845a281cb14a25c40d20a307334a36e21/pyobjc_framework_iosurface-12.2.tar.gz", hash = "sha256:d0315c6ad3b5ee72d3a5c946d9e92a4cace1a96bd0526f0b9f6b8009c26b9716", size = 18607, upload-time = "2026-05-30T12:38:57.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/bb/9f1b513ce177d725b6aa0936f69ece74afa695698ff2f59660b427824b4e/pyobjc_framework_iosurface-12.2.1.tar.gz", hash = "sha256:f886630d6f2419fed9f89152b1e738758b735219bd39506bc12c2e1f65456dea", size = 18604, upload-time = "2026-06-19T16:20:52.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/f8/35fcd4d2504d0b470dd746138f47f6a8d8077fbde6aa85914c999ff9f7d5/pyobjc_framework_iosurface-12.2-py2.py3-none-any.whl", hash = "sha256:3ccd3abe40e21028419a39dbea36f60cb7e34335ab1b81aebb7a1a2f644443c5", size = 4903, upload-time = "2026-05-30T12:11:48.133Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/22/c1a95f27988883450ec1c8210f351da5fb006c753d686e8437426daf821b/pyobjc_framework_iosurface-12.2.1-py2.py3-none-any.whl", hash = "sha256:92cf617b6ad6c216ec5fcdd47584fa0744dc7ff38fee378b2689dfcf46194df1", size = 4925, upload-time = "2026-06-19T16:12:43.545Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-ituneslibrary"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/37/308813d2e80ce9c8c4e5710e0f1e1dc479be03bb06e2f28dc9058862a756/pyobjc_framework_ituneslibrary-12.2.tar.gz", hash = "sha256:780f7e5f354dc2b0a27df4abb6538f730e8a29371a8703bc05edd6ce50466f8e", size = 26172, upload-time = "2026-05-30T12:39:00.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/9d/1b18df4c94a4a45cb9fc86edf2656d1932c1f56c31dcf6ac673cd9138808/pyobjc_framework_ituneslibrary-12.2.1.tar.gz", hash = "sha256:be3afc865881c762765101be35f7216616c5eb4c76025f590e36fe1cbd2518fb", size = 26184, upload-time = "2026-06-19T16:20:53.1Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/c3/6c8fa4798c8f3d5194dc7f1d4ca061840705b7a908b6ba05b3c9449a0b22/pyobjc_framework_ituneslibrary-12.2-py2.py3-none-any.whl", hash = "sha256:9876e99dac601dc523b2f0e528fb21b027693b2b6f7d697fdf460cb819339980", size = 5212, upload-time = "2026-05-30T12:11:49.77Z" },
+    { url = "https://files.pythonhosted.org/packages/19/7d/05c50a1bd493ccc1844a89461ad7eb82b7ea7a361ed219377f8abaa625c4/pyobjc_framework_ituneslibrary-12.2.1-py2.py3-none-any.whl", hash = "sha256:076712e495e2df43dad14e92167e468c4a46b9d06f1b84b98b2b65ff24285043", size = 5237, upload-time = "2026-06-19T16:12:44.426Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-kernelmanagement"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/b7/f367cc6c20fc0e9b80706284a1978fa0ee90ba61c2421d7bab867a3ce4d2/pyobjc_framework_kernelmanagement-12.2.tar.gz", hash = "sha256:01abc525c1edbacf88425a36a055e52d1b4a024299097d9a2b25c34f2df4bafc", size = 11935, upload-time = "2026-05-30T12:39:02.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/34/21b155304cd14f2b6ed9b732c2925b1c23c6eb1a941676e83d972c14dddd/pyobjc_framework_kernelmanagement-12.2.1.tar.gz", hash = "sha256:49591c0603057d2ea2596b9b414c38fe521f506e1320753bb49ccb2262b97bdc", size = 11961, upload-time = "2026-06-19T16:20:53.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/5e/f98eb2645e1899579eb0b30695866611db6c25cef135dfdd323a164a5d8c/pyobjc_framework_kernelmanagement-12.2-py2.py3-none-any.whl", hash = "sha256:14e789ed81eaaf3ca50557015416fdc232400b682b3756efaefe4afd061552e0", size = 3672, upload-time = "2026-05-30T12:11:51.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/57/4b0e4520f06f62e3a70eb50249efe750fd220fe23072e021048a23a2eeb1/pyobjc_framework_kernelmanagement-12.2.1-py2.py3-none-any.whl", hash = "sha256:9facdb93e49717a9e5999ab7b20cd1643ce00119f7b91c4933fec0fe3638edd1", size = 3696, upload-time = "2026-06-19T16:12:45.473Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-latentsemanticmapping"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/bb/2824a4eae4fad404603e5ab859654f4f5c5efb9687b27f97c58915726a44/pyobjc_framework_latentsemanticmapping-12.2.tar.gz", hash = "sha256:20dfeeb005880053dcccc03dc6a58d796dd72d7f282caa625906bebc3631ecd4", size = 15932, upload-time = "2026-05-30T12:39:04.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/37/35c98e572e98df7763c6d7bc437c7aee7d5a36c030c51841d793d0e89939/pyobjc_framework_latentsemanticmapping-12.2.1.tar.gz", hash = "sha256:96e6b523c7fe7944cee30b723f035f9082500c3bf8ba8237013c8e37b112c493", size = 15906, upload-time = "2026-06-19T16:20:54.725Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/16/85b8b7dbc58a0cd0baba9854604be687620433fe354347c0e93e05025551/pyobjc_framework_latentsemanticmapping-12.2-py2.py3-none-any.whl", hash = "sha256:1c87b1dd06626eca6188c2939f0dc1f58104ac9f8979c1dd8fc5f8c7d4d901e7", size = 5472, upload-time = "2026-05-30T12:11:52.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/1e80736b58665094f12ed736f1d675a9658ebb992e33fea72cef35815010/pyobjc_framework_latentsemanticmapping-12.2.1-py2.py3-none-any.whl", hash = "sha256:7d7669ae5c6ca53e6aa7bd70ddfed23914a29169c3f57b94a40a0397abaa66e2", size = 5499, upload-time = "2026-06-19T16:12:46.356Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-launchservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-coreservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/fd/3ecceb569730898ffe9146f3e544415b4e4ea7d3343e424a3cd17500bf5d/pyobjc_framework_launchservices-12.2.tar.gz", hash = "sha256:02c3f25311673fc26eebb256cd0e873c9883575804c98b97a5d2096c8cebcecd", size = 20826, upload-time = "2026-05-30T12:39:06.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/8e/26d4adeb32fcde532d6e3afd342ebfe055017f183b2c2f730a28f1b3de84/pyobjc_framework_launchservices-12.2.1.tar.gz", hash = "sha256:1d288543c1c4e53e6e24314987e18904ada821d6bef5437e6bd9e8e6873fe4a6", size = 20834, upload-time = "2026-06-19T16:20:55.548Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/8d/04c6bb237127a6c109437af6bae244b3695deca6dae67a20d408db736a1b/pyobjc_framework_launchservices-12.2-py2.py3-none-any.whl", hash = "sha256:4a0a478dfee2c53b7f3e2168f3c0e4183621050d324e7225251706500f8f5f0e", size = 3902, upload-time = "2026-05-30T12:11:54.2Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/6ef104cc5c2724d07ebd119ad20c80d40a964f1074e6c72053b5d658556c/pyobjc_framework_launchservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:81ca37abab29e96ebd69e1d97d63789d729510a6fe1f6cd4041e5b24f340f115", size = 3934, upload-time = "2026-06-19T16:12:47.283Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-libdispatch"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fe/e23be301e46c30450955cdb096f16f6a86e7609787a4b8225ec24d6fdc9d/pyobjc_framework_libdispatch-12.2.tar.gz", hash = "sha256:4a41879ef7716b73d70f2e40ff39353d686cbc59d48c93217ed362d2b2baf1ba", size = 40345, upload-time = "2026-05-30T12:39:09.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/3f/561653aff3f19873457c95c053f0298da517be89fdfc0ec35115ed5b7030/pyobjc_framework_libdispatch-12.2.1.tar.gz", hash = "sha256:0d24eda41c6c258135077f60d410e704bc7b5a67adcb2ca463918896c7363795", size = 40336, upload-time = "2026-06-19T16:20:56.371Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/9e/94b587d8c5b243cb6026489752093a45d75fff08c85ed5b8b5548ad3596a/pyobjc_framework_libdispatch-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9fb0028b400661b6b2279e2b611d396a4217bc36aa9dadd3ae21419551f5e091", size = 15634, upload-time = "2026-05-30T12:12:01.08Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ac/f5e01c960287e3484f71a737e7ffd75ca1c192200de70fa342a22181895f/pyobjc_framework_libdispatch-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:265fe4edfd60de111c870932ab8397f845c314332a935aa7a27100fd8562cebc", size = 15651, upload-time = "2026-05-30T12:12:03.156Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/d9/8bcb4e234aee09396d06515ed80fb1f79cee3aeb67a311aa8e81a085584b/pyobjc_framework_libdispatch-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:117ed20ca54e334f657e60b9b9a3de3741d91875fd50ee51ac6a09224912cc68", size = 15918, upload-time = "2026-05-30T12:12:05.257Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/0e/caee3281628ba4913206167062274334a62ba5dedb8dada5fd884a53584f/pyobjc_framework_libdispatch-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fef3158dd4a068a9db8108a5cbf7da385788136e1d8af2e6fb7f82215016ecb2", size = 15679, upload-time = "2026-05-30T12:12:07.217Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/e0/ecf5fb9f11d12271818c5244c57d36ee654abfa2d15799bd594d4f58d931/pyobjc_framework_libdispatch-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:02dc66f1c11e25eceecf3c1b2b397f1727659dcac3e0c7b97784d5af3cfab491", size = 15960, upload-time = "2026-05-30T12:12:09.199Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/74/c1d1d1fc45434dcbab16887273d368d9ad89e65939babcffd502ed308ef9/pyobjc_framework_libdispatch-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a81d9329fdf5094c9bc09b916e1d2fb86ab27138161d3e7ddb76ec2e780a1aba", size = 15699, upload-time = "2026-05-30T12:12:11.103Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/46/6ba13e10cbac853af00ee37444f37826a0688e32d1d22ce2fde4e2add9d3/pyobjc_framework_libdispatch-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8daaf8844b5b328cf8adb6e8c085bf2aad22237956f7c5dc6fbb7a46c5015af0", size = 15990, upload-time = "2026-05-30T12:12:13.077Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8f/42cfa987c07a2b5ce8c236a42b0fb388b8807dac72c25e004cd4905ea9a3/pyobjc_framework_libdispatch-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8f41b5021ff70bc51220a79b41ebd1eacb55fe3ceb67448594f30e491a2c42a5", size = 15656, upload-time = "2026-06-19T16:12:50.361Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/cfe97f1beb13f5b7ca5c4348158c2de886d58ffba5be09a9376557f7d6f6/pyobjc_framework_libdispatch-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9c0ebf99520083bf17c007a544c100056a0d4ae5c346fb89e1bdfe6d041f16f2", size = 15679, upload-time = "2026-06-19T16:12:51.28Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/de/ef6b51bc72fe5ac1df80c34b1b13a97d0922ddd6bc5d3ecf5ead1557bf34/pyobjc_framework_libdispatch-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3f56fd71b963a0b6e440ed2f0ea2fb635221758b7eb908ba38f96f5144b83ca3", size = 15946, upload-time = "2026-06-19T16:12:52.098Z" },
+    { url = "https://files.pythonhosted.org/packages/42/87/5b4a6c8580f2a486daf4b0d14a2356c47abfda401b329e71e46ac9b5460c/pyobjc_framework_libdispatch-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:999bad9a2c9198c837ba8f57a3ca9f05b4fc4bf7b69318baaa266dd2ab2fc8f7", size = 15699, upload-time = "2026-06-19T16:12:52.917Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/44/68cff50cb37a6ea311b7e805105ea13c33043762772714bc25d269c0730d/pyobjc_framework_libdispatch-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3fc93971f40d9757995c1e4b995a1614a468a5178be27e3d81e9bdc0b5e3cf75", size = 15981, upload-time = "2026-06-19T16:12:53.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/5d/1f48e023555817f1271e86849ebd092743fc8bd292b6f82e87aba5df6122/pyobjc_framework_libdispatch-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:26a096c81c8cf272f4f1bb8f6c4b7565e005d273d218b53b83d925da5292633f", size = 15719, upload-time = "2026-06-19T16:12:54.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/44/b45c32851a3bcd367c62804c23aa55ea7918af6e16fddf1df23f5d7ca750/pyobjc_framework_libdispatch-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:82c6512fb4985f3bcd6b60b0cff79a4b483b44d1d2e5405010e34dd4b60aa01b", size = 16009, upload-time = "2026-06-19T16:12:55.513Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-libxpc"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/a2/443c0cad2a13ec038318d391f7ebfec2189ea6d97910c0ded4c863631603/pyobjc_framework_libxpc-12.2.tar.gz", hash = "sha256:6dcae3da5ab706762d68625a391c75a3969609e5676d4091947f5c1185d4f800", size = 37263, upload-time = "2026-05-30T12:39:12.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/e5/92d47d5387baa85461be9802dccd90f6fe9232a98878caad7ab899d207df/pyobjc_framework_libxpc-12.2.1.tar.gz", hash = "sha256:83b814672715ef1f4f83eaaae49416a77db38579e6f6af2e14cd328a76f5d598", size = 37265, upload-time = "2026-06-19T16:20:57.109Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/35/04ee5a0c94c0e59536cd5d20e5afad73704240ed1f5d770a6eebd4fcf992/pyobjc_framework_libxpc-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1e5826137f5fe3c20a1f7f6d3bb55d7f692bbb85a16be209103f32761df3e0c", size = 19753, upload-time = "2026-05-30T12:12:19.57Z" },
-    { url = "https://files.pythonhosted.org/packages/82/f3/9e971bd977c63575359c1e4d95a0c7ac8acba1d0094b190bd738bf64dedd/pyobjc_framework_libxpc-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7caa888b1046a7921121cb44087746803a458002a1182105b3e64734b0ca9f40", size = 19753, upload-time = "2026-05-30T12:12:21.682Z" },
-    { url = "https://files.pythonhosted.org/packages/70/e7/143c999a6dde74bff96697b36270ee6d8b105ce01d11b1a066d573a5d722/pyobjc_framework_libxpc-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56bf8fbc45e722af533bed03889d02c1dd7f81338946575bbad3efb049e8177a", size = 20308, upload-time = "2026-05-30T12:12:23.88Z" },
-    { url = "https://files.pythonhosted.org/packages/08/40/996207b9c0fff0ec877ca9ed88a3e546bdf0f82ac5052a9d3cc84be8e170/pyobjc_framework_libxpc-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2ef1feb41c7f52b771c9dd490d60b267d25983b19e7f6a896a0534bb97fcb728", size = 19486, upload-time = "2026-05-30T12:12:26.018Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b5/59eca99d7dde55d8af5b7639faa0bda9239ddd23f64424ca4ca6fcb22512/pyobjc_framework_libxpc-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2ba3e82597fcb828b60b5a95f6a189ae3374257a99058109ddd4844926579c0b", size = 20012, upload-time = "2026-05-30T12:12:28.244Z" },
-    { url = "https://files.pythonhosted.org/packages/08/d3/a023ec78325f3c5db3a58c17c5eb3323def22ea99c170cdf5361d47c572a/pyobjc_framework_libxpc-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:91d66e792bcdff0680698d8a4f4ca67962afb2810c3edfb652e34ebe6b4a942e", size = 19492, upload-time = "2026-05-30T12:12:30.308Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a9/368f38fa17b507001555ad7e4b6ee243920d6111358656334c038c85bc79/pyobjc_framework_libxpc-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c38d61a2ba5e26ba12bf0566dfa0687f396239c72f9d940d06b1e70af19cddf7", size = 20039, upload-time = "2026-05-30T12:12:32.574Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/27/ab74145db0b6e9eafbcfe24ee5f906f1466ecfa40265b20120affb48f946/pyobjc_framework_libxpc-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:905964e12dd9180e70bc88bb04cdc02e4920a48a045e62ebb47f207ab3085376", size = 19774, upload-time = "2026-06-19T16:12:58.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6432bb6e2333b3dcbc8da1fe26f4436895e3b7046efb70c4cd8c0ee92aea/pyobjc_framework_libxpc-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:158fd1b11eabc4c42d1bb60264ecd19871c3e24ab661e7c6d982bcb5b6cd8da7", size = 19780, upload-time = "2026-06-19T16:12:59.378Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/89cb0149bd82f25f2555e9195d7d8f24be979fd7e88ffda0db6e6e61cbc9/pyobjc_framework_libxpc-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dad8ca82fe4162e85c9a6057382eaa6adc6b3aa22011e1e454d6eafb997dfc02", size = 20332, upload-time = "2026-06-19T16:13:00.296Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d0/afe32cbc4c7cd5a5856532ebc6b90b26d25beb244522a1d13e106a74787c/pyobjc_framework_libxpc-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1610ef8016bdeb83d2193851e5c19fbf6073741d01a0d590afa4501531b788e1", size = 19509, upload-time = "2026-06-19T16:13:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a2/590645eae51a2aa113bf1221351738a6d00b7144323c98a1b08c2702e72b/pyobjc_framework_libxpc-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:90331eb7dee2a50e6cd70463dd156d7f679919b9d03e52864707bfdebea0adcb", size = 20038, upload-time = "2026-06-19T16:13:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/19/35/87cc08847d11d21e385bbdb90d3274230ceabec8cdfa0aa021eb36aced09/pyobjc_framework_libxpc-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:88bba9ba27aa974a6d89dc1bbb5fbec1d96407ac36f01737ce92179d1b1d383d", size = 19515, upload-time = "2026-06-19T16:13:02.846Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/e24b80803a8e7e77fdc8caf36274822c9e13fec173467b21786625bb0462/pyobjc_framework_libxpc-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:153ba3845c64a9f8003a87f22de4b4ec678f2c36c329c8c3c96c30cffe7a0570", size = 20062, upload-time = "2026-06-19T16:13:04.185Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-linkpresentation"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/20/a55fa5ca6fbeb0a0b00515f4aa37cdb946e36fbaba8c8bef6c47774c10b4/pyobjc_framework_linkpresentation-12.2.tar.gz", hash = "sha256:bb910f692f3166d6c5fce44f501a4d64a6067bac9bc26ec9488995fae56bfe6d", size = 13988, upload-time = "2026-05-30T12:39:14.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/21/368316aa17c5a70a29fb5bc23d29e8608509de539ad5402b8e273dcae5f9/pyobjc_framework_linkpresentation-12.2.1.tar.gz", hash = "sha256:96f30800eef18543a4c75fff6b1a7cce7fcd649564784cc523341870908382c9", size = 13978, upload-time = "2026-06-19T16:20:57.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/42/264d202bd16bb6d8b2820c4a0d3eb1267add1c94aef68aeb749927dfff52/pyobjc_framework_linkpresentation-12.2-py2.py3-none-any.whl", hash = "sha256:68f854b4b72fef3477f1fb6604b258207a5950164e8e278330cd4848281eafee", size = 3864, upload-time = "2026-05-30T12:12:33.935Z" },
+    { url = "https://files.pythonhosted.org/packages/54/14/76bdc42790ced9ab3be43a946a4466a0debc3d7e7642fa4836081768c382/pyobjc_framework_linkpresentation-12.2.1-py2.py3-none-any.whl", hash = "sha256:2299fc001002ecf501249a0a61bda35d50aae5057c9f2aca36274261add4fa4d", size = 3887, upload-time = "2026-06-19T16:13:05.149Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-localauthentication"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/bb/68ff2b154ed783d39a1752cbbb7dc9d0ce55c17097dc00fe56d9080c6349/pyobjc_framework_localauthentication-12.2.tar.gz", hash = "sha256:e1d734db5ddf35093307e213115bd122ef8712463be048eabfa4062022373e21", size = 33074, upload-time = "2026-05-30T12:39:16.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/e8/fcbea8814ab28d00e18e4f6fc84af2fbf58eee916bfe85a30685abef0729/pyobjc_framework_localauthentication-12.2.1.tar.gz", hash = "sha256:05162d6d603fe6a9bf8eba8d5df7da379bc2b8eaf2a405bf0132a71477f5ed1c", size = 33086, upload-time = "2026-06-19T16:20:58.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/4c/2893b8b70189597a84d5804e97df123f7596d83e5fa545894f2a0d6e3267/pyobjc_framework_localauthentication-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e1287a84708dd01e959fe3099fb89cff72bba292e0bafdc2e0385e12f0729cc", size = 10876, upload-time = "2026-05-30T12:12:39.478Z" },
-    { url = "https://files.pythonhosted.org/packages/09/28/23c4a20e97d06854248625f53b30543340c17e478e9d6850cbee9ea50736/pyobjc_framework_localauthentication-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:38eab810ace8b5cd5aac593b8f0db99a9851a47e7310e0a010eb33d37043da30", size = 10895, upload-time = "2026-05-30T12:12:41.218Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/05/4b988f1e0f70b404b3e6ee0b0f63e9a368efb2a17c8b900e57992c126b2c/pyobjc_framework_localauthentication-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3b7ad8257cd372950463a4d6fe2f0b5ab14891ca756a8547c3fdb1b3236ec9ca", size = 11042, upload-time = "2026-05-30T12:12:42.808Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/38/a42123af0bc7ed7dba480b742fc97015bcf009dd81e2cf11b9eff79c6ed1/pyobjc_framework_localauthentication-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8ac59a0aa0ea790743b680eec3050d6df5319d5b473c7c1deacb037e2509c9fc", size = 10942, upload-time = "2026-05-30T12:12:44.703Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8e/915a63e42de556ed4da27c2537e0399213d22dbd1ed2bf6dbed43ad53b2f/pyobjc_framework_localauthentication-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ff66f71e12f30c6ee2c4438fa933f9fcb34468e68e5721e8e640a37a90ada0a0", size = 11083, upload-time = "2026-05-30T12:12:46.39Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e1/f8ea9d201f4118c13e8649e4fce9a21dbe196fc42424923fa13907514b17/pyobjc_framework_localauthentication-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8b3bd2d3d9138cc091f977f8f69ebd71c9fa723086b5b1eca8f89f8c7a58410d", size = 10949, upload-time = "2026-05-30T12:12:48.083Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/24d6a3a4e761772925dbd06588cd3085ed6800a4d7991bb3d7b1fd45000a/pyobjc_framework_localauthentication-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1de45570296d7ab3aa0bc66dc6d9a31d6c6b33f950ea3d5bee8e5042c6fde92e", size = 11077, upload-time = "2026-05-30T12:12:49.835Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/60/5c4f1fe4e70dc68ddb3d55dcb8f81ae7806972fa37108a0f9a394020e657/pyobjc_framework_localauthentication-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:591dc5bd8143868c0414a487c433d6c651c44c3f0ec751ad30ff3e0f4260db6a", size = 10905, upload-time = "2026-06-19T16:13:08.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fc/ca8853e87bf1d1bcf2a1331eef8f410a7177aaee6f019c6ee99036d28592/pyobjc_framework_localauthentication-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:29d6de29ece22d49a95279de80405f1441ccec74ea30db5251ffa8f46c51ae94", size = 10920, upload-time = "2026-06-19T16:13:08.781Z" },
+    { url = "https://files.pythonhosted.org/packages/61/af/3a02c67f96bda4f1a2d3d3e5923e5ec70946b62e054ae64b6dfa81695ab9/pyobjc_framework_localauthentication-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:52f89e993950b66d2ec701fb2d5f523a5e6dfafb8e0da9c194aa4fc5aae3a30e", size = 11063, upload-time = "2026-06-19T16:13:09.615Z" },
+    { url = "https://files.pythonhosted.org/packages/40/40/3f4d8628b4b60cbe6ef1c9d96250b4f54854e4f0beecc102a80594899cbc/pyobjc_framework_localauthentication-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:326f9bea423f705d61bdd36ebae087ade99c39c91fcd6643780697d539e8a575", size = 10962, upload-time = "2026-06-19T16:13:10.429Z" },
+    { url = "https://files.pythonhosted.org/packages/04/32/d289d8778665de6098a0f6790198dde03946985ec46dfcd438acd7c99d05/pyobjc_framework_localauthentication-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:49a99b96196e1ebe0791ed546bb538d4c28ee4ffbdd1b0e4c7666d063104f849", size = 11106, upload-time = "2026-06-19T16:13:11.222Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a5/8310eab80699cf11329de3fc7e1ecb276c935f53ff29f3691d72eaa870c3/pyobjc_framework_localauthentication-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:867541c093477d5ed26efdd911fa131db533d837cad575cfa5930a1fb5d7f434", size = 10971, upload-time = "2026-06-19T16:13:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/42ac5c192d2c2c1bb60d91af9e85ed357f3d8f4957056326745e0631609e/pyobjc_framework_localauthentication-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:aa094c1a5b2dbb02fb3be32a0a5fcfb23aea21815827ece2655737d4b8dd7af2", size = 11100, upload-time = "2026-06-19T16:13:12.813Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-localauthenticationembeddedui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-localauthentication" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/93/a9d21a00896d016924d1912f2dd8918f8aa95ac0893c2b110cadc779a16a/pyobjc_framework_localauthenticationembeddedui-12.2.tar.gz", hash = "sha256:cff4e489375b3898f34d8ab378f8d84623ab19e89a35de958825c125aafceca6", size = 14134, upload-time = "2026-05-30T12:39:18.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/be/1cae60d052314b16e2e279cc187b918637e6afa7f3bc7aca6eb2ae6c2256/pyobjc_framework_localauthenticationembeddedui-12.2.1.tar.gz", hash = "sha256:f97666380541a40e593c7ed2214c11da30effcc909a4b13595220050a9888577", size = 14146, upload-time = "2026-06-19T16:20:59.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/94/2e453acd660d9e1e059269c72a95b9f1f2de4a3b7a5dc0f6d6cdfd0eed5e/pyobjc_framework_localauthenticationembeddedui-12.2-py2.py3-none-any.whl", hash = "sha256:0b306917aa011deb364e85c118624d2d80c3eaf67016a345a6c4bc4960416b11", size = 3985, upload-time = "2026-05-30T12:12:51.194Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c5/42b5b4260d20309ab9832c98bbb20585191248c846036e8975b9f194809e/pyobjc_framework_localauthenticationembeddedui-12.2.1-py2.py3-none-any.whl", hash = "sha256:a77da7a7471ee9277d4ae7269fb3d0bc508c5908e93ccf8e4cdf723bde21d1af", size = 4013, upload-time = "2026-06-19T16:13:13.559Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mailkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/44/b8fc4dec34b6f29a98f64f38eb6f37e9729aeee4d2e90887a9ece06010eb/pyobjc_framework_mailkit-12.2.tar.gz", hash = "sha256:e29ea94210faefc46a4aefe0c1647bfb77b42cfc2a4962fb8316cb967b34c47f", size = 23870, upload-time = "2026-05-30T12:39:21.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/09/49fc5fe2ba2489b2844e2a2f25cf526718f34c53847009fff2e9b1f94fc2/pyobjc_framework_mailkit-12.2.1.tar.gz", hash = "sha256:8a8e84f6828f13c7c67c6f8f299889127df05d25ffe52b6c942d69a329681c75", size = 23888, upload-time = "2026-06-19T16:21:00.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/95/2b4b95d7e5e43750631596da4ee8de4800883475864ca9f169881fbefb3b/pyobjc_framework_mailkit-12.2-py2.py3-none-any.whl", hash = "sha256:25b9aa8c513c40d931a7c5cc44571fd090e3d565f2e1153a634f6980b08da733", size = 4994, upload-time = "2026-05-30T12:12:52.648Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cc/4a9e1f5a387df7e5bec26ad3488e414d6fb065c46131072d20f07a6314f8/pyobjc_framework_mailkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:e453e42d8ad97f58593296a85c71ec8c71378f8d5d79ac4548845f5dcba725b9", size = 5018, upload-time = "2026-06-19T16:13:14.528Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mapkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -4822,33 +4794,33 @@ dependencies = [
     { name = "pyobjc-framework-corelocation" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/6b/0f3d14cd1b6f3d30420e268fe6b97f6ab55f1717a4c436ac6e57576c480f/pyobjc_framework_mapkit-12.2.tar.gz", hash = "sha256:65fdf104bd8a1d3e8965c689446b7e42a44ea4bc2da5c871ff389ef7a14ee030", size = 79554, upload-time = "2026-05-30T12:39:26.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/29/6f5a817054f8998629ae4c8146674a78850a56477ebbc8e6cad2732dad3c/pyobjc_framework_mapkit-12.2.1.tar.gz", hash = "sha256:b0d34e03e100adb471b91f0915b6ecb2266251886e54a1729ee534ec832ad392", size = 79578, upload-time = "2026-06-19T16:21:01.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/8b/1f32a9a01f55fcdc86b4044a3c3b100901425c4a901b789586a1458ca44e/pyobjc_framework_mapkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3190f21e6bd9efda626da12e1f2d86bf26c56948dc6863358b0f62875fa5e288", size = 22830, upload-time = "2026-05-30T12:13:00.385Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/23/649ecd0f1b7092390d5012bfccf0d653840a002c215fe5c7b1d0e1ffb069/pyobjc_framework_mapkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4dc30cdae3b30869488ffa936d1bba327b6454809dc1d584083a8033637ab7f3", size = 22867, upload-time = "2026-05-30T12:13:02.802Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/ee/d9a3b6a982a3e7fd04d06d1da9627c76b08c7107e46fff217f35a60f0350/pyobjc_framework_mapkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4245ce0af24948471eca1da30dac432712fb11ce0f65100420bfd74d176359bc", size = 23038, upload-time = "2026-05-30T12:13:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/22/50/679cd8f873fb077ef88cb7d36b485a5235f158dc70bea7a8357c9738cb36/pyobjc_framework_mapkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:45834cdf0845470504077fd352799a32dcee75ea66da20a3874ba1dbc52f95b8", size = 22883, upload-time = "2026-05-30T12:13:07.667Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7c/ffb6b7abbb4a1f86d789b31da2516294465532c896f81665263ae8483f65/pyobjc_framework_mapkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a7e425f626f796da48d3cf8895ccf2835c5b40432675630300bc2fcaae08129", size = 23095, upload-time = "2026-05-30T12:13:10.209Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a9/91f7aed638669796a13b08d7682e0681070f444d9e68c7abbfa60f3dc400/pyobjc_framework_mapkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:35fd5c1fbb0197ea7d44e739c1943270ec2c1e77f3dc6b363884943556b770e5", size = 22897, upload-time = "2026-05-30T12:13:12.601Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/6a/c5198e668724d04acb97fa44a31e2b11f664fa3aa8fc1438f479e928bb9d/pyobjc_framework_mapkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:71095b1129411dcf78aa2ff61f9a00679e5eeb6826ff3ef665a6f23156f4c393", size = 23100, upload-time = "2026-05-30T12:13:14.976Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/29/45ae9a8e02b487270d29cc65e968cce3ea82c9b1fc6d208bc3d305c40f8d/pyobjc_framework_mapkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f423892cba28bef2becdc5cef9011e358f223b66478aecc8ae5e3083c8e1700f", size = 22863, upload-time = "2026-06-19T16:13:17.659Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/bdf2e3e7e6d5a05fb9fe11de7d8b85f75e49eaa3b31a8c7b45b2f28f804e/pyobjc_framework_mapkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e94362c148355d36aec29d7a77c14178e44e464504dd2cbcc8de28b18a5e00e8", size = 22890, upload-time = "2026-06-19T16:13:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a9/744ce0d68454c29522d8dd97a00f4a260cc06941763a2ac6cc189c653e66/pyobjc_framework_mapkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9c128d8e4af7698629545d5761cc1fca5a26a3e13121c2ff7c77e28308922b70", size = 23075, upload-time = "2026-06-19T16:13:19.855Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d4/2b796d0da8e2d90d7402ff58070c61a16be33c842de4eb270d2125e72749/pyobjc_framework_mapkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1263fb5c1e13ad7d34e60b455cd56b79627b4505488cbaaacee9ad8acf4eee80", size = 22914, upload-time = "2026-06-19T16:13:20.785Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/59/adf23b8bf39f02e8820b97eb50f23fb145d7f6d43a471f1b3047ed0209af/pyobjc_framework_mapkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ceb93bb2aa7ced0dc200508d9baa0de2438f8e0194f1dfabe7407ab0d734bafb", size = 23120, upload-time = "2026-06-19T16:13:21.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/64/87caba8d8a9cf4f2556718839a9fac9c9958b1ef3d6933cc4c93cb39bba8/pyobjc_framework_mapkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5b39d0cbeca27e3eef130e5686adc8e0edd06981e0f8afe359ca070ed790f329", size = 22920, upload-time = "2026-06-19T16:13:22.518Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d7/b953ae58dfdef45fe6360a1731986d519277cbf087037da4ce9a89d42f76/pyobjc_framework_mapkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f9ef9633e84afa849bcb923ef0ee9cc78106d210e45637f58941dca4408681f9", size = 23130, upload-time = "2026-06-19T16:13:23.362Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediaaccessibility"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/63/34d6f7af511b116dca7761385b7462eda9f39641a9ead9eb1404d621e571/pyobjc_framework_mediaaccessibility-12.2.tar.gz", hash = "sha256:9036a6412bce491b8ca477d4673b6e441cbf2cb2463d617f82bed818c5bde9d7", size = 17239, upload-time = "2026-05-30T12:39:28.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/46/c07388b3911f10cf84347c0fc7b250792e6bdabbdd9a51083331b8ae58ff/pyobjc_framework_mediaaccessibility-12.2.1.tar.gz", hash = "sha256:6d816a09d874519bea85035db7c62c0566063a5be63e3ab25b2059205576ade8", size = 17250, upload-time = "2026-06-19T16:21:01.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/b9/fb53b336b9d6233ca96e53aec4ea142d49b225f846bbd9e13353477f118b/pyobjc_framework_mediaaccessibility-12.2-py2.py3-none-any.whl", hash = "sha256:2e1d023c738ef09ed57635ae277b3644a09d7313e6bb979ee1c6d68bae57e4a8", size = 4822, upload-time = "2026-05-30T12:13:16.428Z" },
+    { url = "https://files.pythonhosted.org/packages/71/bd/bc6277582c43eb6b4916cbd411352bd5066fa3e1b48ed5add4e41932e4cd/pyobjc_framework_mediaaccessibility-12.2.1-py2.py3-none-any.whl", hash = "sha256:8543ff6664ce35815083ab10a6f4b1b9241594d60c27132e08385b0316d55013", size = 4847, upload-time = "2026-06-19T16:13:24.243Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediaextension"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -4856,336 +4828,336 @@ dependencies = [
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coremedia" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/db/c3c4a933685423d16f69daf8a0dbe026fd45a05e0988ed4842dc2a286097/pyobjc_framework_mediaextension-12.2.tar.gz", hash = "sha256:9affa99bd94774ed91f3fc9f314468b4dc3bc6fc110ee8a81884d3947a9ced12", size = 44550, upload-time = "2026-05-30T12:39:32.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/fd/8f2489cf3673a705d806124edb73ea27438919f58af1fa41dd789163838c/pyobjc_framework_mediaextension-12.2.1.tar.gz", hash = "sha256:d31057582878ec2574559ad253fd448de3f11a68e454d14f0665348c82b3dee0", size = 44554, upload-time = "2026-06-19T16:21:02.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/74/bad12d87ee91c01dc2af72e3e0fe3c4196764eb735759845f1ca1532d817/pyobjc_framework_mediaextension-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1745f140a683cb1a310ff4c1206ad0d2e644cf1cfd1da3fd3be5de224890a4c", size = 38998, upload-time = "2026-05-30T12:13:26.744Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/8b/1576473cd8154bc5e2b36cf2f82bac60ad1223bc09145248639446bcfd18/pyobjc_framework_mediaextension-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37e8a452f17db3bce2b50dec8a20b6851eed88906809d2361385c3b096751ff9", size = 39014, upload-time = "2026-05-30T12:13:30.015Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/31/473101b145d98dc738c021d66496149d38d2b57d746cf69a3665e5403dfc/pyobjc_framework_mediaextension-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5326b3ca9f8ba0f2b51525829bc833f9c441980e3cf6628137e51a50d9e45cbf", size = 39221, upload-time = "2026-05-30T12:13:33.332Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b4/9218de5d1a1018fa9bc52a342a128d1ff547613b8523b2fa48e215fbf281/pyobjc_framework_mediaextension-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9c315b0f9ec9a1a2239213d9b72f4653bc8ae8ff7a915e5c2b8b522e01b01c91", size = 39004, upload-time = "2026-05-30T12:13:36.818Z" },
-    { url = "https://files.pythonhosted.org/packages/69/a0/92f1046924df8ea54bafff6ca836254954f63232fee363cbd82d7084e955/pyobjc_framework_mediaextension-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:048a04da339030f15ec932de42428ed85a90faa6c80f982c710513ce43e54a07", size = 39211, upload-time = "2026-05-30T12:13:40.143Z" },
-    { url = "https://files.pythonhosted.org/packages/99/fa/80b00c06d4326039ae152393f4568ac7881d1080a98e436397b57ef18dc3/pyobjc_framework_mediaextension-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b34f4f1a89810925313ba97064e01b63b597e424749f0b78985c48dd5bf4cba0", size = 38998, upload-time = "2026-05-30T12:13:43.667Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f8/69b14a84ce316af7aac12ce3f7262fae225ead1ae9df1b8f9037762c0cb3/pyobjc_framework_mediaextension-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:bf567e1768b696f554b93c1f850eba474014d079abe70e65bbe816ed69e833bc", size = 39204, upload-time = "2026-05-30T12:13:46.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6e/3b9f69ef0caea40e6175e4226a9a8df7c7997cfb8dbe6ca430575c21b4df/pyobjc_framework_mediaextension-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bbf5ea3683dc5b6a2b0f218ec0e9935a21e6aebe7d00760be78395268fb04770", size = 39048, upload-time = "2026-06-19T16:13:28.614Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/02aa57d87451fab20d27c270545243e4868b2172b0519f75a1c7755a3e04/pyobjc_framework_mediaextension-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:600e289380d19b24d7166027988c63b5fa8cd297a379fa9538dd0bcffd527c0a", size = 39062, upload-time = "2026-06-19T16:13:29.79Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4e/a338813ca7bb23e59d44c15eea0c43d2120de949c93acf408117b17f4051/pyobjc_framework_mediaextension-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c84027e9c775d51ae58c5c532935145ef1ddaae7b24b769e6ff7026b62a7e4ea", size = 39263, upload-time = "2026-06-19T16:13:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/33/5079aef3cfb5740e11f214d8c5ae9318e774f66a8891d72524f1ea2c9384/pyobjc_framework_mediaextension-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1f5554002df229352672d5d2f7ec5b8d63cb8fae762df67da7ce0902ecbd2837", size = 39051, upload-time = "2026-06-19T16:13:32.275Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/16c437191e23c781a61e8008473ace2a4ddfe2f9151c3236427c3ed2c2a7/pyobjc_framework_mediaextension-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:116d9cf91c283bd741ee1f5f8350e858d002a002c655b0378c471ec0d81ddef5", size = 39263, upload-time = "2026-06-19T16:13:33.506Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c6/07abc4c226c2b81457b2aaaf2fa349cfcb26a997117f70292343e431d435/pyobjc_framework_mediaextension-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6d3779c1923a059b8d5c4e5ec5c190d015f63270d4d657e0f5ad1a97df99ff19", size = 39046, upload-time = "2026-06-19T16:13:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4b/c14389fc31083b0f5ac3efdaa6d580ce8099300e5028a96c370d67e78355/pyobjc_framework_mediaextension-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1f0da78f3ccedc09db0d8dfa6d6c008fbb411e5f9eb52c4dc0318b57416d37c1", size = 39257, upload-time = "2026-06-19T16:13:35.423Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-medialibrary"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/44/ec97fab19e92f5d41c4e0f333bcd54f1f76a255406eadd93a95d753da711/pyobjc_framework_medialibrary-12.2.tar.gz", hash = "sha256:9b65eb789cf10b20f2c5bc4d5f4e61e5feb02a43bc213ac3c03b647e30b96634", size = 19019, upload-time = "2026-05-30T12:39:34.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/3b/af0d8cf4bef550b77ecddea3db59bce0ab3ab5e22e258c583e92ba5a630a/pyobjc_framework_medialibrary-12.2.1.tar.gz", hash = "sha256:18fb56e727399f11ea588d2c512b7585147386892d72c65eb9c4b6387abd6643", size = 19052, upload-time = "2026-06-19T16:21:04.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/ee/8583d8c8a738e13f3e70bfb84ad70aab17f2995af55ece36780c1acbfdd1/pyobjc_framework_medialibrary-12.2-py2.py3-none-any.whl", hash = "sha256:3bc97cb03e633a3f6f0a4e9d351210000100ebd1a4b19624c49c4e9bc7b5e574", size = 4357, upload-time = "2026-05-30T12:13:48.479Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/9f38ae220465c54ca064d24a0e42d93dc2da901ec811324c04d2ccc6a229/pyobjc_framework_medialibrary-12.2.1-py2.py3-none-any.whl", hash = "sha256:4d69f910f17bbccb4f815b171270b9279f9d7526b318cf45a7b2ddc84fc38d22", size = 4381, upload-time = "2026-06-19T16:13:36.34Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediaplayer"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-avfoundation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/c0/aec081f84830e483e23a1763339c9c6ef9bd868d44d9aa39a83080b0ac29/pyobjc_framework_mediaplayer-12.2.tar.gz", hash = "sha256:ee4f818a85e89a4c691e368b2709709d11658b81713fe367342af24dba2c5e62", size = 42669, upload-time = "2026-05-30T12:39:37.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b1/eda7f1cbdb98a712239ea1a5deb12821d07055e16c51e8c25167fc801578/pyobjc_framework_mediaplayer-12.2.1.tar.gz", hash = "sha256:6acead24bb8f12e202976142db656c553b4a25ca2348165c35ce02862a93757a", size = 42670, upload-time = "2026-06-19T16:21:04.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/89/a12bf5f69920b8909cf92b3e7722082600db4262293d5b878b58eaae8f7a/pyobjc_framework_mediaplayer-12.2-py2.py3-none-any.whl", hash = "sha256:436d3b410b84c7fa6577c4774faa4acc4bd3ca79f582b183e281ca63429a1574", size = 7176, upload-time = "2026-05-30T12:13:50.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/ca6e7b7c3827c3e835e81fadc7f3a26dd774a7a80fea7fce1cbd1ca044cd/pyobjc_framework_mediaplayer-12.2.1-py2.py3-none-any.whl", hash = "sha256:d37f5ede14fe70c547eac4abb49c9c96086f99acf8236985acadfcb07c851a5b", size = 7200, upload-time = "2026-06-19T16:13:37.48Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mediatoolbox"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/6e/5181efc8c1a077599ab5ac1cb2263ebb43b1603ed994e486f8a983d2e694/pyobjc_framework_mediatoolbox-12.2.tar.gz", hash = "sha256:35fbaa7df491df5b756da1ad2035f0f04f72e556a560cdd9a6ef74ce315c555a", size = 22818, upload-time = "2026-05-30T12:39:39.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/61/4970e65b4efa1aac9493dbf8420fcc5d053433bf21c19eeec6cc7c8f7fee/pyobjc_framework_mediatoolbox-12.2.1.tar.gz", hash = "sha256:f8757deb15870b7543e2880aa4e7bd248fbc92f6a55763a99fda3703b1b1327d", size = 22811, upload-time = "2026-06-19T16:21:05.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/5a/4b31f1751570b12f44ab4472786f48fe2e7540f96e52263ad384f5e2fe16/pyobjc_framework_mediatoolbox-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c722d9b86227fa0d5f091a151b19f80e2811323e6318a577b648412842e6c877", size = 12821, upload-time = "2026-05-30T12:13:55.852Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/5c/3bdcef52f234ce16c9b06aabfac43caeeea68a5068425bdd510e6277c256/pyobjc_framework_mediatoolbox-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:13cca0632cbb91f5c207ec6a9001aebb4bdd1077d3753a5bc7fef7f82c3e9a57", size = 12832, upload-time = "2026-05-30T12:13:57.732Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/6b/8ca72d9579f84560f5a648973032757e5b0c61bf1eb74e763bdca6913ef7/pyobjc_framework_mediatoolbox-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5b876927d92fb35f6ca6a5c8e030cb853a8b5c68add7d59ebec4ae4358a1f5af", size = 13419, upload-time = "2026-05-30T12:13:59.497Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/23/5388bd9a31639e02c9b626c6b4694f807a836b3f6ecd76477a64c9208736/pyobjc_framework_mediatoolbox-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:193f021a90cda4e18523538f99348080147f0e35bb5ed45e44b0f8a964a58851", size = 12805, upload-time = "2026-05-30T12:14:01.315Z" },
-    { url = "https://files.pythonhosted.org/packages/af/aa/e287f682182f1953b2b36d35781c91cced01d0f0ad7fa97836d9498a4bba/pyobjc_framework_mediatoolbox-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58745d0f400c3de07e07b021574f38d73a3f69a886432470fc6e32824785855a", size = 13413, upload-time = "2026-05-30T12:14:03.214Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/99/6685f94cae3b4ee734bdd06fcb29c9c729d44b1cdaaf501cb1836902e0c1/pyobjc_framework_mediatoolbox-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9f028de65634bf4fe2d9addd4c85704778b91abb9f9bafe42f15268b775496e2", size = 12819, upload-time = "2026-05-30T12:14:04.964Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/77/10df782a4107d150672264914259c48fb98f235908716cf915530c26ce4a/pyobjc_framework_mediatoolbox-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f3d541185086c7fc4df76da60c577be8fed06f8507ef35b44082167880476cdd", size = 13438, upload-time = "2026-05-30T12:14:06.665Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8f/9ae04dce47a830fa5c0a43b23188f482694f1bc74bf77381888c08ac731e/pyobjc_framework_mediatoolbox-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2b4f70f6760c5cf49654f6256877e9875423507764af787c770e09214e5891dd", size = 12841, upload-time = "2026-06-19T16:13:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f8/f17e483d63424753f56b397bc93d510035b3bc5a579896eb127cf817b7a3/pyobjc_framework_mediatoolbox-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:53be99e67f027fedac2045c4efac256725e1f6a122830aa4733fc3db608fe014", size = 12854, upload-time = "2026-06-19T16:13:41.706Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d4/afc7d67f91f5efbc3d4885ad2e4ddc2598a500f15973936df47e6c8f4b88/pyobjc_framework_mediatoolbox-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6f3a58249339267f5c40dad9bc945642bf5fa167a9be74353f5c76ef42ed4510", size = 13440, upload-time = "2026-06-19T16:13:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/ecef85b04732a39865a61687c42537ae1d27119f91c586197d196db1cc89/pyobjc_framework_mediatoolbox-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:082c54423dd1080ce7cf9595e73997c6a0ef2e38c15be34ecb1e9a81163e9180", size = 12829, upload-time = "2026-06-19T16:13:43.722Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/97daef9ff7c2d8bcd67c4b8b52f117872f7e9b5e3c4cd561a0c2eebb770d/pyobjc_framework_mediatoolbox-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:88618fa1c1f0f5cd03ec349eb6e864b88fa3f7b88014299cc77cf56de5d4b3f4", size = 13438, upload-time = "2026-06-19T16:13:45.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f9/73bac498691fbb324cc4eedd6ada07e19f4d3f57c45211a7ce54f56a4989/pyobjc_framework_mediatoolbox-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f3b71021c5416c58d756441eeb52f5153ae696fe7ff50b1e470934ff947c1a05", size = 12843, upload-time = "2026-06-19T16:13:47.373Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/37/b6799c5892247a6c5f3b2be13cb8c90ae3cd8d8d115c764f159714ad3689/pyobjc_framework_mediatoolbox-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a2ff7b9ada192d3d949ddcc2d52f2149ce812ceb97fb5f1f67016cbfc7929d03", size = 13463, upload-time = "2026-06-19T16:13:48.496Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-metal"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/a9/ff281c31ce7d0cb819af1989b77258b2d8cffc0b9fad47fcdd39043f4d81/pyobjc_framework_metal-12.2.tar.gz", hash = "sha256:4fb2cfd42cc8e808f08f1f2fe57de713734dd2f495c666296b2c8a5fba9be6dc", size = 238106, upload-time = "2026-05-30T12:39:54.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/46/5920d6cb66cbbe298744889b10b3266b1408ad823855f55cdcb967c0d51d/pyobjc_framework_metal-12.2.1.tar.gz", hash = "sha256:cd362194bdb7fd2a9116b8dc1e6b14ce19629136304cdf6b88d105a969fda72c", size = 238139, upload-time = "2026-06-19T16:21:06.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/dd/948cdfbac4f20decd054b9cf134e8a69e71bf9dc5cbcc91d518bc4fb4f37/pyobjc_framework_metal-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ce5cd713869eaaaa8298c9e21ce750957d063cabde396e8d158c10809b452f4", size = 75906, upload-time = "2026-05-30T12:14:23.044Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/90/f3832396e967ae149b480ebf31da0ab7b033c145b15274b2bd5357d8faf5/pyobjc_framework_metal-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:538826eb6020e2d49e481f7ad390319dfa1016aeeac623f8b76bfe8aaec8a66f", size = 75935, upload-time = "2026-05-30T12:14:28.505Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/95/f36313fab765e90c8400c9423cc0f6af6fec96a919ad894b09681d0b4a88/pyobjc_framework_metal-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b9a9ba61ab834ada0e23fe7d560cf01e6948a88a4aef3342c032683b795bc908", size = 76491, upload-time = "2026-05-30T12:14:33.968Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/92/3c9a3f13a968f8935d3ea46e0ca5d3662b5d5fcaa4faa7b19e68e33956f5/pyobjc_framework_metal-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:06775870d7f40496d647f9ac37793e4a037ffaad43612aea7313460a52ee9e7f", size = 75937, upload-time = "2026-05-30T12:14:39.603Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/34/9244ee1aef137fb8603daa7fcbe3919d4a27c894b120aaa22ba9c1481d5d/pyobjc_framework_metal-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:86296b6bf1b19f0e0c0d4bc1e99954eb666c48a386e61ed805cbaa961cc0cd6e", size = 76541, upload-time = "2026-05-30T12:14:45.26Z" },
-    { url = "https://files.pythonhosted.org/packages/65/c6/a5f5169c2799e67fbc7a159154ff9369dae2c1b0a76a87c1ab3206be9470/pyobjc_framework_metal-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:67619f9778593deb2596f7c7c20c230b93a1ebfd500b5cfd29c2e4d3db1e4a64", size = 76051, upload-time = "2026-05-30T12:14:50.76Z" },
-    { url = "https://files.pythonhosted.org/packages/39/f6/01b2bf593c60b325d4ad9568bb8b7861ddc15196d69bdf0e82871e417d8e/pyobjc_framework_metal-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d044801562c2a411ac65ff8f2f5d4004b3d1bd41082e8bb52b1f7a87ac53813", size = 76675, upload-time = "2026-05-30T12:14:56.186Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b4/a56f0b69cd0ba016da9f2ab64776950a7ca8d7dbf7a4e03b1bdb2fffa947/pyobjc_framework_metal-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:92b1f2e8f4a86bd9ecf307144e1f2c5ccc451fc760534833ddcde58d7624c695", size = 75923, upload-time = "2026-06-19T16:13:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/6a6d547f11ea81d4ee1570d4092947d264e60f02288c119f14332ea3298c/pyobjc_framework_metal-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f39a87b50408afbfc8a78be0c0d164016f114c2f807eb35506051660b386931f", size = 75952, upload-time = "2026-06-19T16:13:52.471Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d5/0001ccf5217cde46c61140f062be050d6760359d2c4bd652b619cbd4361f/pyobjc_framework_metal-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eb247c22391706162bcc14e6fd52101e632a51f3c0aeccb59cea549c019303ce", size = 76508, upload-time = "2026-06-19T16:13:53.398Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/e2d652df1f5604549a346f5048243d627cadae3a18e7491999a045f08f28/pyobjc_framework_metal-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a842860779c2a1c82d80b3800009b4604448d9635f1a69300393184b378cb6af", size = 75961, upload-time = "2026-06-19T16:13:54.466Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e6/fdf12a3cc476a540e064f409ccef28db80fe6bd01b652c9a7c9529869517/pyobjc_framework_metal-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6bbfe26a9d4683d776aeed28ba725102328ef5072eedde4c4df15df67b541c80", size = 76569, upload-time = "2026-06-19T16:13:55.386Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/21/236462c59d7b781705bdaa79307be1d952fed48d6ad561278167b62d5712/pyobjc_framework_metal-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e1be254400cc4038474466ff343093f8955925281f1e1209054d2fff9d6b362d", size = 76073, upload-time = "2026-06-19T16:13:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/32/8e/8deb988841348b718b9168559b393a25e60a3c70d6f5ca0efbaa6285ad38/pyobjc_framework_metal-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9f69b2c846014b19f1a7180b33fed0acf670d72b7e44290018b6bb7fb39d607e", size = 76710, upload-time = "2026-06-19T16:13:57.391Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalfx"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/06/e29f5153fce867015298a9b0b0365777004ff5f4e5276728135afc496269/pyobjc_framework_metalfx-12.2.tar.gz", hash = "sha256:46774b9c938f2af40510a787be291dbc0c7e3778494704489e728fc349183244", size = 33397, upload-time = "2026-05-30T12:39:57.533Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/64/e64620b99d5fae9aa933e4d8189889275a89e4918773af64ea30b202aa89/pyobjc_framework_metalfx-12.2.1.tar.gz", hash = "sha256:c146060268f8c2941dba7695bb1511145035a8468b65d88a668b2eeb4ac8ea07", size = 33394, upload-time = "2026-06-19T16:21:07.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/94/490d8a4339e8e7c02a9e5105307fa40ed4d5e251f4af824238158b7a798a/pyobjc_framework_metalfx-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f26bcdd3bd0ded637abaaedf6e1e42300de4694ea4b50a36322599fc126c43e8", size = 15059, upload-time = "2026-05-30T12:15:02.435Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/10/40bd25526328be5bb7aa14b481146fee3dbb1271662b5b69112f47f2833e/pyobjc_framework_metalfx-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f079710065e4f4628c34a2528b0dd868c9d16e3af58230d5f18f6bd22d2ee74", size = 15072, upload-time = "2026-05-30T12:15:04.464Z" },
-    { url = "https://files.pythonhosted.org/packages/46/d7/5189782d95c4790b704f70dff50951c183e0567aa53fd4892ccbc91b6f8b/pyobjc_framework_metalfx-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:40c7e259991c04f5520c4c40eea02810c50812f2bac2c5ff845828a35d99ccbe", size = 15286, upload-time = "2026-05-30T12:15:06.581Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/9f/400860454b42234d9a3e8b22b9a39281556fd71b8a47a13f1f20e24437a5/pyobjc_framework_metalfx-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d2852041cfd3ab3a316412b3721074778d0ec8164e2f0e89daa3ce00b55d6b54", size = 16341, upload-time = "2026-05-30T12:15:08.529Z" },
-    { url = "https://files.pythonhosted.org/packages/62/73/3f7904cf7048af042f040e563222d9c143d15b3d7572501d0487b5c149b8/pyobjc_framework_metalfx-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0c58b878e2994fdb37a74ad1ac93e3d624e8212c6658d64d1d8f62b18f7aa7a9", size = 16591, upload-time = "2026-05-30T12:15:10.601Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/35/41cd0392d0c501611c32f0ee0e980cdc29b84bc445f4ea705a605f0ce893/pyobjc_framework_metalfx-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bf2f970bf2718d10a87e8fe5dfe5cf7ec9ca6152f9b31e05de54ed97ab799786", size = 16349, upload-time = "2026-05-30T12:15:12.728Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/bd/bfc5faf66e708a4ad384ec54670b4d2d3ff505dfd269d721f1661be31472/pyobjc_framework_metalfx-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8a7ab8fbfd7d54c0b362c7c568ba22e648a4981631001fb29cc93777e33330b9", size = 16582, upload-time = "2026-05-30T12:15:14.82Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/8d0fe1c96e795e6ec5a78ffeb445e3651a3caed505d7c10e2eea67444306/pyobjc_framework_metalfx-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8c1b2b84cb3a2481d95c324cda82ecac6fbe7f6c6a2c05c960b956449cdad1ac", size = 15082, upload-time = "2026-06-19T16:14:00.439Z" },
+    { url = "https://files.pythonhosted.org/packages/92/69/97594e1276302d41ffbbdf065e4e4663fa34487749544f2a19ce3aa5eb46/pyobjc_framework_metalfx-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a4e6a33836b384f2627bb8c68f60365d85d135b6ecc4e3c63392c9ac30a597fa", size = 15096, upload-time = "2026-06-19T16:14:01.69Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b4/796b5f98983ab5354a145069dbaa3622cf57ffa238ce071ee75f717977de/pyobjc_framework_metalfx-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c213297c6738e92e2805ff6029c9b70c882c67d5799e574900941af2d02c13d6", size = 15308, upload-time = "2026-06-19T16:14:03.063Z" },
+    { url = "https://files.pythonhosted.org/packages/75/00/5e6263f04a058fac0a27bb3afdfae925b77c83aba8f116a06f4e6f2d0d98/pyobjc_framework_metalfx-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:74ead433904ab845442eeb992a4eb13274e8c411d4c2605b62f623c8b6f04f53", size = 16370, upload-time = "2026-06-19T16:14:03.867Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b4/5f0f0937fc1ccf42651356bdd8c437468b6b312b6a3cc775c1e3293dfaab/pyobjc_framework_metalfx-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:976c04c1f76ae75f7556c0a82082948f6879ff4f6d026a644b507ececc2c52ab", size = 16615, upload-time = "2026-06-19T16:14:04.814Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/af/a635b139be334cca2c488dae9c45cba5b242cbb33d4962432a99b3aa5d45/pyobjc_framework_metalfx-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f2f7f4c01571031e289d3ad1d9c5b5eb5cebfd7909cb4cc17fc39b696b97fa39", size = 16372, upload-time = "2026-06-19T16:14:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2a/d0fa22d9a13784626e4cb51d0d331766beb2cf9df7fc003acd17ca3f34a4/pyobjc_framework_metalfx-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b4a8a02d165df8be14ad51b8503415bc5d70ecffe3c8f86536166490781e5f93", size = 16605, upload-time = "2026-06-19T16:14:06.977Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/48/3bbf8a296054633a8a297549c919b3ff6f53c469bdcb0046d31fd7c92ee4/pyobjc_framework_metalkit-12.2.tar.gz", hash = "sha256:0f6379b74d64ce9cb864476caa277ab5010da3b0779b7fdc94af7da25f013a1a", size = 28168, upload-time = "2026-05-30T12:39:59.991Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/9e/18cd38c650176a9e4895f5b461c843e90fd85004a379fac799b710e813e4/pyobjc_framework_metalkit-12.2.1.tar.gz", hash = "sha256:f2f8e02f4ddeb1d49a5b3def09eddcb8a718289b6ed635fa5f1807165969e798", size = 28180, upload-time = "2026-06-19T16:21:08.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/3e/1bba6a52949a80a33c00650a1951e9f96ed27bf238e47694e35e4a8f087e/pyobjc_framework_metalkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7de453aef880ba546e87b0d433d203388e579d09f7cee1b6c67f09c7074c79f9", size = 8780, upload-time = "2026-05-30T12:15:20.024Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3d/982672d8b3b97e59214b85e694482f8d4b373d540f3d4eb1ad27c7763b0b/pyobjc_framework_metalkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d1f1e352621d5e89a2066f992a2b03091d180fd4ee3b6c7b58b432e22d76641b", size = 8795, upload-time = "2026-05-30T12:15:21.571Z" },
-    { url = "https://files.pythonhosted.org/packages/87/24/163bbd1c430a7c6adfec59ad92c3f1ec7f3de0ab6739e2f5839edf90f8c5/pyobjc_framework_metalkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a855935379ededd36ab55507af01b796b845a0acad7dddcff9d9f305fd903b82", size = 8939, upload-time = "2026-05-30T12:15:23.113Z" },
-    { url = "https://files.pythonhosted.org/packages/82/7a/d7015d0501c741c470abea665ccea2832e762469b9ef37ccee9575130cc8/pyobjc_framework_metalkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bbcd660af609451ad40bbbfb9ae44fd838a91a5754c19a6496819704bc72dea0", size = 8848, upload-time = "2026-05-30T12:15:24.664Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/94/bacbfdc43870f06d31935cf5efade46d3c9356e6cb52df2c171cc23b81c5/pyobjc_framework_metalkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5aa264c48301952fb6bc549e3e9e8862c41d0666d46ca356cc9606564f3bb59e", size = 8997, upload-time = "2026-05-30T12:15:26.375Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/6a/a79e6f27b96d85efdc896fcf2c7e7a090f2a355716f8c789de2a60e942e9/pyobjc_framework_metalkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:57b499d34ce41bf55b32a56fd1ce53d781d02d7c21d4fc92fd3ffa005e038939", size = 8843, upload-time = "2026-05-30T12:15:28.072Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/1b/f45b8b9423d66dbb463e19df3562e3841841fdf8e03e242926e30f49848b/pyobjc_framework_metalkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5c0fe3df589ccc0bb07086f894457bab37fdc682bf7107bcb5bbeb2c93b0a8f6", size = 8989, upload-time = "2026-05-30T12:15:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e4/4b96ce6a2e396c4ff3d509d0b823a23765b03b5bf3608308b21023308822/pyobjc_framework_metalkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d81f90237743cfb7a65e92d8581d0298feb4d59a20b3995321bfac9eca458f6f", size = 8800, upload-time = "2026-06-19T16:14:09.924Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/73b19059dd6b638a9850f2e2d350e3dfc7244fef9d89f84fc079ae06c558/pyobjc_framework_metalkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd09232de0cdca092a79efa4e73ea12357b1db862527c9ce8172d0c2b688c5c7", size = 8812, upload-time = "2026-06-19T16:14:10.681Z" },
+    { url = "https://files.pythonhosted.org/packages/29/20/1df8c5a560709a81848b6098c99a761813aac3f29defd4847766649dbb25/pyobjc_framework_metalkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a90f5ade5946194025bbfd2981a4099062d671ab2667c95d6ce218c13cc3d032", size = 8969, upload-time = "2026-06-19T16:14:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e9/2ef3900e36b165267007204bccd093389ba373439699c6bff85e6f9000eb/pyobjc_framework_metalkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4666993edc519a447e7c2dba75a90afee9597d6e583e088c80beae725669e5c0", size = 8870, upload-time = "2026-06-19T16:14:12.295Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6d/4fe11d7c809a5a019d048f0f5ba36222fe6d137c44859c7558d3b8f04a08/pyobjc_framework_metalkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1e549bfce38973abbb8df8332696d0bbea1fe990068ffa96e300c45fe6375ee4", size = 9014, upload-time = "2026-06-19T16:14:13.095Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/af9224e90acc2a463dae9e3242fe75d5097e40771803914844cb97c77be0/pyobjc_framework_metalkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:21010a4f50e58f2a494df6325027539efdde53ff211ef5dc9f1873282652c117", size = 8869, upload-time = "2026-06-19T16:14:13.863Z" },
+    { url = "https://files.pythonhosted.org/packages/05/53/e3c2fdce9766d684152093cc86449268030cfbd8e23224dec1dfaece0d44/pyobjc_framework_metalkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:837ab5e81b79db0e7c01763a9ed1a21fa57a27ee4ecb7376b944a92036733e09", size = 9006, upload-time = "2026-06-19T16:14:14.744Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalperformanceshaders"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-metal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/77/9675e6e2ea06d693a75586c4194630c4346e6661bcf9c9299353dde1edf3/pyobjc_framework_metalperformanceshaders-12.2.tar.gz", hash = "sha256:f428f762bcf552f1a8f5533508ae4c73057a7f4f4a93bc997a921edec63b51e6", size = 190423, upload-time = "2026-05-30T12:40:11.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/ff/6938291dd5a71e39f6948037dbb271993d86a3ecd7706e7cc38034feeaea/pyobjc_framework_metalperformanceshaders-12.2.1.tar.gz", hash = "sha256:a4395f8619ad6f1d382aab5cf116e058b18d3646bec6b730c77daa8f692b5de4", size = 190474, upload-time = "2026-06-19T16:21:09.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/09/a0906ac85670c10d7ba2ad597a66515f9d68cf1d16f69e76f9bb90dcc0ef/pyobjc_framework_metalperformanceshaders-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4b4129480193b524fa5b1407922539e2f52e2cb77bc20e16936711d70c4c61e1", size = 34165, upload-time = "2026-05-30T12:15:39.086Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f6/2eaf4c358eb9684b13a08f73239c654029805da1be0ae5052ac0e15fafc5/pyobjc_framework_metalperformanceshaders-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac154ee0c5bd0c715d2b837689a070b811994a772b209784907730793b725012", size = 34176, upload-time = "2026-05-30T12:15:42.108Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/f4/f134c898df89217ae3d07d364c75ac67048dd9106a164d7dcda52f83e5c6/pyobjc_framework_metalperformanceshaders-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:18cda4e2ed06da0caebb11fa54596e273e8d50cdbf243aa1d34fa347da71db77", size = 34374, upload-time = "2026-05-30T12:15:45.258Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d8/fbeb68c5c03d6d4ce8030c2b55b910ce987bec58cfc327971da7936c5f04/pyobjc_framework_metalperformanceshaders-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c6fda7dbcf6b64a9be973248568ec893abd4db96efd89c28a354605fae8dec43", size = 34240, upload-time = "2026-05-30T12:15:48.266Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/16/95c14b3e7a54da1a5cfefeb664cc553286706494825abc4864454a438e06/pyobjc_framework_metalperformanceshaders-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bb9e81a36604523de1a82d28b8b25c32f9fedf58f17dc1ddd01a2676a39b67a3", size = 34462, upload-time = "2026-05-30T12:15:51.325Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d9/bbd6439aeeca621bfd27b9c6dd6d5d43e637a69355878802f0ba49e995b9/pyobjc_framework_metalperformanceshaders-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:40a6743b3352cfbac9209aa29f6404f12939cbff232104b6165eaa8c0723a1b8", size = 34261, upload-time = "2026-05-30T12:15:54.564Z" },
-    { url = "https://files.pythonhosted.org/packages/85/5f/084ffa1fdd63a0007924068a1877ca5e69c0fb475ab312cd053b6e082982/pyobjc_framework_metalperformanceshaders-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:df0768e6ff1e27b6963dbdd851fb771a72539f0357ac667dc9b91898ee77f0e2", size = 34478, upload-time = "2026-05-30T12:15:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/1d95d7a2c2855f9afb7a27378940f52ff87894d98e8bac6e98cb3a0099f2/pyobjc_framework_metalperformanceshaders-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c679e85a4197302bdd7f9f9b17448c4df5c9a66e3ddb2d371814eb84a45261f", size = 34184, upload-time = "2026-06-19T16:14:17.743Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6e/40590459842bd635d0f5e77a520aca827af1331ef70e02955965f5122749/pyobjc_framework_metalperformanceshaders-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:856aa1b620ec04e64870694627435547affe350bda9e00e877e72ab518aec76e", size = 34198, upload-time = "2026-06-19T16:14:18.583Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/0f/f311b511eea76eaa7195164ea82133591c614bdbcf6efc069ef863dc0fa1/pyobjc_framework_metalperformanceshaders-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c1b094b81d0ed3f72b9345e7e4fbc47604934325d3695b4b8f2457701cf90fad", size = 34398, upload-time = "2026-06-19T16:14:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d2/999932228dcae4c691b295a5fb4bcd71abd16ac8dfbe67ceab629eb69582/pyobjc_framework_metalperformanceshaders-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b96cac9d50a9bf72e2bc3e006eac5ec0e7aeaabb65eac620df830c35af9b1fef", size = 34264, upload-time = "2026-06-19T16:14:20.364Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/46/96536afd54579814f2ceaf5a91ff16ae38e20cde7d630e45623171e7164f/pyobjc_framework_metalperformanceshaders-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1449836ff40cbb04a00c72b1c6219571914d895695d6d310bc1433b0181110d6", size = 34469, upload-time = "2026-06-19T16:14:21.265Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2b/4913eaf6eb59f20566f73b9f1b2fe0559aa610c6f8027e6ad20e9fa306f2/pyobjc_framework_metalperformanceshaders-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:db8048e5d7cb8a94b352f3902e330cf0f4de3c103ea07c261bcb495ee2b4ae7d", size = 34285, upload-time = "2026-06-19T16:14:22.184Z" },
+    { url = "https://files.pythonhosted.org/packages/26/fe/db17f4997f342d645b9ae30ec4f542f02612bd56496184a9294fa697c70a/pyobjc_framework_metalperformanceshaders-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:76e1b5f6733f14eed200631f6ba0af187fa89623cb1dcb126bf55dc4eddeba86", size = 34500, upload-time = "2026-06-19T16:14:23.12Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-metalperformanceshadersgraph"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-metalperformanceshaders" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/95/c274ffa29063e6f331a2d7d6942610ea2dc1e1984c647e68aff0f93e35b3/pyobjc_framework_metalperformanceshadersgraph-12.2.tar.gz", hash = "sha256:16249c5cd8d8403b5d81b871b618fdc0a8af0d7c81b461e733c0b5c1f9a9ef80", size = 60209, upload-time = "2026-05-30T12:40:16.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/11/15e3acf0636f9418384cd3e213296ad9882f546889865913cfaee2339ed6/pyobjc_framework_metalperformanceshadersgraph-12.2.1.tar.gz", hash = "sha256:656e70c86645814ef1d02bac74933eebc5ff6427100bee4a3bbffde921020ab6", size = 60199, upload-time = "2026-06-19T16:21:10.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/ca/173cf282b48c454dac9ef40f96b0e5338077803f3fbf0f07c09333d3a9aa/pyobjc_framework_metalperformanceshadersgraph-12.2-py2.py3-none-any.whl", hash = "sha256:e465d7717df4b000e3a529054cdf547e50e175f321b53c9520bcd6c69c08c837", size = 7110, upload-time = "2026-05-30T12:15:59.125Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d5/6aa84d1d976ba8b97cdc6486f09aab85f20ea6ba5079086f1de4426cbb2e/pyobjc_framework_metalperformanceshadersgraph-12.2.1-py2.py3-none-any.whl", hash = "sha256:9ac2270c573e9399c02196ea1725bd3c7ed3699d71ee70286b1f78beb8afaf5e", size = 7134, upload-time = "2026-06-19T16:14:24.104Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-metrickit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/7e/b880dd8c641abbc0807d75396132df80d7d9cb0d64006b078c7f2e169fb8/pyobjc_framework_metrickit-12.2.tar.gz", hash = "sha256:c76cae82489813ca121de0ad6013555aa826f8742adf975028b3e4268ac51e6c", size = 30585, upload-time = "2026-05-30T12:40:19.065Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/5d/1e0662fc1af513a08474ab7b9193012899e6930a490aefd9c2c531862a91/pyobjc_framework_metrickit-12.2.1.tar.gz", hash = "sha256:096878f3e750d12a7018b07ff3468d405ab3ac108f1aa92bc3123fd06934e344", size = 30581, upload-time = "2026-06-19T16:21:11.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/48/3e08c40cb1f5f905a8c24f1969e8b51fd3d00428f554d48d69a36de808bd/pyobjc_framework_metrickit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a0c8f72b143fbdbfcf9f0316da44a6253071c493e07ec46ba7f7b5b91bafb132", size = 8118, upload-time = "2026-05-30T12:16:04.149Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/7a/224f8a506539197efb51df3aa84b269262ee14a6a4ecf9ac08d7267dbb54/pyobjc_framework_metrickit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:db64bd8d99011d67edb16bdb0f923191d95649ee7bc4a276d4f2516e975ec780", size = 8128, upload-time = "2026-05-30T12:16:05.825Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c8/a112d3aa27eb2749d1308122b40fb1b45947199034e37ee5d86759eaeff7/pyobjc_framework_metrickit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eb146093ab8ec597e74307ece22c572b3654a4247d6e0d0fd3f4635f0166286e", size = 8267, upload-time = "2026-05-30T12:16:07.3Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/81/b37fc0c8c58af7537f224da4f1d16e161756c09df62255b2273c245b8def/pyobjc_framework_metrickit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:881f4e1af1f3e8bd5f9b58f9c1f3c2a51e2a119742ab98476a32c1cb03d09e33", size = 8182, upload-time = "2026-05-30T12:16:08.937Z" },
-    { url = "https://files.pythonhosted.org/packages/78/78/ff89dd771d30ae760a2549fc9384eb388b6771af59e8ae07e420d41dbb79/pyobjc_framework_metrickit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e22d5026f99a4b355b7f0090f64ab857aabab672bc288d01078510b645d48ae", size = 8325, upload-time = "2026-05-30T12:16:10.362Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d5/d8fb9b2eb03c6833468541961db44812f6b19f03467577740a68a0aed66c/pyobjc_framework_metrickit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d8ee9eba35773440c26d572b673d80c2fa3c804b595451a01d3ec0ecae23f780", size = 8173, upload-time = "2026-05-30T12:16:12.098Z" },
-    { url = "https://files.pythonhosted.org/packages/30/5e/e2fac8fb3341737891a31cab6a07a0ead428ef2910f8c6ae3ad77af24f89/pyobjc_framework_metrickit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b788a3cf866474dc4569fc253a6c0f62eb02a3b0104e9b2e757da8629d550462", size = 8319, upload-time = "2026-05-30T12:16:13.552Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cd/e70cbd2ade0daf4e8130af6bb4a45793a077d7b064bb3fa04d4f65349936/pyobjc_framework_metrickit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee7253c6451b99f43588be83460bdce90c1c2f94e10fe6cef294d0d44af771a7", size = 8141, upload-time = "2026-06-19T16:14:26.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/651e524176ebce5eff66bc237212949ea247478849ef53308cae5ed8eb75/pyobjc_framework_metrickit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f6c2cc22017377e984fbea0ea6ee15b3c0fecda7fcc42e88d0beb5387ad3a4", size = 8150, upload-time = "2026-06-19T16:14:27.732Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/14/96162ec3e8d8a8131e86ea8459cd8a2c7ec6a28a6ac703d3cf7d6d11b710/pyobjc_framework_metrickit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1357f74151b851760b2520f20ffab69a6a85ed3c1aebd61164bb67e0be417375", size = 8292, upload-time = "2026-06-19T16:14:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4a/6c6fef775e75785277f2511bb76f95b4b97edba7389bcbe1fbff68b526ef/pyobjc_framework_metrickit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:dbabe6b44292b0dad3998921c46a4292e328b4ac0ee26e25f34a2eb9fead452c", size = 8208, upload-time = "2026-06-19T16:14:29.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/68ced20b5005f8856fabd93c65bc878e041a99c155377461519b4027742f/pyobjc_framework_metrickit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ad3a56006b975e0165eb34853e30d6d7b68814b39e7a5bfd02a20cd47234535", size = 8353, upload-time = "2026-06-19T16:14:30.134Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3e/a399de9fbbd3f58f6b2b63648c455225f6777182456ebf489fc60b36970e/pyobjc_framework_metrickit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:cd58c762d163a557d18b23dd6e856086902258afb64064b3a72fa8237144b3f0", size = 8203, upload-time = "2026-06-19T16:14:30.893Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4f/81f2d04fdf116182364e69c2b11f65e4dbef0e95f26150225efce9622297/pyobjc_framework_metrickit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:72b0e04337f4de0a5bf29aae719713265f255d3440dbe7338b6aae92cfa414fa", size = 8343, upload-time = "2026-06-19T16:14:31.707Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-mlcompute"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/32/72a3733b6f3b1c60a18acfa517d28f9bcfff9822a1e21298c50c30c1a944/pyobjc_framework_mlcompute-12.2.tar.gz", hash = "sha256:7a2108c89ccae06e0fa03b1ef08c37bd9fae0ea0727d8b5890254bf44347eeac", size = 55014, upload-time = "2026-05-30T12:40:23.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/2d/16412fc8454bf987c64d7eb18ee0548198b35aad03b4d3cad6047fd18545/pyobjc_framework_mlcompute-12.2.1.tar.gz", hash = "sha256:4ee00b70d549619d63961864d9c2dd93b6db18d1c920242ae961517be7074f84", size = 55020, upload-time = "2026-06-19T16:21:12.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/7f/44c69bb026a7ffc00686a51514b43d7fe1a09682997cabe7a39a016aad0b/pyobjc_framework_mlcompute-12.2-py2.py3-none-any.whl", hash = "sha256:18066ab867e02f5eb2cc66145b4274e6a7105e69165550356ec4a75937db1aae", size = 9622, upload-time = "2026-05-30T12:16:15.333Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9a/f7c94f4ca691822916509a260d9a18c58224b14845ae7dc7c2b56eb0b376/pyobjc_framework_mlcompute-12.2.1-py2.py3-none-any.whl", hash = "sha256:71517c5afdba1213aa4a832fcf3bc1cbe0efac7f4a42ea10cca33bbd4ad1db45", size = 9644, upload-time = "2026-06-19T16:14:32.481Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-modelio"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/42/ff2d205133a753bd95c937b4591559bd10417d88da7debcdb7ef22e00dcc/pyobjc_framework_modelio-12.2.tar.gz", hash = "sha256:3f492868aa12c7107e456238fc718cac0316e8d95f7680b7465e41918d72db2f", size = 83763, upload-time = "2026-05-30T12:40:29.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a5/fbd7e593d0bf0f611b91758a855d1cad14b08f81609a588ce354b5677795/pyobjc_framework_modelio-12.2.1.tar.gz", hash = "sha256:d3706f803dc325c38536fb43fbd4174e958a95f92312a684ae152186661dff2b", size = 83795, upload-time = "2026-06-19T16:21:13.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/a2/84d79cae91284b7fd9c148fc6fbd84e54b5a30c189e0561dc605567d9149/pyobjc_framework_modelio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8d6c6fa5d5024495f7ee163acf872757824c4c2115909fb0f6e9ab045d1a6094", size = 20492, upload-time = "2026-05-30T12:16:22.228Z" },
-    { url = "https://files.pythonhosted.org/packages/57/92/6dc491a2ffe4c852c266d2a3430114fa0a4cee057930556adb5f27e4948c/pyobjc_framework_modelio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a2bcdc8079e4886dbee3c2351da5dfc53fe46d1d8e73a9a751085adce97a74ff", size = 20497, upload-time = "2026-05-30T12:16:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/f6/c4253cdf4ce3d2b55465805499deeecaff9230425366bdb9266c0e811736/pyobjc_framework_modelio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c7999915fad52b6578688d32ab4c761460237cb28b06dd663f81993fa6c4580e", size = 20738, upload-time = "2026-05-30T12:16:26.954Z" },
-    { url = "https://files.pythonhosted.org/packages/79/80/8f106d2a3c5236c05e58cf2652d0f346b723580b158543d33226bf0cdce3/pyobjc_framework_modelio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d8d6e411bf94a589372d2025ad854e1d9d96fa0c49af70898fd92c0265389dfb", size = 20473, upload-time = "2026-05-30T12:16:29.145Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/68/be1d3a840e1aad3d4deb9fe69338af2ea37767b6d90128f89aa04b3e00b1/pyobjc_framework_modelio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa3e1aa0452c75a2a33b465a69f2203c3dbc93d556761814f68546dae6e8d6dc", size = 20716, upload-time = "2026-05-30T12:16:31.418Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/18/d5319d61d40e9409cfe11d26db0cb107d838e9a39c16bf488528f2499b41/pyobjc_framework_modelio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2204e3078e1e10ee43068ec198e2b24a8064901abb4fb040f3f9b06066bcd933", size = 20459, upload-time = "2026-05-30T12:16:33.653Z" },
-    { url = "https://files.pythonhosted.org/packages/02/60/7a9bf4028cd412840acb04110ace00b04399b549298b93fd63a2045122d3/pyobjc_framework_modelio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:4e251c993b7dc123a436cc39802d272893a4c374796b3793d8f6cfd4f1c90f31", size = 20732, upload-time = "2026-05-30T12:16:36.008Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/acaef170056476aca099d56ec837f6f7bdc73c52507f14e577c8f14cb922/pyobjc_framework_modelio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:82343edada3bb065317774a0f58c65f516fec6247113091da7029d06ad7e8431", size = 20511, upload-time = "2026-06-19T16:14:35.344Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a7/6c23682a7b986165d6949e70d0cf9c30d1ff22ae369711b23699f22fef37/pyobjc_framework_modelio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68b53d1aea59dcbe5682f753ded2d3dc4d54598f58a0defe9a1d3219c7a801b0", size = 20522, upload-time = "2026-06-19T16:14:36.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1f/d3c3c89eb0d10b00ed139a4308a3d5e353663c16310628d69d1fae2b774f/pyobjc_framework_modelio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1714a43c35bd4254f5fb51bc5d6b67dfcb2a6b20ff309d34ddd22f03bb1709b8", size = 20759, upload-time = "2026-06-19T16:14:38.045Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d8/a50f8972c14c06a39bd25f28d87490ac6c8bcc1ca81f2237859d784200be/pyobjc_framework_modelio-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0dbf08b900703cc0a6d4e53b10da5d334dd5fed26be010aeda5eb53f93287ccd", size = 20494, upload-time = "2026-06-19T16:14:38.873Z" },
+    { url = "https://files.pythonhosted.org/packages/af/40/89e31e57a16cf9c11757f310e7cc2ae031008fe9aee5baca89f17c521335/pyobjc_framework_modelio-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:32b361d7b80c9b63271c205860bb1961b530f1e79b43eec21e970bdc48497633", size = 20743, upload-time = "2026-06-19T16:14:39.754Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/52310f780e2564103cea0d9681291529b588cf7b0065bb43bfda9dd239c8/pyobjc_framework_modelio-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c3d780628dc0ec585ecf845a8271b0843c619d50b6dae8335cdeb4c0a4054daa", size = 20483, upload-time = "2026-06-19T16:14:40.585Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d8/bf3bf64b81f53f604d94bf190c2b3c2868636d6dcf28ca49bb08cd34dd38/pyobjc_framework_modelio-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:476aadad72bebb9df752651ee2097e620a52e2293dbcd83dd9c0e424d7f401f7", size = 20749, upload-time = "2026-06-19T16:14:41.441Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-multipeerconnectivity"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/3112f721c54e1a09d12d8dc48b165ff51a1147783d8d63a53e1da5b603ca/pyobjc_framework_multipeerconnectivity-12.2.tar.gz", hash = "sha256:7a5879cb83e9a7ea8c8d9e7e11ed3de4c9d67046e6c330b8a5f6332339f631a6", size = 26444, upload-time = "2026-05-30T12:40:31.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/5a/cf3fad5f570ad3aa43010ef03e948d4ac1f0a531d3b7d822f1c19004f59a/pyobjc_framework_multipeerconnectivity-12.2.1.tar.gz", hash = "sha256:06f9a354ef0ef77c45c98ba9ef92bc48961522d7b3ba322e56b4ee3d4a46413c", size = 26450, upload-time = "2026-06-19T16:21:14.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/87/873cc3512150455b387492dcac327e9ad68187b708b06ac4665e750d2bca/pyobjc_framework_multipeerconnectivity-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:548618e01d4df6aa80f3f855af06bbca9e7148c06f174d1b091f54adf5aa63cf", size = 12000, upload-time = "2026-05-30T12:16:41.693Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/50/4080a78aaa2fe925dd2473fde41f650e3433cbc658c062d09b3658e181a0/pyobjc_framework_multipeerconnectivity-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ff0c6305c3b573d97f217a69b8b82b9075d788a82768377a07a456114bec248d", size = 12018, upload-time = "2026-05-30T12:16:43.467Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/75/50488445848adbac42d752d99d126913dadf5e7026aaf28d83c836b6f788/pyobjc_framework_multipeerconnectivity-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5f5de878761b5e1cec4566df0aef13143845a83e4d12c80faeaefd308fd919c4", size = 12198, upload-time = "2026-05-30T12:16:45.195Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/6c/ff2eb6e93c855d62b8fa7b07b76d549e381d2cbe37ffe6988ebdf6148a93/pyobjc_framework_multipeerconnectivity-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4168de44baf26e779a115dba20d4c4415199874316135932f0c1647b638d1571", size = 11995, upload-time = "2026-05-30T12:16:46.938Z" },
-    { url = "https://files.pythonhosted.org/packages/44/6d/ddae986c4c54a47273baa6f068fe7b78b277d1bc4823c6f520d08c434225/pyobjc_framework_multipeerconnectivity-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e97c1fd9656afd8287c111341e44e1cd87ea5dfaabb56a899f589d63bcb1b014", size = 12209, upload-time = "2026-05-30T12:16:48.791Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/54/77a9cecd9ddf1b76711c0a90faa1177101f52057931e83c174e180e9b7d8/pyobjc_framework_multipeerconnectivity-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8863bbe1774901dcca970e2113f95832fdfd2f3473de8df033411611224d65a8", size = 11988, upload-time = "2026-05-30T12:16:50.651Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/0f/0949e62302bbfdfa453e795ae88351b18d213b4308dfb03d4fcbf5b4f443/pyobjc_framework_multipeerconnectivity-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c83025bca07a25bf416e960906375f66ff7fff2ea4411d1be13fd51dce32737f", size = 12203, upload-time = "2026-05-30T12:16:52.288Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2c/3b85949975b600497c7f1f928e2f35344b2b2654550abac1f07d83c0ee89/pyobjc_framework_multipeerconnectivity-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3180c51bb68ed87f53e7b805f3443a510d7db00a1c0344223eabb384123fa0cb", size = 12028, upload-time = "2026-06-19T16:14:44.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6b/546137c9aa171232ef6912f90bcd2cb2b4705d8ccc81cd498885d284d862/pyobjc_framework_multipeerconnectivity-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e566a2dd4ac9b95cc8b4739092501413a1d697a1c34126dce489cf55c0c71a53", size = 12047, upload-time = "2026-06-19T16:14:44.828Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cc/519061d373de8c779487b978eaa48cf60d9ec588f6dd2924dc9faefe8ebc/pyobjc_framework_multipeerconnectivity-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:87049bc0af02bb623bdd90573a6a2abaca7c967520db81477b05d0c38860aa37", size = 12229, upload-time = "2026-06-19T16:14:45.57Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b0/1899d7b277df12d9c1ff6e21465881ec85e7ccafd76da2fbe4440a7d888b/pyobjc_framework_multipeerconnectivity-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b1f0f3bc2dbd15e2231d9b5427c4224428660c1a96a66f2521a859b0c5888aea", size = 12024, upload-time = "2026-06-19T16:14:46.37Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/df2767d489c6083b11e1e3e4f4d60a3993649d378e876a551c7e911f1918/pyobjc_framework_multipeerconnectivity-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f22051fcccbbd16b9a1d4e2f161dc06304f13444ee65035e62ca6ed58a5150b1", size = 12237, upload-time = "2026-06-19T16:14:47.129Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e1/7a6f71aae1c8dfbb87baf9d1072df69570604ae735d7b3140ce00e4a68d6/pyobjc_framework_multipeerconnectivity-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:92f2a113f8ef13b6faa6aa9c95e01b29f10bd30c4652dc074fff747f8b29bdf9", size = 12016, upload-time = "2026-06-19T16:14:48.015Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2b/e9b6864ead5ef7435e30628185ab6908ebb85cd63c3c2b3f7fd788035912/pyobjc_framework_multipeerconnectivity-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3c49e75d0dc605394422ce9e869784c3f911551733044db09c77659de1280880", size = 12231, upload-time = "2026-06-19T16:14:48.946Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-naturallanguage"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/1b/8fe870dd9ffed8943e72328fdd71df69363ea55037107882a3c11182edbe/pyobjc_framework_naturallanguage-12.2.tar.gz", hash = "sha256:f6980ba957bb24501bbe135ffcdd0ff149f33d30e965f033ad153df756b33cc7", size = 27251, upload-time = "2026-05-30T12:40:34.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/12/de013ac3cdbdb3cc616dd373399df4eb34b4459f668456d81f7062bd49c4/pyobjc_framework_naturallanguage-12.2.1.tar.gz", hash = "sha256:fa2d9c7040dcbbe4c7bc83ddfb9e3da20edb49824de8c78d3574aec7065c4043", size = 27243, upload-time = "2026-06-19T16:21:15.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/00/5923b25edd9d64ba7494cb8e28c1c073ec5cbb43a41eaa70bffa4b7a2862/pyobjc_framework_naturallanguage-12.2-py2.py3-none-any.whl", hash = "sha256:8c02a9ea25b888eefb0ac503211e17a9868a1781f5d5bf9c1655445abc14ffe2", size = 5436, upload-time = "2026-05-30T12:16:53.941Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/5c/3c0692cc72de5b9cc6e55d262df6630f43040374eb7454382473067d3379/pyobjc_framework_naturallanguage-12.2.1-py2.py3-none-any.whl", hash = "sha256:5eed3750f7cbd6a9584f2b9942c4b26b7134ed15dc044815ac79841403048be9", size = 5460, upload-time = "2026-06-19T16:14:49.857Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-netfs"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c8/e22988cf11df9b7c7da2ba04b7e9b9435fa7dc4ba3be7d6bb34d60f686eb/pyobjc_framework_netfs-12.2.tar.gz", hash = "sha256:fdb04ecc91864a4b79498a07f4d34f33b5dcae34958d555f5cbd69e20165991d", size = 15139, upload-time = "2026-05-30T12:40:36.186Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ad/28624d75b8339f70fc51bbac131d160a92b87c41ba5684a904304f8a6a09/pyobjc_framework_netfs-12.2.1.tar.gz", hash = "sha256:312b3a6ebcba6b3a03bdc7412560d8ddb5ac336c37a1205e32c6b58d831191f2", size = 15153, upload-time = "2026-06-19T16:21:15.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c1/1584c42fc716ee13d085461913b59f5682fddd76b8094feb760477a8edab/pyobjc_framework_netfs-12.2-py2.py3-none-any.whl", hash = "sha256:864d09a7b671f4407ff577739949c98ae8ba9b013433cf938fb0c86319151248", size = 4161, upload-time = "2026-05-30T12:16:55.515Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e7/6396d25cbfa2237784ada5bcb870531be597b9dbf1a5c5d41d007921d2cc/pyobjc_framework_netfs-12.2.1-py2.py3-none-any.whl", hash = "sha256:04f8f1743f98af10d005f42ec30b26f147d3ee0365b1ff3df2babaf456c75e07", size = 4182, upload-time = "2026-06-19T16:14:50.78Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-network"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/a8/12fcf0341ff377600a102f48266ef85e67af9dc7d894ca40fb18dd8702bb/pyobjc_framework_network-12.2.tar.gz", hash = "sha256:99d7a1900d8250d008eb285b20792d14076eedd665749cb0f48e1e102056207a", size = 62275, upload-time = "2026-05-30T12:40:40.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/32/6a69c5ccbaf38557f6a090b565ea12a773a64f3f29e87e625c03fa46c183/pyobjc_framework_network-12.2.1.tar.gz", hash = "sha256:0cbb405f304f25617f138a2556433e22d4f706e558a78201957f9e2ca3c9ae21", size = 62791, upload-time = "2026-06-19T16:21:16.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/7d/b519d186727fda8eb3d365312e2d4059e104f50525f0c0618083c43755fb/pyobjc_framework_network-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0173665fde7fe004c49e9786a0073ed50f6b2b7f6b78198bda78a01c36ec9650", size = 19630, upload-time = "2026-05-30T12:17:01.972Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/b3/c99e31a29975fe58d81396105518d74cdd1b0de5f8d939e5a5892b7d95f7/pyobjc_framework_network-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6677fac4bfe2d8ae320ffc069767c0e2ca7d50304ad3cf7a77d0a4d08d69465e", size = 19643, upload-time = "2026-05-30T12:17:04.223Z" },
-    { url = "https://files.pythonhosted.org/packages/85/94/233e77df7b4b53aa0316346540ee1345ed6c2d5b1893fd10fe268e1d9a1c/pyobjc_framework_network-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c198226431964487f1213ba17de69eddcaf5ddd1bea406b31c6845cc956da536", size = 19714, upload-time = "2026-05-30T12:17:06.29Z" },
-    { url = "https://files.pythonhosted.org/packages/95/48/9d19d4dacbe35ad331c952501776965686eb93e385fddb8aac9feb02cc14/pyobjc_framework_network-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:842fcdb53fcf86af1f5a2287107955e05f124be1e461a407b77b944628f7a57b", size = 19374, upload-time = "2026-05-30T12:17:08.391Z" },
-    { url = "https://files.pythonhosted.org/packages/93/53/b20568f13df1dde9b8520e84200581a3be120a7a9f57b98086e169a892c8/pyobjc_framework_network-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7f3748fe2d12061b6b4035d2a9575b81ea6911dfd3f2652d23bd913e9aa4b559", size = 19432, upload-time = "2026-05-30T12:17:10.638Z" },
-    { url = "https://files.pythonhosted.org/packages/32/29/3bbde722d3c54a8356c7a942cfa75f54a8589bc22899e95f27ad62967b63/pyobjc_framework_network-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c88b1b8666e007cf3388c17998147d12a9e80b103d21a625df170382990a974b", size = 19385, upload-time = "2026-05-30T12:17:12.667Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/5b/99538f4541949b561788eb2971b1b0f1a60353000f780266508a7cf1a2fd/pyobjc_framework_network-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2157c11fe921fb76af55364b7ca1e9f9679156b2cf2b7b18f1a1e2d25bc4502f", size = 19438, upload-time = "2026-05-30T12:17:14.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c8/098f41c92c847c4c7f0f3efa1bd243555926c34df95dc39d2103bc178710/pyobjc_framework_network-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45d0ad8977ac71624bb6bbd929df8768a39fc8c13e97712bd7d37a4b9b4061e2", size = 19652, upload-time = "2026-06-19T16:14:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1a/4580c0fc4433a9761812cf392b93d7c874be1cb2b34f52c6169621bc284b/pyobjc_framework_network-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ff15672b23decfd9ec9a0051ccd15f4abf098020c4700ff8d2466e597e747eb1", size = 19666, upload-time = "2026-06-19T16:14:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/00/724d2761f1af78b5f108804bdd68896a6d260fc472856c444dd495afef5d/pyobjc_framework_network-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9d2df906f6cb262c74ee6b28f80856eea52d07723c325a04e804357b77c9a335", size = 19735, upload-time = "2026-06-19T16:14:55.656Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ca/36fde1adeb34d7e5000808fcbcab985b78810dce8ee803edf9fb4a73bf45/pyobjc_framework_network-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d84a21895c3ecbbc48d683c7210c0bd12259a3e97cbab16af125248abb3fab4", size = 19396, upload-time = "2026-06-19T16:14:56.623Z" },
+    { url = "https://files.pythonhosted.org/packages/39/bc/882f1c507d512b7cffa39af8bfe4556d2b83bebf5be025e8fdcf21752aec/pyobjc_framework_network-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3a27d2276da4e3bb1e826defddf6b09bd8fa80fd045d3a711bd429785df8f5fd", size = 19453, upload-time = "2026-06-19T16:14:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/17/33/f7f7a3de02f8369070ebfb79261fdf1df3c1857476cd9b10a43c1b73e50f/pyobjc_framework_network-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a9484c5acd6507a7924307239de798aa1d56d35abb5d08664e9767411f40f9c0", size = 19405, upload-time = "2026-06-19T16:14:58.262Z" },
+    { url = "https://files.pythonhosted.org/packages/11/da/7bdbe57f1f288929502226afbdc7bb505ddc49c53fbcfbf47352fc77ba36/pyobjc_framework_network-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3bcc2d70564c0d3c290be0f2be4c129bbeda18ac963f0513f6b5d8e482e1d2c4", size = 19462, upload-time = "2026-06-19T16:14:59.187Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-networkextension"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/f0/bf65ac7714c81159f295d9386d718c9a876fc212f8af54b6da22c2d2873a/pyobjc_framework_networkextension-12.2.tar.gz", hash = "sha256:45bc3e7966cb9fce997832960d8aaf324a187f84019e65fc4432c27046715f70", size = 81296, upload-time = "2026-05-30T12:40:46.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/38/7fdd6bce0c65c4ec01662e4489950b712034faa5adb59428a13ce9d56b0c/pyobjc_framework_networkextension-12.2.1.tar.gz", hash = "sha256:7858164a3e28dc81d317412123fcd664424da9afae63036e31979668ecd5972d", size = 81345, upload-time = "2026-06-19T16:21:17.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/d8/ad0b3dadd27ddffecc697f3155fc387b278d74972ae36e790c3bd69c92da/pyobjc_framework_networkextension-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1b9d588739185994e945fcebf23d1f25bfd0d2893bfc2cddc366a2f421943245", size = 14451, upload-time = "2026-05-30T12:17:20.853Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/91d135890a83c021e2b031c467001802314a5b2c6aa1580669b1bf524060/pyobjc_framework_networkextension-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:631ca462cedf277531800e3cbdf6d4f98aac2dd2ce8512fc855076fa373d6725", size = 14467, upload-time = "2026-05-30T12:17:22.768Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d5/47debfb91e4f0c1bdbb1d4f433662cdc97e0467bf84379764be7dc26dfe3/pyobjc_framework_networkextension-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1f9c7e7aa156d604a2c0764f65ef95131ff0c7724dd9ff35347d96b27836814c", size = 14611, upload-time = "2026-05-30T12:17:25.109Z" },
-    { url = "https://files.pythonhosted.org/packages/30/94/c894b717aafc6c93dfa02424e64025d2f15fe90c283b2166a9131e0c9306/pyobjc_framework_networkextension-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e2bd61562844e400f8b8c5b434be44e42164af3e64ea4f51cdee335f92e9cc8c", size = 14530, upload-time = "2026-05-30T12:17:27.228Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/d1/8073286f4bf3d38edcd506826101d4f421bfb140ab402a4e627ec9f5235a/pyobjc_framework_networkextension-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4a105e5cfe795914f728684e0b5b08647b7d7c106b9602ab782bb0af93f44bd9", size = 14668, upload-time = "2026-05-30T12:17:29.176Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/71/2ee8580786367e4376a2bb76e45c17b81d7b85436382bb40f8236f7f8700/pyobjc_framework_networkextension-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fdd6a5807b30077ce1545b0a9583a8f878f220f6b5f246daa470d77ad0b1a692", size = 14526, upload-time = "2026-05-30T12:17:31.141Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d0/053e00fb31b9b1cd0ecb207ac61f59befc9ccf3f257af7d05445b3a83e8f/pyobjc_framework_networkextension-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:faf4482e957bc76a78d3784ee5b010f9f562eb606118a6a3a30edd59f89f430a", size = 14659, upload-time = "2026-05-30T12:17:33.068Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e9/084b993f44295a3c7a95434d4e655050655a6fae17d8488aea6ab9c65bec/pyobjc_framework_networkextension-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb4c79aae8bd30099a2373d379a7d3cbfc6c210fbcdcb766c58d209dfe710062", size = 14476, upload-time = "2026-06-19T16:15:01.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/26/09becc50d9ca9a00dde6ec835b3b49249b006bd162bf40beb05661897330/pyobjc_framework_networkextension-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94e851bdcd902dfac889daa5017bb9e3bc7086332956d9ecc53ef087d332d1f3", size = 14490, upload-time = "2026-06-19T16:15:02.7Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f9/f1aa8f1ec246ee79018d068beb38a25af39287c671f471545216e338d695/pyobjc_framework_networkextension-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:812cc5a68e464b1a0047048a46e0f1d44718cc39c37ab9d8d2827c34a37cc2a1", size = 14637, upload-time = "2026-06-19T16:15:03.586Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/4e19d49b25a7797c0720755dc7cdc4e54098fe92b128401f34c31ab59a65/pyobjc_framework_networkextension-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e7c43d18132a7140bd4cd8ff81977a3844579020dd22604f06684d0aad667c45", size = 14552, upload-time = "2026-06-19T16:15:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e5/17af4957cc34ba654d61a435bd028cc95253c45d6e1e480cb9b294a75089/pyobjc_framework_networkextension-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d99ac04d1fb84ef4593ee4eb9a18d80e9f7dc687ed642ead6a67ec4cd1ac9fcf", size = 14692, upload-time = "2026-06-19T16:15:05.342Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/ae571a55431fb97f7930c42a62fd84aba12ceabf7fa504b01d18fc5f9abb/pyobjc_framework_networkextension-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e639073b2d2a825af35ff7db046e0fdd969707710b4a77c184e203fee65e5c12", size = 14544, upload-time = "2026-06-19T16:15:06.177Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/08/ebb145dd982e95cddbcb66c9e2bb9e4a238212f67cb9e6005b2d3570eee9/pyobjc_framework_networkextension-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2bf7bcd4712ca3636933f64e5c8fb2f72c5854a7cd6c20738ab88831e37c5922", size = 14680, upload-time = "2026-06-19T16:15:07.03Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-notificationcenter"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/d4/62b27947aa2ff2228b49083245e622eb4840f68c58d6d3e89041f597b5dc/pyobjc_framework_notificationcenter-12.2.tar.gz", hash = "sha256:d7a20fd67851d91db142765aa823a5c60c03c37957cea310a4eaad37640c085e", size = 22134, upload-time = "2026-05-30T12:40:48.715Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/22/6e5b84c0b0b187525fe655508adba71fb208abb747326f2a9da84dd2d6b3/pyobjc_framework_notificationcenter-12.2.1.tar.gz", hash = "sha256:952d0bfff1653f16f9e79336c8eeb928ed517f0212c914191a925a85523b5af6", size = 22159, upload-time = "2026-06-19T16:21:18.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/37/7ba6f07424412b99f3eb9c4ef34e16d156f257b2670cd625d2ec0c7e2c6b/pyobjc_framework_notificationcenter-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1141c58ff04085ef388c7fc4e588d5be9facbfc6d63f405ea6940f990293c493", size = 9872, upload-time = "2026-05-30T12:17:38.161Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ac/2b2465db73f0340538df30728e5cc4a1c3014066651b091406cf2fe96e0e/pyobjc_framework_notificationcenter-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d869a7689086ccb6f5c82a29684f38cbd2293e63a50fb8b06cec6151b497a73e", size = 9896, upload-time = "2026-05-30T12:17:39.78Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0d/bff8fbabbad5f0328852f0d9b7d87551b206c3c76ff9c5ecd863d7613643/pyobjc_framework_notificationcenter-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db911fd4de68f52abda8e812799e87721092f78ac575ec50bff82018e1efb06a", size = 10088, upload-time = "2026-05-30T12:17:41.723Z" },
-    { url = "https://files.pythonhosted.org/packages/18/bb/06fbcdcd37586878ce75cd61218594d0f3c4559262487b870dd4061f8394/pyobjc_framework_notificationcenter-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3425e37a3eaa63dc63b8ca9556472e57d020bb6681885f1e36ef875e67ea07e6", size = 9955, upload-time = "2026-05-30T12:17:43.467Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/f1/3d1e94e67bcbc4dbdad682d421d2545e80bc08d0f742f71311e99c17bd2d/pyobjc_framework_notificationcenter-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:27dc6e162ff3fe446b50e276c97d7e811b71cacef460dc857b0cebc08e6a6286", size = 10165, upload-time = "2026-05-30T12:17:45.078Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/4d/800507135e5018b87343a4ab8cda11ee4d9b3018b3469d2f68f32a1607a7/pyobjc_framework_notificationcenter-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e0b2b48ee6012b8019211d7e8910f5cdfcdfe846b54c79e7ed58deacff5d73fa", size = 9950, upload-time = "2026-05-30T12:17:46.653Z" },
-    { url = "https://files.pythonhosted.org/packages/32/22/09ff226c62948056d15f8b9f7dfdbba873f876f1496ac4193e1b4f26cc7e/pyobjc_framework_notificationcenter-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7287b66979a21d94f132a4bdd2914f6e6d96823d7454c46841722b6d494ecd78", size = 10153, upload-time = "2026-05-30T12:17:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/2e870eb44592692ff85e829b28f2004eece7e1b1c4578dfd715251649b5a/pyobjc_framework_notificationcenter-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e86691f099a752a625b1a03a42f8cd8b28705bae5cb9924c988a7a8bc429d5c", size = 9900, upload-time = "2026-06-19T16:15:09.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/27/a56dece1c44638a8736a0878c8b52b153940183781a6065ca80fd38644b3/pyobjc_framework_notificationcenter-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:72187126a81e4a5f1fecab21b4740628dc6fa75a6a0471a0c115adfb49c04893", size = 9916, upload-time = "2026-06-19T16:15:10.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/37/1acb093763b4b83de911f53f28363bd4a81190511f7794235dd279d850d8/pyobjc_framework_notificationcenter-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c61e2dd16fe34410d972c57e62c6c4949f86e97b12fd1f1079b75ba409df7837", size = 10114, upload-time = "2026-06-19T16:15:11.543Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1a/fb2f8fe66035c42b05900c8533ab4674c56696d180ef6a6f84387cea95dd/pyobjc_framework_notificationcenter-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f91d2354beb4c928f4feda65bc2d73166aff1865a5bdccab2719744398c8d2cc", size = 9983, upload-time = "2026-06-19T16:15:12.391Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fe/ea0cb8dc6771235db520c8ebe2e5899b6c45a835cfeacd82b324b6a5130e/pyobjc_framework_notificationcenter-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:65de365859ab6e87763df7fce64f141d1850e5f23ec88649cf4b0071900a8183", size = 10188, upload-time = "2026-06-19T16:15:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/52/6692a17ccb5f9b124f1c2a1f9dc6a4cb42d267d5478c0e8f4dd5a930538a/pyobjc_framework_notificationcenter-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a3c19ff09ecb73f55a94a45b4004795d60027e0a05dbfb7212e5e8c2855aa9d6", size = 9976, upload-time = "2026-06-19T16:15:14.127Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5b/4fd8da648e6712d4c3558042c285cd1bf36b333dcc40529725487220145b/pyobjc_framework_notificationcenter-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:047ff96770aaa238bdce7f5ce73d954a1b0cab83cbff64188f92e852ad46c112", size = 10177, upload-time = "2026-06-19T16:15:14.953Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-opendirectory"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/43/1c4b9f4e3739c3ab763f42b6e51ea74afebafefa5662b2740a6fb812697a/pyobjc_framework_opendirectory-12.2.tar.gz", hash = "sha256:e9edbe26c4d9aa533f343264d34af96fbef958d0c3a833acd2d64cf0fdb138e7", size = 69875, upload-time = "2026-05-30T12:40:53.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/02/df1979038cdc426990b364b2307ef33f5a6d915e70eda4791daf692024e7/pyobjc_framework_opendirectory-12.2.1.tar.gz", hash = "sha256:1b6dc2eea7857f05063f22e746ae66e8a2a135e41c62b7f3ca7c91f8a5ec5de0", size = 69907, upload-time = "2026-06-19T16:21:19.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/0d/6926ea3ba0f58e52e7a2260b416abd44c4680dc6c5c8e2212ccdd8d649cc/pyobjc_framework_opendirectory-12.2-py2.py3-none-any.whl", hash = "sha256:71d17cc1be29dd2ac50ae76fd654d233bed3b117854bf0ace021d8242a5a5566", size = 11910, upload-time = "2026-05-30T12:17:49.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2a/e4bd17504ad233a38ea2d73a2b9914310c489a34f71418962bf99ff35799/pyobjc_framework_opendirectory-12.2.1-py2.py3-none-any.whl", hash = "sha256:2604cd01e236a1237ee6e52c689e60fb380807c5bda6981dab37dd14d89dd254", size = 11939, upload-time = "2026-06-19T16:15:15.771Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-osakit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/bf/f6ea6b2e15151c79a22feda80d9e2c120d457cf16750c7751408f3dffc7c/pyobjc_framework_osakit-12.2.tar.gz", hash = "sha256:219efdbe36fa6bea1c780b28ad8a1b23ec4ca0ee9ad3cf040da192f883514b81", size = 18910, upload-time = "2026-05-30T12:40:55.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/41/0a010e6e48e5bb248a8c4d6b7f71ecb1cf17c92b194db512b536f60a54a8/pyobjc_framework_osakit-12.2.1.tar.gz", hash = "sha256:6656e6dab5eb2b571cdcd0d68c0084fa2ac5f85f2f06423e132b410c44e87187", size = 18924, upload-time = "2026-06-19T16:21:20.394Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/ad/e79528da31d07f4d227c0f674b94a8a5b0aeac062d6a2df8363dbf0d99c9/pyobjc_framework_osakit-12.2-py2.py3-none-any.whl", hash = "sha256:604f428b00a0b1da1f40fc8a78db96e08b23abc7d666545a0909cc6e7b5ca2fd", size = 4143, upload-time = "2026-05-30T12:17:51.431Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ff/ba06033f6b8b5a43a188c810c4439a35cbc0baf90bfa90e4a1682260c1d7/pyobjc_framework_osakit-12.2.1-py2.py3-none-any.whl", hash = "sha256:00c1996bde228324665795f9fe9e129eccfbeab1c10d8ba34e1b1adae379b482", size = 4166, upload-time = "2026-06-19T16:15:16.725Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-oslog"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -5193,708 +5165,708 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/ba/dc92bab4a4be642226c3f6b71e0a100f70c27027728df00eeaaa588d04f8/pyobjc_framework_oslog-12.2.tar.gz", hash = "sha256:c2213dbb3edff318c731b300509c69bd922ad102311042dddcd9de8287e50a83", size = 22307, upload-time = "2026-05-30T12:40:57.943Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/3b/8a38104775d9472cc360018ca358325135779037122813f5d4cf0f1ce4f6/pyobjc_framework_oslog-12.2.1.tar.gz", hash = "sha256:423e19e08d3f01f3b0d53f2b4503322c0ef9d116c0a1f91fe36273232cf0ff22", size = 22322, upload-time = "2026-06-19T16:21:21.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/62/e7ee1eceb1645615eebf7549e89cc9a5ee815d0a8d1058790faa68a780a7/pyobjc_framework_oslog-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3f88f4921707ed38da239d03f423929b126f0d8361c0500a382c76144b674f55", size = 7882, upload-time = "2026-05-30T12:17:56.321Z" },
-    { url = "https://files.pythonhosted.org/packages/be/13/df0e2bae8e19998101ba238a2cd27c147906c63cd42d1814293bc08f729b/pyobjc_framework_oslog-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ce52bdc6803bf980369d3f265339063fb71391fcf980acadf9f73c4b7af7413d", size = 7902, upload-time = "2026-05-30T12:17:57.82Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/cb/b73921c1ce8a78620c14f00f2907de7430a5dd78cd858b3b72cf43758ee1/pyobjc_framework_oslog-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:102c32f34f772befc22d37bbf3a6a70a88b3389ea6d25111217e84c5bfde40cf", size = 8081, upload-time = "2026-05-30T12:17:59.592Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/d6/8945a6f9ff6f31f90a41e190d944bacd3d3115d73004eb778c95212fe9c6/pyobjc_framework_oslog-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:595f392d7966a28765dc35b7139243ee6cd1467a6edbb1f1ebe20af38e058542", size = 7943, upload-time = "2026-05-30T12:18:01.072Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/ce/d0620e285ec8a2257dd7079d1fb3c44d6b853ce049abcfdefc5fa73d0155/pyobjc_framework_oslog-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7b4048471200aa35b7100dc58afc9c1c36b6b7a969070cec608b6b260a892259", size = 8143, upload-time = "2026-05-30T12:18:02.765Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6d/e7e9ea2ba0e4c4af69651f7aef78ddb2f35232f782526089c9dd727feeee/pyobjc_framework_oslog-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:041b952ad6bfc80637f827ed0007f34ac68352b1d51f83279ab6db66b89d1dc2", size = 7944, upload-time = "2026-05-30T12:18:04.209Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/50/b76c39a5cfed0476ab89926b1c324673f99571336d56d8a099dfcf6dcdc5/pyobjc_framework_oslog-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1bb0922c211b07f50022583ea54ea58cf651963982e325873c6813474c4f0ff0", size = 8145, upload-time = "2026-05-30T12:18:05.925Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c8/834e7bef1853a936a4bdb019f6e55f985ee3bd04ef6e7dc2a6f1a964e144/pyobjc_framework_oslog-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6cb3738d55676285692108f6cd43773ad9589030bda1077e8ff7080e44e635d0", size = 7910, upload-time = "2026-06-19T16:15:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/91/32/f6dc6ca6d9487e9be095193740263e59b700a239dac6b6a3bd75c30d7449/pyobjc_framework_oslog-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0ab4755e4b31d304d8eb04291470a7381d69b0381cec02242bdf37e2a492438", size = 7922, upload-time = "2026-06-19T16:15:20.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/937982d62f343fa41a3b0ccc3b481b73f804a04e185ebfd15044d21529ca/pyobjc_framework_oslog-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bf2a170e8fcef12de89749f085d3ef52f0a3a7084a566f244377012301d91c63", size = 8104, upload-time = "2026-06-19T16:15:21.196Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c1/12795679095752db88da5d3ac93d7e767b8e35b8a487a64405232fbf49f9/pyobjc_framework_oslog-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d16161bf907569eb02be4e0e4b515cd1ec52da4aaac7e4bf825d2853fd2fc2de", size = 7965, upload-time = "2026-06-19T16:15:21.978Z" },
+    { url = "https://files.pythonhosted.org/packages/07/82/5e6342650a407fab78cd20bdd4f94ae165eac8b951263f34a79c544999a0/pyobjc_framework_oslog-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1253dda3bce3ab7174ba215f011cad47e11b43c8406edb09e99bb122b34af021", size = 8168, upload-time = "2026-06-19T16:15:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/56/a62a21f3125117ba54c2da16db061bc48037387ccea2a9f962f065293985/pyobjc_framework_oslog-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c2fb370aa829850de13643191ff26a1a23b2d5b77649e883b274607866e417af", size = 7963, upload-time = "2026-06-19T16:15:23.859Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b5/47330df78d9ca18fe2ce003ca1a76ca4341be98b263d879c80683c980c7b/pyobjc_framework_oslog-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5b4bda2651fc0a5ceeb28e8a82ddf5ad23bbe86b9feaf9df8f10c3d283d4f9a2", size = 8167, upload-time = "2026-06-19T16:15:24.677Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-passkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/ed/68c8657d080f53706ea7e6cd77a4babb2b8f95a0c73471db5a56c5742988/pyobjc_framework_passkit-12.2.tar.gz", hash = "sha256:14a9b37b290942e86633ac59f923195d0038ff0f746443d914dfd5858cba9eff", size = 68267, upload-time = "2026-05-30T12:41:02.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/b9/5762ada91652118bd08b4bd236e4cff00edf5211403ee49cd8563a2330c2/pyobjc_framework_passkit-12.2.1.tar.gz", hash = "sha256:28de8925d89b705b9344e59498d15e5a10935e982b19eed10f0d498c5e670e7b", size = 68251, upload-time = "2026-06-19T16:21:21.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/31/97632296672a105db7e30f005f036216f341a20d6b0c651f25a458eb970b/pyobjc_framework_passkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e24dcfe31e1635b6d858c5386b8fde4bade3eefc869aa683b0bf681bf1d72ab", size = 14451, upload-time = "2026-05-30T12:18:11.899Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/b0/dc2ca2ccf1377eb980220ea1b392803c0d7f42b2164960ed5a04361ec592/pyobjc_framework_passkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3ca56bc17cd5ac7fea74caec55f3329a2b21c9462f70f1799a1896cb2fc9c06d", size = 14465, upload-time = "2026-05-30T12:18:13.945Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/24/1355ea6c97237c844e689e1f6b92481c3382693590af67a637a7c5205df7/pyobjc_framework_passkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f58e668a4e827e2bfb7ddc41aae68025c980b5ec25d218ea8a49740159268f8e", size = 14627, upload-time = "2026-05-30T12:18:15.871Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/40/a96eae0e665cec73c5d9e0a5760dae1b623483349e618985772f09be400e/pyobjc_framework_passkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:737215ab0ae39960e4b94d70380b873e06002a8905589cafc92b01bb9e54af77", size = 14469, upload-time = "2026-05-30T12:18:17.816Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/fa/a0e28ff2e0fc0ba620a603df0b642a83a8b5c1468377e5b6a6c6100b4db6/pyobjc_framework_passkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6c47fead9168df3cb8985f572ae1bcbd200b5edfb8c50e8387df70c915e8e734", size = 14625, upload-time = "2026-05-30T12:18:19.796Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/b5/8c9f7b433b4d4a773ec29b788254c700e5b269f28f8348c80e1a634cee5b/pyobjc_framework_passkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9e77169e91a10b33eaf650b9af160c8c4797a90f409577ccebf45cd5279dcd27", size = 14458, upload-time = "2026-05-30T12:18:21.763Z" },
-    { url = "https://files.pythonhosted.org/packages/16/28/5ce999f434a082e21c1a85f65232ada04eb5967244b18cf370645cdf8cd2/pyobjc_framework_passkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8bf020af75bc581438700af5d5cf170d18bac9be8cc953dab057846dbf95bd4d", size = 14621, upload-time = "2026-05-30T12:18:23.636Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b4/6f1fa4a3cfa23baef9eac38cf2df7b8dc8f64f99e0796c77cb909a6d95bf/pyobjc_framework_passkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:85df88aeba17f3aaa86f4eae1f0cba99ada8c18df7fd1ca49548276399417e26", size = 14472, upload-time = "2026-06-19T16:15:27.47Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/3500af51c2758b71cd2e3835a08df33cdce6b5c72b8275f7e1d776c0b610/pyobjc_framework_passkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:28e1c22d9476cdafe7839f368fd6e8c99f4925aa85e4f9126e5921f4c7e834a1", size = 14485, upload-time = "2026-06-19T16:15:28.371Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2c/addcb03ccdd59685043af645974d56aeb9867ac87a9e29acb0cbfca88d97/pyobjc_framework_passkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e51509baa9f4883b1583c410dfcf8b68372a4457e13cd57f4c9490c6e9895e06", size = 14651, upload-time = "2026-06-19T16:15:29.194Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7f/85a5e3c85c1e152d73b8e820d2ddcd3d9bc7d9aa339a32f2e25a14892862/pyobjc_framework_passkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6edade68d8c530e7fdaa7cb888899e8e7466b976e5736980136caf6b39903e2a", size = 14492, upload-time = "2026-06-19T16:15:30.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/eb/1c21b7018b1a62ff4c99498253f1a0e9d4d9fe28c43ce8c1c5fc713c0d46/pyobjc_framework_passkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:872c816839d89097fcdbf60c5a22ed277277d299d0ebc4db3b598702c750f22a", size = 14650, upload-time = "2026-06-19T16:15:31.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/eb/eb100daa0f738eea6e89efa365af68ca2d45934d1dd11a383c31b61cade5/pyobjc_framework_passkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:71805f7f9ee46976136b11f4563d490dd47219472f1648c3aba8a13e826ec1de", size = 14483, upload-time = "2026-06-19T16:15:32.312Z" },
+    { url = "https://files.pythonhosted.org/packages/19/43/c696150723da6916f03172c3cbdd1bec6e3876844de913f92f698dcaafdc/pyobjc_framework_passkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:50baf3bad86dd86c8f9e081df408cffe0830b18446775afc32acd69146560500", size = 14648, upload-time = "2026-06-19T16:15:33.285Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-pencilkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/f0/39d09038bea6f2130ed6ad9de9034a2ebf3babd9eb5ad75a70f60160cfd6/pyobjc_framework_pencilkit-12.2.tar.gz", hash = "sha256:a224250d5bd8490e619792570bf2b03849b875757c076412ef83bddf58a3d2c5", size = 20122, upload-time = "2026-05-30T12:41:04.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/6a/f8831e5b5bbdc3e999f3bd95c7e297bd8d8641ec3c1fcd153c77616e0e2f/pyobjc_framework_pencilkit-12.2.1.tar.gz", hash = "sha256:2545561beece43d63c745b6bbc4503cc7c55ad0792d4206916c75da26a4dca49", size = 20110, upload-time = "2026-06-19T16:21:22.756Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/d6/45dc7133e4d561b725718a2d8cd016605a6fe7bcf3f12a002c34a309ee4c/pyobjc_framework_pencilkit-12.2-py2.py3-none-any.whl", hash = "sha256:aec57e9ebe2a875d4fc17c46ef16ffcee74ba7551dcd6d83207efb05c3377187", size = 4245, upload-time = "2026-05-30T12:18:25.228Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c6/eb126b4b6e93ce53ba1451b04fb5a7724c9569e8ff185d34c56ebec869bb/pyobjc_framework_pencilkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:d8214b76615d7f0fb6295ee21c679edeb889a03f355c1774f792dfb93bd313a5", size = 4266, upload-time = "2026-06-19T16:15:34.139Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-phase"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-avfoundation" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/4e/3102eb1fa234c851e23213701d3cda26eb3516c61598dcc7e3f26eb17724/pyobjc_framework_phase-12.2.tar.gz", hash = "sha256:fc1ec192bf7aac2627425c5f1fdabc3df614d100d18a6273b25ec4593f257eca", size = 40747, upload-time = "2026-05-30T12:41:08.372Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/61/1ecd9506eee8698ab1156a7d99980d668e22b73cde9638cec98cd3d610f4/pyobjc_framework_phase-12.2.1.tar.gz", hash = "sha256:31392185ec0d3b0c5974c9b71f0c540843b1bdd884819484e627c6c0d592388a", size = 40754, upload-time = "2026-06-19T16:21:23.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/80/9d526e002b9be65dd80abc2cc5c62afe8a85f353282f33d212c6b44b52db/pyobjc_framework_phase-12.2-py2.py3-none-any.whl", hash = "sha256:e8b85d7b2743b61f8920ad044f7e8370de80e5a4ca4f85ff42b6047b04e5f821", size = 7187, upload-time = "2026-05-30T12:18:26.949Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b9/a09f9ec64fc04cbaf2070055fa44d03454f6592328493b940fd1496f4560/pyobjc_framework_phase-12.2.1-py2.py3-none-any.whl", hash = "sha256:426b407f9ff0fe2b55128e3c0e9a949db4b0a909ca095d65303c247865961dc2", size = 7211, upload-time = "2026-06-19T16:15:35.089Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-photos"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/a9/3845e4976742f15baf7decd63202b16326196596ee95271eb1eacbb388ed/pyobjc_framework_photos-12.2.tar.gz", hash = "sha256:126d2d2aa78ea0e704db807ee2c7f7b418d8a859a0cb8df6ee31e66fd371c2ab", size = 58662, upload-time = "2026-05-30T12:41:12.67Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/cf/af57f3b72daec93cd92b091473cac35f7616aeb2db5e4ca3a25c984aa5d1/pyobjc_framework_photos-12.2.1.tar.gz", hash = "sha256:e405e612c48563609fe32da9aec9286ed8cab10e226dc58ae6910e141fc46f44", size = 58673, upload-time = "2026-06-19T16:21:24.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/e4/71d6ff0833727d3958bf7dd0239d25a05a5d4d52475e443c5e25f6ffedbf/pyobjc_framework_photos-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c9e2311970d031ee7fd5cb6531ac9236ed70902910cf448a2adad61c516be68", size = 12522, upload-time = "2026-05-30T12:18:32.426Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/39/2195f0457e021692c80db6b31334d26fa08db64ced2751040384de8b5fca/pyobjc_framework_photos-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f3caf43105e0d142abc6b10bb851dc107158682d9dbb612d053cee80385f0f7", size = 12537, upload-time = "2026-05-30T12:18:34.198Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ca/3c305cec64c242f2f66533650ec955c93af89772a910c64c4eb4c6748ec2/pyobjc_framework_photos-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:59a9ac81947dc6140093ec2f4131842c8820f6ad9a51226c56e15b43ebacf011", size = 12715, upload-time = "2026-05-30T12:18:36.022Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/87/809159a91d74d25b098bf1b1551029329c348144caf726dc1aefd67892c6/pyobjc_framework_photos-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:facf2989cdf8cac7a34d6e5b6d410aa873b78edcd90da1e5d4812e30f5ad6b5b", size = 12586, upload-time = "2026-05-30T12:18:37.817Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8e/4adf7cd8b7ce70ee16f28ab92258959f10e4de60ff8839f0230eddef60ca/pyobjc_framework_photos-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1931ea06e6bbb6025c3d24b0311415c3676c61157b1ccfe4f41eda12240adeaf", size = 12774, upload-time = "2026-05-30T12:18:39.731Z" },
-    { url = "https://files.pythonhosted.org/packages/02/28/00586042f82ecafd48e82d15ea6aebb2300b0f524a613b3f6cab1214621a/pyobjc_framework_photos-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0ff24a985f6fb0a876346f320afe77f3cbc8617b8cacdb3cc010218187cb1d15", size = 12584, upload-time = "2026-05-30T12:18:41.51Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5c/0863492ca4780a11ac86e5c6a309e9acc00271581e77dabc1544eeaa05b7/pyobjc_framework_photos-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b82f8aaed4f43dd344b45c81f2a661b607443b5bd221fe612f948a7f9a71acfe", size = 12767, upload-time = "2026-05-30T12:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cb/b141cb95f75e94578e28062a033b4ae3bacb5a0660452e04df728a8b8d25/pyobjc_framework_photos-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:516320e2d3ab7c73bb196f7eb46afa289654829013ae79a51d663700e15ddab0", size = 12549, upload-time = "2026-06-19T16:15:37.983Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2f/599c2bcddbd5514b0a670a022a27b60c04198eec91eec025b25738ae71a4/pyobjc_framework_photos-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8be8e21b65627b4c55367c51258c22f7d73d3dbf7412a341e49684a1da1b60bc", size = 12561, upload-time = "2026-06-19T16:15:38.754Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cc/a1c26f3dcc216f3973c1fa7bf19d05f995db70a783790ff682ef96f77c83/pyobjc_framework_photos-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:060ff64355662599bdc1413601c04f1e7d3b8b318d92dec9ab72bdf1cebc08fd", size = 12743, upload-time = "2026-06-19T16:15:39.565Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c1/b17e9fed6c94b52bb00d0916638be9e47b4e32eecffb33431f89951ce6ce/pyobjc_framework_photos-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:423d8cc595912f3e3d7dd0b24809e171ba51d5f359f05e604d1bbc1aed7808a7", size = 12610, upload-time = "2026-06-19T16:15:40.445Z" },
+    { url = "https://files.pythonhosted.org/packages/96/73/0e8de5913643a0370c9089e9ce7cbd5f84da384bcec9426d164f0d92aa67/pyobjc_framework_photos-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7438abb6354b1f34c58804048ac26fd57a8084ee6be283d6e99827c940c31b7a", size = 12795, upload-time = "2026-06-19T16:15:41.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/57/6780525cd80cf915aa958ba917da2f1ffaf27c8964add3548db6deee1b8a/pyobjc_framework_photos-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c49b8515e34b685c18862b68d04978378cfe29dadcc72d2d9af92054758ee629", size = 12607, upload-time = "2026-06-19T16:15:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/f102112441b5ff4f8abd4ef023a9d09f0de9e5ed8a31b8f7b86b73147d5a/pyobjc_framework_photos-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9a575225535e90715488e75c343183044459dba13920651e283ea52f102715c6", size = 12793, upload-time = "2026-06-19T16:15:43.008Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-photosui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/62/9b4322779ac45e8971d613c23f19284d7c6ac2492b2384c8eaa4582e6dfd/pyobjc_framework_photosui-12.2.tar.gz", hash = "sha256:c85ebf27f523dca57fadf767a4d72739c760d7c7236f5e5c8fbe4f80e696c9fd", size = 33856, upload-time = "2026-05-30T12:41:15.824Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/e0/5e8aa49c3fe59572f9097bcea75844352c33c88fbdfcc518c6eef7657c88/pyobjc_framework_photosui-12.2.1.tar.gz", hash = "sha256:cb37100f2c75640d036a9fecf476a6fb68d1cafb5878c0e3f7c47054a63218a1", size = 33856, upload-time = "2026-06-19T16:21:25.249Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/81/5233f2e0c255d73e0fe20cfdb5914bdd50c1df8c911ad5eba6759d870476/pyobjc_framework_photosui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1bc96dba3085d5ae6d5f311ec4c82cdafb04b5519a6014e3ae7915086408346a", size = 11784, upload-time = "2026-05-30T12:18:48.825Z" },
-    { url = "https://files.pythonhosted.org/packages/99/c4/c2f9cc556bde2e1e85cc20103ef34705da6e695b542330d5fff7eff17cdd/pyobjc_framework_photosui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2630d9f61df8f786b1a42a30872e856be2ae7a2fd21c995c5d7d88705cc784ed", size = 11793, upload-time = "2026-05-30T12:18:50.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/68/f9696cd18c479e67b9b911c5a8d7243034fe36c6bf6482add22ae1076dc0/pyobjc_framework_photosui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9c3e0cdbca02ee749b3d56ff332a4a69b8d378550131df4e4003733c6331728d", size = 11994, upload-time = "2026-05-30T12:18:52.323Z" },
-    { url = "https://files.pythonhosted.org/packages/af/c7/5dbd150e31f3ba6a972f7006bad934836e2063c1c81c4a245cb4eb6e190a/pyobjc_framework_photosui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:75ac87647349f556c91cca0d584720fefaa303fb472f20e31c4eefc4a7d7ffc2", size = 11791, upload-time = "2026-05-30T12:18:54.055Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a1/709f881022cff00e7b6f08fb53b68161be16b0979861adb465403de5b696/pyobjc_framework_photosui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:70e9ab782e9ae83d79da7718e9db4c491ce7fdd58d18bc00a27e4b1e9ea113e8", size = 11976, upload-time = "2026-05-30T12:18:55.753Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/90/8ecf14ae1227be6b049c237a25f4c5986aa1a77661dd62d0e9550c4cbe61/pyobjc_framework_photosui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:18cddf0afffb005cb06ef6c10c3ea61dc7387162264e469c2aaaf261970a1022", size = 11784, upload-time = "2026-05-30T12:18:57.48Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/e7/de8dbad22bc3ceeb7ed61de59762a409a1773a066369df3cb9ff7016d0d4/pyobjc_framework_photosui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:52f74cc40c1dc129e073331910b627bb53f457645ac1bd1802176cca23c49a1f", size = 11977, upload-time = "2026-05-30T12:18:59.182Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8e/66323978657e7cb281aae60eb7d4cd1738c495b04b1e8a435cbbbd02dc00/pyobjc_framework_photosui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a8f0723e75c73d1ed3a29f3a6d374ce2275cf95d32aa8880e1bafe90a0354462", size = 11804, upload-time = "2026-06-19T16:15:45.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d1/8ea0b4977612dfa496c73a08feeb197b9016c702e3cbf19360cb0268a9d4/pyobjc_framework_photosui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:03ab0b9d9dcf3e50b62f8579ee11592d0049044044ec1a2b5eebce3e75d56893", size = 11816, upload-time = "2026-06-19T16:15:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8e/d68e34582ba82ff27c4d7e1b64332bd7b76c51eafed29efaf7f8944a941c/pyobjc_framework_photosui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:872af4d088ded84a2a4cbc07aea10d98746221409d3179474e84c1a45f5f871c", size = 12013, upload-time = "2026-06-19T16:15:47.391Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9e/12605c68e8dc2bd5564d2d5122eef304158f078247e51cf6b666d9420bbd/pyobjc_framework_photosui-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e9f68423c00f418c1d0a27ca6c86f81da509d25490efd17f274d2d37ee569999", size = 11812, upload-time = "2026-06-19T16:15:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/8ac06f3f49b82e23e3bf37fb4bb9838cee7b99d44496d524f0cc29ccedd1/pyobjc_framework_photosui-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bcdcae68c773736c8171486c608df427f0bedfd6e80ec81005cadef28ae8b349", size = 12001, upload-time = "2026-06-19T16:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f6/34665725e0f6fab6875213abf4ac6267db3ac1511951388ce84d63790baa/pyobjc_framework_photosui-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e3d2b4446a9b818abddad6d201212ee8fbaf699632e857bc255dd98143cbafb4", size = 11811, upload-time = "2026-06-19T16:15:50.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ea/4acf8e674823bf6f01f89599a50cae87249398ddd1d173979a23ce5440a0/pyobjc_framework_photosui-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5f8560bbcec3b81755be8b4cf78fd38d81914ef6f7cd2d4e74c77f8ee3848a88", size = 11997, upload-time = "2026-06-19T16:15:50.9Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-preferencepanes"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/86/73de5b65736cea66bb0159d9a37c007abceee8ecd3a059211241aa2d77cb/pyobjc_framework_preferencepanes-12.2.tar.gz", hash = "sha256:4928aa6fb30b24af3aa7379125ceca91687e97b08715909689d549a0a73266d3", size = 25151, upload-time = "2026-05-30T12:41:18.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f2/788a198c7b8c44a27c2b358c2cd846bbd97bb6d9c8c457cb248c3c0a8958/pyobjc_framework_preferencepanes-12.2.1.tar.gz", hash = "sha256:1b8e839b364b792441201c1112e17cd6d42f493987169da04ec65eda365d2ede", size = 25113, upload-time = "2026-06-19T16:21:26.178Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/5d/b75418c408c5e969352307b5fd4d739e55b3618cf94e729ba9768e453f2a/pyobjc_framework_preferencepanes-12.2-py2.py3-none-any.whl", hash = "sha256:ccd142fb1d26f20e660651008fce1440f0abc1897bd5ffb5546cd77e89bb31a6", size = 4803, upload-time = "2026-05-30T12:19:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/b1/bc42da075faf6e4201bfe2ec4bfda95b71877a15df4a501977ef739b7128/pyobjc_framework_preferencepanes-12.2.1-py2.py3-none-any.whl", hash = "sha256:026ff87afba2d381e3d9dadc58957580558e1a705291da6794107220a3cd8102", size = 4829, upload-time = "2026-06-19T16:15:51.915Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-pushkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/40/23d8b7065434179984df6f4bb18c6ead5400ed2f85b7080282c600106022/pyobjc_framework_pushkit-12.2.tar.gz", hash = "sha256:8f6b6879920bf9650f2288adb0dc8f809a807825c29136b6492561712234b0b3", size = 20471, upload-time = "2026-05-30T12:41:22.736Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/dd/d0ad735548407e862717b7ef08a29dd51b3b9c1c1987ce43f76c25d72c34/pyobjc_framework_pushkit-12.2.1.tar.gz", hash = "sha256:12800cf33aadfdda5df3e487d4ce3d8a79a2a0efcebbd5b1e11a1ff8a1a4067c", size = 20464, upload-time = "2026-06-19T16:21:28.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/e6/c787ca0efe193b7f8eb907ef13eefb47efedf513d42214f5ec7411867a51/pyobjc_framework_pushkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:955d18de1963fa09f41fa797470f943d0f85f3d2ea5db3d618798e92e54b4575", size = 8282, upload-time = "2026-05-30T12:19:07.379Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/73/d315aac0efb5466a0235ea69aefac9883add2f5fb90ee363372abeaab299/pyobjc_framework_pushkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:358e5e381d37fc1199d0e18eae0ec9bc88145545c985a75ffae37918c0634a3c", size = 8299, upload-time = "2026-05-30T12:19:09.129Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6f/8ee291088ec4b6469b9b51674d0f160929395164483136cccf2569bb85c2/pyobjc_framework_pushkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11a5efd1e08cce341b0882cf4b47ba120f288c04594d714c0149c2a357518b05", size = 8438, upload-time = "2026-05-30T12:19:10.855Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/40/1b139236ac991f39723b9fbed278f655be4d6837f90d10214203e442064e/pyobjc_framework_pushkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19dc136cfe89f43b3ff3e0643106aa4e527ac03936e50cc9d3bc2d91dd2a3226", size = 8356, upload-time = "2026-05-30T12:19:12.318Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/73/18dd6ab8aa631a616c88ff7451bd7d57c8f49d44c7a4aec0a7ad13ba3c6a/pyobjc_framework_pushkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e8099d9db9c9a66b2b098dd36fa03116bbe82387bca27c34969eca207b74b6f", size = 8489, upload-time = "2026-05-30T12:19:14.024Z" },
-    { url = "https://files.pythonhosted.org/packages/26/d1/a80f3bed47908c156d83ef9b6d80c3a0a949ce4fad0f45e5bcf982d1240e/pyobjc_framework_pushkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:23654c78ddb89412ab0f57ab36734789566525de0d357e22edc22f30a63d7971", size = 8349, upload-time = "2026-05-30T12:19:15.479Z" },
-    { url = "https://files.pythonhosted.org/packages/96/e4/c0fc4a461ba75e64bfe0681a1ea469932e8df8c5ae7536b438de6ee2dde1/pyobjc_framework_pushkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d943e4c56d5e2ac5652c8b4d62187235d401d00fddce28e06a2db857772460c", size = 8495, upload-time = "2026-05-30T12:19:17.23Z" },
+    { url = "https://files.pythonhosted.org/packages/52/80/366a0f1210c433857f0639b040e643fc31accfaef38ab2ab5f6ee93733a1/pyobjc_framework_pushkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:675f65d1ce111debdd3e371a6e50296ef9345d8123311c658f16f3e9bf8cb106", size = 8305, upload-time = "2026-06-19T16:15:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/bf/69a637549c72fc4da253a1319e1cbeb13b0abcbdb24d09a3c21ddcb031a8/pyobjc_framework_pushkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3feb1c38ccde8e24548e5a5032d5adc2cb354f1aaa0c7ebed6babd2fdb86cda", size = 8326, upload-time = "2026-06-19T16:15:56.429Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f9/28b5c789ec9167435f0a095cecab27230e41496c33c0a458df546754a2eb/pyobjc_framework_pushkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9dd060c626f17365803f5dbffe0ceb3062e3710886ee9a7c887f3f70b3285802", size = 8460, upload-time = "2026-06-19T16:15:57.351Z" },
+    { url = "https://files.pythonhosted.org/packages/68/68/8eea4540ff3201b1fb0e6301655af3d8e92293e3be23343cdbcf77b7bc2e/pyobjc_framework_pushkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8ff35a63097b6b7268cadc7cf7754f5d966296847e0b084a8aa9716f86d05cbc", size = 8381, upload-time = "2026-06-19T16:15:58.276Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ca/4ece7bbf8f62acae3f4d0ad46f2b5867f74b8d1c04e4d136b4a2b5058ab6/pyobjc_framework_pushkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:53928c675b70e71f2e68cb7732e7cf114c1f17ef80bcdb0fdf8060e69ca7239d", size = 8515, upload-time = "2026-06-19T16:15:59.086Z" },
+    { url = "https://files.pythonhosted.org/packages/81/aa/18ae91101a5138b19b8773e1d5ceba9d58f9e1964e75cbf9ec917db8a4d7/pyobjc_framework_pushkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:60457988a79883028b3ca5f6e8cebc7051f553f34e98ed16c8a1885d01c46de6", size = 8372, upload-time = "2026-06-19T16:15:59.974Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3e/9ee2507c94e80d05de593cee7e0198027b066f255af8701fd4481b178aa5/pyobjc_framework_pushkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:92413a410fb59f8e6b2c7a3c2c4b35721c2245fe4d5afe94cf5c7db065372916", size = 8520, upload-time = "2026-06-19T16:16:00.885Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-quartz"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/a3/5ae4c90c13999b46315f549694f25c374c48a9f7ab18f98ace6e74f4a5c1/pyobjc_framework_quartz-12.2.tar.gz", hash = "sha256:b343395d4790323b0376fe20c83ac468510ba19f65429323ca211708c939d107", size = 3215525, upload-time = "2026-05-30T12:44:27.759Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/98/3b1fa78ddb1cd10d0edd4d49a3d00301d941f535694ac444fbed53ec7504/pyobjc_framework_quartz-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8b238979d62b6e0b90d466477eee968d8f2f6720e850af2472e01cef349293b4", size = 218969, upload-time = "2026-05-30T12:19:58.528Z" },
-    { url = "https://files.pythonhosted.org/packages/96/56/670a847a3a8ee2799f405b876a2f20914f22b4865f1d8157169095c21d94/pyobjc_framework_quartz-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:214c19aadfd100d9202994a22fbced804f7d60f8473de6f292111cc1668f9373", size = 219383, upload-time = "2026-05-30T12:20:12.444Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ef/598bd4d1fb796305648c03667938f08bb59ed4e0bcdc1591fd2c6238abf2/pyobjc_framework_quartz-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4e0634ee9782e480587a074d1d08867fa7ef0d845c2f6cbaef6a48b7d2c3899f", size = 224436, upload-time = "2026-05-30T12:20:26.608Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b4/7ec90f6480b554173df109b570915c26d286c414d9444d2066fc93567781/pyobjc_framework_quartz-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:08f7c7b42de70875cee15f4d0e217471e382ffac44d0a5bcfd30f583b9b41adb", size = 219749, upload-time = "2026-05-30T12:20:40.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f7/9a6cc42345d7a89c7344763e931476c9bf00d3b16ef1e862b1f720709afe/pyobjc_framework_quartz-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57553e7085191f9421ec78fe57a8a0c8462e39d675014ac1e4b389381f04535a", size = 224703, upload-time = "2026-05-30T12:20:54.835Z" },
-    { url = "https://files.pythonhosted.org/packages/41/76/a831a11a67fe36898b4b887bfe7694a291e08a96266416a832a9de97bec8/pyobjc_framework_quartz-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6fbd127d864108103d4980292ffca32bd9c1e5f643e0abd5773fdde2918afaca", size = 219804, upload-time = "2026-05-30T12:21:08.79Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/77/3223cef0bf8cc97f1d586ad1b6c79e04bfbe2a47a1fe5bd1ad3abd862325/pyobjc_framework_quartz-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:359738c88b12427a30d73a3d202002ab910e31eebf6bee4550495ec8aa64a004", size = 224750, upload-time = "2026-05-30T12:21:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fc/d7c7b3134cdbd1a487f3f77b5be125d87a6c9e7d9411035739d99335cc0c/pyobjc_framework_quartz-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:de9c8cca7e95290c8d540466af11c7cdfe3a5458e6f56c34006d5b45243f9ed9", size = 219000, upload-time = "2026-06-19T16:16:04.29Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4b/861f91a1565d3189ee899e177b915551fb9a7e2ca25414025a8974f04e74/pyobjc_framework_quartz-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9bc7f507192691841ee4eba5bf36990b259df83ac728efed2d7ea1cd021e4", size = 219403, upload-time = "2026-06-19T16:16:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/b27010d2f288737f627f74be6d5549f49c841542365c84b9a3011fe39ce7/pyobjc_framework_quartz-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bfc0d2badd819823d21df8069dcf9544ce360ed747a8895c51bdb25d8d125f45", size = 224458, upload-time = "2026-06-19T16:16:07.252Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5d/85ffd9d433989205d572a50d625c63b29c05e0c5235a725f15ae1023672c/pyobjc_framework_quartz-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ceb56939c337b36d9d81185ade31f77dc52c85cf79bb16e53e9b32f54b6bb3f5", size = 219769, upload-time = "2026-06-19T16:16:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/b917e4b63d72ea84a27121076f3033f23f6497c0e6ce8d304766c899897f/pyobjc_framework_quartz-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8105c98b798f2bf81c05c54bddeeadbf62f0b5dfec13bd6e719dd2cdf7e1cddf", size = 224717, upload-time = "2026-06-19T16:16:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e2/f3c1ed3228f7430ef5ade23db6f1fcbae99290f177ce5653348fd9e05f4d/pyobjc_framework_quartz-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbc214f1a216b5d3651bc832d0ac4589f029f3f37cd6cbb370aac12a7c77942c", size = 219825, upload-time = "2026-06-19T16:16:11.433Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2a/2c99a5ad2fe0a11600ea123b8e9a08ff138fcb2ad1e13e376f4bd4aa1d96/pyobjc_framework_quartz-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca61624a0b0e6286d8a0f97f47eb9011e4e81e9a339db436d48af527e7065bb1", size = 224770, upload-time = "2026-06-19T16:16:13.035Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-quicklookthumbnailing"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/c7/e19792f6473714f4144ff2c579f2a231eeb81e405388140471f9f6ffaa4c/pyobjc_framework_quicklookthumbnailing-12.2.tar.gz", hash = "sha256:b0104142f0eb950e849ea25f40c01715069e1bdb3de69949c1b4732c8f5c693f", size = 15771, upload-time = "2026-05-30T12:44:30.263Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/49/41d06038c50a750d6172b875d45ec8a180650b98c6e0d8cdce43b4120ef1/pyobjc_framework_quicklookthumbnailing-12.2.1.tar.gz", hash = "sha256:1b348b674569b8df40ef6acebbcdc4e7e8b347b0a437c824b35a6d6f91acc398", size = 15765, upload-time = "2026-06-19T16:21:31.579Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5d/012d04a9fe4117f727e0436b7b6c9a30f780e04ee51f1d6e28bb6d1a8700/pyobjc_framework_quicklookthumbnailing-12.2-py2.py3-none-any.whl", hash = "sha256:a60bdc283a44a70ad7a12840010b76d42ffd580c4bffb630da3874b229d30a74", size = 4306, upload-time = "2026-05-30T12:21:24.611Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1f/1a92542d6b2d879422a20c99124aad3d9e176a9ff65bdf0d1cecb381cbd1/pyobjc_framework_quicklookthumbnailing-12.2.1-py2.py3-none-any.whl", hash = "sha256:747a99db601e0a7ca48fbd32909c803f47211adc194a4c41a5b5430738b3464c", size = 4329, upload-time = "2026-06-19T16:16:15.183Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-replaykit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/28/9562e12a0f13ba9c03ec59694af026500265cba2bc71468bf5985230ff3e/pyobjc_framework_replaykit-12.2.tar.gz", hash = "sha256:f971842973fad039642a67e3432b864e8bed815228d67d07b52174fceadca86f", size = 27206, upload-time = "2026-05-30T12:44:32.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/a0/2d5903651b581cc9c64cd08d67088310807a169e60465c46d016ac53e2dd/pyobjc_framework_replaykit-12.2.1.tar.gz", hash = "sha256:c5a712ff52ab58c58a53a27e47dba2d3823b13f2587a395855e9c4f0510af6a1", size = 27213, upload-time = "2026-06-19T16:21:32.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/f4/2377e7bcf93257ada33941e8ea7993357bde6e679fccfe44f9f36c9b9988/pyobjc_framework_replaykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b60c6b287dd8b991bd432acb4fe061f8939df56aa65741dc777565aa0615f68", size = 10149, upload-time = "2026-05-30T12:21:29.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e3/bf9e3cc9fb4f3629b42e510f40539e323af43597601bf1ae5275a8468572/pyobjc_framework_replaykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ae67c235356b4442dd0765ba3b911acf6f597894ad27b6b6c322b55ea501be6e", size = 10165, upload-time = "2026-05-30T12:21:31.556Z" },
-    { url = "https://files.pythonhosted.org/packages/03/ad/a34116524dd3d7cae22cef8125a897c4533b9dff9236cf4e00f06ca01012/pyobjc_framework_replaykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2040fe7d3da7ac485c32f620bc0a2ffb8c5c1052ca67e2d36db78533bbd84e9c", size = 10348, upload-time = "2026-05-30T12:21:33.309Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/2f/c6f524971e6f61e763ce6c36ea9ecca4d61d423e79c26fc715e06ebd879b/pyobjc_framework_replaykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4479558bbaa1d0292e77d1d01b56eb6593a47310c9c49d213061b35094f0a948", size = 10220, upload-time = "2026-05-30T12:21:34.924Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/57/06b54386c5d2079172682193030fa39bae31872b9ab85c208145b7569a6b/pyobjc_framework_replaykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa7785a906efcac0d5cd6c68c61bf0e0800c041c2a56ec179298a2df4af3f798", size = 10414, upload-time = "2026-05-30T12:21:36.53Z" },
-    { url = "https://files.pythonhosted.org/packages/34/37/cab6961855ff727e6ccc2e7766dd2429d042721f2929d38b3e2ecd174d07/pyobjc_framework_replaykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9d429b4bc0f0ed7b07242e103f8652b79eca93e81d0730071377eb54b3c47152", size = 10219, upload-time = "2026-05-30T12:21:38.087Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/7a/9f755469b7ca6f962c0c3afa503ff6a67e5bc8f654728a1f2bea33a5bab2/pyobjc_framework_replaykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:95be424c8b99c0beaa068fe999c2cf31a449095b9f89fb56bff2a5961d1995e3", size = 10410, upload-time = "2026-05-30T12:21:39.659Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c2/9e1c99f86d7a11925b0009fb9051bbd4f7e2cf512e8bb470131b9c87f79b/pyobjc_framework_replaykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b682657b641df5a78195a8f8a7abc6be04aa445dfb73814c96a12d3f252fa5d8", size = 10176, upload-time = "2026-06-19T16:16:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/834b5e916fdcdccde827e2d5bb4137f5ae34b7e225cde1ed845f848f0336/pyobjc_framework_replaykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:18d5cbdc48436f5f612f37163ab2315518220f88aae39d81c7fd1460da8ad510", size = 10190, upload-time = "2026-06-19T16:16:19.16Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7f/9b55c3b25cea2ee2506980b626256beff02541c978f55caf91f3643bff3f/pyobjc_framework_replaykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:daaca45e9b94b2cdf6f76ecfdcccb51faf5342cbf8d7a4741ef361406376740e", size = 10368, upload-time = "2026-06-19T16:16:20.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4a/00c76c2b2274f96057b5abf8c4de903b2b358dd0d8a0c7a14a6b75cc0ebd/pyobjc_framework_replaykit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:70c68b9394ff0aa4c9bff16ce13fdef81bf778b07d85e6f01d8a39945d7d320c", size = 10243, upload-time = "2026-06-19T16:16:21.216Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f3/ee0da9e4923cc54068acdddec46f440c9627124deca9939cf2d506cb613c/pyobjc_framework_replaykit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:efaa9d6285774d69469b00fac76bed50cd3e300d46388329a67fffb5bbc745d8", size = 10438, upload-time = "2026-06-19T16:16:22.171Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d6/fb3425e69aaa8e6d9c46182220e5ed131d7ce0b11f708fd307779bb36f69/pyobjc_framework_replaykit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d48c5467c5b71d038b00e04106576741da6a38894b9bbb4e1f5b58f4116b7683", size = 10243, upload-time = "2026-06-19T16:16:23.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/51/96c871e6fa2e978cf0bc1ec06cf8eefed6db8ec8dc72b0d1469578ce0f82/pyobjc_framework_replaykit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0ea6641401a45197b6f5397f45009f504e15ce03c719c4455c38def2f915d86f", size = 10434, upload-time = "2026-06-19T16:16:24.103Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-safariservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/e5/8caad7cc12d7452f9f78f931bec253f04577c6a876a9884834572223462c/pyobjc_framework_safariservices-12.2.tar.gz", hash = "sha256:35f76589201c9857f36fcae027c79ae2719d4463e1bb35996f78de9f570a0a58", size = 27300, upload-time = "2026-05-30T12:44:35.242Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/8b/638f43f5f7936dc3919fbb7a76a1efb3826941e49df12bbbb4b95342a594/pyobjc_framework_safariservices-12.2.1.tar.gz", hash = "sha256:5da28790b389efa21a33d2d48d3322dc3670077ec9c8af9054824d42153e0298", size = 27306, upload-time = "2026-06-19T16:21:33.237Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/2b/731f8bc8601aebb0e23032d5a0e6cd9af7abfb55192f95ec999c913443f0/pyobjc_framework_safariservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9657d68f73454f1f147ff4c6526fff28a5bafb769d628091cc8cca5d89882e", size = 7314, upload-time = "2026-05-30T12:21:44.344Z" },
-    { url = "https://files.pythonhosted.org/packages/83/56/c3bf80c5abf766078fc6815a91c287a72772eb675eb538fa8e3aad426dd5/pyobjc_framework_safariservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d7883793626c82eb645c99b719cffa856f8fa6d2bc19ce9fabedf5611888b7e9", size = 7339, upload-time = "2026-05-30T12:21:46.007Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/19/bbd38d764573a907e9287aec7fd065904b136042a6f4d8d9b488cdb67640/pyobjc_framework_safariservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f97571814b69ca81baa3570a4338e9c7679a7505c5f05b28938890ed71d95ff6", size = 7344, upload-time = "2026-05-30T12:21:47.611Z" },
-    { url = "https://files.pythonhosted.org/packages/84/6c/10d2e963d630ba86a0dd72d83ce9e6a8d59bea309d76a71868ec4bdfff3e/pyobjc_framework_safariservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6d5df844c6e10ef54a87ff9d847037978cd1cbf4ef87e31333a56726767ab5ff", size = 7371, upload-time = "2026-05-30T12:21:49.238Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/0f/fa12873da4842d5b0c253c3412a7e00251e7f5392007e5fd9f71a92c2d4d/pyobjc_framework_safariservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79a9960e0d04487ac0554d25668efda8ba0bfeffc68936d841fdb1be9b44b93c", size = 7380, upload-time = "2026-05-30T12:21:50.689Z" },
-    { url = "https://files.pythonhosted.org/packages/58/9b/eec655a20a7732b2159ea8dda119b59fbaea7ae6864648e36fde50f314c9/pyobjc_framework_safariservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:de57e964f0dc86e40d9dd4b1a240fa889c80218970a1e716c45950d5da38ec34", size = 7390, upload-time = "2026-05-30T12:21:52.28Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/82/75e9d7f2662b252e073fb8ce771ca689cd733ede5bd9ee07e8198e1436d1/pyobjc_framework_safariservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fad17d1e4f9a0a680cb9778c3aec4f31ebcf86ffbaa7f1850a368dd21b2075eb", size = 7394, upload-time = "2026-05-30T12:21:53.768Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/c60149609a5f7dd91e35d43a3317ab9bfcceffba6780254533d42945422f/pyobjc_framework_safariservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:46779f1c6a53fe561bafb95379a7bb66535938e622a23b8308f4125f443fa81a", size = 7344, upload-time = "2026-06-19T16:16:26.825Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7b/15dbacb24573d8fbdbc80685c440c5506829c9e36dc48b32d4f515a0190e/pyobjc_framework_safariservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:210ae2a93175fff88ccbc6c50a58ff981158a2d6bfe4edaa1880aa2fc5f4ccc4", size = 7362, upload-time = "2026-06-19T16:16:28.023Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d0/ee671fef9dfba5fb54cb8f00dd8f80b907ffe39acbba7e4b89d122a7b420/pyobjc_framework_safariservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:98dfc05920eff91fa5db9cc64cf764be8b588ae179ecf33985fa7a9f81e044ba", size = 7368, upload-time = "2026-06-19T16:16:29.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/5edb0bd367c8dfd787359cc989a18e9224cfeef979808f61bad92a20249a/pyobjc_framework_safariservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2dbf52cd5c33e04b65f48891dbb1627612bb23e381d91161dcd53dc76d31e70d", size = 7394, upload-time = "2026-06-19T16:16:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1c/eeab5f53ba9d3901ab7ac045e6e4988a8b3284f2e87f8f3317eb82736136/pyobjc_framework_safariservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:05591b89870f2fbe77c57185eec3b21f08583193628e00c88b7173ba35a6c965", size = 7402, upload-time = "2026-06-19T16:16:30.896Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/74/f323de081cf336d5889a5ec79611073c3be3f3e0f0819214d7d9a9e59cee/pyobjc_framework_safariservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d852eaa503a9031f5232418b38dc439013eeccd77131e3fddccf9e580be5214a", size = 7411, upload-time = "2026-06-19T16:16:31.745Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ef/c3e91e0829d045240b6ae00664da5346cfa26b98c3d3ac6a3ecd27a21032/pyobjc_framework_safariservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:53b7d50145705b7de5e19f44185a7f20f716921be2f7ed2cecc000cd773c16c8", size = 7419, upload-time = "2026-06-19T16:16:32.566Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-safetykit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/c2/7a6c1c356ba3d9164357c353142e6d9354f999b45f204c57c5f2162a47dd/pyobjc_framework_safetykit-12.2.tar.gz", hash = "sha256:3161c4cd35261615ea38e64bd1db9de19c66d18d4d350bbe7d4eb4f69207e256", size = 20867, upload-time = "2026-05-30T12:44:37.319Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/57/ec33de6440eec0c805643dec1115d7a0cc21be8e8e13dfff52e66de6a0e3/pyobjc_framework_safetykit-12.2.1.tar.gz", hash = "sha256:33defe7e4155dff6abf0a2990bb2a918447b9339199ca92c2f3f219d48189ebf", size = 20855, upload-time = "2026-06-19T16:21:34.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/b9/57f5f140685596bce0587b8348c996ae03b5f3f399bd8513d63780b691fb/pyobjc_framework_safetykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:13c471d8122a52bc0ae26263b22291475465fa00b5da488e096967c305d65bed", size = 8577, upload-time = "2026-05-30T12:21:58.553Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c9/f33171cb2129b39fc8ce4a2dfd5ccb9d5fd7fcff795b90efa85462490609/pyobjc_framework_safetykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:93020a92a64dba726e8e1fb03079b4697d49e67f0338b33a63eab76a1a797033", size = 8594, upload-time = "2026-05-30T12:22:00.181Z" },
-    { url = "https://files.pythonhosted.org/packages/54/1d/2abc135c5b8674511bf72a194e2ee7d9fd23cc37ad6a9a8884451aa2a6b1/pyobjc_framework_safetykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6dee8522c45cca1017ebc52198a89d81cf12b4e1fc751e8fab87059326b9c9d2", size = 8748, upload-time = "2026-05-30T12:22:01.766Z" },
-    { url = "https://files.pythonhosted.org/packages/34/87/351f935618c953e54258ba6d83a72343afe4296417ea5479f90233c6d1a9/pyobjc_framework_safetykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:650eeb355a74e39781dffe9ec364f9a7628f30f4bb4fd8080fdb850d90dad83f", size = 8644, upload-time = "2026-05-30T12:22:03.312Z" },
-    { url = "https://files.pythonhosted.org/packages/55/8e/5960031b9c56da88e4fc96f4fe8eb19bd1c41acbfcb84ab0d9f0ed554032/pyobjc_framework_safetykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b2994d2c0d49a18b41a627c504fafff167eb54511111c0bce132c20269a784d3", size = 8807, upload-time = "2026-05-30T12:22:05.281Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/3a/cdb5155f81decd0aee51a730129dc2826b5d84b4690585c8140093a2075a/pyobjc_framework_safetykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a0ab5169593c99b96fbe09506fa89eed88e799c274cf70d99817699c253d3b11", size = 8646, upload-time = "2026-05-30T12:22:06.994Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a2/c5eee93c915e26b38c1f324aaeac223145d099572d6e7f0096999b3c8de4/pyobjc_framework_safetykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e65386962f80aa4f85d11ee4f0470c05348b8282493336ca3adf9bb8feade375", size = 8804, upload-time = "2026-05-30T12:22:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/ed6f62913c9b3bf2259de53caffd58758565625e0c04f1d970644452b53a/pyobjc_framework_safetykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f5e757c9565d104c442b81babcbc4998daf0326b14d928dfae42c5459580a309", size = 8600, upload-time = "2026-06-19T16:16:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/db/08/81833a95ca16ce0379bbbfb8f1524f2d862942457f9f6f05d0c5c1bf1b41/pyobjc_framework_safetykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:eb272c4f8304fc2c8db9652020b01f2a6026c91fca59072189264d03894293fb", size = 8614, upload-time = "2026-06-19T16:16:36.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9d/6ff0294bfe087f428dd28861da0953c8bc7d0f540caf8cc4e724bc8550dd/pyobjc_framework_safetykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0122066ee790375e97ef888af8134c13f00c3b890d44769c6c74f3b126438506", size = 8775, upload-time = "2026-06-19T16:16:37.789Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/db/1563ae0f10f4f07a22298383c6e176e443cb9666ab57c27798a8738b0b03/pyobjc_framework_safetykit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:052e4ca43b48856e32876c433c38590e6e668bd72bdfc820772b76188bad80e5", size = 8665, upload-time = "2026-06-19T16:16:38.936Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a9/5f74b8158bb7ae337f0d23e07303988120abf2c669bfdb4eaaff665f8436/pyobjc_framework_safetykit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7f048af0941796ef80627b88c1411b376ff9c0217ebac402422e1f3fe3a0b644", size = 8832, upload-time = "2026-06-19T16:16:39.942Z" },
+    { url = "https://files.pythonhosted.org/packages/21/94/b697512ea9e57ced080e2201cfe289dcd1c18e9975a1eb35353425f89639/pyobjc_framework_safetykit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:152d800a3b3755f45330582158e198edd6809be026b6e78aa1a858095edd3f69", size = 8666, upload-time = "2026-06-19T16:16:40.857Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/b1/c436e56d692afca134f641c4818f230e147c4bd16e3aee14fb9c6ac706fb/pyobjc_framework_safetykit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:dc1e4b65e87d6501c571752550d248853918f4141faf1d3c9e6dc41aca1b0862", size = 8822, upload-time = "2026-06-19T16:16:41.68Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-scenekit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/c8/963293a476d7c80f60d93e3da2b1f6016913e827fdde63d3b9b7ec96164b/pyobjc_framework_scenekit-12.2.tar.gz", hash = "sha256:de58706317e567d0a5f257f9a4a66fafa037c5c8ef79051c19066b42477e301f", size = 131982, upload-time = "2026-05-30T12:44:45.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/4f/4c614327db5c8a9af6fd8995bacd5f4d3c331c1be66f29722bac3af594cb/pyobjc_framework_scenekit-12.2.1.tar.gz", hash = "sha256:9f5939ecdfa9c13347f6ab61173ba5eb386766cfebd82200fe7173f70aa34083", size = 132003, upload-time = "2026-06-19T16:21:35.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/b0/613f52cdd4b4fbe0735564ee8883d168d39b832c9146700fc9263a55ee4d/pyobjc_framework_scenekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e623bd497088caec95e666b8f99bfcf89096d943b90038bb243b582e8707e6ca", size = 34800, upload-time = "2026-05-30T12:22:18.024Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/e1/c117e5db66ceb6c13f0bb44c40210749e2d9c61eb5d77d50e731dceb8865/pyobjc_framework_scenekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b1795cf860b19fb04116236b6de3a46ffac9f8b03c46863128d36207cc53a40", size = 34827, upload-time = "2026-05-30T12:22:21.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/44/645de9525dbd6258954b8001336df1f3ae85559acae9a119049089975270/pyobjc_framework_scenekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0d0bcea0b7a4a13046a666a5b316c1b3ebfdd90a63226fcd5b7943fd9ee9d615", size = 35142, upload-time = "2026-05-30T12:22:24.247Z" },
-    { url = "https://files.pythonhosted.org/packages/49/56/8f9b1e188357488d143016852b1b203690a5d070d76e2266244daebca92a/pyobjc_framework_scenekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7a28a88d7643c12c17a2bcc90899eb1c4d6750d48bc7fb71b8ea0bf9091c22df", size = 34933, upload-time = "2026-05-30T12:22:27.432Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/3b/51883f04be248965015f96045f449cda35c4dcc249c054d25244e552aa41/pyobjc_framework_scenekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ffccf8f84a60f671261c1fb997e4f8ed55d71603db0aaf1806032307dcb86ed", size = 35225, upload-time = "2026-05-30T12:22:30.464Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/8a/c1934d6cbd824ac2cd674f3adbb516f73fd55e9f8298e8c0bc785d3bd1cd/pyobjc_framework_scenekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c881852ddf8fde16d1d124c6c664e2938d3f00839df1375bf54dacf260d1f6cd", size = 34965, upload-time = "2026-05-30T12:22:33.666Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/15/3a3c0d53150ec202ee8fa55fa5d374d046cc63d22db74a7804214b38a108/pyobjc_framework_scenekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0b8b92b25f35889a7d05f350faf0986af2306430321e09a758469f043810cbf5", size = 35261, upload-time = "2026-05-30T12:22:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/74/99/4c880fe6fa3bfcf980566b8d6b1e608a586d97f43bbeaf658a2889cc1ef8/pyobjc_framework_scenekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a79aabfbbaba44098e5cfaec2f87ae3d04a31f1e250283dcf7ab08cadceed1ab", size = 34816, upload-time = "2026-06-19T16:16:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bd/e87bc4fce0ddc9806f31eedeffb5c8b9b309888026faf3ca4d1ae7414ee9/pyobjc_framework_scenekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6de30a01c643892bc1fa5f3254c17351ec9c72c7ab9af9c895290e8191dc057d", size = 34842, upload-time = "2026-06-19T16:16:45.406Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2e/abf47653356f62712729828ee06a9bc1ee8c67b1e4bba96a37f0cfae39b0/pyobjc_framework_scenekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6cb7213c8f9c5d3a111b3850082f545001fbcea6173606e0986354350c83cbaa", size = 35158, upload-time = "2026-06-19T16:16:46.298Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/bd6d503b2d1b9809aa601424f9428bbc5814d19627e9bef24f9dd8d6669f/pyobjc_framework_scenekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd6c2b0b56a2487c7ea8f5e18cedeeef04e3c28b8fdd54917e8b8df45306d0c6", size = 34952, upload-time = "2026-06-19T16:16:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/11/15cef017994c8ada57aff1ef855cbd1916c1fd40725621e48cd7235a8ce8/pyobjc_framework_scenekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e840a4b48bae1a135cbdce82f81ce1187ffd23e7eb2ffdfc84a2db5cb758fe2", size = 35241, upload-time = "2026-06-19T16:16:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/4fd8bf2a03d37a1f5bd3a2d2e897405033339ae4bdd1524cfcacd8cfe7e9/pyobjc_framework_scenekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:80b5768e346e5e2f9489a8851c0e867b4a8258092c2574e892993825763d3b4c", size = 34988, upload-time = "2026-06-19T16:16:49.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c6/9f70347af44836cc5e847be9597ce05c8a5f0a1423b58683d8f3567d4e96/pyobjc_framework_scenekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cc7769ebcfa1cc17f3046220d2a06927d2429a5f40ccf66bcdfe2c23868ca8ed", size = 35276, upload-time = "2026-06-19T16:16:50.09Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-screencapturekit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coremedia" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/e5/469c73f6ba9bf9ae6d4a93aa23838f288dabee88555402754dee000ec884/pyobjc_framework_screencapturekit-12.2.tar.gz", hash = "sha256:7f45f2e170b97dfde3e6c7d3b867ec3ec03caf3aac9259fde4ba0272d912b00e", size = 37813, upload-time = "2026-05-30T12:44:49.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/a6/b7e72e32d3334e13eae592cbcd9f3c060c43adf78ddfebd0eb9c6be0ab05/pyobjc_framework_screencapturekit-12.2.1.tar.gz", hash = "sha256:e419cbf9c2f9cbd172d1c6e5bc69a44e0a7d9e45cf43058d48eeda4f785ce860", size = 37840, upload-time = "2026-06-19T16:21:36.099Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/3a/461e7b200fb656c9581ae7e4bdbad58a81fc1b95b594a448b92b8858c5e7/pyobjc_framework_screencapturekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ea666ebfd9da6a3db9eb9a36b22834ab381842d2ce0fafe19e782a03ed592aee", size = 11576, upload-time = "2026-05-30T12:22:42.324Z" },
-    { url = "https://files.pythonhosted.org/packages/73/5e/e64b2a94e8f950dc2418a274049c01ad3f8f3f54fbabe6912c72a72dff5b/pyobjc_framework_screencapturekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca8378bf217d3ac48db0bb62218b8bcf6b69bd35e1ba66608bec8c31e0f0fbf5", size = 11590, upload-time = "2026-05-30T12:22:44.063Z" },
-    { url = "https://files.pythonhosted.org/packages/21/25/892fe4f54b8ccecbcce6f05c98e377021ec4ada9b226b18523ac97c04025/pyobjc_framework_screencapturekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c1be8a80eaa2a929cde641526f81e7452ff156234372d27c5084df472a74843a", size = 11766, upload-time = "2026-05-30T12:22:45.744Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ed/94d8e98d2d035604e80ea72449b0e5a3fc63072a6f1aac7c76e3e5dff688/pyobjc_framework_screencapturekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d2b4d13114bcea42f4643ff263e4c5ac1d006289b2ed04ad0390180a4525bef6", size = 11646, upload-time = "2026-05-30T12:22:47.448Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/b1/eef4bc88c093a68c65553a263ebef50fc1f280682e6bded1d0d1394e6b15/pyobjc_framework_screencapturekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8aa43d36d8840560c3521833b5c2abe45008bfd1c45c980a6fd85aa29430673c", size = 11850, upload-time = "2026-05-30T12:22:49.337Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7c/21f8b109ff5fc2a5de9dfef5c7b2dd3a6678395636c9835419410bb29a8e/pyobjc_framework_screencapturekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1784792b5809946eec69792429d332cd818614fb6899f7cce35f7c9d8c357355", size = 11641, upload-time = "2026-05-30T12:22:51.03Z" },
-    { url = "https://files.pythonhosted.org/packages/42/3c/94f3c62be42642759ea9fe3428e8e859b3ecb738b9955ce35ade5d645797/pyobjc_framework_screencapturekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:560e81da652b05b0d10b16a62eeefa5e10cb05fabcae455f1c75da55c952be32", size = 11846, upload-time = "2026-05-30T12:22:52.781Z" },
+    { url = "https://files.pythonhosted.org/packages/55/eb/76a25a68695f8502ca17ad0f482ed3e8d1714a7fdaed86728388778510c7/pyobjc_framework_screencapturekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:407dfcd80e493d11ce54163d4cc973119f6a507cd695875f4cdbfde6f2db42d8", size = 11596, upload-time = "2026-06-19T16:16:52.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/c65ea6d42f9873ee6a1d63d4db1db334d60536ba679382688647bd626cc0/pyobjc_framework_screencapturekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d23bc1d0ac0068f328a97c1ed95d611cb2b8517c76345ddbbd21e5e8bc85a898", size = 11616, upload-time = "2026-06-19T16:16:53.772Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8f/b57ec1a7632d7d49f01fc4b322c2c81fe62757c5ad78bd19f0fe085b6aed/pyobjc_framework_screencapturekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3269ee9ecc1cde271cffb1e763672469b70375fb6aff00394a0387cc622070ae", size = 11794, upload-time = "2026-06-19T16:16:54.604Z" },
+    { url = "https://files.pythonhosted.org/packages/30/1a/efebaf2d5f48ecbd231b2b79df2be4c25a7ebe1804a7c36c3902acd81457/pyobjc_framework_screencapturekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1cc27066b907726389bde47aca1afd27c2af13c4eb88b40f3b813082987e01", size = 11673, upload-time = "2026-06-19T16:16:55.347Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/95/55ce785f8e619d4e953b3672ccb5b81b16b11c48509dbe38689426022b8a/pyobjc_framework_screencapturekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9d4493a95a5eca7b8d5287fda6b2614a1d62def22b24f01eb743fc371c018ae6", size = 11876, upload-time = "2026-06-19T16:16:56.285Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/f010d9fcb42fad7251a84b061f79b0347c23ee19789b28ac137373bf3579/pyobjc_framework_screencapturekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9f6041f81a7a9b4da29fb4ab1cd6912447ccf557cfdea294db3754898895d6b2", size = 11669, upload-time = "2026-06-19T16:16:57.114Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2f/720037603723ffeeb5ffbc1be47af1b1253647493ca245f01d457823b021/pyobjc_framework_screencapturekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:075f1faf3fb6239b104b2ef6f78f9bf5b0bac062aa48c560c9abfeb629282196", size = 11869, upload-time = "2026-06-19T16:16:57.89Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-screensaver"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/47/475b9d9462fb72f264c600178905e0f149d0dc3ac549940477cc582aa24c/pyobjc_framework_screensaver-12.2.tar.gz", hash = "sha256:2aefc58e53b42c33d0d06b4c846147c7b15b065254c588bef0ce8871ccf6d9d7", size = 22793, upload-time = "2026-05-30T12:44:51.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/32/a3826be36a6473c6bed8f3a7cbd879b8feadfd83463cb1ff615aba66e414/pyobjc_framework_screensaver-12.2.1.tar.gz", hash = "sha256:15eba02075a065283e763c8087b9c6fa565907c95e0575a383c1a6ef4c9b1868", size = 22814, upload-time = "2026-06-19T16:21:36.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/9f/e2c143ea0f0ccd29f8c7e199d2bc81d198ea0c6d3d63948b314f6a26afa4/pyobjc_framework_screensaver-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4572cb659fdde2df5e6fe9a6e6972e87a4a04ef60c64fb8766bdb6d281782f4a", size = 8463, upload-time = "2026-05-30T12:22:57.818Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/cc/168c45769e522b7982702c2b2af9891036e7653d8bc50a3871f529c9fb8a/pyobjc_framework_screensaver-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e4a2e2205effaa1dcbf5365e25011b057ae70deadeb29b0782c0af6dc2592f7c", size = 8481, upload-time = "2026-05-30T12:22:59.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/bd/f0ee37d17d48f64c1232cf89fcac33ba56454be63062ca50150ff0002799/pyobjc_framework_screensaver-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:921dc983e81b0aab7f102bcd115b4c5cbc347d251b00167ca58ccec7c6ba10cf", size = 8493, upload-time = "2026-05-30T12:23:01.134Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2d/a91eaee7dff0443e0930d9572d172370dccc15a2aefe37e2a21e01d04e35/pyobjc_framework_screensaver-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa9e2b9527ecffa4cad752f50b02b521016641d07faf78717ce801a95f934598", size = 8526, upload-time = "2026-05-30T12:23:02.753Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6c/1660f902c6d3e985fc5b864744e8c3929381e30f0491cd3145c22da13dc7/pyobjc_framework_screensaver-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4b174df55aaad1040b17bb8856ba79ac3c76e2076163ff66b264b89b6e2ee2eb", size = 8543, upload-time = "2026-05-30T12:23:04.315Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/a3/45eb28982e10c6ddd124d6e31b07ec4de929242d4d92c661e3bf03d1e176/pyobjc_framework_screensaver-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:270331dc16e72e692e6b732d0536c289a3b46f60aa149a36b7c78518fbc8a0b9", size = 8560, upload-time = "2026-05-30T12:23:05.923Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d5/4a810a651e854e90fc271bf4bb61d7f10d00530464062593b9b28c5081c3/pyobjc_framework_screensaver-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d5a32f11b57ca5d3399a9bb39c1f7eb76a5f303a008e82e6f022013aa6c7f4ae", size = 8570, upload-time = "2026-05-30T12:23:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3b/126bc97a45a4bc359e26e567da2518c6b891e842c1061ed1f942a1341b28/pyobjc_framework_screensaver-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8f43926bc686453af7798f460144beaaaea09ffc296bf20d1b38c9e420f94b4d", size = 8492, upload-time = "2026-06-19T16:17:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/06/33c369a75297e3b86ae977d473d24d2e141fe0e5c6663ab829b9e5960509/pyobjc_framework_screensaver-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7535dec51e71d41bbbf2100f49b26f8539e34fb34ec9943d7f075b8ebd46b26b", size = 8512, upload-time = "2026-06-19T16:17:01.332Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/f9/2617d0713f2b49a7acd2977f6f0b7f1cf7eb57e0ed6666b56a7e7bd1d5f6/pyobjc_framework_screensaver-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3fe3232d9aebf919ca2413c373f96915e55b904a1ad362091e79d142e634841f", size = 8519, upload-time = "2026-06-19T16:17:02.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b0/7651f7bf92c24a218afa69ff7dbb515b6354e9386a21957c619c5f7bd471/pyobjc_framework_screensaver-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:367b252aefba2856d51d6b7e899770a8c4fff5bee6cc5487eab03f317e1b5383", size = 8556, upload-time = "2026-06-19T16:17:02.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/06/7235f5c2f6aed47b61c642341444d531db54baa1fe49ac02cc1169c8aec2/pyobjc_framework_screensaver-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e0311a13bc1408c1fc9d62e2f905aa5809ecbdee67fa8e5381c86364e012163f", size = 8573, upload-time = "2026-06-19T16:17:03.717Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/37/d73f9f3c156c87b1c2643e446ccc7bfbb2467d48c06324935840c545d038/pyobjc_framework_screensaver-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8f9769b5e5384bc812c87aa4346766f34408ec8f5ae94e0c8e14202a71f90f7f", size = 8588, upload-time = "2026-06-19T16:17:04.525Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/fa/adf2f598fbfd5073a3e3c45221e5c7bf6587e45b4a30194531c1f539c4ac/pyobjc_framework_screensaver-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:45c2943314245929e306bd38a8ff92dbb18a6a7c5326b0e10004555fc1f86a00", size = 8590, upload-time = "2026-06-19T16:17:05.501Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-screentime"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e1/acd5b9635c905305cdd367d1e5e06f71db13c44ac3384f0241845b180272/pyobjc_framework_screentime-12.2.tar.gz", hash = "sha256:0f708bf1707f2db5c4d13397471bd13cb8c1516ea204d7c4cca8f448295caa4e", size = 14069, upload-time = "2026-05-30T12:44:52.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/93/27470ca21f4c596a0692a3e9cfcd45d38c3bab6f0566bbb5af4e3cfb8b98/pyobjc_framework_screentime-12.2.1.tar.gz", hash = "sha256:c97e700995c03183a1a73f2eaaf90f5ed66d68e8c2e40ff7ed2fddbc77ff7b2f", size = 14074, upload-time = "2026-06-19T16:21:37.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/a6/2bdf31496600ffcbbb958910e03726e238f6a0ac6a7f3862cdbc28cab9c1/pyobjc_framework_screentime-12.2-py2.py3-none-any.whl", hash = "sha256:ef463bf9cf66ab2679a6fdc3da0a51bca3050bee4ff7614ac714edaa13e36003", size = 3979, upload-time = "2026-05-30T12:23:09.049Z" },
+    { url = "https://files.pythonhosted.org/packages/43/75/d434c86454bf4c21855b69f145799699a2d1650067575c4eeeccc6738ff0/pyobjc_framework_screentime-12.2.1-py2.py3-none-any.whl", hash = "sha256:b252234f5f1e01d6f3dbfde44a6019169100c2337f24b65694ffdd6ddfaa3c4d", size = 4002, upload-time = "2026-06-19T16:17:06.29Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-scriptingbridge"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/81/59528ce5c27667c0effcb6af24d039767df0faafe3ad006f154a82d270ef/pyobjc_framework_scriptingbridge-12.2.tar.gz", hash = "sha256:b1420622d923cfe6218904a6a997eae4984653d32554b16374690c347f8ab55d", size = 21239, upload-time = "2026-05-30T12:44:55.141Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/97/908c6a8a4eb665c952dd8b6c670eb2ad40661c31721ed47470d1329115b3/pyobjc_framework_scriptingbridge-12.2.1.tar.gz", hash = "sha256:779b2238b33b61fb9ab4fc71d080e42ef7e27562506f5ca9d783effc4c769a5e", size = 21226, upload-time = "2026-06-19T16:21:38.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/fb/e3ffa8a5812302b208d0063254c3f6b1560cb0cdc18862280df471c899e3/pyobjc_framework_scriptingbridge-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8292259f1ef59c503e003d96e05e489b6834cb6ac0ae92712cefed7a957bd7f3", size = 8359, upload-time = "2026-05-30T12:23:14.267Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/5b/ed96c67b88ce1408f1778d1235a7c3c354980e4c925ce53bfbea0b424c78/pyobjc_framework_scriptingbridge-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ea7944907fe696a8192f2a9861e148b9a0161ac3415ab6ce6e76230181a10264", size = 8376, upload-time = "2026-05-30T12:23:15.823Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/57/9658c1a8576038e571308c3f21a6f38050808a7e379b1149c9b55abed746/pyobjc_framework_scriptingbridge-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dfab9213a60840f15d0ebb2572237fea569ff69d2a593f524e8c7074b6cf657", size = 8525, upload-time = "2026-05-30T12:23:17.429Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/70/d4476462f9a922b4346a1aba5d43280102f718a95d33d42ade716deb6991/pyobjc_framework_scriptingbridge-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:be526303d2304e1cc88f00b673153f52e4af8324d1a58833442bec9164e4342b", size = 8413, upload-time = "2026-05-30T12:23:19.16Z" },
-    { url = "https://files.pythonhosted.org/packages/64/bc/e742f299d2a929b4e4c3a3e82e6a1db0dad05e69c6cd75c9c9f122eef559/pyobjc_framework_scriptingbridge-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:cfc8f1fb2ecd22cdf5bd3ad7c7d1b10329d7302b69761c07a32c2810d016aa6a", size = 8567, upload-time = "2026-05-30T12:23:20.691Z" },
-    { url = "https://files.pythonhosted.org/packages/73/76/335f77cd6ed5f8cc921998f10f8ecf588352c41402d46584d29855dab94e/pyobjc_framework_scriptingbridge-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:db40b1c7670f909198984ba1a57154ad6d896af425c9599ec8e6ba5921d0f9c4", size = 8414, upload-time = "2026-05-30T12:23:22.275Z" },
-    { url = "https://files.pythonhosted.org/packages/24/2f/31cad6ed0e2ba683ca8f7c5fd285fd266fc09ca105ba3ae1ce1934f606e3/pyobjc_framework_scriptingbridge-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:31cf0969d00e61a2f783ca5865d9d650a4be0ad1afded93cd575125187285693", size = 8567, upload-time = "2026-05-30T12:23:23.877Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/aa/21a22afd311b14ea317c09aa6b238232f8d45e7795005f032c97bb9816db/pyobjc_framework_scriptingbridge-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:89153d5bbf44b2ab5a63b646712ecb86b1a64606c3082934ec5c6be4c8a192b4", size = 8381, upload-time = "2026-06-19T16:17:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3a/7e83276e69d5dca85597dbb5129fafd1f453bcd9c44f9ef1996292cc1fbe/pyobjc_framework_scriptingbridge-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:093ae30d045bd5348bed5fb34c826565d0d385305fb75159b46fc2bc1d7d226d", size = 8402, upload-time = "2026-06-19T16:17:09.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/44/64b578077c04d505849bed5ce06af49ebb3a8cb69fd4d2eb0b97b0c9243a/pyobjc_framework_scriptingbridge-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2b620a2c3eccc446c21be0d93a343cdf709b1c300ccc8e83a4c0a7ba0c30e90b", size = 8551, upload-time = "2026-06-19T16:17:10.564Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/9257cef0ea8739fbcac8e21ee9bdaedf06632e218f3de09724498126b296/pyobjc_framework_scriptingbridge-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:57ed9cb870ed86a7a8bd42f1b418bbfeb5886c09a448429f190ea4bedd18bd38", size = 8441, upload-time = "2026-06-19T16:17:11.384Z" },
+    { url = "https://files.pythonhosted.org/packages/da/38/48908ac4804d8f324c8cffd9027744e231ff8ca97c51e63f270b202d8e4f/pyobjc_framework_scriptingbridge-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a0899b94bb908ac9bd0dcf1feaea545d1477ce7bcd6d6665e7dbb551a75c7339", size = 8592, upload-time = "2026-06-19T16:17:12.202Z" },
+    { url = "https://files.pythonhosted.org/packages/48/32/fc95c045f310d9d2bdf200cba3ad83baf9acaa373e1211d40fb6b5c849d9/pyobjc_framework_scriptingbridge-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:526bc671d9a3a401d3d310376f05503ae7f1381eb7ef1a274af90a8b6514e209", size = 8437, upload-time = "2026-06-19T16:17:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/26/49d0912123fa7744cd2a866b50197500676e2d4d5e9d190434739e7bdbed/pyobjc_framework_scriptingbridge-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:776afb47d013841b66c28c065a80863918b1530420db62db8e852247b2e0148d", size = 8593, upload-time = "2026-06-19T16:17:13.875Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-searchkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-coreservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/f1/2240da12e22d6e7273f60bc7fa7ec160ab67d8a3c7801010d480f661a16d/pyobjc_framework_searchkit-12.2.tar.gz", hash = "sha256:aec05c1fa302e11a8e1e737a67ed8ce2bf1e04e9e249796b3b923e90e7b07b9f", size = 31137, upload-time = "2026-05-30T12:44:57.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/53/be9909e2c3672242d5a4f8223a5132d39f3ae9e9b82062e214ddc4db828b/pyobjc_framework_searchkit-12.2.1.tar.gz", hash = "sha256:1fe1ceb2db1d8c86f75484dd9f88ac39dd3d2cffba250498ba0e2312435214cf", size = 31141, upload-time = "2026-06-19T16:21:39.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ef/4e69b33a88e31e6d4e2ef9d266771b81bd20fce0eeffc1fa7c79ce9b3ec7/pyobjc_framework_searchkit-12.2-py2.py3-none-any.whl", hash = "sha256:eb004bbc4522e7e7a8ee3751539056e18c204fd591ac8a2ffa6a8146117ab3fe", size = 3732, upload-time = "2026-05-30T12:23:25.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d2/10e5fc076f236f96fefea233cd31eb15374c393bd8d737cb41b49ac746a1/pyobjc_framework_searchkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:936e41880d48da6742128bc900de37d14771e718087719589d589e858aa2ea60", size = 3760, upload-time = "2026-06-19T16:17:14.683Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-security"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/3c/7778dd8e196373feabc54841b87e495148da3fe20d305f39397546afaaee/pyobjc_framework_security-12.2.tar.gz", hash = "sha256:ef4d2d852a09360929e284c6f355964d84ac88b170207de1ac299fa1e1c33e40", size = 181056, upload-time = "2026-05-30T12:45:09.053Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/72/be521a3961089017555936422be5b8a27c3cbceba84445bb1bdf7d602727/pyobjc_framework_security-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:817986dfa66e5a323ada063f4af52e699e7ac58aeea054a54344f2ad5af9683b", size = 41278, upload-time = "2026-05-30T12:23:35.974Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ea/20d93a62d2f3d54dccac9e3d9de617d27c229ccce42b8bd0d7f4bb4461aa/pyobjc_framework_security-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:703b8544d2623a854f438b13ef4561402e6228eacfb0f0b2cbf28d2704815f44", size = 41278, upload-time = "2026-05-30T12:23:39.428Z" },
-    { url = "https://files.pythonhosted.org/packages/17/a7/9725d152c8f23c6f2d3bb7fc2c2c9bbcbc7908a91de935c80fc5ed54c6c5/pyobjc_framework_security-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10f03ed38e915f823640cbc19d5a921ee29ae266f0d76a2910c53fcd7cd61447", size = 42156, upload-time = "2026-05-30T12:23:42.945Z" },
-    { url = "https://files.pythonhosted.org/packages/75/39/6cf09f7d53a37dc9be7ff2215d067fead65229c54e7153885f1a2bdba57f/pyobjc_framework_security-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a837738a85884518fa7d50de4b88c1df0fcc67241a05dec1b36272cb3aa37e22", size = 41350, upload-time = "2026-05-30T12:23:46.406Z" },
-    { url = "https://files.pythonhosted.org/packages/59/3a/a479f9aa83d7b2f763afeb33f06f23d23948cfb81ce55e6ff04c91b514c1/pyobjc_framework_security-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:448b9658b59bcf56f4bcdf9345592fb719db711cb0f490f75cdffc82121b7c8f", size = 42904, upload-time = "2026-05-30T12:23:49.901Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/8c/a6024c130e82cf471fc1ea479fe9f387712ba22ff9d9db7b9450bcec3dd5/pyobjc_framework_security-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:65845ed21358e07544b57adebcf0b18de80afcc51c9c1da705689e35aa33d9f9", size = 41354, upload-time = "2026-05-30T12:23:53.349Z" },
-    { url = "https://files.pythonhosted.org/packages/55/1e/1ec868d695d173c6d44d5ed9b1f86b1398839a1539589ae545422548fbba/pyobjc_framework_security-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e1ffef0aff259884e728cdf4105610c462eeb7f9f624a670c24ca47cb4744eef", size = 42924, upload-time = "2026-05-30T12:23:56.846Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5b/2719bc4062e6c27083191fd20e365ae02d0bf1c22f4d1a88211e3d96b369/pyobjc_framework_security-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76ff6e44e62d3e15651540493879bf16687d862c4f10f3cadade757811c8b8d0", size = 41300, upload-time = "2026-06-19T16:17:17.702Z" },
+    { url = "https://files.pythonhosted.org/packages/15/90/dccd4cd6877ef208957dc1f3675287d8614a4dcd2a3ee0a5e56f5fb5a1ba/pyobjc_framework_security-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:990013baba29d6f985d8950b23701129b2597b3d16f628b785fe97596d8a8de3", size = 41299, upload-time = "2026-06-19T16:17:18.511Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/af/f9e8040e0c3ef6a50392a46ad1df482a666aa615180d40730b00282ff81f/pyobjc_framework_security-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:066a3e5e9d368e7a6ba8dd52be2077a634ef12a54fbfcc78b3b8154a8f988a1d", size = 42179, upload-time = "2026-06-19T16:17:19.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3c/76e2a8bb8d5fe48f0e8e25c6abec1609f3667cc39935017badfe9e9603f2/pyobjc_framework_security-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:5319ae49b8874363ab51c6ff4d85d4ea0cfa6d836fe0306e901ba9ae560b880d", size = 41370, upload-time = "2026-06-19T16:17:20.501Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6e/7120956e9833b2c70757eec1f65f57c191e00662cf74c4545d88315643fa/pyobjc_framework_security-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:21618431e0dbfbd3d4029445e3118af88e5d7e52ddecf9a2d17c759c51628d85", size = 42926, upload-time = "2026-06-19T16:17:21.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/0bafc557523e5755f74dd5363386a1e9b03f611e2e36df0737a508cd5ab4/pyobjc_framework_security-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fa192e9df479375e6242adcadb9a44f32907dd7fe1207608710cd3af65fe3c84", size = 41376, upload-time = "2026-06-19T16:17:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/47/33/33d266117e46fef148caa4f986b3d896cb9bfd76bef48bd761cb60c758ee/pyobjc_framework_security-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:07cd044a7996f9a897040c49055fa3bdf565acac4a25b834a72e60602376146d", size = 42944, upload-time = "2026-06-19T16:17:23.371Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-securityfoundation"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/20/7fc0158fb92a894699ecf510c3be138c249817276c8346e70fd2a8868371/pyobjc_framework_securityfoundation-12.2.tar.gz", hash = "sha256:03d51d2945f4ceeb7f5fe60e28f9f18f9e96797152467d523d374f6f242eb89f", size = 13080, upload-time = "2026-05-30T12:45:11.227Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/9e/c1b6426d9ba602ceda4f5bf438705e05930d46c3ef561a89736e1b9cea51/pyobjc_framework_securityfoundation-12.2.1.tar.gz", hash = "sha256:b10f7c6f2fea27f105e69e0ef455df10e911748a4a414aff74f9dede48dd2cd3", size = 13103, upload-time = "2026-06-19T16:21:41.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/86/f3fe3bea55f684182e65a4762204802c5fdd7f0b67db77f5dff2a2b3b2f6/pyobjc_framework_securityfoundation-12.2-py2.py3-none-any.whl", hash = "sha256:7e1c8307799cc819cf5891ed046b78eae4907e267592456688fe15f5892ec16f", size = 3801, upload-time = "2026-05-30T12:23:58.268Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/03/b439d6af2c215a59e71cdb2cf00959415f0dd1ec0fd84b0a517c403290a0/pyobjc_framework_securityfoundation-12.2.1-py2.py3-none-any.whl", hash = "sha256:4f3f52573805977e94f3b50af27cacbe2abdd05fd96fac4be746685e523e1e85", size = 3826, upload-time = "2026-06-19T16:17:24.38Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-securityinterface"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/21/d164e409e47ae4460d9320d21de17c825017731a870dee1a2905fd187127/pyobjc_framework_securityinterface-12.2.tar.gz", hash = "sha256:096ea141b84f5128d367f4a7800073c801200bde86a451c735708137a4f23183", size = 27756, upload-time = "2026-05-30T12:45:13.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/24/5486d26d86abf4edb639de2eb5598b6c5cebe33a1aa19d55575694d72160/pyobjc_framework_securityinterface-12.2.1.tar.gz", hash = "sha256:08e58cc05741e8515f157854831063261a7247497c996a120f90148b8aa78842", size = 27798, upload-time = "2026-06-19T16:21:41.816Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/75/9d541b257b320ad7f76237399e6bfeebe96a1dfb877b32ab5c08bf39c0c8/pyobjc_framework_securityinterface-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1022c258f7caabf5cb5267da7c48766ee3329942d228782f9ce70080b34aed5b", size = 10786, upload-time = "2026-05-30T12:24:04.084Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/6a/39f94ce520d5661866ba15c69264eec1af67ed8e757d5ba9c25ddf0c5577/pyobjc_framework_securityinterface-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8741dff8c98a9cf585e5dd582c3fc2df124a0b5b885e9c128a53afb960b6e4fb", size = 10795, upload-time = "2026-05-30T12:24:06.026Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/9d/a18302f5aac77c33b8f3e6e6b529d3cca2d934c893c880b756c8bd6434d5/pyobjc_framework_securityinterface-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d1e56bce8179bb4b5e71986162491423173c6178663e5ca9f1f5c4ac0a493adb", size = 11136, upload-time = "2026-05-30T12:24:07.847Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/98/f738a5e68a4f19e650f9614d83fb043d4e18895f38aa4b1515c765e0c8cf/pyobjc_framework_securityinterface-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a54d16c9e0a0810059bd8a64debe77854d357b974b387d0fa55879845e67e46e", size = 10835, upload-time = "2026-05-30T12:24:09.467Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ce/5b0b179384f9b5cfdc7c5718a81011ec3d347d525a7da735e7189d1a9a6d/pyobjc_framework_securityinterface-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad5b7b6f33981ebf1857042708fa56f0bb3040656f9ff63e0bc4b76407ff96d6", size = 11180, upload-time = "2026-05-30T12:24:11.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/9f/9c72ef65d981f36d8e7d55974498a2a38c7b2a4f119afe23472d010f34c9/pyobjc_framework_securityinterface-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:94881d2f4267629385296f5814949e0ee03f051f86987ddf0286c66ca12996f8", size = 10833, upload-time = "2026-05-30T12:24:12.822Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c2/1d4f371c224583ef7c850db3f1b20e7f7a5bd65532d561408789a1f19777/pyobjc_framework_securityinterface-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b7cf4225eb732c473eccad19a14a0b11d3ad38e41bfd0bed0447bfbcc8fc339b", size = 11184, upload-time = "2026-05-30T12:24:14.686Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/46/8dcb2c1983ca1fcb8279de27264c4b5e00484caaf714c7b846c7800dc898/pyobjc_framework_securityinterface-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e15228ac342d553464f990435e81ee67c4f2fa5cca99388933cee72fd8764193", size = 10807, upload-time = "2026-06-19T16:17:26.996Z" },
+    { url = "https://files.pythonhosted.org/packages/19/13/3c18031c450eb8677f600f86af9c6569174d093dbf60af0bef202813b681/pyobjc_framework_securityinterface-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b93c778e431c0290b0eaeefdd0e9f502a5defa172a82710d697537a4ff8db7c", size = 10820, upload-time = "2026-06-19T16:17:27.862Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/88/da14ec8edd7d22245bf3230a5b2c0127a73b7b8ae5d036053ce16a722e0e/pyobjc_framework_securityinterface-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1bc4a9c50583bebc061b734e382389a50bd62ad5fdaadeb8585024278b96dea9", size = 11161, upload-time = "2026-06-19T16:17:28.683Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/e11a20ec8a2cdb15e9b0cc2dad354480ac92fdfb902faccb47500d5141b6/pyobjc_framework_securityinterface-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b427588d565fc4af5717e9ee2a017d01b6d8c22ba0b68799e2fe5001215db179", size = 10857, upload-time = "2026-06-19T16:17:29.465Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c3/3e8a084ceed6c2a8256c67e6bb167b8fbddb163465514dfae3ffbeca18e5/pyobjc_framework_securityinterface-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0351cf5555cb4d7d2c04a4cd8047611d76b015c254259832adf8cd416e3efec6", size = 11205, upload-time = "2026-06-19T16:17:30.221Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ca/9544778341cee37392614102156b60056a16237b1cc9d7dba55e9d523817/pyobjc_framework_securityinterface-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9970c0cfdf9d07335c9a6dc123893e430a9184e84e258e68878730ed9e47366a", size = 10863, upload-time = "2026-06-19T16:17:31.046Z" },
+    { url = "https://files.pythonhosted.org/packages/44/27/9206c1d8aec4f4a27e3d4d52bb138d46370104d48b008c8ae0825dd321c0/pyobjc_framework_securityinterface-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:258b237ec6f2efa13ea7518491c0d5d48092ad5c5cbfa9274a45ac303859339a", size = 11209, upload-time = "2026-06-19T16:17:31.936Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-securityui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-security" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/f0/bd802a0bca727076fc117b57046a953bbf57cb41656fda917ebf066f287f/pyobjc_framework_securityui-12.2.tar.gz", hash = "sha256:9ce580490d7be95d7ef4b6cfdb9af80b62be486932a89aa402accc86596df934", size = 12587, upload-time = "2026-05-30T12:45:15.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/f9/5aed7140a5f22102cbffad47e1f8a6cc231a428b2021a1731925da9a78f1/pyobjc_framework_securityui-12.2.1.tar.gz", hash = "sha256:87b07746fb9ca7634c3c74f89bf6ab90dffbfe0c0ffb89551aefce0e35353a50", size = 12648, upload-time = "2026-06-19T16:21:42.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/a5/db3bc24bd588cb704bb7db16f0f73177b0488c7577d676ced3932f1f41ee/pyobjc_framework_securityui-12.2-py2.py3-none-any.whl", hash = "sha256:d6cc86e9c039e8a1ac0227947277fb2b46ca2b9f9bb1fb7f7b081a3717ac045e", size = 3603, upload-time = "2026-05-30T12:24:16.206Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b166bb5b4f5fa80dbf9c09074d435c41b04dc741f8a4cd37b241a2c884ce/pyobjc_framework_securityui-12.2.1-py2.py3-none-any.whl", hash = "sha256:e1e0d9ff4671aff464b7af48b1e10bf9aeeffc1ee40c91fd1ac301ab19d87e45", size = 3626, upload-time = "2026-06-19T16:17:32.783Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-sensitivecontentanalysis"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/f9/e18f459b2957f208718e7ff6a9f2715ad66509bb3bb1d4988d4c5820941b/pyobjc_framework_sensitivecontentanalysis-12.2.tar.gz", hash = "sha256:796d6cd3696daa7ac9116b35e7b2d520e86b687a8433443b755db8fd0cdd8315", size = 14411, upload-time = "2026-05-30T12:45:17.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/8e/50648c1e4029611acfa6a5cc6c20e3f36d9754414c7c9c690ef142ee1c6e/pyobjc_framework_sensitivecontentanalysis-12.2.1.tar.gz", hash = "sha256:e958e4333b72e7bd93a32be6c3118c50be8e98de6ca7a41bbf076a712ab2ca21", size = 14428, upload-time = "2026-06-19T16:21:43.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/37/3c92718706b58f76eeacbafc5d6ba1b09a5ff684cd8f47ee7b53dc139d70/pyobjc_framework_sensitivecontentanalysis-12.2-py2.py3-none-any.whl", hash = "sha256:5beb7d718e6dea0b17c14560ebaa3474f7aa349e412f974573cfae84cd7121b7", size = 4246, upload-time = "2026-05-30T12:24:17.732Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/38/ee90dce73e9eabcc5c80ee514b2affcc89dd3b47dfeaaaff20a1cb0b5e33/pyobjc_framework_sensitivecontentanalysis-12.2.1-py2.py3-none-any.whl", hash = "sha256:918c362c11673308191a9d94c2c59a368d4cc39e354694e1da5c99b3609cb47c", size = 4269, upload-time = "2026-06-19T16:17:33.696Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-servicemanagement"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/d6/c31e62d53305b30110cae00013b0947b5cec17ee77afe3e1376d5fe1ea1c/pyobjc_framework_servicemanagement-12.2.tar.gz", hash = "sha256:9c7b698f4354a36ad0448dccba57e724ac682a1276eef3971b8d85d7ac7a6488", size = 15263, upload-time = "2026-05-30T12:45:18.771Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/2b/289270180fc32c2297907e6576355aaabf004297d9830a62f9792a5bc95b/pyobjc_framework_servicemanagement-12.2.1.tar.gz", hash = "sha256:99ceee681fea1e57246d33acbe199100f2e35a09cac97ae1c271e34073c28763", size = 15295, upload-time = "2026-06-19T16:21:44.189Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/67/d02639a189926546ddd2afd5015c0a5574e8310c2a59633bff0ad2b90b2a/pyobjc_framework_servicemanagement-12.2-py2.py3-none-any.whl", hash = "sha256:fa8b9d3bcfd0d2e6feb0884f3a95fda9cd681baf0b0ca457ec3f611de9439f7f", size = 5427, upload-time = "2026-05-30T12:24:19.271Z" },
+    { url = "https://files.pythonhosted.org/packages/30/15/ba63887c27663a7107f289a44072c04c6b351b52177c63d8004640fa7325/pyobjc_framework_servicemanagement-12.2.1-py2.py3-none-any.whl", hash = "sha256:8c84c82a09bf00046ef2d43f910204cd362fd1eceb706176c30d079ee208f2ed", size = 5456, upload-time = "2026-06-19T16:17:34.619Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-sharedwithyou"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-sharedwithyoucore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/bb/afb864c9b6835bae72d55208e52d79734a88d597edc89c437a717da34ef5/pyobjc_framework_sharedwithyou-12.2.tar.gz", hash = "sha256:215aefe1baee8d31dce55b38bd653cdecf0a74dddcf89277d64fcb8d6beafb9d", size = 27301, upload-time = "2026-05-30T12:45:21.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/85/8a2d509a27814d56e064f15469b8fd9720ce5c7ec669bcb0cf4b2e800b25/pyobjc_framework_sharedwithyou-12.2.1.tar.gz", hash = "sha256:b1908b9822244ea31d4d546118389c69687982e5fa67bc72cbf1a9e09f1f84b3", size = 27310, upload-time = "2026-06-19T16:21:45.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/26/421a8222319cc41cdcddc0fc7a0c8f096fe313971cb92e50f56f50098a27/pyobjc_framework_sharedwithyou-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eaecd376e2a3e682d7e666703a2a03d22a1c39cf38762e36863b7a20a3c9da07", size = 8808, upload-time = "2026-05-30T12:24:24.426Z" },
-    { url = "https://files.pythonhosted.org/packages/22/2d/5df7613183733cb6d8bcb811d3b423cf97a24a12803cda0caaaa5018e5c1/pyobjc_framework_sharedwithyou-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1e6d829807fb4edd2eaf5752319649b99a4574d359cd0742c71c7ec0037fec82", size = 8826, upload-time = "2026-05-30T12:24:25.996Z" },
-    { url = "https://files.pythonhosted.org/packages/16/cc/5b5bb308f516f9ad75089595f3bf06eb08e1641cf4b66747473cb45bdf12/pyobjc_framework_sharedwithyou-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ee9b7aba9c09b8f7c75982cfc714f16d2c8db9dff54eaba689b4ee51f84c2124", size = 8962, upload-time = "2026-05-30T12:24:27.619Z" },
-    { url = "https://files.pythonhosted.org/packages/41/08/24a827de4d50388848aef2c162756b3bcf24545f2650dfe6602939df53b6/pyobjc_framework_sharedwithyou-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9556e5da95153991712b9556f5c19804a98c578c6a3e41fe240d414c77319484", size = 8871, upload-time = "2026-05-30T12:24:29.228Z" },
-    { url = "https://files.pythonhosted.org/packages/72/33/91efbfb9e4b41aa40180e3e835f18988dfa6c79f4897afbcea5e043eb99a/pyobjc_framework_sharedwithyou-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7cc06ff9b28cf3b30f599c96e076ae885d02511a02ee41d9e3127fd0230d2b9b", size = 9017, upload-time = "2026-05-30T12:24:31.043Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/d3/9350031f1e0bac76cb84a3cd34df609992980c1b69586b904cccb98110c3/pyobjc_framework_sharedwithyou-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1557bd65b7eb6ddbad3bb152ea31b2f1cb7bffdb525de8ae400bbeb1cac8e1e0", size = 8866, upload-time = "2026-05-30T12:24:32.741Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1b/75c970532fa1dc09d3fe297d4078d6e6d239989a821ddbd3e0427aa634e5/pyobjc_framework_sharedwithyou-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:53b4e3b844c9d9f8105350ce49028702f7c4e03da01e63cfe39d325d6c853cf2", size = 9014, upload-time = "2026-05-30T12:24:34.347Z" },
+    { url = "https://files.pythonhosted.org/packages/46/47/d9810da0987abdf3b21df2d8d872e46f4d916a5fa45ab43370136375a7ae/pyobjc_framework_sharedwithyou-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32188fc96282ba4d3686587d200d5c0304ec3e0cd5cfbb8d0bdadc5ab1fcb300", size = 8832, upload-time = "2026-06-19T16:17:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/bf963d03e57084970380d99af331cf5b6d3cb214a949fd8d8a7f266edd5e/pyobjc_framework_sharedwithyou-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:927a95d78693f2b2323dbc117d1fcf638612cbfb19d2fd0f6077c19c22eb92cd", size = 8846, upload-time = "2026-06-19T16:17:38.044Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6f/56ac0ba0950a3e20cc9e8993432466241b8b5fbb08867840dd796cbd9f38/pyobjc_framework_sharedwithyou-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46d20007e80717f04506a7afee2b6bdcc5ca50a345d7a26fd3f0cd7d97e5cba0", size = 8984, upload-time = "2026-06-19T16:17:38.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a2/b8aba1597228ffad1fe1293bc16e7056b1d17d592794f369a9f0615bce58/pyobjc_framework_sharedwithyou-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:60c29e58e6cf6d760a337c6ae76186ae3fbe1dcec4877cf8c6b2827bcdd40836", size = 8894, upload-time = "2026-06-19T16:17:39.66Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c1/f60ac8d3ad890c5f25d784b277b3f6319dba0aa7cad711d7d0812c50a73c/pyobjc_framework_sharedwithyou-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:52470d61f146dd5783a8a69acdb114fe8e7dee4e7d6853ae214460ccee11e485", size = 9041, upload-time = "2026-06-19T16:17:40.635Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ce/2f743a3865b82d017ea8b6bf74d4b84fae71b01ac230544e19ad6f666ac1/pyobjc_framework_sharedwithyou-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f56137c9a1b53a69b76061c7cfe0f8739b5c42140891a326fd68b7d1e2be702a", size = 8888, upload-time = "2026-06-19T16:17:41.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/b33cbed5b00e5a8d158b0b32812fba1ee5ba6edbc96788f3e8a3ca316f61/pyobjc_framework_sharedwithyou-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:52d02b2188c9009946c3dbdb65db0b032a9a1546448c7f761f5be14d84250abe", size = 9037, upload-time = "2026-06-19T16:17:42.275Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-sharedwithyoucore"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/02/4b1809c63319c277d88542576f86b7d7abcffd57ccd876d47d4623d6d5fb/pyobjc_framework_sharedwithyoucore-12.2.tar.gz", hash = "sha256:212bd551676cf0ae791eb8d7b5f6a4b10090e2d407721124d691e3020f709e51", size = 24303, upload-time = "2026-05-30T12:45:23.444Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/05/5e9ba6cdde040717004115a1254ee315434bf7df5f2ee9f9f9ce619bf6dd/pyobjc_framework_sharedwithyoucore-12.2.1.tar.gz", hash = "sha256:b8a4d2d79702756d9fffc5e17f83b45d52c469579acde873a487842ac334384c", size = 24333, upload-time = "2026-06-19T16:21:45.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/eb/09c4906bcfa9d67629cc6e950018c0e070b2a3130eb66dc58502d423b9b4/pyobjc_framework_sharedwithyoucore-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:091e58f4e1d976c0e6cedb3955f05e7376b2f5c7b226510affe7107428b80cb6", size = 8577, upload-time = "2026-05-30T12:24:39.278Z" },
-    { url = "https://files.pythonhosted.org/packages/34/3e/913bc40fce99ee370c940261eb59d65bd4f9961354c5059bd4d5612e32b2/pyobjc_framework_sharedwithyoucore-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3cc10c8a03892a3da8bff22235e31baa24a931f5bcd1994fc0124a197f14f70e", size = 8594, upload-time = "2026-05-30T12:24:40.949Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/94/67b218f72f4a6be6926691fc85266437edd7fcc837cec755a43bc0daa206/pyobjc_framework_sharedwithyoucore-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0286e5dfb8bc9530de31b0e686d052019d91e17fff3ea35c0338ac62e23659b6", size = 8721, upload-time = "2026-05-30T12:24:42.525Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/b8/062c40dc958ad481a1936c334111c9630d3ad542b1a0e7ccac0c95bc7552/pyobjc_framework_sharedwithyoucore-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:24b9233ff69030a7e55615a80b8c1dc13049ec6d14ae673aec3b6a5ebaf0fc5f", size = 8643, upload-time = "2026-05-30T12:24:44.325Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1e/35e59ed5475d2343f8d03ce568a94aaec9a82262983fe2ddef425e841a33/pyobjc_framework_sharedwithyoucore-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:49d0217ff0569e575a9cc1c432cc4147e4a2307d701fa2bc287471424f139aae", size = 8787, upload-time = "2026-05-30T12:24:46.042Z" },
-    { url = "https://files.pythonhosted.org/packages/44/56/92de20611af1f8cb82d23f50556ec1f3bd421664f3d38485eb0f3d5818b7/pyobjc_framework_sharedwithyoucore-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c0c3d6f7b763ec13a4f12d43cfadb80b13490d802de47cb63a982ea84895ba08", size = 8641, upload-time = "2026-05-30T12:24:47.74Z" },
-    { url = "https://files.pythonhosted.org/packages/12/05/d7d4b49116e31e02eaab9acb583c5ab5febbedf041ecf49a80de8e4c81ab/pyobjc_framework_sharedwithyoucore-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:afe3582b4af25afa5bf94a6af3cd7cdfa3bc966f754502d3054c419754e67ca3", size = 8781, upload-time = "2026-05-30T12:24:49.333Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0b/c26f3af20af44e755f33ba8c75a5439bd8e2fd4bfd406da1211fc08dd8a4/pyobjc_framework_sharedwithyoucore-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:26d3c00be64f9e422be6a902dd2e95532c7ef4e6149ef756dfc2811a71a1c6e6", size = 8599, upload-time = "2026-06-19T16:17:44.808Z" },
+    { url = "https://files.pythonhosted.org/packages/07/26/fd4dd0b314bbe91b58cdc30b0621a8c6efee2fa9a9a75a4f985d9f14b492/pyobjc_framework_sharedwithyoucore-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:25d42419c12d964bcadce37a4cc2e3825d5227bd1bf00767902a702136bdc1c4", size = 8614, upload-time = "2026-06-19T16:17:45.633Z" },
+    { url = "https://files.pythonhosted.org/packages/08/90/d2177377c80ab30c30a292686e84b298b09c431303fa0c26ebdaf9fd5cca/pyobjc_framework_sharedwithyoucore-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c6ca2669c6c7d1a061acbf0c12c55aac3848a43d580b9aa96ffea69d36985086", size = 8748, upload-time = "2026-06-19T16:17:46.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/aa/2878309744e21c37c66c72e1d1b3519888706220b8857253c6be54702efe/pyobjc_framework_sharedwithyoucore-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:803748c78c9b062cd0aba8205be6c178ce6fa2eb227d9ac3bf26b484cd2f4517", size = 8664, upload-time = "2026-06-19T16:17:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/f4c5764d5971fadc6d73c45d28d29ebb67086e007bb08bb731442aceb7f4/pyobjc_framework_sharedwithyoucore-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f991c7b52cdc831244ab49f76ec20fd331a561f364aa33ceadebc684e7fac7da", size = 8810, upload-time = "2026-06-19T16:17:48.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d8/cde9e276d2540eaf4d619a299c50c7b594c77ca0ac4cd68d341d308019a0/pyobjc_framework_sharedwithyoucore-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5544a515a902b796a22272fabe83a3fd39256de9cf243d90cfb7c02ec9e3f7d", size = 8665, upload-time = "2026-06-19T16:17:48.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/67/639e301589e643658c2e45d8312f31df3257205948f10be6c2e0fff4024f/pyobjc_framework_sharedwithyoucore-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0defd143c6633a4032e705a77c9c340bd11d5581bdc098e43455c35ea7c43e16", size = 8795, upload-time = "2026-06-19T16:17:49.618Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-shazamkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/c5/5cc4e2c0cb5e3fb3a3e3a4eb75aa85da70c5491125efef25e581516ec108/pyobjc_framework_shazamkit-12.2.tar.gz", hash = "sha256:9bfd2790b331b36ebdd9f80dab1fcc80b816ee19a1fb5ae981e5b4a8fb2e7084", size = 26080, upload-time = "2026-05-30T12:45:25.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/7b/12a46aee28ffc14a5118ab45be8f0f629feece3548df81d934e31e723ada/pyobjc_framework_shazamkit-12.2.1.tar.gz", hash = "sha256:4cfa9325e381e8b365b2d4725b9165a5e52f7986f28dcf23c3e7f0bd3bddf3aa", size = 26062, upload-time = "2026-06-19T16:21:46.513Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/06/c4d7d2d455acdbe009e2cc91040260ca288b502b9ad76e4f05661470b7ea/pyobjc_framework_shazamkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8033175f28a4f0bead5878a6e420bdd4e60d00281e50b7d711105ad9d4248748", size = 8637, upload-time = "2026-05-30T12:24:54.279Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e4/837c888b09e330599601446b0da9ec3101ee1ad4250113c5f4a040ea76d1/pyobjc_framework_shazamkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:05b0f1efc47471a2962f947dcf764355086a37061307880ca4853df3d7d202df", size = 8648, upload-time = "2026-05-30T12:24:55.896Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/48/ca405138c3deae6a18b8750ab8b1e688add932e149ce234bb132b999e034/pyobjc_framework_shazamkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ef389bb99ac4c74741fa1b08f4b08721cbeed3522f2d8e167a9105545d5d29f6", size = 8796, upload-time = "2026-05-30T12:24:57.441Z" },
-    { url = "https://files.pythonhosted.org/packages/47/25/b0cec78700270e3a99215b60566a28c6dee4e70dd2d6cd93f8d31399d24e/pyobjc_framework_shazamkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d116b4e3e09c92ee33dbe4852570510ab7ca0f43a1f02d708ef10b7d6a681b19", size = 8707, upload-time = "2026-05-30T12:24:59.124Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/d7/1e07eda03786619d6c30c717cbc1163351098217068032d31170eff9b311/pyobjc_framework_shazamkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc79ae05fed89d1aab4762ce23e9bcbeda300990c88d1fcbadda87b6425c40cb", size = 8854, upload-time = "2026-05-30T12:25:00.71Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/2a/d3ca6f9ca9b0d5c22bdad0bc41621778af5d36e30134a6dea414031c7fcd/pyobjc_framework_shazamkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5a0f3410c2852c057f79bfcc00627cb6b429ebbb72803d72422258f005c7f1c", size = 8703, upload-time = "2026-05-30T12:25:02.295Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/e6/90918334be4850363b06b0d0773547d57969238f446fd37b6268b44117d6/pyobjc_framework_shazamkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c20fb1da41721b3818f4f1253f11d29b0f0568ab5b2c96724c6eecc74ce26bd0", size = 8853, upload-time = "2026-05-30T12:25:03.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/24/7e327525ed03ed041fb97c5f32bd9e0ca79bd282f50d373be68f8f71f14c/pyobjc_framework_shazamkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee31a56ae4d15401e10f79fa07f7f79c5cc747afa9a5ce581654f82ee5b3c6d9", size = 8661, upload-time = "2026-06-19T16:17:52.177Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a0/5247501e4d5482c0977025d9914d481ad5029f9f372a84475c01240940e2/pyobjc_framework_shazamkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6b5fcc07180a2fb5a1cef0f38cbdb24caa869e423f612116bc67135dee59b44d", size = 8675, upload-time = "2026-06-19T16:17:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d0/ad91bcaf2f43bbbc5a7b67cf1c0544e2dd875befb95664540346e9328324/pyobjc_framework_shazamkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0ccde3a967120d3285fcc40d48f34f345bc6f0b4accb4ff64799535030bc3e3a", size = 8820, upload-time = "2026-06-19T16:17:54.278Z" },
+    { url = "https://files.pythonhosted.org/packages/03/32/46d5a58ef0c0956586d7bee5ce846bcebc0d167ec353b6fdfbd7ec14b4e3/pyobjc_framework_shazamkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2d7a35d6e66e99b44810a3045c1922d3feaedaef546ccaf930c44312c1b83d3f", size = 8729, upload-time = "2026-06-19T16:17:55.104Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/aa19849a9ecb5f8db5d7e904826b78e76f6e1ef4dad15431d4da8243ab4b/pyobjc_framework_shazamkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:450bebfde1979e6776ca880c1765d9b9a2b08c4433301cff256bf20944541de4", size = 8876, upload-time = "2026-06-19T16:17:55.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/46/857e30042b4161eaa7169e17a77bec4fa61ed12fc69203bc3d0f3d74a427/pyobjc_framework_shazamkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:449d63cd4403963d3d1cdd6e56bea738367fc85bd8c3f861f81caaba05ca677a", size = 8726, upload-time = "2026-06-19T16:17:56.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f5/2c310004afd4f85d45e4bfc470cae6067a6c195fc2cf8a552de7d3fdecf4/pyobjc_framework_shazamkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e429463fe172944232e95a6e2e7a22aacf09885423928574e868c5a0b20d7fe3", size = 8883, upload-time = "2026-06-19T16:17:57.613Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-social"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/8e/30527d2219e08e0d042c1190ffb64425aca051701f50823d5376a22bf573/pyobjc_framework_social-12.2.tar.gz", hash = "sha256:0f5e8c3e6bfd36f8c552b58b42d8d1ff4c8bf18c74776cdc3e830c272a904118", size = 13754, upload-time = "2026-05-30T12:45:27.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/25/0a3ba41ba7aa0380968854a53f02e549afe0b5af89856abfcc2f8988e050/pyobjc_framework_social-12.2.1.tar.gz", hash = "sha256:c2877c7ddbed8f3ea17065687725df57243d25b64beb3b885e8a18482c24bf7f", size = 13751, upload-time = "2026-06-19T16:21:47.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/93/e8f2405693ca24878b1fe1cf58d4aa58b293f4e774af64a56aeba904b33b/pyobjc_framework_social-12.2-py2.py3-none-any.whl", hash = "sha256:d012f52721d694000b37999b2fed213332bf89e8a682f4d29656db4d8c6c7087", size = 4464, upload-time = "2026-05-30T12:25:05.261Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/81/91b2b6420d8c72ffae0df08249d3f5bf8f6f2a2ba2f4f90d071855d74913/pyobjc_framework_social-12.2.1-py2.py3-none-any.whl", hash = "sha256:3d76bce48e3eced0683096a8f8d32ba233c44db8cb9469f881a783932f29c2f5", size = 4494, upload-time = "2026-06-19T16:17:58.466Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-soundanalysis"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/0a/19357da779f1b8942f69acfaa3f4568c0b117d6c1b5820af2a50d25dde31/pyobjc_framework_soundanalysis-12.2.tar.gz", hash = "sha256:37dee57e3f75121b690550601fc136e0931f3be56a87357cdfae7696886850fc", size = 15773, upload-time = "2026-05-30T12:45:29.585Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/43/b6a1644c01010c50dd4a69b0e4ed144139d60d7900edae937486c62af73b/pyobjc_framework_soundanalysis-12.2.1.tar.gz", hash = "sha256:d17bdea63c2b910c2046ba43383b29b82d594a37feee4431d45b55adc08a3882", size = 15777, upload-time = "2026-06-19T16:21:47.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/8b/fb4db5583f5be6a5537baa1ecc39ae56f2bc1bdd6fc8dc7912e7c48b36fa/pyobjc_framework_soundanalysis-12.2-py2.py3-none-any.whl", hash = "sha256:d669deee79636bc6858e40039d5c9b4cca47af7b4cf042c787c52f39b5b5ab40", size = 4221, upload-time = "2026-05-30T12:25:06.842Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/2e8f86936aea345432c6d0d080513dc53eac417f4a485d9b8ffb2d5db885/pyobjc_framework_soundanalysis-12.2.1-py2.py3-none-any.whl", hash = "sha256:4385f492320a304bf64ca772e4a5b29d796f0fc160ff764ed060ac1456aa3cdc", size = 4244, upload-time = "2026-06-19T16:17:59.484Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-speech"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d7/b4c297150b863946fc4064dd927445d0539140524629e4d0b12f704577c0/pyobjc_framework_speech-12.2.tar.gz", hash = "sha256:14058f3ab48e29a68de5925297754a8bc6157b60c17cb24b3e8560290769e9aa", size = 27785, upload-time = "2026-05-30T12:45:32.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/fe/0d1f1710d77deb2aefbdcca344b682f86277a0cf2df55f49615bdee213e1/pyobjc_framework_speech-12.2.1.tar.gz", hash = "sha256:77e01c6e92b34e3bb47dc5b0c43a59cb7941a7eb6ce595ca3de3a686a5df21fa", size = 27772, upload-time = "2026-06-19T16:21:48.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/23/11012a4842dffdc15e30910f7cc6ae45c7b137859e3d1916c7c7558e4e74/pyobjc_framework_speech-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8d940d444912b69f6ec02878a0fab554305bb9c196c87550033a212dec758a0e", size = 9263, upload-time = "2026-05-30T12:25:12.18Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/bb/4262b2565e6fd0137b07b661a828acc48d65c6280124755feeac8fd1964b/pyobjc_framework_speech-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4647b2775c3bdd3016fb5cce155dd03ca7a8f04902211868a68099511e8ea9f7", size = 9285, upload-time = "2026-05-30T12:25:13.879Z" },
-    { url = "https://files.pythonhosted.org/packages/96/48/4071527182ef72ee5e31158cfbdf11d6f97265708e94a0a1ed138f2620e0/pyobjc_framework_speech-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:df58c5d6ec1ac5425565a1544659c8c45c78b0f7984ac50ff4590b5b6b872a5d", size = 9441, upload-time = "2026-05-30T12:25:15.502Z" },
-    { url = "https://files.pythonhosted.org/packages/37/97/0bb1b78cfcf5613a1e9e90043cda358791f275d366274efea11ae9c08b2d/pyobjc_framework_speech-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:74993681f0d7ef50a5c132346f74142729c477fb917a584f84c204ba6fd4332c", size = 9343, upload-time = "2026-05-30T12:25:17.081Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e1/ce08ba2974fd740b8dd9ec79215807a5d178a91dfdf0b264361c51813f5c/pyobjc_framework_speech-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ad06446848adcc7b03f731e60147122ed599e523a54a325585f401c53c045e5", size = 9502, upload-time = "2026-05-30T12:25:18.724Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/31/51968e6e9633e0dba0d54558579fe7b3f2147cf99179b9aa9c6e80f9eb26/pyobjc_framework_speech-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dd88f54107bf75bdce4445734453ad5ca3446e12cdc9ef270414ce5254fe011f", size = 9333, upload-time = "2026-05-30T12:25:20.492Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ea/5a661d61a5ba35faf697bdd08a23fd81afa1683ae2d11b01f7df0446b54a/pyobjc_framework_speech-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5dbd2321eb4a6d39e53143798b5b23388d975b4b7fb1cf0e91089a21c36286cb", size = 9493, upload-time = "2026-05-30T12:25:22.091Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/10/0415e5368531cec9274b4d028d2075a2e3b9752af8d6c75aec75603fbee4/pyobjc_framework_speech-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:20e70519b54b09ca3ded0bf4b19dace1d39847caebebebdc4381f127dc58f33c", size = 9287, upload-time = "2026-06-19T16:18:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f1/b89ca277820479cba6aeab75ee50357efa902ea4d4a6f7871bc66c1c7403/pyobjc_framework_speech-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:774d6d07193fb49ffbc5c39447eafca21ca5b2058ae41f79af876aa6cce5d726", size = 9305, upload-time = "2026-06-19T16:18:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/be/dc1620d483e55337a529982c04d58edba4f77ec435c9700a78319171bcaa/pyobjc_framework_speech-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f425a3a11c282dfbcb0b3f3e218f5f155232c94406b31ec395c40aa9e309a0e0", size = 9465, upload-time = "2026-06-19T16:18:04.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6b/426c949ab1a5bc59fa6fe90bdd20f59661a87816d75397787a00611ee0d1/pyobjc_framework_speech-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:64d44383fb9fac20f457e902e1ea4b680c871ffb9b3e88862c482dcd59da7df7", size = 9371, upload-time = "2026-06-19T16:18:05.035Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/00/6dd086d3b241648374314730f6a520e0cce309d581f9682a34d78613d66e/pyobjc_framework_speech-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e646d8c781baf531e5943c2376c92ffeeb0a8bdf4f48d93f88e59b5033d12b55", size = 9525, upload-time = "2026-06-19T16:18:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/87/67/02afd94b537c9303e7a83da184d8a92fd7a41a50d0c7042ea7b0ea6e7f1b/pyobjc_framework_speech-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6ef705bf457651ee3c0089a3c4a0a14d6241189f51a3255fee0424caccb9d9f5", size = 9357, upload-time = "2026-06-19T16:18:06.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c8/39fd8ac2922c78b092dc26c175c549e1dcd628f50b73f1768ce12be95997/pyobjc_framework_speech-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1f62eefa6b576f6cf0d558a6e9ee5a1e9f99c973f3bb0c5521a5d7a356db9e0c", size = 9519, upload-time = "2026-06-19T16:18:07.494Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-spritekit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/1d/84896e2233d2f90444e3be44282ad6e8600b485ce96c37566ed5bd255204/pyobjc_framework_spritekit-12.2.tar.gz", hash = "sha256:75e8fd8040f77c7585247004b9c59971de84cbcb707070f391c8508888750565", size = 83896, upload-time = "2026-05-30T12:45:37.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/0a/3da8666b42a696b1d82a283ba442f2941060fa304359d4855c3c6072dd3d/pyobjc_framework_spritekit-12.2.1.tar.gz", hash = "sha256:989a25cb2e9d45ecb97655f55464e44a342eb525a891e46a563aae27c683eac0", size = 83906, upload-time = "2026-06-19T16:21:49.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/5a/0aca87af17d9000be6893349d3968c36d3f40c2c2e3ef1fadc4fa2e4bad2/pyobjc_framework_spritekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a9f5a77acbd93f2280ae8a098b7fd1690c2b16f93fcee7dacca350dbff196deb", size = 18623, upload-time = "2026-05-30T12:25:28.551Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/39/abc521893bd60cf5b88ece0091e83fd30717c58a2dbce712d9d9da2e5b3b/pyobjc_framework_spritekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d8ce3c810728a0a54f0af3063ed7ae45a8d0ae6c5a5ba405d02d08cf2c2bc6e5", size = 18645, upload-time = "2026-05-30T12:25:30.826Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/44/aaa0c92b8bf0b9b32c13fc62fdf506e3a868f3451670291441fe008bf9e9/pyobjc_framework_spritekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a8a68b20f5377ee1530f752bb693388a3dcc085b1c2cdaf6930427d1cf5791a4", size = 18914, upload-time = "2026-05-30T12:25:32.947Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/ba/23397f87cd54bfcecd8be53e52b00882405ad27036eae8a5c835b7acc9c2/pyobjc_framework_spritekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a7009d0693b72308500f9297cad80d8d95545d58637fcc43129a744c7c18d662", size = 18615, upload-time = "2026-05-30T12:25:35.01Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/cd/93164071434421d26d3c6b707494f2e5536b8eccdd779ba6aff4cd4a7569/pyobjc_framework_spritekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a1b4c138f57ae297c5842370bd13f188238da8430bd0f4687a420c3545192fc", size = 18892, upload-time = "2026-05-30T12:25:37.06Z" },
-    { url = "https://files.pythonhosted.org/packages/38/9b/731043fc52dd2f51b817b24d365a78a8c7f2be9a31136f13021bdd6fca85/pyobjc_framework_spritekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2a5d2ab99193bfd9af9adbb78e2e6805f2714dfa2d8fb440830f79d21eca06b5", size = 18630, upload-time = "2026-05-30T12:25:39.323Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e9/ed3a076908faecef04e17a57889c444f2d5339a3c439b18cfd5d618eee2a/pyobjc_framework_spritekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0bc636ce5448dbcfbb0306cec2eca6170b68c11a3041a671a52a1a6f5e127aea", size = 18902, upload-time = "2026-05-30T12:25:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bb/d19a875a22e30759be9ec33c7f238126d14c5b9cde515fad9c708577585c/pyobjc_framework_spritekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:182326b96722731536018564a890fce1b6cd9860d5fde3e0c2dfe31c3108f7fd", size = 18650, upload-time = "2026-06-19T16:18:10.321Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e6/83366c41ed99c17d690aaf76574e083d885d00c96b615a8552f284b318df/pyobjc_framework_spritekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee809a16cb549197f124240d1387e0da8ad9dee9bd853ab302fd8538de2cc381", size = 18668, upload-time = "2026-06-19T16:18:11.573Z" },
+    { url = "https://files.pythonhosted.org/packages/05/58/76cb4ff81419708ef45095d588f9f73a75a7c6a4c1c0f3070f3ab981ae2d/pyobjc_framework_spritekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:780d80b09c3a5f368efd5d567291bdf52cc07da079e75260776904ff4c5bac17", size = 18935, upload-time = "2026-06-19T16:18:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/15/58/06ea038a30f55ad8a748d187d74aa83d2464979b058eaa6925a68455e6a9/pyobjc_framework_spritekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a72410b7e9e4e1363f69dbcf1f2a0055275c7a3d205f707d5d29fa2406f39211", size = 18637, upload-time = "2026-06-19T16:18:13.439Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/cd/83f8a7508a43915ee5e88841b98deae8b5d1e3b0ce3a7596d3636a03a6da/pyobjc_framework_spritekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79310eb2221dadcb5e0e8dae31f28f4d8f78cef73cebd7403220b82702ccb781", size = 18914, upload-time = "2026-06-19T16:18:14.251Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/06/d2c35beb5aec1b97ee13d72adceb6dfecfbdb1a4c836f89e9dd9e00c6e1c/pyobjc_framework_spritekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3dc6f3f7db1b971175416481bf9b20d0f39be0a6266c04ed3a999e4755453256", size = 18649, upload-time = "2026-06-19T16:18:15.098Z" },
+    { url = "https://files.pythonhosted.org/packages/61/36/0ca18d7a78ceec1c2d0f2e7f1d993511fc7d138d676c5b9ffd12e6278bb5/pyobjc_framework_spritekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:22d2e8218bd59e05d37c2e0faa0f67711a3a1f0f78e3a1f31680c0587d2cb622", size = 18925, upload-time = "2026-06-19T16:18:16Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-storekit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/ce/3c5e9ee38040e4770af6aafa0fd11080b34a20dc2c718d2524db5b048bce/pyobjc_framework_storekit-12.2.tar.gz", hash = "sha256:f50699484da541b9d028503441bcb745eeff0becadc75556783aaf76b8764975", size = 40947, upload-time = "2026-05-30T12:45:41.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/2e/d299e11aefcc70414281e5f82e2297a314c108c5bf81091149f1c3f6411a/pyobjc_framework_storekit-12.2.1.tar.gz", hash = "sha256:5d3b306f08810c485a4bd184bc6e45cc92eaf4cb6d4b88bf701bcb854ab66f59", size = 40971, upload-time = "2026-06-19T16:21:50.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/80/d8447ff5cdf292df364c12ca0d912a29247a2caba0e710f4f0a02461ab9d/pyobjc_framework_storekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e0acf29d337a0b046bb4cc8d876823e56f83a9530933842eef270a12a2e9c9d5", size = 12880, upload-time = "2026-05-30T12:25:47.112Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/b7/16adfa4c5aedad949ea10a751c60e343745afe889706bb8d71491ff57732/pyobjc_framework_storekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94d2daae9e5166cfa9d694acb2e51bf1d3856cf7ce6c74a84e13d80dbe6915ec", size = 12894, upload-time = "2026-05-30T12:25:48.888Z" },
-    { url = "https://files.pythonhosted.org/packages/39/c9/bcf7f4c1087b7f83d190335d2149e8ecd5591064419ea820dac09b47bf4b/pyobjc_framework_storekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:922da8a72885d79c3c30dd3d36e9a966dcdd642c08f258b4b099a3f0e3ded643", size = 13091, upload-time = "2026-05-30T12:25:50.719Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/8f/ca5b9b3688df3d30e564d6f48f9d63456a5bf76c98a5c0746f261766b7d0/pyobjc_framework_storekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1e8b62a74c2174e8685471fcb302a0cf263b521b9e14ff65018eb2e3c13beacd", size = 12885, upload-time = "2026-05-30T12:25:52.619Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/8d/9f63e339267bc7f73f9fb901e0164c56309789ddaa70e68e0fd10dc6bfd7/pyobjc_framework_storekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b0629d80932a2ee24c60b67ba2ee868071422d6b56a99fa1e14163d00a5213b7", size = 13074, upload-time = "2026-05-30T12:25:54.464Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/b0/61ec475dcfbd8ccfda19fc2030ff68981486951b91881dc7e69daba6b74a/pyobjc_framework_storekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f5b6030c8e1353eebbe98e3ea90e0d0f0353ee014d2a8b5746b580c7ccfdcf4", size = 12878, upload-time = "2026-05-30T12:25:56.295Z" },
-    { url = "https://files.pythonhosted.org/packages/19/39/32b266ce05533e3273926a380fdacdc6d1c83404bf8cfe1292c02b770537/pyobjc_framework_storekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6204fbbf29f01875cc6683999fc6f627dc6edf4bded6bed68583422ed0d847f4", size = 13080, upload-time = "2026-05-30T12:25:58.095Z" },
+    { url = "https://files.pythonhosted.org/packages/09/09/9cb870b865d1adb49a910df20b2347ceecd07d906e58b14a5c807bf67e30/pyobjc_framework_storekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4394366c2d4442c41faadaa030202f4b8a6272b8ec25828a04504f5b40179b6e", size = 12903, upload-time = "2026-06-19T16:18:18.964Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/931bc925612fd74d09679ec976c45bdb2e41492e63d287594e11e6b1d5ac/pyobjc_framework_storekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3dab34b774ae217dfff0bc636925cd39c072300aed322e107936f15b9c2184ca", size = 12919, upload-time = "2026-06-19T16:18:19.987Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0b/eee8956c1d94824357ac92674ce9e4c96285612a22d290da00aad647291c/pyobjc_framework_storekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11a40b897ef4d042079daf2fc4d05fe910d6fc737fdf15d3873875721fcea69a", size = 13117, upload-time = "2026-06-19T16:18:20.999Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2e/5e2badd9e8b75b735dbc5cd37863410a1abe2bdb704b653bd2283a13b7ba/pyobjc_framework_storekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0d398dd266a050944b7f3b3762820377edd7f4043829ea1be932a3b30896e72e", size = 12908, upload-time = "2026-06-19T16:18:21.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f0/af9c8e9a395a69015b0aabbd04853b438692c3a195d136c6f9ffe293a8b9/pyobjc_framework_storekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8b4851593b80482e74dfd1c189b5140a79659069fae54aa3c505aaa859114e33", size = 13099, upload-time = "2026-06-19T16:18:22.753Z" },
+    { url = "https://files.pythonhosted.org/packages/59/09/eec2af1f269f73d54735b05069ce60cbe4e59db14b49e98d7afa3831b3c0/pyobjc_framework_storekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0a958caa5905c3e2de270b09a75cb012a22499943df494cc899fb36b5541a28b", size = 12901, upload-time = "2026-06-19T16:18:23.981Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/01/3b2384b06ab47750c8f4ffb93137e265ef72fd1dcbb3035d806bc2f1e1f7/pyobjc_framework_storekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ff6b0cd7ed194b248f1d4db50073b85fb6c67574183ae31c9261d94218c8881b", size = 13102, upload-time = "2026-06-19T16:18:24.762Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-symbols"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/06/042965972619d440c69037105764accd700053c658dbcbc2914ba4682ab5/pyobjc_framework_symbols-12.2.tar.gz", hash = "sha256:06c00d97047ee79fad95f95380d308c6dc1200d688cf4adf954382d65f138b10", size = 14785, upload-time = "2026-05-30T12:45:43.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/1f/6575bd54a71ccae067b56cbe9277b65d095c9a9880c9e059d8d2e845a8ae/pyobjc_framework_symbols-12.2.1.tar.gz", hash = "sha256:c15d32ae7c94e0e95fd83bc2099437a70671b79d0f438a1b0cd1f3eb2cc6f365", size = 14778, upload-time = "2026-06-19T16:21:51.277Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/de/168b3925a76417978e5bc5921c8ac0a278e5a672302a20ca10f18d317695/pyobjc_framework_symbols-12.2-py2.py3-none-any.whl", hash = "sha256:abc83c18ef8733897667d0b4d79400e3c38828347985bcad4aaf40b0cd61c94a", size = 3526, upload-time = "2026-05-30T12:25:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/163c7af387d5f65cbd55a5814596b1f4cb5c26b28e2e9ad6c2f331cc920b/pyobjc_framework_symbols-12.2.1-py2.py3-none-any.whl", hash = "sha256:95199cb08207680ee36bcfdc4cab5d4c5eaa0ae81e01b1a752066effa6c9b039", size = 3548, upload-time = "2026-06-19T16:18:25.705Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-syncservices"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-coredata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/e4/ac36cf4a79c52c865d92b148b024ee0fcda7e9efa45017cc64654558654b/pyobjc_framework_syncservices-12.2.tar.gz", hash = "sha256:354f7aab848d4f2ce055886a083d07be752ebedf5fe1dcb3cbedd489fd4bfa05", size = 34830, upload-time = "2026-05-30T12:45:46.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/8d/ad9492c9f0a305e4a1e30968407385cd4bc61051a1a2f9c40677c964fff9/pyobjc_framework_syncservices-12.2.1.tar.gz", hash = "sha256:c351286f14d257e20f8305665825fd73f108c8f0d787e4643818dee5debb3511", size = 34867, upload-time = "2026-06-19T16:21:52.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/a6/01f21cf774b952fcca49f23a67c9d2f4a52b7bf5e2436a4911bc69e4077a/pyobjc_framework_syncservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:87e95555da2ab0f87e8b3e48df7515e61cd5929f331a1c6cd9ba4f8b92310fe2", size = 13414, upload-time = "2026-05-30T12:26:05.587Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1c/1ef02418ff43f53ac9ef49035b34fcdf664fcd5632d3d796cafddd01fd57/pyobjc_framework_syncservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9ff8eb0475033f24434b1dfd7f77a8c458f9ef7ed692e59b9e5a26c22692e0d", size = 13429, upload-time = "2026-05-30T12:26:07.387Z" },
-    { url = "https://files.pythonhosted.org/packages/21/ea/df2f2e636b8616ccb4c8d2b15ddd29275245ba60a7666dc9287b4fe977a5/pyobjc_framework_syncservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10c1dff31d1499b618b3741956219577f2254b04df2fbf10a65a49ed3ff3dff2", size = 13599, upload-time = "2026-05-30T12:26:09.354Z" },
-    { url = "https://files.pythonhosted.org/packages/33/0a/6971856780f54f9f2ed94dd034fce70e02653dad10902badb10ad2c1442d/pyobjc_framework_syncservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d7944f195da7488e89df0f18130a5ed6db29fcbd9404e76d108f9e4aeccf2576", size = 13404, upload-time = "2026-05-30T12:26:11.164Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/06/b8b39fb6130c49c9747ad52836bfd61308771a08f3ba4a6192fecc34005b/pyobjc_framework_syncservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:05ea5b32ed1ad19c958103ba9a2bee6696c0e217e2259c49908d710b2255f01c", size = 13586, upload-time = "2026-05-30T12:26:13.073Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/6f/505ddd49c8c5236a05d46bac82f00989d50c8f9cee425843971435b0ad35/pyobjc_framework_syncservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:35b96ea6b1e85124039dbb195ee46b6bc1986c4fe43cd44dc376f8f4cf01e382", size = 13398, upload-time = "2026-05-30T12:26:14.907Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c6/6d70e0ee36a927e77c02336744103e1da4b99af9654634717100be525f79/pyobjc_framework_syncservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f80b37b92d409b22b9a63d67f45f75c91b14986b6939bf69a11a55497953c651", size = 13581, upload-time = "2026-05-30T12:26:16.823Z" },
+    { url = "https://files.pythonhosted.org/packages/37/43/504b6ef68ed22a3546aa42339f7e6c3d6953c856cbe28158ce231611eba3/pyobjc_framework_syncservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4cdce34f17d978f349e22dd6604a46bc01c25cd23142b856c393ffd28d6e687a", size = 13442, upload-time = "2026-06-19T16:18:29.174Z" },
+    { url = "https://files.pythonhosted.org/packages/da/de/feb58f62fb4a5a2970cb8660a48e4fd8f9480771c66a0c82ec3f87d25418/pyobjc_framework_syncservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4a569b68068163df043146b999b606e431b6cb4de4ccd24861031321fa442eda", size = 13455, upload-time = "2026-06-19T16:18:29.976Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/af/fd67ce6c70f9329261dff246322f08000fad6f96f940e8f0a3859c85d7ea/pyobjc_framework_syncservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8ade4390f80e4b8d9f94610a3310d1c4cadc195e7db09a9702bec39bd8a0aa8b", size = 13626, upload-time = "2026-06-19T16:18:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7d/78bced3548a0243c4cd0eeb7b4732972b1ee35d9750a1cb47a8e1aed9543/pyobjc_framework_syncservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:5aa55b01b440d9c2d3ac55c676b5a8e512d1adab43aec1012c3d0756f415de07", size = 13426, upload-time = "2026-06-19T16:18:32.078Z" },
+    { url = "https://files.pythonhosted.org/packages/12/74/65cbe27a99ca7cc8c4b6e30de51a040162a25d2d7ab6f5e3b17c12bdf2a8/pyobjc_framework_syncservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc0a3bfc317930edde03f76fd776d9aba548a911bd870b8a0b272091d2d3e852", size = 13613, upload-time = "2026-06-19T16:18:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/09/b936f2a9504161a570dd63231c4ebb4a18e822830eaf767abaddc2e3f1b3/pyobjc_framework_syncservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5bc5b8981b29e45af0ec68040dc6313678217e83b556c6c7fd1b26e68e02f2d3", size = 13429, upload-time = "2026-06-19T16:18:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2a/26c5e0b8256917b0f19e7bd056df0bec241288ae286266331c21d85c40ca/pyobjc_framework_syncservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b10b47d7242b8db20230da090b72b6fe688d513b0ec0d47bb3abff1bcf6b61b5", size = 13611, upload-time = "2026-06-19T16:18:34.941Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-systemconfiguration"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/de/30ce4e5e41d2bc965b5598ba4f3595ac3eaa088e26cc99d519f68d62c7b9/pyobjc_framework_systemconfiguration-12.2.tar.gz", hash = "sha256:017bb958c436b6aa90e04a99fe3fdce3787e8c1db80d165ff0071273bdbf242f", size = 63332, upload-time = "2026-05-30T12:45:50.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/6f/805ee24f58c13eb593e458ec1f79d94d3415edace02eec7c614ef3518f69/pyobjc_framework_systemconfiguration-12.2.1.tar.gz", hash = "sha256:877a90eafe3df72625e50d61fc9c6dbd40e8cdabab7c4101992090107bb71ddb", size = 63314, upload-time = "2026-06-19T16:21:53.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/cc/c105a396dcabb8eb9c787c8447a379c6041db3971e89946e843ad07ae059/pyobjc_framework_systemconfiguration-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e2784dfd11381c5f420ca4c93966c6fbbe3f726899c49aef81a3a11fc55c38e", size = 21542, upload-time = "2026-05-30T12:26:24.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/e3/fb4e684f873347039ea5136c0a5f7a0ae18ce7b4caaee8508e013fd47f03/pyobjc_framework_systemconfiguration-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d0b290b3cfd77fde1f4234590afa0be7785c02ff2cd5b591ef8d07e2cd0caecd", size = 21533, upload-time = "2026-05-30T12:26:26.467Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0e/948a070637f7f0ffcf2dd3b5a323c77694a1ed0ae04e54dd4fddea9cfac2/pyobjc_framework_systemconfiguration-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d4b81bb37f365891a14bb4a09d735784a0bbe2c594b89a1cb87e17f1db7abac8", size = 21946, upload-time = "2026-05-30T12:26:28.795Z" },
-    { url = "https://files.pythonhosted.org/packages/18/07/9b72143a735bd5d17e5e81e3862097438c8020acecb9e72511584e86718c/pyobjc_framework_systemconfiguration-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8a384b7cc722a7a266707bf3f145cb4cca88facea5000ef2928327ad3de1ea51", size = 21563, upload-time = "2026-05-30T12:26:31.289Z" },
-    { url = "https://files.pythonhosted.org/packages/40/70/db8f3860f1fb56a80407b16ab3b2a33f4d3e71834556eeeeb6e16ebdfe0a/pyobjc_framework_systemconfiguration-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ac6f7e2c54223d7aae5bc0b71880bede7e26b5ee754c11a23f4bd5cedd4dda45", size = 21956, upload-time = "2026-05-30T12:26:33.889Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8a/2ac3a3c0599159944b940bc8a8882048490980f51ecc1ce8d579c09c484d/pyobjc_framework_systemconfiguration-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a3971c02199f6b85830f5f29610478133ec9fdea8e3f82208fb58f2f4db822c7", size = 21571, upload-time = "2026-05-30T12:26:36.357Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f4/38ec9b9994fcd6ec4dae5ed58650882e108fb6fb269f6edf21e25c052dd0/pyobjc_framework_systemconfiguration-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6e54a0df0b04b09f0bd7665db7c4887750ac70d243acbc9b8bf146947796cc1e", size = 21962, upload-time = "2026-05-30T12:26:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/f153e2db0cc3724b6cd3c1e939149fb93a6d7b4b9c0ab75a8d7ecdadb02f/pyobjc_framework_systemconfiguration-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9671060ab587eaf485eb8e1d6b328d664ba4a210c4ebffbf7dd2705d741bf90a", size = 21570, upload-time = "2026-06-19T16:18:37.853Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bb/ecff9943e5bd24b78319f683e9219209db502f46a3dff24d1e50bcf9d74c/pyobjc_framework_systemconfiguration-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:06e93a97364681543592bff38f801e2942eb272d68101ccbf3278a8fa043c645", size = 21565, upload-time = "2026-06-19T16:18:38.829Z" },
+    { url = "https://files.pythonhosted.org/packages/71/dc/ecc0b5a79d54507be2a3bb8a5088471bbd2a5bd8d2f89dd07538f3bf2551/pyobjc_framework_systemconfiguration-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e3aa4706f81d8334c717d44567314ebbdf03e62259ede99a89f4703789c212a2", size = 21979, upload-time = "2026-06-19T16:18:39.662Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f7/8e476085716dce017c92c1b24f66a49d09d5bb86d45a82942df6296086d1/pyobjc_framework_systemconfiguration-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c1327154369fd07dd0b9f02a4fd65068c531ffa99f8e0efbab51f03446750f33", size = 21587, upload-time = "2026-06-19T16:18:40.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ee/404d50f15729d0cdc06f89763b089ccf86ef2103776332ac5313a6a31067/pyobjc_framework_systemconfiguration-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2573755bdc6480470d2cf2cb24c529371bcc3658953ba0efa87e0a6af5b68144", size = 21983, upload-time = "2026-06-19T16:18:41.497Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/43/40c9c0d44007c8185d992da1b1d39359acdf701d1c41f14e274bb676c7b9/pyobjc_framework_systemconfiguration-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:150e1b5f35c4badf34b98c56aacc128f631d5084857c86ccccfb4d78e35a7257", size = 21601, upload-time = "2026-06-19T16:18:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ff/a637bebb60880c96dcad2c888e66d4eb2f6d2609ceea3cfd1fad606384d4/pyobjc_framework_systemconfiguration-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a1ac9972a24e8900bd09313afe3550579a3e7ef643766f38da2f965e0d9c7e1f", size = 21995, upload-time = "2026-06-19T16:18:43.339Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-systemextensions"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/4a/49dd15416665943fe08999c3d5d8675c6dc153c720b9cc17e83215350a46/pyobjc_framework_systemextensions-12.2.tar.gz", hash = "sha256:2ec1edcd9d12451ef74969eae546b4661514381d7d60221240560ca9a743f506", size = 21675, upload-time = "2026-05-30T12:45:52.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/1b/6edbfef0f03ff67bc22ba03ac7027aee804ea5b16512dd9547dab5786c81/pyobjc_framework_systemextensions-12.2.1.tar.gz", hash = "sha256:4f9f6d729544acfab49fe02a4b38712112c51f07790f8d4bf7ac3bb18c334839", size = 21667, upload-time = "2026-06-19T16:21:53.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f1/24d65afb6a7e5cfaebe2d9f36eccb4e97ae18c0222fd36dcf44a592664e1/pyobjc_framework_systemextensions-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e82bc31c3b847e293006e749ad17004b5e046e9cda2a8ab74310b9e6b431d4f0", size = 9201, upload-time = "2026-05-30T12:26:43.706Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/76/f9490cb2be6a6c06ba2132a50d33d368dd90a917284a712614eec818c08b/pyobjc_framework_systemextensions-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dc3c41d413a867483511edbd3332d3a13fa0011119fadf0e4c642ea1b97b7bec", size = 9217, upload-time = "2026-05-30T12:26:45.252Z" },
-    { url = "https://files.pythonhosted.org/packages/db/4c/a9e07ceece91b207e2554166675f299f05b0fe9af93868b91eaeedfeb2d0/pyobjc_framework_systemextensions-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8c131f836a61df9064020382b6b1b80965799ae44cdb197ef4696167e0796bf2", size = 9375, upload-time = "2026-05-30T12:26:46.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/5a/606fab2d2bd2d0ca4ab834b7a73547ae5f8faa095e64f20e210f976733ec/pyobjc_framework_systemextensions-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8accafc90d9707cbbc35461b37d00ecac48e569440ad935d23ab6e28cf8ebb9d", size = 9289, upload-time = "2026-05-30T12:26:48.411Z" },
-    { url = "https://files.pythonhosted.org/packages/06/6b/34403dc90bf0f59f6bc2aee0d386c2d18f85885f90d672702292a69e4c90/pyobjc_framework_systemextensions-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0a7b8a301e288a7d2f560f7028226393eb4fc8a34f32b23ad1693ecf851684dc", size = 9446, upload-time = "2026-05-30T12:26:49.95Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/85/6f85d38abf47a979fa658c18c1fe905de891177438b4a2ca293a787d1dbb/pyobjc_framework_systemextensions-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fa8b186c217230aa74044df091e3bd2d3a0b962ba47a8465727d914767b9288d", size = 9279, upload-time = "2026-05-30T12:26:51.503Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/05/6959ac75f0c08862681fa1fa46527e1d0f51f9a846176515f1ca6ba8e4e6/pyobjc_framework_systemextensions-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0cf56fa70539445d64c7582ad7ee7ea11f7f15d2f4ce24745d3123522bdae666", size = 9440, upload-time = "2026-05-30T12:26:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/a70c451b3ae4cf8387b0f0d709754e8f87db7057f2e0bb5ab0d73f96cc98/pyobjc_framework_systemextensions-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b871a52125eff3c6ea10b769920d64fddcbc26a58bb3759545f914cf0c5cc9fa", size = 9221, upload-time = "2026-06-19T16:18:45.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/20ec0f1239d58a0f8ccaebfc545f27c26904faab81f4e6e7d07efeba1f71/pyobjc_framework_systemextensions-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ded8228991aedcc2b3f9d8c7a0af5f9e9cd9125af562d68817e6ce0bf8a2a713", size = 9239, upload-time = "2026-06-19T16:18:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/94/c6f40110f2da5bbea11f41ed906888aa726bc22b465b39027b1ea5d4c516/pyobjc_framework_systemextensions-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ae954da6267be3d7bafd53ee8357c8b5d3c13dd56359a0d862b69f5cb7eea260", size = 9395, upload-time = "2026-06-19T16:18:48.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/41/0c7ec750b86f92e4100bfabf9adb121516b0c869fb3da39b4d6214e388b4/pyobjc_framework_systemextensions-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9231d0d14502d51e18a2ba89a4d7f2e310489b0f60e2b951887e8852880563ca", size = 9306, upload-time = "2026-06-19T16:18:49.309Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1b/bafbd1f9f53b31f8dcf1f4775206de0cd07fd66d1aecd9b39ba9f9e96507/pyobjc_framework_systemextensions-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a38e9ef6f5fa5f4dbc4d1e6bae8d169f3f0301a52e14de45ad3631033daa4436", size = 9464, upload-time = "2026-06-19T16:18:50.151Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/a36d6951585b12ec57c3d98c103046ebb34bfc5a1c48df0ea2d7b54c3401/pyobjc_framework_systemextensions-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dfb2884c0fe97893c4b226dd7d95bdec43f7f8a574347a1e80280bbf87230736", size = 9302, upload-time = "2026-06-19T16:18:50.947Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6c/da629b65b470c5eec528e1e8ec703d8654701bd03078bf1e15df508b1950/pyobjc_framework_systemextensions-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1412d2c62f9df0f52160f7edafcdd608259b6c70925cdb520f45f16a46d2c685", size = 9465, upload-time = "2026-06-19T16:18:52.08Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-threadnetwork"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/e6/8b1744871062c39cce64d43ab20b11344ef5f1b93993c1b737da2faa3acd/pyobjc_framework_threadnetwork-12.2.tar.gz", hash = "sha256:2d7df5938094e3aa93210a079ebf3e801a20c84a3b759573ddf05ec2c2cbf083", size = 13327, upload-time = "2026-05-30T12:45:54.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/a2f44eade30d2231938acb81ef049f4172afd6e9acbdff55eca036e75038/pyobjc_framework_threadnetwork-12.2.1.tar.gz", hash = "sha256:98397cf45354750c4b5a1237f6961c616d12f3ad0a570b3808a03e5d3373f64a", size = 13341, upload-time = "2026-06-19T16:21:54.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/7e/dfa9e914c1f192d6afdb504efc01f5aac777a73d43cfe103896bb5072ee2/pyobjc_framework_threadnetwork-12.2-py2.py3-none-any.whl", hash = "sha256:08c7a03e11c60dca7b3f219db744986b90b8797d61b6842e0c0bad192e723f48", size = 3805, upload-time = "2026-05-30T12:26:54.517Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cd/822620f1c4f00e24fced4a267113a77d7fafe394d0b516b8c94ff01f62b0/pyobjc_framework_threadnetwork-12.2.1-py2.py3-none-any.whl", hash = "sha256:75afa29eb2884cb9c5ddf5bbc81fed7f45f168422ae897c1a791374152c9ffd0", size = 3827, upload-time = "2026-06-19T16:18:53.181Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-uniformtypeidentifiers"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/54/e270da2b0b4ab1fb0dc7f4e616d1a6e141583f88409c0742f6ebfcf7a064/pyobjc_framework_uniformtypeidentifiers-12.2.tar.gz", hash = "sha256:19cc82f1bbf3bc0999597779711422f6c9d7340634d699ae64d9bc7c0d79f984", size = 20704, upload-time = "2026-05-30T12:45:56.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/19/4f314697bc8f519fe6505afe51d83d7fdcae93239b7bab5941f4bebc1f9e/pyobjc_framework_uniformtypeidentifiers-12.2-py2.py3-none-any.whl", hash = "sha256:f140a378cfe6a8ca47ce3b04fd5a4c4bec1fcbedac8acc87e2c18985bb805203", size = 5019, upload-time = "2026-05-30T12:26:56.001Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/44/18a7b3c3b4f9f6784fddf64ed5a2c148577d0300705a50e8ab81da8fc71d/pyobjc_framework_uniformtypeidentifiers-12.2.1-py2.py3-none-any.whl", hash = "sha256:ea08413ad895a7dfea13670e26548bcf5b00154084cdfb5d8f96603320e77cf3", size = 5042, upload-time = "2026-06-19T16:18:54.085Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-usernotifications"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/c3/f1d43ac73b5fce42a00bcb68ac53edd7180217df60a25985e2477c9c389b/pyobjc_framework_usernotifications-12.2.tar.gz", hash = "sha256:b7773e84fe40e746f706055267ba2b1dc9e0a34e6575719f1e515354f72583a0", size = 33908, upload-time = "2026-05-30T12:45:59.61Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/77/bdd49a1fe4d89ce86078e94121cf6e9c7e2f733215556194da04c512075e/pyobjc_framework_usernotifications-12.2.1.tar.gz", hash = "sha256:64379ab6b603949ea20b7852343cbcff7403443b4876ec8ac0c03bd0f11b1b22", size = 33955, upload-time = "2026-06-19T16:21:56.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/39/d9dbc214cd2516c6ad0ff28f97c50c0e8178b8b293f61974bf2efc5b4e2c/pyobjc_framework_usernotifications-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b5533378b934430f73bb0092df19e54d67ab9f3e61ac8116a0480916c8c4c0b9", size = 10185, upload-time = "2026-05-30T12:27:00.986Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/e3/a962cbd3739cbb01b2b5697e336babb15307fb473500524bd7e730446b7e/pyobjc_framework_usernotifications-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dbc51fc214446f622b4670bca7efb8969ad84cdee21672da3c872fa3aff5aff5", size = 10198, upload-time = "2026-05-30T12:27:02.504Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/8e/2a44292fc4e96682054f74a1aab1c303fa5caf5820e5cd67b0d23b52750f/pyobjc_framework_usernotifications-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e329301b42181a95c2ac5f71491529ac1260afa9b26b16a104db275bbafdcb18", size = 10357, upload-time = "2026-05-30T12:27:04.132Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/00/659908e2a3654564727daddc494624531e9950274627130b74f918e9fa84/pyobjc_framework_usernotifications-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c227579be5f40579b6345400578c0f0c56dc85811d56b912937ee2408dd00b83", size = 10265, upload-time = "2026-05-30T12:27:05.736Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f5/0996481a6c3c99c42c5eff47c8d136b84a5a1108276dadf4f58830c73814/pyobjc_framework_usernotifications-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:969f60adca5420ea1c4a42b3d5eb0aa0654ddfca4ca3a10a9774933b8bac65fc", size = 10421, upload-time = "2026-05-30T12:27:07.286Z" },
-    { url = "https://files.pythonhosted.org/packages/22/2e/04150a39eeb077dd1a637744c5920f3f64590a022c38573a1c12987472ec/pyobjc_framework_usernotifications-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3889af591a44859a11ed4c2ea4a7bdd90ed61d17bb3b27dd4aade24d80a0bda5", size = 10256, upload-time = "2026-05-30T12:27:09.278Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/2b/e1a7f0b6b19c4f73341a1ae1dd9d063998777fe092c5f8ca5e84906e7187/pyobjc_framework_usernotifications-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1656cc4d2be411447196df1c8b63466000bfaccbf144ab97715ec42eecbd497f", size = 10423, upload-time = "2026-05-30T12:27:10.858Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2d/c40189560f8db4ab9f29a9c79eb7b2d89544d80a27252de5112ebcabdd4b/pyobjc_framework_usernotifications-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:12fab51085e4796e04783e457d9355b805afbd1cb13bf9d207e5fb7e1a32fb36", size = 10211, upload-time = "2026-06-19T16:18:56.988Z" },
+    { url = "https://files.pythonhosted.org/packages/21/71/cff5abc272742148f086cf00b5625e6a7f23171dd7b23d075f16a26e47c9/pyobjc_framework_usernotifications-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:273ef82c7ddc1701d56b586cde2615360618c1b2d17fb5c24bac77a5f02b6092", size = 10221, upload-time = "2026-06-19T16:18:57.775Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/75b4c4c15dd4f4f3c190424244ca35976e3a29c51740b7648f3fa78eb73a/pyobjc_framework_usernotifications-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e872d65dc71bc297401819106b5e5c4b758aa38247d74284bce20e63a2bdbfa1", size = 10379, upload-time = "2026-06-19T16:18:58.507Z" },
+    { url = "https://files.pythonhosted.org/packages/36/00/7a7c79a3700bcc24c9cabfac984ae38ddcfef72e6564aeaf4c3237009279/pyobjc_framework_usernotifications-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b43a46b4a95bdbf0d2acf1ec0d709b376c4149c618693a05745485c741ad4f28", size = 10283, upload-time = "2026-06-19T16:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/81/dda0b17f8761bf9aec3e1eb26aedb5590a51946ff4e8ef62e12870c639fd/pyobjc_framework_usernotifications-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4050919639556e63854e9965d942f928745ac346b52b0cb7acd3823b8a9af153", size = 10444, upload-time = "2026-06-19T16:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/bd/4b6d4d7aea2f1b99f73548f01f964769e04574e0bd823afad003736290e1/pyobjc_framework_usernotifications-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0811da6cf3e4b5dce91ad61888204b08281b86c889c4241309f55bcf996bce03", size = 10280, upload-time = "2026-06-19T16:19:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8c/fcaadbea1daa56e73aef844f89e2534b51b04e61881e2b6cef0727e0f72f/pyobjc_framework_usernotifications-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fc70d0f149716b8488934921a28e96716d2db7eeac4bcb1043b970c52d551613", size = 10445, upload-time = "2026-06-19T16:19:01.904Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-usernotificationsui"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
     { name = "pyobjc-framework-usernotifications" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/5f/d58600259b0b99ff3745eef91570d0ced05fa1b26083f2846082acc15249/pyobjc_framework_usernotificationsui-12.2.tar.gz", hash = "sha256:8c3298cddd27be794ad46a2783304b6fb1f0ad4d65933c34ba3e43e58ecdb406", size = 13462, upload-time = "2026-05-30T12:46:01.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/9a/566813aed69566c68045fc080b2238f62df131826d16da42529e89d56434/pyobjc_framework_usernotificationsui-12.2.1.tar.gz", hash = "sha256:ea6aecea828e088416aa6d14055c023cac6aa03ea0cdded8baba679ce5414cc8", size = 13457, upload-time = "2026-06-19T16:21:57.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/29/f4413e1941e153a770b2d85faee4d3a4f9be67b69f5823f63db8dd091356/pyobjc_framework_usernotificationsui-12.2-py2.py3-none-any.whl", hash = "sha256:a5d92117c2d18e2b6365f5e39daf45a68491a66ac9103b1bc94df43b8868c256", size = 3930, upload-time = "2026-05-30T12:27:12.318Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4d/ae257ba381d779ff760eea94fc12df5aded3bbf9da4304f66f70962ad68c/pyobjc_framework_usernotificationsui-12.2.1-py2.py3-none-any.whl", hash = "sha256:25464587228e128758a1ea9d8b0abdb872d2a957d1c554d791796a39ddc0e4ce", size = 3953, upload-time = "2026-06-19T16:19:02.794Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-videosubscriberaccount"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/3d/cace0ae1dd453f9da495311675d4fabe7adf89e94e7b99e26f45ba0fa713/pyobjc_framework_videosubscriberaccount-12.2.tar.gz", hash = "sha256:821f5485545238fd997dc26aff8ab2c838b43d664a7ec6a030ba67b09c2b799d", size = 21360, upload-time = "2026-05-30T12:46:03.619Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/4a/b3485f9e123b05a44852f07ca9387d8ad719a3ecbe0a10e2d2f726a460ff/pyobjc_framework_videosubscriberaccount-12.2.1.tar.gz", hash = "sha256:7af53b410d3943be09d8601bd8d50fd0e193e4e5577fdaa2f801d7f9dbc0454d", size = 21346, upload-time = "2026-06-19T16:21:58.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/03/f3b0c4ed85b4883d5fcd48ba2efd807507c3a5ce7c3aa7d4366dce81f503/pyobjc_framework_videosubscriberaccount-12.2-py2.py3-none-any.whl", hash = "sha256:b158b03e1432dc229fabc96451f5ac8db5ab228792354f0f26419a973777c700", size = 4866, upload-time = "2026-05-30T12:27:14.012Z" },
+    { url = "https://files.pythonhosted.org/packages/38/78/4dc23b84c668c10dfde26c861c697b4bd682d1d137422a0546e742c08455/pyobjc_framework_videosubscriberaccount-12.2.1-py2.py3-none-any.whl", hash = "sha256:ac43567833a4aa21fec81d39449d080b2cd58d6b02de76b57004067bdf37ba76", size = 4890, upload-time = "2026-06-19T16:19:03.85Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-videotoolbox"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -5902,39 +5874,39 @@ dependencies = [
     { name = "pyobjc-framework-coremedia" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/2c/af5a91d12bb265697fb13ccdbac7068e04e8f40c36139b314ea477982aa3/pyobjc_framework_videotoolbox-12.2.tar.gz", hash = "sha256:33d0838f706c771667b0be5737036d303b677bb243ba64df9ea2fa6860ea9f76", size = 64923, upload-time = "2026-05-30T12:46:08.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/82/307369b27b00b38cf6b6e021fcdce0ae6f1a91f24fed9b090addbe90f1e2/pyobjc_framework_videotoolbox-12.2.1.tar.gz", hash = "sha256:83582abc25e55ed04f0267fa69923839d779a11da3d34ee8c93ad1a66439e48d", size = 64995, upload-time = "2026-06-19T16:21:59.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/de/d4f998122a36cc7f7bd07c297a30f776455e00b27d24fd63b778c72421d8/pyobjc_framework_videotoolbox-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36576a1cebd379efeff58f7e016fb2eef5bfe36c4649f7fb197157fe61842b5e", size = 18983, upload-time = "2026-05-30T12:27:20.923Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/08/48b4af0452930b1865dee4e847113d5b6d2530a19ad111b6f551d8b5bd8a/pyobjc_framework_videotoolbox-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3393990f9f566dadada78b06c134bcefcabd50731b5322110759e0d26d9ca280", size = 18999, upload-time = "2026-05-30T12:27:22.983Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/d111f5d93f88f0d4d7150d318a6e089b0e08196cc29bdcae3c6af7c9891b/pyobjc_framework_videotoolbox-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:06dea99b364c3628037332c5fbffcb341f32a4cc7acd0ea4813a83b78fe1f70c", size = 19209, upload-time = "2026-05-30T12:27:25.22Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/f3bf7ebc231abb84a57fd5125850883380ea9a7cbb5f1c218cc7a8a3c386/pyobjc_framework_videotoolbox-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:49f12920f8a7ed85c110145dd628b38d387319a2b7cd399e70b5359aa8724614", size = 18996, upload-time = "2026-05-30T12:27:27.37Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/34/79754107f661cb958871f52b0c8b0a935f6b09a118ab4b56fa53780d0a67/pyobjc_framework_videotoolbox-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58a547a45fb92c9335f52814cd234a80383cbadd0f5e8897d11b5ddaec6606f8", size = 19192, upload-time = "2026-05-30T12:27:29.434Z" },
-    { url = "https://files.pythonhosted.org/packages/10/40/5cb09ce331ca581b9cc9e50cfb22deede8862dc40386174785fe84ef3a58/pyobjc_framework_videotoolbox-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ca98d2604f00273bac4977cba830ebe48a2b0a0b5d8068b551599780ac0045c2", size = 18999, upload-time = "2026-05-30T12:27:31.523Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/a3/852fd3029533d7a94c86f00383fab060dc77664bdc330b7734c87877fbaf/pyobjc_framework_videotoolbox-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f3a916bbaa8826e91f8ef9cd53564fd3be33135d92acdadfc7e85b49d3245c8d", size = 19193, upload-time = "2026-05-30T12:27:33.643Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/64/804ef9bda687dd3ead9ecd9e2fe29842a5acaee95bfa5f5d6932716090e9/pyobjc_framework_videotoolbox-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:67e03405bf7ea4790688c3937c5838dd8e1d25aa95923a7bb71ba3c49031d1af", size = 19004, upload-time = "2026-06-19T16:19:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/eb/771c0564a82e4e9ff8a4369100d6a3720824ac65a8e899c70da970e89ed4/pyobjc_framework_videotoolbox-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:efead1dc80cfd7612b952e831bb1e4b3ce9b13e6e4848ee82c28fcd5eaf718d3", size = 19024, upload-time = "2026-06-19T16:19:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e7/0725ee9ad4576c432fcc38f90c78b0f377034aa71460420d4dde649a1d00/pyobjc_framework_videotoolbox-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:45bb85a114280763e7b4b5f9f726be1b0ed97041ef3816e77fee2268211d6732", size = 19231, upload-time = "2026-06-19T16:19:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/68/54/65e0076b81322d53b1235fab0e180be212a906cbe1f0e94c4875dfa052f5/pyobjc_framework_videotoolbox-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0fb2e7be0568af5864077be2856a88121667f839e96304907b05a4b6ecd770e0", size = 19017, upload-time = "2026-06-19T16:19:09.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/3685cc3c4ec52086a5a1e26cf3574e2c7f84214a86cdd1e1f19c21ef616f/pyobjc_framework_videotoolbox-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:eb0d58dc6ce118c5e8610fc76112a769a02fb6ed201e4f89c655ca1ac75218be", size = 19215, upload-time = "2026-06-19T16:19:10.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b6/b956d04ddd26a8b07d3df0a49f0352cc773203a14e3fdcd98edf2f42d024/pyobjc_framework_videotoolbox-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:37d70510fb35f85a3ef4e37047e0ed6008e78bc83728ece763efb87d2919ca75", size = 19025, upload-time = "2026-06-19T16:19:10.945Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/80/ffb0ba5ad6911fe66e7faa8901cbbb580facc9f41ed05cbb41751ebe2512/pyobjc_framework_videotoolbox-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0339694a3caaa3a6415a5c845b812caedaecba8be9b322c17777d9e4258ff203", size = 19215, upload-time = "2026-06-19T16:19:11.995Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-virtualization"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/b4/16c8280c717f393e524e32de93bcb18952ca852ebbf5aaed38dac68d2e01/pyobjc_framework_virtualization-12.2.tar.gz", hash = "sha256:021249f0cd72e4756dfba096bda0e9ebd9294ba7738f1bdbb2742e461ac5671e", size = 49152, upload-time = "2026-05-30T12:46:12.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/49/5c306fac7b85c4f875b01f38266b75b9b8ba80a9747bfcc692c9b83adffb/pyobjc_framework_virtualization-12.2.1.tar.gz", hash = "sha256:dd752180219ddc54112876576debca9f3316e91ce75afce622981eeb8c9a0f4a", size = 49190, upload-time = "2026-06-19T16:22:00.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/39/c348fdc27fc68729faeaf8510596ee70a4d97d9fe51b68c365c47a1bd5cb/pyobjc_framework_virtualization-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2b9fbd756c7fc8fb0a78b235612e643e9bebe04f6e047ecb7e80a832510c744b", size = 13600, upload-time = "2026-05-30T12:27:39.302Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/a2e2a3676286359dcf4d5898652e904925006dba0eca959759472be37651/pyobjc_framework_virtualization-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:48667f1318bdc3e3599123dafb1d9df3369a6d8d3a64fb36f9eaf86ef2ea4808", size = 13617, upload-time = "2026-05-30T12:27:41.616Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/22/3e04b58c4a1ecc27518a8c5b8ca13cea7b74106928b1bd130a0564cb54a6/pyobjc_framework_virtualization-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:68e8989bf2cfb294116cdfd583d6ac092f9209ccca2af5b79fb697adbdae4653", size = 13821, upload-time = "2026-05-30T12:27:43.448Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/c8/8fa0b9ca53e7ab283d65c0ecde625344e55c493f2b31f330944171c119ec/pyobjc_framework_virtualization-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:365f797477eec5cc79f076e7a986937ff54d2ca1a136b4e0bb0fcac4bfa888aa", size = 13606, upload-time = "2026-05-30T12:27:45.26Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/10/0455b8ebef3412e7247867dc760dac1c8c0c1a4eb30fb45830f088b0cf3b/pyobjc_framework_virtualization-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6a1dbdba76fa72829662547deaedf9bc38829be245e88a0781fb83934a2caded", size = 13814, upload-time = "2026-05-30T12:27:47.066Z" },
-    { url = "https://files.pythonhosted.org/packages/72/48/5ea61a159ed12a9715233e1b90af5a8d384c9964f402f1f2e03dbf41197a/pyobjc_framework_virtualization-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e4c38f21be12dc1199dd263cf5ab8e07290f98d9462c8873827e43d37332a9dc", size = 13596, upload-time = "2026-05-30T12:27:48.924Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/3e/ddb09e174928a927512643f531e69823ffda8487c258eaa0705b56bec4bf/pyobjc_framework_virtualization-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b3531955330c0bb91daffd28f161c9c481a4683c2ff17b944bf216126d3580c5", size = 13807, upload-time = "2026-05-30T12:27:50.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0a/d5e4670a5b12fa3150b25b7f7a7694a72d8895527d33c0e33d63753a7086/pyobjc_framework_virtualization-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c90011e2f90dd5593996cb80f9c4739bd4a12db7303086678217a08909ee045", size = 13626, upload-time = "2026-06-19T16:19:15.082Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d3/fb9b5f4d457715d165293cf7112d7405128ab461c957c7dbe19d4dba5ca3/pyobjc_framework_virtualization-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee6423823b4b851d76567e44c649493eff6cda7ada94a86942a4c706f3e22f36", size = 13642, upload-time = "2026-06-19T16:19:16.051Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8c/146a46d88eaa8071f36c28c759790ba853b5d4630d53f22d8d74a871f13b/pyobjc_framework_virtualization-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:862c7d9c8ddb47eb086bb55271459e6107be904c526bdd3d520787a89d4e6c72", size = 13841, upload-time = "2026-06-19T16:19:16.928Z" },
+    { url = "https://files.pythonhosted.org/packages/81/84/03fd75be82d47a27ca16bf8c5b467a78322a5e3692b5d76bd67b14d27a3e/pyobjc_framework_virtualization-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:047ae558051db4682f42f8d18f3391aa454ae5b64ef676c4e7580323aa457a87", size = 13628, upload-time = "2026-06-19T16:19:17.814Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/587ebffbd4f9781b88fc18607f10ba17510df40fc79cb6660a4a9a6c64cb/pyobjc_framework_virtualization-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:503cbd9b7d995500a6dcaa0c3d131c41d3b694a9789d396465205fdf0090a130", size = 13836, upload-time = "2026-06-19T16:19:18.67Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/07/455cf0cdae517ab0b879621b5c48ee81228d9305fa995ce982be5f4f0c55/pyobjc_framework_virtualization-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:363f43c0a96c41d4cb1430c9faa5cc7c8b5cdaa2c66bc0be93e904c8611a5feb", size = 13621, upload-time = "2026-06-19T16:19:19.487Z" },
+    { url = "https://files.pythonhosted.org/packages/47/96/53ca0653a397196b2ba4969d6f0820102336de4d420b3311050b4630eff8/pyobjc_framework_virtualization-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ab87f688824575e0e09dcb0672f59ca76d468c55c229e34a356d4ee5ccc757b9", size = 13832, upload-time = "2026-06-19T16:19:20.337Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-vision"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
@@ -5942,43 +5914,43 @@ dependencies = [
     { name = "pyobjc-framework-coreml" },
     { name = "pyobjc-framework-quartz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/51/aed3761cfa2f0335a8fc4cdfa04c54b3fece5242745d5dd2370f38efcff5/pyobjc_framework_vision-12.2.tar.gz", hash = "sha256:0e90244f98ede5ec16ac129ed4bbd7cf0ec07247bac6f06e9cb612db23a68a3b", size = 72582, upload-time = "2026-05-30T12:46:17.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/1fdffff1b6bf124b260a2169869f4b71a08b9f6603698f7dec990d5ae5f3/pyobjc_framework_vision-12.2.1.tar.gz", hash = "sha256:debfd59dd7d962a6053bf733370148c11a9ec44091b517a0966f48d81c305879", size = 72683, upload-time = "2026-06-19T16:22:01.102Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/e6/c8606a1a106f5361360762eb26a9736ad4ea9528202b85b6dfe2a9e8a82f/pyobjc_framework_vision-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:77628f8c12a2f8072e8a8ab780cd0fd716f279153dcd883ce058bf2d1843b16d", size = 16924, upload-time = "2026-05-30T12:27:57.619Z" },
-    { url = "https://files.pythonhosted.org/packages/79/34/9c92c1d70a98818edb4e113f771bb264c2e7f08ec6bba501e0196c500dc4/pyobjc_framework_vision-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:df4d7d3ccdd723334ab62e6e2051d04e3554724be90102db353874938f101e05", size = 16938, upload-time = "2026-05-30T12:27:59.678Z" },
-    { url = "https://files.pythonhosted.org/packages/16/a5/1cf2213da57b1941f788baf0505c3cc4c98fbbdcdf1ac3a19290331ca4d1/pyobjc_framework_vision-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:76737fa3440c504993995537643b6529d47c1affecba426f00c716cd93a07a9b", size = 17081, upload-time = "2026-05-30T12:28:01.972Z" },
-    { url = "https://files.pythonhosted.org/packages/20/f3/3f87679134adab71b2366c5349fe3a68eb2edcf5ff62fcb872855243e6e2/pyobjc_framework_vision-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b6d12bcb96d711a4b5d1743aa7b1af7dec9e2f840b0e5ec200aed262da3fb587", size = 16917, upload-time = "2026-05-30T12:28:04.196Z" },
-    { url = "https://files.pythonhosted.org/packages/26/e2/4c1419e9429bed0c1bac0fa6ea705c32c8d9e098fa5ba3f8b49a4f916ff0/pyobjc_framework_vision-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:45c7d3fda44f740b4c0a9c1b86d9af137994172f2990e0650112f7eb8e77e48e", size = 17068, upload-time = "2026-05-30T12:28:06.264Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/8a/6da11857e32d588c16cd474dc768c45e31e0b6e9fc48d10b34a12850e6fb/pyobjc_framework_vision-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c08a08dd979886e2435a53714ef95af6da4a0dc1b2e37236cdd292b5b8707060", size = 16906, upload-time = "2026-05-30T12:28:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/92/f4/01b8d88c29f46f3b7690d49e0a5ddf992a2ee214e83451820301607f3b95/pyobjc_framework_vision-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d9080e4882e292c2d3c0726127e516a5c7774e96faf199a2c74aafcc1b6aa60", size = 17073, upload-time = "2026-05-30T12:28:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1b/ee3aa7d1517d2d161cd9c2d00b9fc19206d2472b4bb35e98835ec9992d02/pyobjc_framework_vision-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fa2e56d891eab12a0ddac2373c69957c108f70dea56f5a9a6081a3c2f905c98b", size = 16947, upload-time = "2026-06-19T16:19:23.209Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/1bc00a6b6031b7d6985a0547d2b41ed4ea029c3ffbfe31c8040bb14f6674/pyobjc_framework_vision-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a041188213ae84153d5fe74cd69468827c150cb7157e2649e40a2a3cedb8f55d", size = 16963, upload-time = "2026-06-19T16:19:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/59/af/e6618858bd8f9be6c58ea7238b7ec224d1a31df506dd912c41672fe4f369/pyobjc_framework_vision-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e288cb41349d6e84cfac0822a0c1fb476bf5fa094913b19e8c2899e90a1a9e8f", size = 17105, upload-time = "2026-06-19T16:19:24.817Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/76/67d7098ab8e3d55b24425feccf452620f234d558400d9e5eb7ca56c60a9d/pyobjc_framework_vision-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:da4f6811c23bdfa701ed727d6e46a83729606476cee435c2461f0f25579b8080", size = 16939, upload-time = "2026-06-19T16:19:25.627Z" },
+    { url = "https://files.pythonhosted.org/packages/97/99/9b46821533d1b138e69a230cc17ee6a7be24bcb6093daf6ab2096fdc21d5/pyobjc_framework_vision-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a319b6e809ac03c41fbbcb1b8e449c8bc9b6e2b0e06c3c67cbe4ce8e040a1f78", size = 17097, upload-time = "2026-06-19T16:19:26.538Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6d/74e275165801d0309f9915b0def9b73f546b1ab378892f86e5bb26a2f2d3/pyobjc_framework_vision-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2dd7ce3563afbbcbc10d9bb5e777b3d0cd77d4d5a9f7b0c32d0f65eeb5d34f0f", size = 16927, upload-time = "2026-06-19T16:19:27.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/e2b0286125ddbe475e74de668b470b8d9bec7a26cd95de70178f8b382ca4/pyobjc_framework_vision-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5aafb8fd87b5580b98a9f4a6de18013fd000f78a5f0930b2160fa82775de84fd", size = 17097, upload-time = "2026-06-19T16:19:28.232Z" },
 ]
 
 [[package]]
 name = "pyobjc-framework-webkit"
-version = "12.2"
+version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-core" },
     { name = "pyobjc-framework-cocoa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ba/0e17f151d80854285a84b3c96f48d55b0c61ae683060a52cd50084ef4c64/pyobjc_framework_webkit-12.2.tar.gz", hash = "sha256:498353fe812006f7fe2829a679018fcff3ed2684aa31c08d8a8af929ee9283b6", size = 332359, upload-time = "2026-05-30T12:46:37.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/ae/0cfe909116627905542390c7d6a33a3090b6e7f2174b9d75f9c8a661d431/pyobjc_framework_webkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bd1e0f6f340a5516c853aa59fde381e002f2c109ae64a05ad4e99a2b74375fcb", size = 50337, upload-time = "2026-05-30T12:28:24.926Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/32/bea045cf4e2c697ea9b68ed7d60b0e765a8b0e46d30a4eb26bf178be817c/pyobjc_framework_webkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9fafcbf5a071cf9ad3fbc28155a99287ff9dc9efcaa41fe3ed3d79b6e5576450", size = 50367, upload-time = "2026-05-30T12:28:28.846Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/3e/d29fc44f6d346a5a97883ae76bfa030a5b6ff3b019bafd58ad8ea14588d2/pyobjc_framework_webkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:751f3138441c81fdddc555f0bd31f5f3ad3ec72ae2ed626af24925ce32054353", size = 50840, upload-time = "2026-05-30T12:28:32.75Z" },
-    { url = "https://files.pythonhosted.org/packages/00/e1/12288f728e2862d7932a1b21aa5a059ae67708900e4f0873c88053edb761/pyobjc_framework_webkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6cba6e76e33c62369d0fa8cb4b83959db4c53888173cb3546a15cd998c8e8aec", size = 50475, upload-time = "2026-05-30T12:28:36.862Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/98/6373d02bc5dd9653207f1f766e55c2659aa01b65bf94b9d00584e7142312/pyobjc_framework_webkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:43a18df9a8d6b6f1f003a732eee0a0fcd01c2d31566be2b2ba8ee732c1a32cf9", size = 50938, upload-time = "2026-05-30T12:28:40.942Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/22/22d4b3d39d41fa94aa8bb904ec546199d940edcdbc9594c4ad3517d49692/pyobjc_framework_webkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:50dbd5210f80c7834b1af2b675712f6134217d713f2b2a8d9f96cf29be6ec8f0", size = 50469, upload-time = "2026-05-30T12:28:45.058Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1b/09cb42c5ede2a5025c4695b2beb37216a4d200511aa3eb4b9faadf1a517d/pyobjc_framework_webkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e8895b2cbc8b5d4c1475a3094771d3b8e6dbbd19ec3200922b1cd91d649e8043", size = 50936, upload-time = "2026-05-30T12:28:49.013Z" },
+    { url = "https://files.pythonhosted.org/packages/84/47/7a2099eb2e062c6230a9440f1795cf34056ca5e16ef25c8aad7c059b8734/pyobjc_framework_webkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7e04dcc08cdc59380113ea1232af75a0a04c2426418ebe967b4c0045c973f776", size = 50372, upload-time = "2026-06-19T16:19:31.581Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a4/202ec288808011d3f459d000d593e88b1118f2d1d5a4dfaaf5232f2c2ac2/pyobjc_framework_webkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23bee8bf7077f91da4e3ae54a00c7f5e4414319e15f98be8584dbd67c4043fae", size = 50387, upload-time = "2026-06-19T16:19:32.522Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a4/f796e94b43a66704b6ae17c747c7b97fd4b79348f1cfa9bef7b008aaa718/pyobjc_framework_webkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00ffb254f97e9ffdd0a82c1faa61a07f6072ba900fa8aba70c83c21198b52e4e", size = 50853, upload-time = "2026-06-19T16:19:33.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/d24716fef19ccc3d880e99029458803f0174c05df310d991eb97ea3a0799/pyobjc_framework_webkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:67030258c3cd66e8495ccfccef3d2d58010ff0209284c5115e5afdb0e9fd6de1", size = 50499, upload-time = "2026-06-19T16:19:34.45Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/6c/817119a52efcc229a30ceff56a0641005a431806a1f555e0571626ba313a/pyobjc_framework_webkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5d91527c9950c79269dd0d70f2bb8668c298dd06930637c1c063ce5f274a87e5", size = 50967, upload-time = "2026-06-19T16:19:35.474Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/59/5fac0754d53b2a72aed6f424dfc72e5fa245f83cb57c2e00d02e45390fca/pyobjc_framework_webkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:657825081484c9920c50b76b469b9583f116225b0449c9d95c46cbc8c640adc8", size = 50498, upload-time = "2026-06-19T16:19:36.397Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0c/e997e33d99d4ad91da2cf70f0e51ac39b03c58ba210548e9e944bbb421be/pyobjc_framework_webkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f46adcc6227873f2b14d74b2e789c937f227722274ab59b9fa3c04c6ecb46dd5", size = 50958, upload-time = "2026-06-19T16:19:37.424Z" },
 ]
 
 [[package]]
 name = "pyotp"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/c6/c5d96a86fd0bf6fa1bbb5c5c341ff3208638b692727a683c8289068d9a11/pyotp-2.10.0.tar.gz", hash = "sha256:d01e9703443616b03c57c700b5cbffd56a1f929c1b0f8f03131bc78c1fca9d3f", size = 18625, upload-time = "2026-06-14T03:48:49.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/65/33/7b83bde70eddaaaaef487751a9c3a5cc0c0be54620ded0e120ebdc401ff9/pyotp-2.10.0-py3-none-any.whl", hash = "sha256:1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c", size = 13768, upload-time = "2026-06-14T03:48:47.831Z" },
 ]
 
 [[package]]
@@ -5992,11 +5964,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.3"
+version = "6.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/de/edd6908e6d81068f9a70c3164f391390bd8f89b96afeef917933b848a094/pypdf-6.14.0.tar.gz", hash = "sha256:cb3f797cc05e61fc6dd1e5735fd1b1bc2946112abc47f7184f68d5d72aa6a696", size = 6489606, upload-time = "2026-06-22T14:45:55.38Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/79/aec83d5dd98784a1afac704b38070609e1571b37a9111ec98f13051c4141/pypdf-6.14.0-py3-none-any.whl", hash = "sha256:48d4bf5c5352b06ecb2794c0fbe9e91ca6648c77e4be6734517dede9f31790e2", size = 348961, upload-time = "2026-06-22T14:45:53.179Z" },
 ]
 
 [[package]]
@@ -6010,7 +5982,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -6019,9 +5991,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -6096,11 +6068,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.31"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/7e/9b35ad8f3d9ca680f7c87a88f19612fdd8da9796c4d3b46e560ac79dcc4a/python_multipart-0.0.31.tar.gz", hash = "sha256:fc631183bb13e56db3158a4909908dfb2e23565286744e798241e63750e5d680", size = 46689, upload-time = "2026-06-04T08:27:49.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/1e/7f7f299527a5a8ad90acd5f2f78dfa6c8495c6301a3205106ea68a84de96/python_multipart-0.0.31-py3-none-any.whl", hash = "sha256:8408153d68a9773291fc1da39a8b85a50044bddbabd2dd72e9229776b7b15e28", size = 29996, upload-time = "2026-06-04T08:27:47.804Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -6295,15 +6267,15 @@ wheels = [
 
 [[package]]
 name = "reportlab"
-version = "4.5.1"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "pillow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/3f/b3861b7e40c9d66f4a04e018958d681d16b948bfd1963c962d43a8c23f66/reportlab-4.5.1.tar.gz", hash = "sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494", size = 3939748, upload-time = "2026-05-12T10:14:13.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/d6/4b7b0cf56880eb96533e607967be6a939e344675601e033d113a0bfa1f4e/reportlab-5.0.0.tar.gz", hash = "sha256:e4494a0c6623ae213bb856fba523171b2b54a7bf629fda02d5e525a7b899a784", size = 3701928, upload-time = "2026-06-18T11:34:31.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/45/ea7fad10122440de6e845568d106bffdc456ca0e8a1d8ae10b46016087e4/reportlab-4.5.1-py3-none-any.whl", hash = "sha256:06fce8cb56c83307cfa4909cdf4e6a2ddbb44e5d6ef4d2edca896d7e9769f091", size = 1957812, upload-time = "2026-05-12T10:14:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/07/70085c17a369605f15e301d10ab902115019b1126c7253d964afc230c7d6/reportlab-5.0.0-py3-none-any.whl", hash = "sha256:9d5a3affa84919e1111ede580031266a570e93b1ce388219621347965ff1d93c", size = 1956710, upload-time = "2026-06-18T11:34:29.07Z" },
 ]
 
 [[package]]
@@ -6472,27 +6444,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.15"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
-    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
-    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]
@@ -6513,8 +6485,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6577,15 +6549,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
 ]
 
 [[package]]
@@ -6704,14 +6676,14 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.67.3"
+version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
 ]
 
 [[package]]
@@ -6975,11 +6947,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Every agent text reply was silently dropped — for every LLM provider, not just custom/self-hosted ones — because the event callback unconditionally skipped the SDK's own `MessageEvent`, trusting a token-streaming path that never actually fires.

- **Root cause**: `services/ai-agent` always runs conversations through a `RemoteWorkspace`/`RemoteConversation` (the Docker sandbox). In openhands-sdk, `RemoteConversation.__init__` accepts a `token_callbacks` kwarg but never wires it to anything — it's swallowed by a `**_: object` catch-all. So `_make_token_callback` never fires, and `_make_event_callback`'s unconditional skip of agent `MessageEvent`s (added on the assumption the token path would persist it instead) meant the reply was never saved anywhere. Confirmed live: before this fix, **zero** agent `MessageEvent` rows existed across this project's entire conversation history, despite agents completing real tool-call work — the text reply itself just never showed up.
- **`executor.py`**: adds `_TurnState`, a flag shared between the two callbacks. The token callback marks it only after it *successfully* persists a message; the event callback consumes it and only skips the raw `MessageEvent` if that flag was set, otherwise it falls through and persists the event itself. The streaming path stays primary (cleaner content, no SDK wrapper fields) but can no longer silently swallow a reply.
- **`pyproject.toml` / `uv.lock`**: bump `openhands-sdk`/`openhands-tools` to `>=1.29.0` (and refresh other dev deps) — this is the version where the bug is actually exercised in production.
- **Tests (`tests/test_executor.py`)**: unit tests exercising the real `_make_event_callback`/`_make_token_callback` closures together (background event-loop thread, mocked DB/Valkey), proving the fallback persists the reply when the token callback never fires and doesn't duplicate when it does.
- **E2E suite (`tests/e2e/`)**: drives the real `run_conversation()` against the actual `ghcr.io/openhands/agent-server` Docker sandbox and a fake, scriptable OpenAI-compatible LLM server (no model weights). Three scenarios:
  - happy-path reply persists correctly
  - a multi-step tool-call flow (tool call → observation → final reply), proving `ActionEvent`/`ObservationEvent`/`MessageEvent` all persist and `_TurnState` resets correctly across iterations
  - an LLM-failure path (fake server returns 500), proving the conversation is marked `failed` and the frontend gets notified instead of hanging
  - Gated behind `PACA_E2E=1`, mirroring how `services/api`'s Go e2e suite is gated — skips cleanly with no Docker calls when unset.
- **CI (`ai-agent-pr-ci.yml`)**: new `test-e2e` job, runs on every PR touching `services/ai-agent/**`.

Fixes #211. See also #214 (same underlying cause, different surfaced symptom).

## Test plan

- [x] `uv run pytest -q` — 79 passed, 3 skipped (e2e tests skip cleanly without `PACA_E2E=1`)
- [x] `PACA_E2E=1 uv run pytest tests/e2e -v` — all 3 e2e tests pass against the real Docker sandbox (~3 min)
- [x] Regression-verified by hand: temporarily reverted the `_TurnState` fix and confirmed both the happy-path and tool-call e2e tests fail with "the agent's reply was never persisted"; restored the fix and confirmed they pass again
- [x] `ruff check` / `ruff format --check` clean on all touched files