### PR TITLE
Add configurable view page sizes and server-side task search

### DIFF
--- a/apps/web/src/components/projects/interactions/board-view.test.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.test.tsx
@@ -104,7 +104,6 @@ function renderBoard(
 			taskTypes={taskTypes}
 			canCreate={false}
 			canEdit={true}
-			searchQuery=""
 			tasksQueryKey={["tasks"]}
 			onCreateTask={vi.fn()}
 			onTaskClick={vi.fn()}
@@ -181,22 +180,6 @@ describe("BoardView", () => {
 			renderBoard([t1, t2]);
 			expect(screen.getByText("Todo Task")).toBeInTheDocument();
 			expect(screen.getByText("Done Task")).toBeInTheDocument();
-		});
-
-		it("applies filter to hide tasks that don't match searchQuery", () => {
-			const t1 = makeTask({
-				id: "t1",
-				title: "Alpha task",
-				status_id: "status-todo",
-			});
-			const t2 = makeTask({
-				id: "t2",
-				title: "Beta task",
-				status_id: "status-todo",
-			});
-			renderBoard([t1, t2], { searchQuery: "alpha" });
-			expect(screen.getByText("Alpha task")).toBeInTheDocument();
-			expect(screen.queryByText("Beta task")).not.toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/components/projects/interactions/board-view.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.tsx
@@ -579,7 +579,7 @@ export function BoardView({
 							type="button"
 							onClick={pg.onLoadMore}
 							disabled={pg.isLoadingMore}
-							className="mt-1 w-full rounded-lg border border-dashed border-border/40 py-1.5 text-sm font-medium text-muted-foreground/70 hover:border-primary/40 hover:text-primary transition-all duration-150 disabled:opacity-50"
+							className="mt-1 w-full rounded-lg border border-dashed border-border/40 py-1.5 text-xs font-medium text-muted-foreground/70 hover:border-primary/40 hover:text-primary transition-all duration-150 disabled:opacity-50"
 						>
 							{pg.isLoadingMore ? "Loading…" : "View more"}
 						</button>
@@ -786,7 +786,7 @@ export function BoardView({
 	};
 
 	return (
-		<div className="flex flex-1 min-h-0 gap-4 overflow-x-auto px-6 py-5 pb-8">
+		<div className="flex flex-1 min-h-0 items-start gap-4 overflow-auto px-6 py-5 pb-8">
 			{effectiveColumnDefs.map((colDef) => {
 				const isCollapsed = collapsedColumns.has(colDef.key);
 				const displayCount = getDisplayCount(colDef.key);

--- a/apps/web/src/components/projects/interactions/board-view.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.tsx
@@ -44,7 +44,6 @@ interface BoardViewProps {
 	viewConfig?: ViewConfig;
 	canCreate: boolean;
 	canEdit: boolean;
-	searchQuery: string;
 	tasksQueryKey: unknown[];
 	onCreateTask: (
 		statusId: string,
@@ -85,7 +84,6 @@ export function BoardView({
 	viewConfig,
 	canCreate,
 	canEdit,
-	searchQuery,
 	tasksQueryKey,
 	epics = [],
 	onCreateTask,
@@ -175,31 +173,10 @@ export function BoardView({
 		[swimlaneBy, viewCtx],
 	);
 
-	// ── Filtering ─────────────────────────────────────────────────────────────
-
-	const filteredTasks = useMemo(
-		() =>
-			tasks.filter((t) => {
-				if (searchQuery) {
-					const q = searchQuery.toLowerCase();
-					const taskId = taskIdPrefix
-						? `${taskIdPrefix}-${t.task_number}`
-						: `#${t.task_number}`;
-					if (
-						!t.title.toLowerCase().includes(q) &&
-						!taskId.toLowerCase().includes(q)
-					)
-						return false;
-				}
-				return true;
-			}),
-		[tasks, searchQuery, taskIdPrefix],
-	);
-
 	// ── Column tasks helper ───────────────────────────────────────────────────
 
 	const getColumnTasks = (colKey: string): Task[] =>
-		filteredTasks.filter((t) =>
+		tasks.filter((t) =>
 			getTaskColumnKeys(t, columnBy, viewCtx).includes(colKey),
 		);
 
@@ -448,7 +425,7 @@ export function BoardView({
 			// Build columns from unique task values (for number/text fields)
 			const seen = new Set<string>();
 			const dynamic: ColumnGroupDef[] = [];
-			for (const t of filteredTasks) {
+			for (const t of tasks) {
 				for (const k of getTaskColumnKeys(t, columnBy, viewCtx)) {
 					if (!seen.has(k)) {
 						seen.add(k);
@@ -474,7 +451,7 @@ export function BoardView({
 		);
 	}, [
 		columnDefs,
-		filteredTasks,
+		tasks,
 		columnBy,
 		viewCtx,
 		isStatusGrouping,

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -606,9 +606,12 @@ export function InteractionLayout({
 		!viewsQuery.isLoading &&
 		activeView?.layout !== "Roadmap";
 
-	// Page size: board = 20, list/roadmap = 5 on first page
+	// Initial page size: configured view setting wins; otherwise board = 20, list/roadmap = 5 on first page.
+	// "Load more" batches use the separate configuredPageSize below, defaulting to 20 regardless of layout.
 	const isBoard = activeView?.layout === "Board";
-	const initialColPageSize = isBoard ? 20 : 5;
+	const configuredPageSize = activeViewConfig?.page_size;
+	const configuredInitialPageSize = activeViewConfig?.initial_page_size;
+	const initialColPageSize = configuredInitialPageSize ?? (isBoard ? 20 : 5);
 
 	// Base options for column queries (shared filters, excluding the dimension used for column grouping)
 	const colBaseOpts = useMemo(
@@ -717,7 +720,8 @@ export function InteractionLayout({
 	);
 
 	const initialGlobalPageSize =
-		activeView?.layout === "Roadmap" ? 5 : undefined;
+		configuredInitialPageSize ??
+		(activeView?.layout === "Roadmap" ? 5 : undefined);
 	const fallbackQueryOpts = allTasksQueryOptions(projectId, {
 		...fallbackBaseOpts,
 		pageSize: globalExpandedPageSize ?? initialGlobalPageSize,
@@ -767,7 +771,7 @@ export function InteractionLayout({
 			if (!cursor) return;
 			const colOpts = buildColumnFilter(colKey, columnBy, {
 				...colBaseOpts,
-				pageSize: 20,
+				pageSize: configuredPageSize ?? 20,
 				cursor,
 			});
 			if (!colOpts) return;
@@ -799,6 +803,7 @@ export function InteractionLayout({
 			projectId,
 			colLoadingMore,
 			initialColPageSize,
+			configuredPageSize,
 		],
 	);
 
@@ -825,7 +830,7 @@ export function InteractionLayout({
 		try {
 			const result = await listAllTasks(projectId, {
 				...fallbackBaseOpts,
-				pageSize: 20,
+				pageSize: configuredPageSize ?? 20,
 				cursor: globalNextCursor,
 			});
 			setGlobalExtraTasks((prev) => [...prev, ...result.items]);
@@ -844,6 +849,7 @@ export function InteractionLayout({
 		fallbackBaseOpts,
 		globalLoadingMore,
 		initialGlobalPageSize,
+		configuredPageSize,
 	]);
 
 	const tasks = useMemo(() => {

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -81,6 +81,8 @@ import { TaskDetailModal } from "./task-detail-modal";
 import { UNASSIGNED_FILTER_ID, ViewSettingsPanel } from "./view-settings-panel";
 import {
 	getColumnGroupDefs,
+	getDefaultInitialPageSize,
+	getDefaultPageSize,
 	getTaskColumnKeys,
 	type TaskFieldUpdate,
 	type ViewContext,
@@ -614,12 +616,13 @@ export function InteractionLayout({
 		!viewsQuery.isLoading &&
 		activeView?.layout !== "Roadmap";
 
-	// Initial page size: configured view setting wins; otherwise board = 20, list/roadmap = 5 on first page.
-	// "Load more" batches use the separate configuredPageSize below, defaulting to 20 regardless of layout.
-	const isBoard = activeView?.layout === "Board";
+	// Initial page size: configured view setting wins; otherwise falls back to
+	// the active layout's default (see PAGE_SIZE_DEFAULTS in view-utils.ts).
+	// "Load more" batches use the separate configuredPageSize below.
 	const configuredPageSize = activeViewConfig?.page_size;
 	const configuredInitialPageSize = activeViewConfig?.initial_page_size;
-	const initialColPageSize = configuredInitialPageSize ?? (isBoard ? 20 : 5);
+	const initialColPageSize =
+		configuredInitialPageSize ?? getDefaultInitialPageSize(activeView?.layout);
 
 	// Base options for column queries (shared filters, excluding the dimension used for column grouping)
 	const colBaseOpts = useMemo(
@@ -732,8 +735,7 @@ export function InteractionLayout({
 	);
 
 	const initialGlobalPageSize =
-		configuredInitialPageSize ??
-		(activeView?.layout === "Roadmap" ? 5 : undefined);
+		configuredInitialPageSize ?? getDefaultInitialPageSize(activeView?.layout);
 	const fallbackQueryOpts = allTasksQueryOptions(projectId, {
 		...fallbackBaseOpts,
 		pageSize: globalExpandedPageSize ?? initialGlobalPageSize,
@@ -783,7 +785,7 @@ export function InteractionLayout({
 			if (!cursor) return;
 			const colOpts = buildColumnFilter(colKey, columnBy, {
 				...colBaseOpts,
-				pageSize: configuredPageSize ?? 20,
+				pageSize: configuredPageSize ?? getDefaultPageSize(activeView?.layout),
 				cursor,
 			});
 			if (!colOpts) return;
@@ -816,6 +818,7 @@ export function InteractionLayout({
 			colLoadingMore,
 			initialColPageSize,
 			configuredPageSize,
+			activeView?.layout,
 		],
 	);
 
@@ -842,7 +845,7 @@ export function InteractionLayout({
 		try {
 			const result = await listAllTasks(projectId, {
 				...fallbackBaseOpts,
-				pageSize: configuredPageSize ?? 20,
+				pageSize: configuredPageSize ?? getDefaultPageSize(activeView?.layout),
 				cursor: globalNextCursor,
 			});
 			setGlobalExtraTasks((prev) => [...prev, ...result.items]);
@@ -850,7 +853,7 @@ export function InteractionLayout({
 			// Grow the effective page size so the next WS-triggered refetch
 			// returns the same number of items currently visible.
 			setGlobalExpandedPageSize(
-				(prev) => (prev ?? initialGlobalPageSize ?? 20) + result.items.length,
+				(prev) => (prev ?? initialGlobalPageSize) + result.items.length,
 			);
 		} finally {
 			setGlobalLoadingMore(false);
@@ -862,6 +865,7 @@ export function InteractionLayout({
 		globalLoadingMore,
 		initialGlobalPageSize,
 		configuredPageSize,
+		activeView?.layout,
 	]);
 
 	const tasks = useMemo(() => {

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -32,6 +32,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
 import {
 	allTasksQueryOptions,
 	bulkMoveViewTaskPositions,
@@ -505,6 +506,13 @@ export function InteractionLayout({
 		!activeViewConfig?.sort_by ||
 		activeViewConfig?.sort_by?.toLowerCase() === "manual";
 	const [searchQuery, setSearchQuery] = useState("");
+	// Debounced so search doesn't fire a request on every keystroke now that
+	// it's a server-side query (needed for correct pagination — see colBaseOpts).
+	const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+	const debouncedSetSearchQuery = useDebouncedCallback(
+		(q: string) => setDebouncedSearchQuery(q),
+		300,
+	);
 	const [searchOpen, setSearchOpen] = useState(false);
 	const searchRef = useRef<HTMLInputElement>(null);
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -631,6 +639,7 @@ export function InteractionLayout({
 			sumField: activeViewConfig?.field_sum,
 			sortBy: activeViewConfig?.sort_by,
 			viewId: effectiveViewId,
+			search: debouncedSearchQuery || undefined,
 		}),
 		[
 			context,
@@ -642,6 +651,7 @@ export function InteractionLayout({
 			activeViewConfig?.field_sum,
 			activeViewConfig?.sort_by,
 			effectiveViewId,
+			debouncedSearchQuery,
 		],
 	);
 
@@ -708,6 +718,7 @@ export function InteractionLayout({
 			taskTypeIds: apiFilters.task_type_ids,
 			sortBy: activeViewConfig?.sort_by,
 			viewId: effectiveViewId,
+			search: debouncedSearchQuery || undefined,
 		}),
 		[
 			context,
@@ -716,6 +727,7 @@ export function InteractionLayout({
 			apiFilters,
 			activeViewConfig?.sort_by,
 			effectiveViewId,
+			debouncedSearchQuery,
 		],
 	);
 
@@ -1436,13 +1448,17 @@ export function InteractionLayout({
 							<input
 								ref={searchRef}
 								value={searchQuery}
-								onChange={(e) => setSearchQuery(e.target.value)}
+								onChange={(e) => {
+									setSearchQuery(e.target.value);
+									debouncedSetSearchQuery(e.target.value);
+								}}
 								placeholder="Search tasks…"
 								className="w-36 bg-transparent text-xs font-medium outline-none placeholder:text-muted-foreground/50"
 								onKeyDown={(e) => {
 									if (e.key === "Escape") {
 										setSearchOpen(false);
 										setSearchQuery("");
+										setDebouncedSearchQuery("");
 									}
 								}}
 							/>
@@ -1451,6 +1467,7 @@ export function InteractionLayout({
 								onClick={() => {
 									setSearchOpen(false);
 									setSearchQuery("");
+									setDebouncedSearchQuery("");
 								}}
 								className="flex size-5 items-center justify-center rounded-md text-muted-foreground/60 hover:text-foreground transition-all duration-150"
 							>
@@ -1524,7 +1541,6 @@ export function InteractionLayout({
 						viewConfig={activeViewConfig}
 						canCreate={canCreate}
 						canEdit={canEdit}
-						searchQuery={searchQuery}
 						tasksQueryKey={tasksListQueryKey}
 						columnPagination={columnPagination}
 						onCreateTask={handleCreateTask}
@@ -1550,14 +1566,12 @@ export function InteractionLayout({
 				) : activeView?.layout === "Roadmap" ? (
 					<RoadmapView
 						tasks={tasks}
-						taskIdPrefix={taskIdPrefix}
 						statuses={statuses}
 						taskTypes={creatableTaskTypes}
 						members={members}
 						sprints={sprints}
 						customFields={customFields}
 						columnBy={columnBy}
-						searchQuery={searchQuery}
 						canCreate={canCreate}
 						pagination={globalPagination}
 						onCreateTask={handleCreateTask}
@@ -1574,7 +1588,6 @@ export function InteractionLayout({
 						epics={epicTasks}
 						viewConfig={activeViewConfig}
 						canCreate={canCreate}
-						searchQuery={searchQuery}
 						columnPagination={columnPagination}
 						onCreateTask={handleCreateTask}
 						onTaskClick={handleTaskClick}

--- a/apps/web/src/components/projects/interactions/list-group.tsx
+++ b/apps/web/src/components/projects/interactions/list-group.tsx
@@ -415,7 +415,7 @@ export function ListGroup({
 			type="button"
 			onClick={groupPagination.onLoadMore}
 			disabled={groupPagination.isLoadingMore}
-			className="flex w-full items-center justify-center border-t border-border/10 py-2 text-sm font-medium text-muted-foreground/60 hover:text-primary hover:bg-primary/5 transition-all duration-150 disabled:opacity-50"
+			className="flex w-full items-center justify-center border-t border-border/10 py-2 text-xs font-medium text-muted-foreground/60 hover:text-primary hover:bg-primary/5 transition-all duration-150 disabled:opacity-50"
 		>
 			{groupPagination.isLoadingMore ? "Loading…" : "View more"}
 		</button>

--- a/apps/web/src/components/projects/interactions/list-view.tsx
+++ b/apps/web/src/components/projects/interactions/list-view.tsx
@@ -31,7 +31,6 @@ export interface ListViewProps {
 	epics?: Task[];
 	viewConfig?: ViewConfig;
 	canCreate: boolean;
-	searchQuery: string;
 	onCreateTask: (
 		statusId: string,
 		title: string,
@@ -82,7 +81,6 @@ export function ListView({
 	epics = [],
 	viewConfig,
 	canCreate,
-	searchQuery,
 	onCreateTask,
 	onTaskClick,
 	manualSort,
@@ -112,25 +110,6 @@ export function ListView({
 		[statuses, taskTypes, members, customFields, sprints],
 	);
 
-	const filtered = useMemo(
-		() =>
-			tasks.filter((t) => {
-				if (searchQuery) {
-					const q = searchQuery.toLowerCase();
-					const taskId = taskIdPrefix
-						? `${taskIdPrefix}-${t.task_number}`
-						: `#${t.task_number}`;
-					if (
-						!t.title.toLowerCase().includes(q) &&
-						!taskId.toLowerCase().includes(q)
-					)
-						return false;
-				}
-				return true;
-			}),
-		[tasks, searchQuery, taskIdPrefix],
-	);
-
 	const groupDefs = useMemo(
 		() => getColumnGroupDefs(columnBy, viewCtx),
 		[columnBy, viewCtx],
@@ -143,7 +122,7 @@ export function ListView({
 		} else {
 			const seen = new Set<string>();
 			const dynamic: ColumnGroupDef[] = [];
-			for (const t of filtered) {
+			for (const t of tasks) {
 				for (const k of getTaskColumnKeys(t, columnBy, viewCtx)) {
 					if (!seen.has(k)) {
 						seen.add(k);
@@ -169,7 +148,7 @@ export function ListView({
 		);
 	}, [
 		groupDefs,
-		filtered,
+		tasks,
 		columnBy,
 		viewCtx,
 		isStatusGrouping,
@@ -183,7 +162,7 @@ export function ListView({
 	);
 
 	const getGroupTasks = (groupKey: string): Task[] =>
-		filtered.filter((t) =>
+		tasks.filter((t) =>
 			getTaskColumnKeys(t, columnBy, viewCtx).includes(groupKey),
 		);
 

--- a/apps/web/src/components/projects/interactions/roadmap-view.tsx
+++ b/apps/web/src/components/projects/interactions/roadmap-view.tsx
@@ -415,7 +415,7 @@ export function RoadmapView({
 								type="button"
 								onClick={pagination.onLoadMore}
 								disabled={pagination.isLoadingMore}
-								className="rounded-lg border border-border/40 px-4 py-1.5 text-sm font-medium text-muted-foreground hover:border-primary/50 hover:text-primary transition-all duration-150 disabled:opacity-50"
+								className="rounded-lg border border-border/40 px-4 py-1.5 text-xs font-medium text-muted-foreground hover:border-primary/50 hover:text-primary transition-all duration-150 disabled:opacity-50"
 							>
 								{pagination.isLoadingMore ? "Loading…" : "View more"}
 							</button>

--- a/apps/web/src/components/projects/interactions/roadmap-view.tsx
+++ b/apps/web/src/components/projects/interactions/roadmap-view.tsx
@@ -40,14 +40,12 @@ function fmtDate(ms: number): string {
 // ─── Types ────────────────────────────────────────────────────────────────────
 interface RoadmapViewProps {
 	tasks: Task[];
-	taskIdPrefix?: string;
 	statuses: TaskStatus[];
 	taskTypes: TaskType[];
 	members?: ProjectMember[];
 	sprints?: Sprint[];
 	customFields?: CustomFieldDefinition[];
 	columnBy?: string;
-	searchQuery: string;
 	canCreate?: boolean;
 	onCreateTask?: (
 		statusId: string,
@@ -79,14 +77,12 @@ interface BarData {
 // ─── Component ────────────────────────────────────────────────────────────────
 export function RoadmapView({
 	tasks,
-	taskIdPrefix = "",
 	statuses,
 	taskTypes,
 	members = [],
 	sprints = [],
 	customFields = [],
 	columnBy = "status",
-	searchQuery,
 	canCreate = false,
 	onCreateTask,
 	onTaskClick,
@@ -94,21 +90,6 @@ export function RoadmapView({
 }: RoadmapViewProps) {
 	// Stable "now" — fixed at mount so all bars are consistent
 	const now = useMemo(() => Date.now(), []);
-
-	const filtered = useMemo(
-		() =>
-			tasks.filter((t) => {
-				if (!searchQuery) return true;
-				const q = searchQuery.toLowerCase();
-				const id = taskIdPrefix
-					? `${taskIdPrefix}-${t.task_number}`
-					: `#${t.task_number}`;
-				return (
-					t.title.toLowerCase().includes(q) || id.toLowerCase().includes(q)
-				);
-			}),
-		[tasks, searchQuery, taskIdPrefix],
-	);
 
 	const viewCtx = useMemo(
 		() => ({ statuses, taskTypes, members, customFields, sprints }),
@@ -131,7 +112,7 @@ export function RoadmapView({
 	// ── Timeline geometry ──────────────────────────────────────────────────────
 	const { chartWidth, toPx, months, todayPx } = useMemo(() => {
 		const allMs: number[] = [];
-		for (const t of filtered) {
+		for (const t of tasks) {
 			const s = parseDateMs(t.start_date);
 			const d = parseDateMs(t.due_date);
 			if (s !== null) allMs.push(s);
@@ -176,7 +157,7 @@ export function RoadmapView({
 		}
 
 		return { chartWidth, toPx, months, todayPx: toPx(now) };
-	}, [filtered, now]);
+	}, [tasks, now]);
 
 	const todayInRange = todayPx >= 0 && todayPx <= chartWidth;
 
@@ -382,14 +363,14 @@ export function RoadmapView({
 					</div>
 
 					{/* ── Content ────────────────────────────────────────────── */}
-					{filtered.length === 0 ? (
+					{tasks.length === 0 ? (
 						<div className="flex flex-col items-center py-20 text-muted-foreground/40">
 							<CalendarDays className="mb-2 size-7" />
 							<p className="text-sm font-medium">No tasks to display</p>
 						</div>
 					) : (
 						groupDefs.map((group) => {
-							const groupTasks = filtered.filter((t) =>
+							const groupTasks = tasks.filter((t) =>
 								getTaskColumnKeys(t, columnBy, viewCtx).includes(group.key),
 							);
 							if (groupTasks.length === 0) return null;

--- a/apps/web/src/components/projects/interactions/view-settings-panel.tsx
+++ b/apps/web/src/components/projects/interactions/view-settings-panel.tsx
@@ -41,7 +41,9 @@ import {
 	buildFieldSumOptions,
 	buildSortByOptions,
 	buildSwimlaneOptions,
+	DEFAULT_PAGE_SIZE,
 	DEFAULT_VISIBLE_FIELDS,
+	PAGE_SIZE_OPTIONS,
 } from "./view-utils";
 
 // ── Category visual config ────────────────────────────────────────────────────
@@ -850,6 +852,9 @@ export function ViewSettingsPanel({
 	const fieldSumOpts = buildFieldSumOptions(customFields);
 
 	const sortByValue = draft.sort_by ?? "manual";
+	// Mirrors the runtime default in interaction-layout.tsx: board views show
+	// 20 cards per column on first load, table/roadmap views show 5.
+	const defaultInitialPageSize = view?.layout === "Board" ? 20 : 5;
 	const filterSprintIds = filterConfigToIds(draft.filters?.sprints);
 	const filterStatusIds = filterConfigToIds(draft.filters?.statuses);
 	const filterAssigneeIds = filterConfigToIds(draft.filters?.assignees);
@@ -974,6 +979,28 @@ export function ViewSettingsPanel({
 									value={draft.field_sum ?? "count"}
 									options={fieldSumOpts}
 									onChange={(v) => update({ field_sum: v })}
+								/>
+							</SettingRow>
+
+							<SettingRow label="Initial size">
+								<DynamicSelect
+									value={String(
+										draft.initial_page_size ?? defaultInitialPageSize,
+									)}
+									options={PAGE_SIZE_OPTIONS}
+									onChange={(v) =>
+										update({ initial_page_size: v ? Number(v) : undefined })
+									}
+								/>
+							</SettingRow>
+
+							<SettingRow label="Per page">
+								<DynamicSelect
+									value={String(draft.page_size ?? DEFAULT_PAGE_SIZE)}
+									options={PAGE_SIZE_OPTIONS}
+									onChange={(v) =>
+										update({ page_size: v ? Number(v) : undefined })
+									}
 								/>
 							</SettingRow>
 						</div>

--- a/apps/web/src/components/projects/interactions/view-settings-panel.tsx
+++ b/apps/web/src/components/projects/interactions/view-settings-panel.tsx
@@ -41,8 +41,9 @@ import {
 	buildFieldSumOptions,
 	buildSortByOptions,
 	buildSwimlaneOptions,
-	DEFAULT_PAGE_SIZE,
 	DEFAULT_VISIBLE_FIELDS,
+	getDefaultInitialPageSize,
+	getDefaultPageSize,
 	PAGE_SIZE_OPTIONS,
 } from "./view-utils";
 
@@ -852,9 +853,10 @@ export function ViewSettingsPanel({
 	const fieldSumOpts = buildFieldSumOptions(customFields);
 
 	const sortByValue = draft.sort_by ?? "manual";
-	// Mirrors the runtime default in interaction-layout.tsx: board views show
-	// 20 cards per column on first load, table/roadmap views show 5.
-	const defaultInitialPageSize = view?.layout === "Board" ? 20 : 5;
+	// Mirrors the runtime defaults in interaction-layout.tsx (see
+	// PAGE_SIZE_DEFAULTS in view-utils.ts).
+	const defaultInitialPageSize = getDefaultInitialPageSize(view?.layout);
+	const defaultPageSize = getDefaultPageSize(view?.layout);
 	const filterSprintIds = filterConfigToIds(draft.filters?.sprints);
 	const filterStatusIds = filterConfigToIds(draft.filters?.statuses);
 	const filterAssigneeIds = filterConfigToIds(draft.filters?.assignees);
@@ -996,7 +998,7 @@ export function ViewSettingsPanel({
 
 							<SettingRow label="Per page">
 								<DynamicSelect
-									value={String(draft.page_size ?? DEFAULT_PAGE_SIZE)}
+									value={String(draft.page_size ?? defaultPageSize)}
 									options={PAGE_SIZE_OPTIONS}
 									onChange={(v) =>
 										update({ page_size: v ? Number(v) : undefined })

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -290,6 +290,17 @@ export const FIELD_SUM_COUNT: { key: string; label: string } = {
 	label: "Count",
 };
 
+/** Default "load more" page size applied when a view has no page_size saved yet. */
+export const DEFAULT_PAGE_SIZE = 20;
+
+export const PAGE_SIZE_OPTIONS: { key: string; label: string }[] = [
+	{ key: "5", label: "5" },
+	{ key: "10", label: "10" },
+	{ key: "20", label: "20" },
+	{ key: "50", label: "50" },
+	{ key: "100", label: "100" },
+];
+
 /** All built-in fields available for the Field Picker. Title is excluded — it is always visible. */
 export const BUILTIN_FIELDS: { key: string; label: string }[] = [
 	{ key: "assignee", label: "Assignee" },

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -3,6 +3,7 @@ import {
 	resolveFilterConfig,
 	type Sprint,
 	type Task,
+	type ViewLayout,
 } from "@/lib/interaction-api";
 import type {
 	CustomFieldDefinition,
@@ -290,8 +291,33 @@ export const FIELD_SUM_COUNT: { key: string; label: string } = {
 	label: "Count",
 };
 
-/** Default "load more" page size applied when a view has no page_size saved yet. */
-export const DEFAULT_PAGE_SIZE = 20;
+/**
+ * Per-layout pagination defaults, keyed by `ViewLayout`. `initial` is the page
+ * size used on a view's first load; `perPage` is the batch size used by
+ * subsequent "load more" fetches. A saved view's `initial_page_size` /
+ * `page_size` always takes priority over these — they only apply when unset.
+ * Plugin views render arbitrary content and don't paginate through this
+ * mechanism, so they reuse the Table (list) defaults.
+ */
+export const PAGE_SIZE_DEFAULTS: Record<
+	ViewLayout,
+	{ initial: number; perPage: number }
+> = {
+	Table: { initial: 5, perPage: 20 },
+	Board: { initial: 20, perPage: 20 },
+	Roadmap: { initial: 100, perPage: 100 },
+	Plugin: { initial: 5, perPage: 20 },
+};
+
+export function getDefaultInitialPageSize(
+	layout: ViewLayout | undefined,
+): number {
+	return PAGE_SIZE_DEFAULTS[layout ?? "Table"].initial;
+}
+
+export function getDefaultPageSize(layout: ViewLayout | undefined): number {
+	return PAGE_SIZE_DEFAULTS[layout ?? "Table"].perPage;
+}
 
 export const PAGE_SIZE_OPTIONS: { key: string; label: string }[] = [
 	{ key: "5", label: "5" },

--- a/apps/web/src/hooks/use-debounced-callback.ts
+++ b/apps/web/src/hooks/use-debounced-callback.ts
@@ -1,18 +1,18 @@
 import { useCallback, useRef } from "react";
 
-export function useDebouncedCallback<T extends (...args: unknown[]) => void>(
-	callback: T,
+export function useDebouncedCallback<Args extends unknown[]>(
+	callback: (...args: Args) => void,
 	delay: number,
-): T {
+): (...args: Args) => void {
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const callbackRef = useRef(callback);
 	callbackRef.current = callback;
 
 	return useCallback(
-		((...args: unknown[]) => {
+		(...args: Args) => {
 			if (timerRef.current) clearTimeout(timerRef.current);
 			timerRef.current = setTimeout(() => callbackRef.current(...args), delay);
-		}) as T,
+		},
 		[delay],
 	);
 }

--- a/apps/web/src/lib/interaction-api.test.ts
+++ b/apps/web/src/lib/interaction-api.test.ts
@@ -267,6 +267,35 @@ describe("interaction-api", () => {
 			expect(config.params?.view_id).toBeUndefined();
 			expect(config.params?.backlog).toBeUndefined();
 		});
+
+		it("includes a trimmed search param when provided", async () => {
+			mockGet.mockResolvedValue(
+				ok({ items: [], total: 0, page: 1, page_size: 200 }),
+			);
+
+			await listAllTasks(PROJECT_ID, { search: "  login bug  " });
+
+			expect(mockGet).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/tasks`,
+				expect.objectContaining({
+					params: expect.objectContaining({ search: "login bug" }),
+				}),
+			);
+		});
+
+		it("omits the search param when blank or whitespace-only", async () => {
+			mockGet.mockResolvedValue(
+				ok({ items: [], total: 0, page: 1, page_size: 200 }),
+			);
+
+			await listAllTasks(PROJECT_ID, { search: "   " });
+
+			const [, config] = mockGet.mock.calls[0] as [
+				string,
+				{ params: Record<string, unknown> },
+			];
+			expect(config.params?.search).toBeUndefined();
+		});
 	});
 
 	// ── layoutToViewType ─────────────────────────────────────────────────────

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -114,6 +114,10 @@ export interface ViewConfig {
 	slice_by?: string;
 	filters?: ViewFilters;
 	collapsed_columns?: string[];
+	/** Saved number of tasks to fetch when paginating further ("load more") within this view. Unset falls back to a fixed default. */
+	page_size?: number;
+	/** Saved number of tasks to fetch on the first load of this view, independent of page_size. Unset falls back to the layout's default. */
+	initial_page_size?: number;
 	/** Populated only for plugin views (view_type = "plugin") */
 	plugin_manifest_id?: string;
 	plugin_component?: string;

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -425,6 +425,8 @@ export interface ListTasksOptions {
 	/** When provided for a manual-sort view, passed as view_id so the backend
 	 *  can JOIN view_task_positions and return tasks in saved position order. */
 	viewId?: string;
+	/** Free-text search matched server-side against title and "#<task_number>". */
+	search?: string;
 }
 
 function buildTaskQueryParams(opts: ListTasksOptions = {}) {
@@ -462,6 +464,7 @@ function buildTaskQueryParams(opts: ListTasksOptions = {}) {
 	if (opts.viewId) {
 		params.view_id = opts.viewId;
 	}
+	if (opts.search?.trim()) params.search = opts.search.trim();
 	return params;
 }
 

--- a/services/api/internal/domain/sprint/entity.go
+++ b/services/api/internal/domain/sprint/entity.go
@@ -171,6 +171,14 @@ type ViewConfig struct {
 	SliceBy          string       `json:"slice_by,omitempty"`
 	Filters          *ViewFilters `json:"filters,omitempty"`
 	CollapsedColumns []string     `json:"collapsed_columns,omitempty"`
+	// PageSize is the saved number of tasks to fetch when paginating further
+	// (e.g. "load more") within this view. Zero means unset; the client falls
+	// back to its own default.
+	PageSize int `json:"page_size,omitempty"`
+	// InitialPageSize is the saved number of tasks to fetch on the first load
+	// of this view, independent of PageSize. Zero means unset; the client
+	// falls back to its own per-layout default.
+	InitialPageSize int `json:"initial_page_size,omitempty"`
 	// Plugin view fields (only set when view_type = "plugin")
 	// PluginID stores the plugin manifest identifier (reverse-DNS), not the
 	// plugin UUID used by plugin-extension-settings APIs.

--- a/services/api/internal/domain/task/repository.go
+++ b/services/api/internal/domain/task/repository.go
@@ -105,6 +105,9 @@ type TaskFilter struct {
 	TaskTypeNull bool        // true → only tasks where task_type_id IS NULL
 	BacklogOnly  bool        // true → only tasks where sprint_id IS NULL
 	CursorAfter  *string     // opaque base64 cursor; when set, replaces offset-based paging
+	// Search, when non-nil and non-blank, restricts results to tasks whose title
+	// or "#<task_number>" id contains the text (case-insensitive).
+	Search *string
 }
 
 // CustomFieldDefinitionRepository defines persistence operations for custom

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -448,6 +448,28 @@ func applyTaskFilter(b *queryBuilder, filter taskdom.TaskFilter) {
 	case len(filter.TaskTypeIDs) > 0:
 		b.addInClause("task_type_id", uuidSliceToStrSlice(filter.TaskTypeIDs))
 	}
+
+	if filter.Search != nil {
+		if q := strings.TrimSpace(*filter.Search); q != "" {
+			pattern := "%" + escapeLikePattern(q) + "%"
+			p1 := b.placeholder()
+			b.args = append(b.args, pattern)
+			p2 := b.placeholder()
+			b.args = append(b.args, pattern)
+			b.whereClauses = append(b.whereClauses, fmt.Sprintf(
+				"(title ILIKE %s OR ('#' || task_number::text) ILIKE %s)", p1, p2))
+		}
+	}
+}
+
+// escapeLikePattern escapes the LIKE/ILIKE wildcard characters (% and _) and
+// the backslash escape character itself, so free-text search input is matched
+// literally instead of as a glob pattern.
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	s = strings.ReplaceAll(s, "_", `\_`)
+	return s
 }
 
 // applyTaskSort returns the FROM/JOIN extension and ORDER BY clause.

--- a/services/api/internal/service/sprint/view_service_test.go
+++ b/services/api/internal/service/sprint/view_service_test.go
@@ -318,6 +318,31 @@ func TestViewService_UpdateView_Config(t *testing.T) {
 	}
 }
 
+func TestViewService_UpdateView_Config_PageSize(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeViewRepo()
+	svc := sprintsvc.NewViewService(repo)
+
+	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
+		SprintID:    uuidPtr(uuid.New()),
+		Name:        "Table View",
+		ViewType:    sprintdom.ViewTypeTable,
+		ViewContext: sprintdom.ViewContextSprint,
+	})
+
+	cfg := sprintdom.ViewConfig{PageSize: 50, InitialPageSize: 10}
+	updated, err := svc.UpdateView(ctx, created.ProjectID, created.ID, sprintdom.UpdateViewInput{Config: &cfg})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Config.PageSize != 50 {
+		t.Errorf("expected page_size=50, got %d", updated.Config.PageSize)
+	}
+	if updated.Config.InitialPageSize != 10 {
+		t.Errorf("expected initial_page_size=10, got %d", updated.Config.InitialPageSize)
+	}
+}
+
 func TestViewService_UpdateView_NotFound(t *testing.T) {
 	ctx := context.Background()
 	svc := sprintsvc.NewViewService(newFakeViewRepo())

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,6 +32,20 @@ type fakeTaskRepo struct {
 	findDefaultTypeErr   error               // injected error for FindDefaultTaskType
 	findDefaultStatusErr error               // injected error for FindDefaultTaskStatus
 	setDefaultStatusErr  error               // injected error for SetDefaultTaskStatus
+}
+
+// taskMatchesSearch mirrors the postgres repo's title / "#<task_number>" ILIKE
+// matching so the fake exercises the same filter contract as production.
+func taskMatchesSearch(t *taskdom.Task, filter taskdom.TaskFilter) bool {
+	if filter.Search == nil {
+		return true
+	}
+	q := strings.ToLower(strings.TrimSpace(*filter.Search))
+	if q == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(t.Title), q) ||
+		strings.Contains(fmt.Sprintf("#%d", t.TaskNumber), q)
 }
 
 func newFakeTaskRepo() *fakeTaskRepo {
@@ -239,6 +254,9 @@ func (r *fakeTaskRepo) ListTasks(_ context.Context, projectID uuid.UUID, filter 
 		if filter.AssigneeID != nil && (t.AssigneeID == nil || *t.AssigneeID != *filter.AssigneeID) {
 			continue
 		}
+		if !taskMatchesSearch(t, filter) {
+			continue
+		}
 		cp := *t
 		all = append(all, &cp)
 	}
@@ -350,6 +368,9 @@ func (r *fakeTaskRepo) CountTasks(_ context.Context, projectID uuid.UUID, filter
 		if filter.BacklogOnly && t.SprintID != nil {
 			continue
 		}
+		if !taskMatchesSearch(t, filter) {
+			continue
+		}
 		count++
 	}
 	return count, nil
@@ -374,6 +395,9 @@ func (r *fakeTaskRepo) SumTaskField(_ context.Context, projectID uuid.UUID, filt
 			continue
 		}
 		if filter.BacklogOnly && t.SprintID != nil {
+			continue
+		}
+		if !taskMatchesSearch(t, filter) {
 			continue
 		}
 		if fieldKey == "story_points" {
@@ -969,6 +993,83 @@ func TestListTasks_FilterBySprint(t *testing.T) {
 	}
 	if len(tasks) != 1 || tasks[0].Title != "In Sprint" {
 		t.Errorf("expected 1 filtered task In Sprint, got %v", tasks)
+	}
+}
+
+func TestListTasks_FilterBySearch_MatchesTitleCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Fix login bug"})
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Add signup flow"})
+
+	search := "LOGIN"
+	tasks, _, err := svc.ListTasks(ctx, projectID, taskdom.TaskFilter{Search: &search}, 20, taskdom.TaskSort{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].Title != "Fix login bug" {
+		t.Errorf("expected 1 filtered task 'Fix login bug', got %v", tasks)
+	}
+}
+
+func TestListTasks_FilterBySearch_MatchesTaskNumber(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	first, _ := svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "First task"})
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Second task"})
+
+	search := fmt.Sprintf("#%d", first.TaskNumber)
+	tasks, _, err := svc.ListTasks(ctx, projectID, taskdom.TaskFilter{Search: &search}, 20, taskdom.TaskSort{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != first.ID {
+		t.Errorf("expected 1 filtered task matching %s, got %v", search, tasks)
+	}
+}
+
+func TestListTasks_FilterBySearch_BlankIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Task one"})
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Task two"})
+
+	blank := "   "
+	tasks, _, err := svc.ListTasks(ctx, projectID, taskdom.TaskFilter{Search: &blank}, 20, taskdom.TaskSort{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected blank search to be a no-op returning 2 tasks, got %d", len(tasks))
+	}
+}
+
+func TestCountTasks_FilterBySearch(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Fix login bug"})
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Fix logout bug"})
+	_, _ = svc.CreateTask(ctx, taskdom.CreateTaskInput{ProjectID: projectID, Title: "Add signup flow"})
+
+	search := "fix"
+	count, err := svc.CountTasks(ctx, projectID, taskdom.TaskFilter{Search: &search})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected count=2, got %d", count)
 	}
 }
 

--- a/services/api/internal/transport/http/dto/view_dto.go
+++ b/services/api/internal/transport/http/dto/view_dto.go
@@ -40,6 +40,12 @@ type ViewConfigDTO struct {
 	SliceBy          string          `json:"slice_by,omitempty"`
 	Filters          *ViewFiltersDTO `json:"filters,omitempty"`
 	CollapsedColumns []string        `json:"collapsed_columns,omitempty"`
+	// PageSize is the saved number of tasks to fetch when paginating further
+	// (e.g. "load more") within this view.
+	PageSize int `json:"page_size,omitempty"`
+	// InitialPageSize is the saved number of tasks to fetch on the first load
+	// of this view, independent of PageSize.
+	InitialPageSize int `json:"initial_page_size,omitempty"`
 	// PluginManifestID is the reverse-DNS plugin manifest identifier
 	// (for example "com.paca.bdd").
 	PluginManifestID string `json:"plugin_manifest_id,omitempty"`
@@ -76,6 +82,8 @@ func ViewFromEntity(v *sprintdom.SprintView) ViewResponse {
 			SliceBy:          v.Config.SliceBy,
 			Filters:          v.Config.Filters,
 			CollapsedColumns: v.Config.CollapsedColumns,
+			PageSize:         v.Config.PageSize,
+			InitialPageSize:  v.Config.InitialPageSize,
 			PluginManifestID: v.Config.PluginID,
 			PluginComponent:  v.Config.PluginComponent,
 		},
@@ -99,6 +107,8 @@ func toViewConfig(d *ViewConfigDTO) sprintdom.ViewConfig {
 		SliceBy:          d.SliceBy,
 		Filters:          d.Filters,
 		CollapsedColumns: d.CollapsedColumns,
+		PageSize:         d.PageSize,
+		InitialPageSize:  d.InitialPageSize,
 		PluginID:         d.PluginManifestID,
 		PluginComponent:  d.PluginComponent,
 	}

--- a/services/api/internal/transport/http/dto/view_dto_test.go
+++ b/services/api/internal/transport/http/dto/view_dto_test.go
@@ -142,6 +142,51 @@ func TestViewFromEntity_PluginConfigRoundtrip(t *testing.T) {
 	}
 }
 
+// TestViewFromEntity_PageSizeRoundtrip verifies the page_size field is copied
+// from domain config to DTO config.
+func TestViewFromEntity_PageSizeRoundtrip(t *testing.T) {
+	entity := &sprintdom.SprintView{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+		Name:      "Table",
+		ViewType:  sprintdom.ViewTypeTable,
+		Config: sprintdom.ViewConfig{
+			PageSize: 50,
+		},
+	}
+
+	resp := dto.ViewFromEntity(entity)
+
+	if resp.Config.PageSize != 50 {
+		t.Errorf("PageSize: want 50, got %d", resp.Config.PageSize)
+	}
+}
+
+// TestViewFromEntity_InitialPageSizeRoundtrip verifies the initial_page_size
+// field is copied from domain config to DTO config, independently of
+// PageSize.
+func TestViewFromEntity_InitialPageSizeRoundtrip(t *testing.T) {
+	entity := &sprintdom.SprintView{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+		Name:      "Board",
+		ViewType:  sprintdom.ViewTypeBoard,
+		Config: sprintdom.ViewConfig{
+			PageSize:        20,
+			InitialPageSize: 10,
+		},
+	}
+
+	resp := dto.ViewFromEntity(entity)
+
+	if resp.Config.InitialPageSize != 10 {
+		t.Errorf("InitialPageSize: want 10, got %d", resp.Config.InitialPageSize)
+	}
+	if resp.Config.PageSize != 20 {
+		t.Errorf("PageSize: want 20, got %d", resp.Config.PageSize)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // toViewConfig (via CreateViewRequest / UpdateViewRequest) roundtrip
 // ---------------------------------------------------------------------------
@@ -228,6 +273,54 @@ func TestCreateViewRequest_ToCreateInput_PluginConfigRoundtrip(t *testing.T) {
 	}
 	if input.Config.PluginComponent != "KanbanByPriority" {
 		t.Errorf("PluginComponent: want %q, got %q", "KanbanByPriority", input.Config.PluginComponent)
+	}
+}
+
+// TestCreateViewRequest_ToCreateInput_PageSizeRoundtrip verifies the
+// page_size field is copied from DTO config to domain config through
+// toViewConfig.
+func TestCreateViewRequest_ToCreateInput_PageSizeRoundtrip(t *testing.T) {
+	sprintID := uuid.New()
+	projectID := uuid.New()
+
+	req := dto.CreateViewRequest{
+		Name:     "Table",
+		ViewType: sprintdom.ViewTypeTable,
+		Config: &dto.ViewConfigDTO{
+			PageSize: 100,
+		},
+	}
+
+	input := req.ToCreateInput(sprintID, projectID)
+
+	if input.Config.PageSize != 100 {
+		t.Errorf("PageSize: want 100, got %d", input.Config.PageSize)
+	}
+}
+
+// TestCreateViewRequest_ToCreateInput_InitialPageSizeRoundtrip verifies the
+// initial_page_size field is copied from DTO config to domain config through
+// toViewConfig, independently of PageSize.
+func TestCreateViewRequest_ToCreateInput_InitialPageSizeRoundtrip(t *testing.T) {
+	sprintID := uuid.New()
+	projectID := uuid.New()
+
+	req := dto.CreateViewRequest{
+		Name:     "Board",
+		ViewType: sprintdom.ViewTypeBoard,
+		Config: &dto.ViewConfigDTO{
+			PageSize:        20,
+			InitialPageSize: 10,
+		},
+	}
+
+	input := req.ToCreateInput(sprintID, projectID)
+
+	if input.Config.InitialPageSize != 10 {
+		t.Errorf("InitialPageSize: want 10, got %d", input.Config.InitialPageSize)
+	}
+	if input.Config.PageSize != 20 {
+		t.Errorf("PageSize: want 20, got %d", input.Config.PageSize)
 	}
 }
 

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -339,6 +339,7 @@ func parseTaskSort(ctx context.Context, svc taskdom.Service, projectID uuid.UUID
 //   - assignee_id=<uuid> or assignee_ids=<uuid,uuid>
 //   - task_type_ids=<uuid,uuid>
 //   - parent_task_id=<uuid>
+//   - search=<text> (matches title or "#<task_number>", case-insensitive)
 func (h *TaskHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 	projectID, err := parseProjectID(r)
 	if err != nil {
@@ -429,6 +430,9 @@ func (h *TaskHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		filter.ParentTaskID = &id
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("search")); raw != "" {
+		filter.Search = &raw
 	}
 	if cursorRaw := r.URL.Query().Get("cursor"); cursorRaw != "" {
 		filter.CursorAfter = &cursorRaw

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -53,6 +54,20 @@ func newFakeTaskRepoIT() *fakeTaskRepo {
 		counters:      make(map[uuid.UUID]int64),
 		viewPositions: make(map[string]float64),
 	}
+}
+
+// taskMatchesSearch mirrors the postgres repo's title / "#<task_number>" ILIKE
+// matching so the fake exercises the same filter contract as production.
+func taskMatchesSearch(t *taskdom.Task, filter taskdom.TaskFilter) bool {
+	if filter.Search == nil {
+		return true
+	}
+	q := strings.ToLower(strings.TrimSpace(*filter.Search))
+	if q == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(t.Title), q) ||
+		strings.Contains(fmt.Sprintf("#%d", t.TaskNumber), q)
 }
 
 // addViewPosition seeds a manual position for a task within a view. Used in
@@ -248,6 +263,9 @@ func (r *fakeTaskRepo) ListTasks(_ context.Context, projectID uuid.UUID, filter 
 		if filter.AssigneeID != nil && (t.AssigneeID == nil || *t.AssigneeID != *filter.AssigneeID) {
 			continue
 		}
+		if !taskMatchesSearch(t, filter) {
+			continue
+		}
 		cp := *t
 		// Populate ViewPosition when sorting by view_position so the fake
 		// behaves like the postgres repo (which gets it via LEFT JOIN).
@@ -312,6 +330,9 @@ func (r *fakeTaskRepo) CountTasks(_ context.Context, projectID uuid.UUID, filter
 		if filter.AssigneeID != nil && (t.AssigneeID == nil || *t.AssigneeID != *filter.AssigneeID) {
 			continue
 		}
+		if !taskMatchesSearch(t, filter) {
+			continue
+		}
 		count++
 	}
 	return count, nil
@@ -333,6 +354,9 @@ func (r *fakeTaskRepo) SumTaskField(_ context.Context, projectID uuid.UUID, filt
 			continue
 		}
 		if filter.StatusID != nil && (t.StatusID == nil || *t.StatusID != *filter.StatusID) {
+			continue
+		}
+		if !taskMatchesSearch(t, filter) {
 			continue
 		}
 		if fieldKey == "story_points" {
@@ -1364,6 +1388,66 @@ func TestIntegrationTasks_ListWithSprintFilter(t *testing.T) {
 	}
 	if count := taskListCount(t, w.Body.Bytes()); count != 1 {
 		t.Errorf("expected 1 filtered task, got %d", count)
+	}
+}
+
+func TestIntegrationTasks_ListWithSearchFilter(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/tasks", projectID)
+
+	serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"title": "Fix login bug",
+	}))
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"title": "Add signup flow",
+	}))
+	var created struct {
+		Data struct {
+			TaskNumber int64 `json:"task_number"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(createW.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	// Search matches title case-insensitively, and pagination metadata
+	// (total_count) reflects the filtered set, not the full project.
+	w := serve(r, authedJSONReq(t.Context(), http.MethodGet, base+"?search=LOGIN", tok, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("search by title: expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if count := taskListCount(t, w.Body.Bytes()); count != 1 {
+		t.Errorf("expected 1 task matching title search, got %d", count)
+	}
+	if total := taskListTotalCount(t, w.Body.Bytes()); total != 1 {
+		t.Errorf("expected total_count=1 for title search, got %d", total)
+	}
+
+	// Search also matches by "#<task_number>".
+	searchURL := fmt.Sprintf("%s?search=%s", base, url.QueryEscape(fmt.Sprintf("#%d", created.Data.TaskNumber)))
+	w = serve(r, authedJSONReq(t.Context(), http.MethodGet, searchURL, tok, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("search by task number: expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if count := taskListCount(t, w.Body.Bytes()); count != 1 {
+		t.Errorf("expected 1 task matching task-number search, got %d", count)
+	}
+
+	// A search with no matches returns an empty (not error) result.
+	w = serve(r, authedJSONReq(t.Context(), http.MethodGet, base+"?search=nonexistent", tok, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("search with no matches: expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if count := taskListCount(t, w.Body.Bytes()); count != 0 {
+		t.Errorf("expected 0 tasks for non-matching search, got %d", count)
 	}
 }
 

--- a/services/api/test/integration/view_test.go
+++ b/services/api/test/integration/view_test.go
@@ -1685,3 +1685,81 @@ func TestIntegrationViews_UpdateConfig_TaskTypes(t *testing.T) {
 		t.Errorf("task_types.items.normal after patch: want {all:true}, got %v", items["normal"])
 	}
 }
+
+// TestIntegrationViews_UpdateConfig_PageSize verifies that PATCHing a view
+// with page_size and initial_page_size persists both independently and
+// returns them on a subsequent GET.
+func TestIntegrationViews_UpdateConfig_PageSize(t *testing.T) {
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionSprintsRead, authz.PermissionSprintsWrite},
+		},
+	}
+	sprintRepo := newFakeSprintRepoIT()
+	viewRepo := newFakeViewRepoIT()
+	r := buildViewTestRouter(viewRepo, sprintRepo, store)
+	tok := issueViewToken(t, uuid.NewString())
+	sprintID := seedSprintIT(t, sprintRepo, projectID)
+	itemBase := fmt.Sprintf("/api/v1/projects/%s/views", projectID)
+	base := fmt.Sprintf("%s?context=sprint&sprint_id=%s", itemBase, sprintID)
+
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"name":      "Board View",
+		"view_type": "board",
+	}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d", createW.Code)
+	}
+	viewID := viewIDFrom(t, createW.Body.Bytes())
+
+	// PATCH page_size and initial_page_size independently.
+	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, itemBase+"/"+viewID, tok, map[string]any{
+		"config": map[string]any{
+			"page_size":         50,
+			"initial_page_size": 10,
+		},
+	}))
+	if patchW.Code != http.StatusOK {
+		t.Fatalf("patch: expected 200, got %d (%s)", patchW.Code, patchW.Body.String())
+	}
+
+	var patchResp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(patchW.Body.Bytes(), &patchResp); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	cfg, _ := patchResp.Data["config"].(map[string]any)
+	if cfg == nil {
+		t.Fatal("expected config in patch response")
+	}
+	if pageSize, _ := cfg["page_size"].(float64); pageSize != 50 {
+		t.Errorf("page_size: want 50, got %v", cfg["page_size"])
+	}
+	if initialPageSize, _ := cfg["initial_page_size"].(float64); initialPageSize != 10 {
+		t.Errorf("initial_page_size: want 10, got %v", cfg["initial_page_size"])
+	}
+
+	// GET the view back and verify both fields survive the round trip.
+	getW := serve(r, authedJSONReq(t.Context(), http.MethodGet, itemBase+"/"+viewID, tok, nil))
+	if getW.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d (%s)", getW.Code, getW.Body.String())
+	}
+	var getResp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(getW.Body.Bytes(), &getResp); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	getCfg, _ := getResp.Data["config"].(map[string]any)
+	if getCfg == nil {
+		t.Fatal("expected config in get response")
+	}
+	if pageSize, _ := getCfg["page_size"].(float64); pageSize != 50 {
+		t.Errorf("after GET, page_size: want 50, got %v", getCfg["page_size"])
+	}
+	if initialPageSize, _ := getCfg["initial_page_size"].(float64); initialPageSize != 10 {
+		t.Errorf("after GET, initial_page_size: want 10, got %v", getCfg["initial_page_size"])
+	}
+}


### PR DESCRIPTION
## Summary

Page sizes per view were hardcoded (Board: 20, List/Roadmap: 5 on first load, 20 per "load more") forcing users to repeatedly click "View more," especially on Roadmap/Timeline views. This bundles two changes that share the same pagination plumbing in `interaction-layout.tsx`:

- **Configurable page sizes** — closes #213
- **Server-side task search** — required because the old client-side search only filtered tasks already fetched into memory, which breaks once page sizes can be small/configurable

### Configurable page sizes
- `ViewConfig` gains two independent optional fields, `page_size` ("load more" batch size) and `initial_page_size` (first-load size), persisted per view (`domain/sprint/entity.go`, `transport/http/dto/view_dto.go`).
- New "Initial size" / "Per page" dropdowns in the view settings panel, offering 5/10/20/50/100 (`PAGE_SIZE_OPTIONS` in `view-utils.ts`).
- Added per-layout defaults (`PAGE_SIZE_DEFAULTS`): Table 5/20, Board 20/20, Roadmap 100/100 (up from a hardcoded 5 — directly addresses #213's complaint about Timeline/backlog views). Plugin views reuse the Table default since they don't paginate through this mechanism. A saved view's configured value always wins; the layout default only applies when unset.
- `interaction-layout.tsx` resolves page size as `configured ?? layout default` for both the column-grouped pagination path (Board/grouped List) and the global pagination path (Roadmap/ungrouped), for initial load and "load more" alike.
- Minor adjacent cleanup: "View more" button text dropped from `text-sm` to `text-xs` for consistency across Board/List/Roadmap; Board view container switched from `overflow-x-auto` to `overflow-auto` with `items-start` so columns align to the top.

### Server-side task search
- New `search` query param on `GET /tasks`: matches `title` or `'#' || task_number` case-insensitively (`task_repository.go`, `task_handler.go`, `domain/task/repository.go`). User input is escaped (`escapeLikePattern`) so `%`, `_`, and `\` are matched literally instead of as ILIKE wildcards.
- Removed client-side search filtering from `board-view.tsx`, `list-view.tsx`, `roadmap-view.tsx`; `interaction-layout.tsx` now threads `search` through to the task-list query options instead, debounced 300ms (`useDebouncedCallback`) so it doesn't fire a request per keystroke.
- **Known limitation**: the server only matches the bare `#<task_number>` form, not a project's custom task-ID prefix (e.g. `ENG-42`), which the old client-side filter also matched. Searching by bare task number or by title is unaffected.

## Test plan

- [x] `go build ./...` and `go test ./...` (all backend packages) — including new `TestIntegrationTasks_ListWithSearchFilter`, `TestIntegrationViews_UpdateConfig_PageSize`, and unit coverage for search/page-size round trips
- [x] `npx tsc -b --noEmit` and `npx vitest run` (260 tests) — including new `interaction-api.test.ts` coverage for the trimmed/omitted `search` param