### PR TITLE
feat: allow username reuse after soft delete and update uniqueness co…

### DIFF
--- a/services/api/internal/repository/postgres/user_repository_test.go
+++ b/services/api/internal/repository/postgres/user_repository_test.go
@@ -33,7 +33,7 @@ func openUserRepoTestDB(t *testing.T) (*sqlx.DB, uuid.UUID) {
 		);
 		CREATE TABLE users (
 			id TEXT PRIMARY KEY,
-			username TEXT NOT NULL UNIQUE,
+			username TEXT NOT NULL,
 			password_hash TEXT NOT NULL,
 			full_name TEXT NOT NULL,
 			role_id TEXT NOT NULL,
@@ -41,7 +41,8 @@ func openUserRepoTestDB(t *testing.T) (*sqlx.DB, uuid.UUID) {
 			created_at DATETIME,
 			updated_at DATETIME,
 			deleted_at DATETIME
-		);`
+		);
+		CREATE UNIQUE INDEX uni_users_username_active ON users (username) WHERE deleted_at IS NULL;`
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
 		t.Fatalf("create schema: %v", err)
 	}
@@ -191,5 +192,32 @@ func TestUserRepository_FindByUsernameIncludingDeleted_FindsSoftDeleted(t *testi
 	}
 	if got.ID != u.ID {
 		t.Fatalf("expected id %s, got %s", u.ID, got.ID)
+	}
+}
+
+func TestUserRepository_Create_AllowsUsernameReuseAfterDelete(t *testing.T) {
+	db, roleID := openUserRepoTestDB(t)
+	repo := NewUserRepository(db)
+	ctx := context.Background()
+
+	original := testUser(uuid.New(), roleID)
+	if err := repo.Create(ctx, original); err != nil {
+		t.Fatalf("create original user: %v", err)
+	}
+	if err := repo.Delete(ctx, original.ID); err != nil {
+		t.Fatalf("delete original user: %v", err)
+	}
+
+	replacement := testUser(uuid.New(), roleID) // same "alice" username as original
+	if err := repo.Create(ctx, replacement); err != nil {
+		t.Fatalf("expected username reuse after delete to succeed, got: %v", err)
+	}
+
+	got, err := repo.FindByUsername(ctx, replacement.Username)
+	if err != nil {
+		t.Fatalf("find by username: %v", err)
+	}
+	if got.ID != replacement.ID {
+		t.Fatalf("expected active user to be the replacement %s, got %s", replacement.ID, got.ID)
 	}
 }

--- a/services/api/internal/service/user/user_service.go
+++ b/services/api/internal/service/user/user_service.go
@@ -102,8 +102,9 @@ func (s *Service) ListGlobalPermissions(ctx context.Context, id uuid.UUID) ([]st
 // Create registers a new user with a hashed password.
 // If Role is provided, it is resolved to a RoleID via roleRepo.
 func (s *Service) Create(ctx context.Context, in userdom.CreateInput) (*userdom.User, error) {
-	// Check username uniqueness across active and soft-deleted users.
-	_, err := s.repo.FindByUsernameIncludingDeleted(ctx, in.Username)
+	// Check username uniqueness among active users only; a soft-deleted
+	// user's username is freed up for reuse.
+	_, err := s.repo.FindByUsername(ctx, in.Username)
 	if err == nil {
 		return nil, userdom.ErrUsernameTaken
 	}

--- a/services/api/internal/service/user/user_service_test.go
+++ b/services/api/internal/service/user/user_service_test.go
@@ -253,7 +253,7 @@ func TestCreate_Success(t *testing.T) {
 func TestCreate_DuplicateUsername(t *testing.T) {
 	existing := &userdom.User{ID: uuid.New(), Username: "alice"}
 	svc := usersvc.New(&stubRepo{
-		findByUsernameIncludingDeleted: func(_ context.Context, _ string) (*userdom.User, error) { return existing, nil },
+		findByUsername: func(_ context.Context, _ string) (*userdom.User, error) { return existing, nil },
 	})
 
 	_, err := svc.Create(context.Background(), userdom.CreateInput{
@@ -263,6 +263,42 @@ func TestCreate_DuplicateUsername(t *testing.T) {
 	})
 	if !errors.Is(err, userdom.ErrUsernameTaken) {
 		t.Fatalf("expected ErrUsernameTaken, got %v", err)
+	}
+}
+
+func TestCreate_AllowsUsernameReuseAfterSoftDelete(t *testing.T) {
+	roleID := uuid.New()
+	deletedUser := &userdom.User{ID: uuid.New(), Username: "alice"}
+	svc := usersvc.New(
+		&stubRepo{
+			// Active lookup finds nothing — the only "alice" on record is soft-deleted.
+			findByUsername: func(_ context.Context, _ string) (*userdom.User, error) {
+				return nil, userdom.ErrNotFound
+			},
+			findByUsernameIncludingDeleted: func(_ context.Context, _ string) (*userdom.User, error) {
+				return deletedUser, nil
+			},
+		},
+		&stubRoleRepo{
+			findByName: func(_ context.Context, _ string) (*globalroledom.GlobalRole, error) {
+				return &globalroledom.GlobalRole{ID: roleID, Name: userdom.RoleUser}, nil
+			},
+		},
+	)
+
+	got, err := svc.Create(context.Background(), userdom.CreateInput{
+		Username: "alice",
+		Password: "password123",
+		FullName: "Alice",
+	})
+	if err != nil {
+		t.Fatalf("expected username reuse after soft-delete to succeed, got: %v", err)
+	}
+	if got.Username != "alice" {
+		t.Errorf("unexpected username: %s", got.Username)
+	}
+	if got.ID == deletedUser.ID {
+		t.Fatal("expected a new user ID, not the deleted user's ID")
 	}
 }
 

--- a/services/api/migrations/000016_scope_username_unique_to_active.sql
+++ b/services/api/migrations/000016_scope_username_unique_to_active.sql
@@ -1,0 +1,14 @@
+-- 000016_scope_username_unique_to_active.sql
+-- Scopes the username uniqueness constraint to active (non-deleted) users
+-- so a username freed up by a soft-deleted account can be reused, matching
+-- the uq_project_members_active pattern used elsewhere.
+
+BEGIN;
+
+DROP INDEX IF EXISTS uni_users_username;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uni_users_username_active
+    ON users (username)
+    WHERE deleted_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Soft-deleting a user permanently retired their username: `Create` checked uniqueness via `FindByUsernameIncludingDeleted`, and the DB had a global `UNIQUE` constraint on `username`, so a freed-up username could never be reissued to a new account. This scopes the uniqueness check to active (non-deleted) users only, matching the `uq_project_members_active` pattern already used for project members.

- **Migration** (`000016_scope_username_unique_to_active.sql`) — drops the global `uni_users_username` index and replaces it with a partial unique index `uni_users_username_active` scoped `WHERE deleted_at IS NULL`.
- **`user_service.go`** — `Create` now checks `FindByUsername` (active-only) instead of `FindByUsernameIncludingDeleted`, so a soft-deleted account's username no longer blocks signup.
- **Tests** — added `TestUserRepository_Create_AllowsUsernameReuseAfterDelete` (repo-level, exercises the new partial index) and `TestCreate_AllowsUsernameReuseAfterSoftDelete` (service-level); updated `TestCreate_DuplicateUsername`'s stub to match the new active-only lookup.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./...` (all backend packages, including the new repository and service tests above)
