### PR TITLE
Feature/implement database backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ todos.json
 # air (Go hot-reload) build artifacts
 services/api/tmp/
 
+# Local database dumps from the dev db-backup service
+deploy/backups/
+
 # Playwright
 test-results
 playwright-report

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,7 +109,7 @@ _Goal: production-grade stability, security, and observability for real teams._
 - 📋 Health check endpoints for all services
 - 📋 Prometheus metrics export
 - 📋 Structured JSON logging
-- 📋 Backup and restore tooling for PostgreSQL data
+- ✅ Backup and restore tooling for PostgreSQL data
 - 📋 Upgrade migration guide and tooling
 
 ### Performance & Scale

--- a/deploy/.env.dev.example
+++ b/deploy/.env.dev.example
@@ -19,3 +19,15 @@ PUBLIC_HOST=http://localhost
 #   VITE_ALLOWED_HOST=dev.example.com
 #
 VITE_ALLOWED_HOST=
+
+# Optional: override the db-backup service's schedule, retention, and output
+# directory. Defaults (in docker-compose.dev.yml) run daily at 02:00 UTC,
+# keep 7 days, and write to ./backups (relative to deploy/).
+#
+# For fast local testing, point BACKUP_CRON at a tight interval instead, e.g.
+# every 2 minutes:
+#   BACKUP_CRON=*/2 * * * *
+#
+# BACKUP_DIR=./backups
+# BACKUP_CRON=0 2 * * *
+# BACKUP_RETENTION_DAYS=7

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -29,8 +29,11 @@ DATABASE_URL=
 # Database backups.
 # A db-backup container writes a gzip-compressed pg_dump to BACKUP_DIR on the
 # schedule below, pruning dumps older than BACKUP_RETENTION_DAYS. Works against
-# the bundled postgres container or an external DATABASE_URL. Disable with
-# --scale db-backup=0.
+# the bundled postgres container or an external DATABASE_URL. Disable for the
+# current run with --scale db-backup=0, or set BACKUP_ENABLED=false below to
+# keep it off across upgrades too (upgrade.sh reads this back instead of
+# re-deriving a default).
+BACKUP_ENABLED=true
 BACKUP_DIR=./backups
 # Standard 5-field cron syntax (minute hour day-of-month month day-of-week).
 # Default below runs daily at 02:00. Examples: "*/30 * * * *" every 30 minutes,

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -26,6 +26,20 @@ POSTGRES_PASSWORD=replace-with-a-strong-postgres-password
 # Default: postgres://paca:POSTGRES_PASSWORD@postgres:5432/paca?sslmode=disable
 DATABASE_URL=
 
+# Database backups.
+# A db-backup container writes a gzip-compressed pg_dump to BACKUP_DIR on the
+# schedule below, pruning dumps older than BACKUP_RETENTION_DAYS. Works against
+# the bundled postgres container or an external DATABASE_URL. Disable with
+# --scale db-backup=0.
+BACKUP_DIR=./backups
+# Standard 5-field cron syntax (minute hour day-of-month month day-of-week).
+# Default below runs daily at 02:00. Examples: "*/30 * * * *" every 30 minutes,
+# "0 */6 * * *" every 6 hours, "0 2 * * 0" weekly on Sunday at 02:00.
+BACKUP_CRON=0 2 * * *
+BACKUP_RETENTION_DAYS=7
+# Uncomment to interpret BACKUP_CRON in a specific timezone instead of UTC.
+# TZ=America/New_York
+
 # Redis/Valkey settings.
 # Default: redis://valkey:6379/0
 REDIS_URL=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -212,6 +212,57 @@ PACA_REALTIME_IMAGE=pacaai/paca-realtime:1.2.3
 PACA_AI_AGENT_IMAGE=pacaai/paca-ai-agent:1.2.3
 ```
 
+### Database backups
+
+A `db-backup` container runs alongside the stack and writes a gzip-compressed
+`pg_dump` on a cron schedule you control, pruning dumps older than the
+configured retention period. It works against the bundled `postgres` container
+or an external `DATABASE_URL`.
+
+Configure it in `.env`:
+
+```bash
+BACKUP_DIR=./backups            # host directory dumps are written to
+BACKUP_CRON=0 2 * * *           # standard 5-field cron syntax, default 02:00 daily
+BACKUP_RETENTION_DAYS=7         # dumps older than this are deleted
+# TZ=America/New_York           # interpret BACKUP_CRON in this zone instead of UTC
+```
+
+`BACKUP_DIR` is bind-mounted into the container, so it must be a path (relative
+to wherever you run `docker compose`, or absolute) — not a bare name.
+`BACKUP_CRON` accepts any standard cron expression, e.g. `*/30 * * * *` (every
+30 minutes) or `0 2 * * 0` (weekly, Sunday at 02:00). The install script prompts
+for all three; existing installs get them backfilled by `upgrade.sh` with these
+same defaults.
+
+Scheduling is handled by `crond` inside the container, which blocks until the
+next due minute rather than polling, and the container is capped at 0.5 CPU /
+256MB (see `deploy.resources.limits` on the service) — so it stays effectively
+idle (well under 1MB RSS, 0% CPU observed) between runs and can't compete for
+host resources during the brief dump window either. Raise the memory limit in
+`docker-compose.yml` directly if you have an unusually large database.
+
+Dumps are written by the container's root user, so deleting or moving them
+directly on the host may require `sudo`.
+
+**Restore** (bundled PostgreSQL container):
+
+```bash
+gunzip -c backups/paca-<timestamp>.sql.gz | docker compose exec -T postgres psql -U ${POSTGRES_USER:-paca} -d ${POSTGRES_DB:-paca}
+```
+
+**Restore** (external PostgreSQL, using `DATABASE_URL`):
+
+```bash
+gunzip -c backups/paca-<timestamp>.sql.gz | psql "$DATABASE_URL"
+```
+
+Disable automated backups (e.g. if a managed database already handles this):
+
+```bash
+docker compose --env-file .env up -d --scale db-backup=0
+```
+
 ## Development Compose
 
 Use [`docker-compose.dev.yml`](./docker-compose.dev.yml) for local development and contributor onboarding.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -222,6 +222,7 @@ or an external `DATABASE_URL`.
 Configure it in `.env`:
 
 ```bash
+BACKUP_ENABLED=true             # set to false to turn off backups permanently
 BACKUP_DIR=./backups            # host directory dumps are written to
 BACKUP_CRON=0 2 * * *           # standard 5-field cron syntax, default 02:00 daily
 BACKUP_RETENTION_DAYS=7         # dumps older than this are deleted
@@ -232,8 +233,15 @@ BACKUP_RETENTION_DAYS=7         # dumps older than this are deleted
 to wherever you run `docker compose`, or absolute) — not a bare name.
 `BACKUP_CRON` accepts any standard cron expression, e.g. `*/30 * * * *` (every
 30 minutes) or `0 2 * * 0` (weekly, Sunday at 02:00). The install script prompts
-for all three; existing installs get them backfilled by `upgrade.sh` with these
+for all four; existing installs get them backfilled by `upgrade.sh` with these
 same defaults.
+
+`BACKUP_ENABLED` is the persisted record of whether the service should run at
+all — `--scale db-backup=0` only suppresses it for a single `up` invocation,
+so `upgrade.sh` reads `BACKUP_ENABLED` back on every upgrade to decide whether
+to re-apply that scale flag automatically, rather than guessing from
+`DATABASE_URL` alone. Set it (not just the scale flag) if you want a "no" to
+backups during install to stay a "no" on every future upgrade.
 
 Scheduling is handled by `crond` inside the container, which blocks until the
 next due minute rather than polling, and the container is capped at 0.5 CPU /
@@ -262,6 +270,10 @@ Disable automated backups (e.g. if a managed database already handles this):
 ```bash
 docker compose --env-file .env up -d --scale db-backup=0
 ```
+
+To keep it disabled across future `upgrade.sh` runs as well, also set
+`BACKUP_ENABLED=false` in `.env` — otherwise `upgrade.sh` has no record of the
+choice and may re-enable it on the next upgrade.
 
 ## Development Compose
 
@@ -323,7 +335,7 @@ and re-run the script:
 
 ```bash
 docker compose -f deploy/docker-compose.dev.yml exec db-backup \
-  touch -d '10 days ago' /backups/paca-fake.sql.gz
+  sh -c 'touch -t "$(date -d "@$(($(date +%s)-10*86400))" +%Y%m%d%H%M)" /backups/paca-fake.sql.gz'
 docker compose -f deploy/docker-compose.dev.yml exec db-backup run-backup.sh
 ls deploy/backups/   # paca-fake.sql.gz should be gone
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -304,6 +304,44 @@ and use Docker Compose only for PostgreSQL and Valkey.
 | MinIO S3 API | 9000 | Local object store (S3-compatible) |
 | MinIO Console | 9001 | MinIO web UI (credentials: `minioadmin` / `minioadmin`) |
 
+### Database backups (dev)
+
+`docker-compose.dev.yml` includes the same `db-backup` service as production
+(see [Database backups](#database-backups) above), pointed at the local
+`postgres` container by default. It starts automatically with the rest of the
+stack and writes dumps to `deploy/backups/`.
+
+To test it without waiting for the cron schedule, trigger a dump on demand:
+
+```bash
+docker compose -f deploy/docker-compose.dev.yml exec db-backup run-backup.sh
+ls deploy/backups/
+```
+
+To test retention pruning, backdate a dummy file past the retention window
+and re-run the script:
+
+```bash
+docker compose -f deploy/docker-compose.dev.yml exec db-backup \
+  touch -d '10 days ago' /backups/paca-fake.sql.gz
+docker compose -f deploy/docker-compose.dev.yml exec db-backup run-backup.sh
+ls deploy/backups/   # paca-fake.sql.gz should be gone
+```
+
+To watch the cron schedule itself fire, override `BACKUP_CRON` in
+`deploy/.env.dev` (e.g. `*/2 * * * *` for every 2 minutes) and tail the logs:
+
+```bash
+docker compose --env-file deploy/.env.dev -f deploy/docker-compose.dev.yml up -d db-backup
+docker compose -f deploy/docker-compose.dev.yml logs -f db-backup
+```
+
+Restore a dump into the local dev database:
+
+```bash
+gunzip -c deploy/backups/paca-<timestamp>.sql.gz | docker compose -f deploy/docker-compose.dev.yml exec -T postgres psql -U paca -d paca
+```
+
 Stop the development stack:
 
 ```bash

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -41,7 +41,7 @@ services:
   # To test retention pruning, backdate a dump's mtime past the retention
   # window and re-run the script above:
   #   docker compose -f deploy/docker-compose.dev.yml exec db-backup \
-  #     touch -d '10 days ago' /backups/paca-fake.sql.gz
+  #     sh -c 'touch -t "$(date -d "@$(($(date +%s)-10*86400))" +%Y%m%d%H%M)" /backups/paca-fake.sql.gz'
   db-backup:
     image: postgres:16-alpine
     environment:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -29,6 +29,73 @@ services:
       timeout: 5s
       retries: 10
 
+  # ── Database backups ─────────────────────────────────────────────────────────
+  # Dev mirror of the db-backup service in docker-compose.prod.yml — same
+  # entrypoint script and cron mechanism, pointed at the local postgres
+  # container by default. Writes to BACKUP_DIR on the schedule given by
+  # BACKUP_CRON, pruning dumps older than BACKUP_RETENTION_DAYS.
+  #
+  # To test without waiting for the cron schedule, run the backup on demand:
+  #   docker compose -f deploy/docker-compose.dev.yml exec db-backup run-backup.sh
+  #
+  # To test retention pruning, backdate a dump's mtime past the retention
+  # window and re-run the script above:
+  #   docker compose -f deploy/docker-compose.dev.yml exec db-backup \
+  #     touch -d '10 days ago' /backups/paca-fake.sql.gz
+  db-backup:
+    image: postgres:16-alpine
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgres://paca:paca@postgres:5432/paca?sslmode=disable}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-7}
+      # Standard 5-field cron syntax: minute hour day-of-month month day-of-week.
+      # Default: 02:00 daily. Override in .env.dev with something like
+      # "*/2 * * * *" to watch it fire every 2 minutes while testing.
+      BACKUP_CRON: ${BACKUP_CRON:-0 2 * * *}
+      TZ: ${TZ:-UTC}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        if [ "$$(echo "$$BACKUP_CRON" | wc -w)" -ne 5 ]; then
+          echo "Invalid BACKUP_CRON '$$BACKUP_CRON': expected 5 fields (minute hour day month weekday)" >&2
+          exit 1
+        fi
+
+        cat > /etc/backup.env <<EOF
+        DATABASE_URL="$$DATABASE_URL"
+        BACKUP_RETENTION_DAYS="$$BACKUP_RETENTION_DAYS"
+        EOF
+
+        cat > /usr/local/bin/run-backup.sh <<'EOS'
+        #!/bin/sh
+        set -e -o pipefail
+        . /etc/backup.env
+        ts="$$(date +%Y%m%d-%H%M%S)"
+        tmp="/backups/.paca-$${ts}.sql.gz.tmp"
+        out="/backups/paca-$${ts}.sql.gz"
+        if pg_dump "$$DATABASE_URL" --no-owner | gzip > "$$tmp"; then
+          mv "$$tmp" "$$out"
+          echo "Backup written: $$out"
+          find /backups -maxdepth 1 -name 'paca-*.sql.gz' -mtime "+$${BACKUP_RETENTION_DAYS}" -delete
+        else
+          echo "Backup failed at $${ts}" >&2
+          rm -f "$$tmp"
+        fi
+        EOS
+        chmod +x /usr/local/bin/run-backup.sh
+
+        mkdir -p /var/spool/cron/crontabs
+        echo "$$BACKUP_CRON /usr/local/bin/run-backup.sh >>/proc/1/fd/1 2>>/proc/1/fd/2" > /var/spool/cron/crontabs/root
+
+        echo "Database backup service started — schedule: $$BACKUP_CRON $$TZ (retention: $$BACKUP_RETENTION_DAYS days)."
+        exec crond -f -d 8
+    volumes:
+      - ${BACKUP_DIR:-./backups}:/backups
+    depends_on:
+      postgres:
+        condition: service_healthy
+        required: false
+
   valkey:
     image: valkey/valkey:8-alpine
     ports:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -66,6 +66,76 @@ services:
       timeout: 5s
       retries: 10
 
+  # ── Database backups ─────────────────────────────────────────────────────────
+  # Writes a gzip-compressed pg_dump to BACKUP_DIR on the schedule given by
+  # BACKUP_CRON (standard 5-field cron syntax), deleting dumps older than
+  # BACKUP_RETENTION_DAYS. Works against the bundled postgres container above
+  # or an external DATABASE_URL. Suppress with --scale db-backup=0.
+  # Scheduling is delegated to crond, which blocks until the next due minute
+  # (no polling loop), and the container is capped under resources.limits — so
+  # it stays near-idle on CPU/memory except for the brief daily dump window.
+  # Restore: gunzip -c <file>.sql.gz | docker compose exec -T postgres psql -U ${POSTGRES_USER:-paca} -d ${POSTGRES_DB:-paca}
+  db-backup:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-paca}:${POSTGRES_PASSWORD:-changeme}@postgres:5432/${POSTGRES_DB:-paca}?sslmode=disable}
+      BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-7}
+      # Standard 5-field cron syntax: minute hour day-of-month month day-of-week.
+      # Interpreted in TZ below (UTC by default). Default: 02:00 daily.
+      BACKUP_CRON: ${BACKUP_CRON:-0 2 * * *}
+      TZ: ${TZ:-UTC}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        if [ "$$(echo "$$BACKUP_CRON" | wc -w)" -ne 5 ]; then
+          echo "Invalid BACKUP_CRON '$$BACKUP_CRON': expected 5 fields (minute hour day month weekday)" >&2
+          exit 1
+        fi
+
+        # Cron jobs run with a minimal environment, so persist what the backup
+        # script needs and have it source this file explicitly.
+        cat > /etc/backup.env <<EOF
+        DATABASE_URL="$$DATABASE_URL"
+        BACKUP_RETENTION_DAYS="$$BACKUP_RETENTION_DAYS"
+        EOF
+
+        cat > /usr/local/bin/run-backup.sh <<'EOS'
+        #!/bin/sh
+        set -e -o pipefail
+        . /etc/backup.env
+        ts="$$(date +%Y%m%d-%H%M%S)"
+        tmp="/backups/.paca-$${ts}.sql.gz.tmp"
+        out="/backups/paca-$${ts}.sql.gz"
+        if pg_dump "$$DATABASE_URL" --no-owner | gzip > "$$tmp"; then
+          mv "$$tmp" "$$out"
+          echo "Backup written: $$out"
+          find /backups -maxdepth 1 -name 'paca-*.sql.gz' -mtime "+$${BACKUP_RETENTION_DAYS}" -delete
+        else
+          echo "Backup failed at $${ts}" >&2
+          rm -f "$$tmp"
+        fi
+        EOS
+        chmod +x /usr/local/bin/run-backup.sh
+
+        mkdir -p /var/spool/cron/crontabs
+        echo "$$BACKUP_CRON /usr/local/bin/run-backup.sh >>/proc/1/fd/1 2>>/proc/1/fd/2" > /var/spool/cron/crontabs/root
+
+        echo "Database backup service started — schedule: $$BACKUP_CRON $$TZ (retention: $$BACKUP_RETENTION_DAYS days)."
+        exec crond -f -d 8
+    volumes:
+      - ${BACKUP_DIR:-./backups}:/backups
+    depends_on:
+      postgres:
+        condition: service_healthy
+        required: false
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 256M
+
   # ── Valkey (Redis-compatible cache / pub-sub) ────────────────────────────────
   valkey:
     image: valkey/valkey:8-alpine

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -315,12 +315,16 @@ fi
 heading "Database backups"
 
 SCALE_DB_BACKUP=""
+BACKUP_ENABLED="true"
 BACKUP_DIR="./backups"
 BACKUP_CRON="0 2 * * *"
 BACKUP_RETENTION_DAYS="7"
 
 # validate_cron VALUE
-# Mirrors the db-backup container's own check: exactly 5 whitespace-separated fields.
+# Checks the same field count the db-backup container enforces at startup
+# (exactly 5 whitespace-separated fields), plus a basic character check per
+# field to catch obviously invalid values (e.g. typos) before they're written
+# to .env and silently ignored by crond.
 validate_cron() {
     local v="$1"
     local -a fields
@@ -329,6 +333,13 @@ validate_cron() {
         error "Cron schedule must have exactly 5 fields (minute hour day month weekday)."
         return 1
     fi
+    local f
+    for f in "${fields[@]}"; do
+        if [[ ! "$f" =~ ^[0-9*,/-]+$ ]]; then
+            error "Invalid cron field '${f}' — only digits and * , - / are supported."
+            return 1
+        fi
+    done
     return 0
 }
 
@@ -336,6 +347,7 @@ if [[ -n "$SCALE_POSTGRES" ]]; then
     # db-backup runs pg_dump against the bundled container; an external/managed
     # database is assumed to already have its own backup mechanism.
     SCALE_DB_BACKUP="--scale db-backup=0"
+    BACKUP_ENABLED="false"
     info "Using an external database — skipping automated backups (its provider"
     info "likely already handles this). To have Paca back it up instead, set"
     info "BACKUP_DIR/BACKUP_CRON/BACKUP_RETENTION_DAYS in .env and start without"
@@ -350,6 +362,7 @@ else
 
     if [[ "$INCLUDE_BACKUPS" == "no" ]]; then
         SCALE_DB_BACKUP="--scale db-backup=0"
+        BACKUP_ENABLED="false"
         info "Automated backups will be skipped."
     else
         ask BACKUP_DIR "Directory to store backups in" "$BACKUP_DIR"
@@ -595,6 +608,10 @@ POSTGRES_PASSWORD=${POSTGRES_PASSWORD_VALUE}
 DATABASE_URL=${DATABASE_URL_OVERRIDE}
 
 # ── Database backups ─────────────────────────────────────────────────────────
+# BACKUP_ENABLED records your choice below so upgrade.sh can honor it later
+# instead of guessing — flip to false (and optionally --scale db-backup=0) to
+# turn backups off permanently.
+BACKUP_ENABLED=${BACKUP_ENABLED}
 BACKUP_DIR=${BACKUP_DIR}
 # Standard 5-field cron syntax, interpreted in UTC. Uncomment TZ below to change.
 BACKUP_CRON=${BACKUP_CRON}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -314,14 +314,6 @@ fi
 
 heading "Database backups"
 
-echo "  Writes a gzip-compressed database dump to a directory you choose, on a"
-echo "  cron schedule you set, pruning dumps past the retention period. Works"
-echo "  with the bundled PostgreSQL container or an external database."
-echo ""
-
-INCLUDE_BACKUPS="yes"
-yes_no INCLUDE_BACKUPS "Enable automated database backups?" "y"
-
 SCALE_DB_BACKUP=""
 BACKUP_DIR="./backups"
 BACKUP_CRON="0 2 * * *"
@@ -340,20 +332,37 @@ validate_cron() {
     return 0
 }
 
-if [[ "$INCLUDE_BACKUPS" == "no" ]]; then
+if [[ -n "$SCALE_POSTGRES" ]]; then
+    # db-backup runs pg_dump against the bundled container; an external/managed
+    # database is assumed to already have its own backup mechanism.
     SCALE_DB_BACKUP="--scale db-backup=0"
-    info "Automated backups will be skipped."
+    info "Using an external database — skipping automated backups (its provider"
+    info "likely already handles this). To have Paca back it up instead, set"
+    info "BACKUP_DIR/BACKUP_CRON/BACKUP_RETENTION_DAYS in .env and start without"
+    info "--scale db-backup=0."
 else
-    ask BACKUP_DIR "Directory to store backups in" "$BACKUP_DIR"
-    while true; do
-        ask BACKUP_CRON "Backup schedule (cron syntax, interpreted in UTC unless you set TZ in .env later)" "$BACKUP_CRON"
-        if validate_cron "$BACKUP_CRON"; then
-            break
-        fi
-    done
-    ask BACKUP_RETENTION_DAYS "Days of backups to keep" "$BACKUP_RETENTION_DAYS"
-    mkdir -p "$BACKUP_DIR"
-    info "Backups will run on '${BACKUP_CRON}' (UTC), written to ${BACKUP_DIR} (kept for ${BACKUP_RETENTION_DAYS} days)."
+    echo "  Writes a gzip-compressed database dump to a directory you choose, on a"
+    echo "  cron schedule you set, pruning dumps past the retention period."
+    echo ""
+
+    INCLUDE_BACKUPS="yes"
+    yes_no INCLUDE_BACKUPS "Enable automated database backups?" "y"
+
+    if [[ "$INCLUDE_BACKUPS" == "no" ]]; then
+        SCALE_DB_BACKUP="--scale db-backup=0"
+        info "Automated backups will be skipped."
+    else
+        ask BACKUP_DIR "Directory to store backups in" "$BACKUP_DIR"
+        while true; do
+            ask BACKUP_CRON "Backup schedule (cron syntax, interpreted in UTC unless you set TZ in .env later)" "$BACKUP_CRON"
+            if validate_cron "$BACKUP_CRON"; then
+                break
+            fi
+        done
+        ask BACKUP_RETENTION_DAYS "Days of backups to keep" "$BACKUP_RETENTION_DAYS"
+        mkdir -p "$BACKUP_DIR"
+        info "Backups will run on '${BACKUP_CRON}' (UTC), written to ${BACKUP_DIR} (kept for ${BACKUP_RETENTION_DAYS} days)."
+    fi
 fi
 
 # ── Object storage ────────────────────────────────────────────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -310,6 +310,52 @@ else
     info "A bundled PostgreSQL container will be started."
 fi
 
+# ── Database backups ──────────────────────────────────────────────────────────
+
+heading "Database backups"
+
+echo "  Writes a gzip-compressed database dump to a directory you choose, on a"
+echo "  cron schedule you set, pruning dumps past the retention period. Works"
+echo "  with the bundled PostgreSQL container or an external database."
+echo ""
+
+INCLUDE_BACKUPS="yes"
+yes_no INCLUDE_BACKUPS "Enable automated database backups?" "y"
+
+SCALE_DB_BACKUP=""
+BACKUP_DIR="./backups"
+BACKUP_CRON="0 2 * * *"
+BACKUP_RETENTION_DAYS="7"
+
+# validate_cron VALUE
+# Mirrors the db-backup container's own check: exactly 5 whitespace-separated fields.
+validate_cron() {
+    local v="$1"
+    local -a fields
+    read -ra fields <<< "$v"
+    if (( ${#fields[@]} != 5 )); then
+        error "Cron schedule must have exactly 5 fields (minute hour day month weekday)."
+        return 1
+    fi
+    return 0
+}
+
+if [[ "$INCLUDE_BACKUPS" == "no" ]]; then
+    SCALE_DB_BACKUP="--scale db-backup=0"
+    info "Automated backups will be skipped."
+else
+    ask BACKUP_DIR "Directory to store backups in" "$BACKUP_DIR"
+    while true; do
+        ask BACKUP_CRON "Backup schedule (cron syntax, interpreted in UTC unless you set TZ in .env later)" "$BACKUP_CRON"
+        if validate_cron "$BACKUP_CRON"; then
+            break
+        fi
+    done
+    ask BACKUP_RETENTION_DAYS "Days of backups to keep" "$BACKUP_RETENTION_DAYS"
+    mkdir -p "$BACKUP_DIR"
+    info "Backups will run on '${BACKUP_CRON}' (UTC), written to ${BACKUP_DIR} (kept for ${BACKUP_RETENTION_DAYS} days)."
+fi
+
 # ── Object storage ────────────────────────────────────────────────────────────
 
 heading "Object storage"
@@ -539,6 +585,13 @@ POSTGRES_PASSWORD=${POSTGRES_PASSWORD_VALUE}
 # Override: leave blank to use the bundled postgres container above.
 DATABASE_URL=${DATABASE_URL_OVERRIDE}
 
+# ── Database backups ─────────────────────────────────────────────────────────
+BACKUP_DIR=${BACKUP_DIR}
+# Standard 5-field cron syntax, interpreted in UTC. Uncomment TZ below to change.
+BACKUP_CRON=${BACKUP_CRON}
+BACKUP_RETENTION_DAYS=${BACKUP_RETENTION_DAYS}
+# TZ=America/New_York
+
 # ── Cache (Valkey) ────────────────────────────────────────────────────────────
 # Leave blank to use the bundled Valkey container.
 REDIS_URL=
@@ -583,6 +636,7 @@ echo -e "  ${BOLD}Version     ${RESET}${PACA_VERSION}"
 echo -e "  ${BOLD}Public URL  ${RESET}${PUBLIC_URL}"
 echo -e "  ${BOLD}HTTPS       ${RESET}$( [[ "$USE_HTTPS" == "yes" ]] && echo "Enabled (${SITE_ADDRESS})" || echo "Disabled (plain HTTP)" )"
 echo -e "  ${BOLD}Database    ${RESET}$( [[ -n "$SCALE_POSTGRES" ]] && echo "External PostgreSQL" || echo "Bundled PostgreSQL container" )"
+echo -e "  ${BOLD}Backups     ${RESET}$( [[ -n "$SCALE_DB_BACKUP" ]] && echo "Disabled" || echo "'${BACKUP_CRON}' UTC → ${BACKUP_DIR} (kept ${BACKUP_RETENTION_DAYS}d)" )"
 echo -e "  ${BOLD}Storage     ${RESET}$( [[ "$STORAGE_PROVIDER" == "s3" ]] && echo "AWS S3 (${STORAGE_BUCKET})" || echo "Self-hosted MinIO" )"
 echo -e "  ${BOLD}Web app     ${RESET}$( [[ -n "$SCALE_WEB" ]] && echo "External / CDN (container skipped)" || echo "Bundled container" )"
 echo -e "  ${BOLD}AI Agent    ${RESET}$( [[ -n "$SCALE_AI_AGENT" ]] && echo "Disabled" || echo "Enabled" )"
@@ -597,7 +651,7 @@ if [[ "$START" != "yes" ]]; then
     warn "Installation files are ready. Start Paca manually with:"
     echo ""
     bold "  cd $(pwd)"
-    bold "  ${COMPOSE_CMD} --env-file .env up -d ${SCALE_POSTGRES} ${SCALE_MINIO} ${SCALE_WEB} ${SCALE_AI_AGENT} --pull always"
+    bold "  ${COMPOSE_CMD} --env-file .env up -d ${SCALE_POSTGRES} ${SCALE_DB_BACKUP} ${SCALE_MINIO} ${SCALE_WEB} ${SCALE_AI_AGENT} --pull always"
     echo ""
     exit 0
 fi
@@ -608,6 +662,7 @@ heading "Starting Paca"
 
 SCALE_OPTS=()
 [[ -n "$SCALE_POSTGRES"  ]] && SCALE_OPTS+=($SCALE_POSTGRES)
+[[ -n "$SCALE_DB_BACKUP" ]] && SCALE_OPTS+=($SCALE_DB_BACKUP)
 [[ -n "$SCALE_MINIO"     ]] && SCALE_OPTS+=($SCALE_MINIO)
 [[ -n "$SCALE_WEB"       ]] && SCALE_OPTS+=($SCALE_WEB)
 [[ -n "$SCALE_AI_AGENT"  ]] && SCALE_OPTS+=($SCALE_AI_AGENT)

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -278,25 +278,35 @@ fi
 
 # Backfill variables for the db-backup service introduced after this install
 # was created. Installations from before that release have neither in .env.
-if ! has_env_var .env BACKUP_DIR; then
-    backup_env_once
-    set_env_var .env BACKUP_DIR "./backups"
-    info "Added BACKUP_DIR=./backups to .env."
+# Only relevant for the bundled postgres container — a non-blank DATABASE_URL
+# means an external/managed database is in use, which is assumed to already
+# have its own backup mechanism (mirrors the bundled-vs-external check in
+# install.sh).
+SCALE_OPTS=()
+if [[ -z "$(get_env_var .env DATABASE_URL)" ]]; then
+    if ! has_env_var .env BACKUP_DIR; then
+        backup_env_once
+        set_env_var .env BACKUP_DIR "./backups"
+        info "Added BACKUP_DIR=./backups to .env."
+    fi
+    if ! has_env_var .env BACKUP_RETENTION_DAYS; then
+        backup_env_once
+        set_env_var .env BACKUP_RETENTION_DAYS "7"
+        info "Added BACKUP_RETENTION_DAYS=7 to .env."
+    fi
+    if ! has_env_var .env BACKUP_CRON; then
+        backup_env_once
+        set_env_var .env BACKUP_CRON "0 2 * * *"
+        info "Added BACKUP_CRON=0 2 * * * to .env (runs daily at 02:00 UTC)."
+    fi
+    _BACKUP_DIR="$(get_env_var .env BACKUP_DIR)"
+    _BACKUP_DIR="${_BACKUP_DIR:-./backups}"
+    mkdir -p "$_BACKUP_DIR"
+    warn "A new db-backup service now writes a daily database dump to ${_BACKUP_DIR}. Disable with --scale db-backup=0 if you already back up this database elsewhere."
+else
+    SCALE_OPTS+=(--scale db-backup=0)
+    info "Using an external database (DATABASE_URL is set) — skipping the automated db-backup service."
 fi
-if ! has_env_var .env BACKUP_RETENTION_DAYS; then
-    backup_env_once
-    set_env_var .env BACKUP_RETENTION_DAYS "7"
-    info "Added BACKUP_RETENTION_DAYS=7 to .env."
-fi
-if ! has_env_var .env BACKUP_CRON; then
-    backup_env_once
-    set_env_var .env BACKUP_CRON "0 2 * * *"
-    info "Added BACKUP_CRON=0 2 * * * to .env (runs daily at 02:00 UTC)."
-fi
-_BACKUP_DIR="$(get_env_var .env BACKUP_DIR)"
-_BACKUP_DIR="${_BACKUP_DIR:-./backups}"
-mkdir -p "$_BACKUP_DIR"
-warn "A new db-backup service now writes a daily database dump to ${_BACKUP_DIR}. Disable with --scale db-backup=0 if you already back up this database elsewhere."
 
 # ── Pull and restart ──────────────────────────────────────────────────────────
 
@@ -305,7 +315,7 @@ heading "Pulling images and restarting"
 # shellcheck disable=SC2086
 $COMPOSE_CMD --env-file .env pull
 # shellcheck disable=SC2086
-$COMPOSE_CMD --env-file .env up -d --remove-orphans "$@"
+$COMPOSE_CMD --env-file .env up -d --remove-orphans ${SCALE_OPTS[@]+"${SCALE_OPTS[@]}"} "$@"
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -276,6 +276,28 @@ if [[ "$GATEWAY_VARS_ADDED" == "1" ]]; then
     info "Already behind another TLS terminator (a load balancer, Cloudflare, etc.)? Set SITE_ADDRESS=:80 in .env to keep this gateway on plain HTTP."
 fi
 
+# Backfill variables for the db-backup service introduced after this install
+# was created. Installations from before that release have neither in .env.
+if ! has_env_var .env BACKUP_DIR; then
+    backup_env_once
+    set_env_var .env BACKUP_DIR "./backups"
+    info "Added BACKUP_DIR=./backups to .env."
+fi
+if ! has_env_var .env BACKUP_RETENTION_DAYS; then
+    backup_env_once
+    set_env_var .env BACKUP_RETENTION_DAYS "7"
+    info "Added BACKUP_RETENTION_DAYS=7 to .env."
+fi
+if ! has_env_var .env BACKUP_CRON; then
+    backup_env_once
+    set_env_var .env BACKUP_CRON "0 2 * * *"
+    info "Added BACKUP_CRON=0 2 * * * to .env (runs daily at 02:00 UTC)."
+fi
+_BACKUP_DIR="$(get_env_var .env BACKUP_DIR)"
+_BACKUP_DIR="${_BACKUP_DIR:-./backups}"
+mkdir -p "$_BACKUP_DIR"
+warn "A new db-backup service now writes a daily database dump to ${_BACKUP_DIR}. Disable with --scale db-backup=0 if you already back up this database elsewhere."
+
 # ── Pull and restart ──────────────────────────────────────────────────────────
 
 heading "Pulling images and restarting"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -277,33 +277,44 @@ if [[ "$GATEWAY_VARS_ADDED" == "1" ]]; then
 fi
 
 # Backfill variables for the db-backup service introduced after this install
-# was created. Installations from before that release have neither in .env.
-# Only relevant for the bundled postgres container — a non-blank DATABASE_URL
-# means an external/managed database is in use, which is assumed to already
-# have its own backup mechanism (mirrors the bundled-vs-external check in
-# install.sh).
+# was created. Installations from before that release have none of these in
+# .env.
+#
+# BACKUP_ENABLED is the source of truth when present: it records the explicit
+# choice made in install.sh (including "no, don't back up this bundled
+# database"), so an upgrade must never override it. Only when it's entirely
+# absent — an install that predates BACKUP_ENABLED itself — do we fall back to
+# deriving a default from DATABASE_URL, mirroring the bundled-vs-external
+# check in install.sh, and then record that derived choice so future upgrades
+# read it back instead of re-deriving it.
 SCALE_OPTS=()
-if [[ -z "$(get_env_var .env DATABASE_URL)" ]]; then
+if has_env_var .env BACKUP_ENABLED; then
+    if [[ "$(get_env_var .env BACKUP_ENABLED)" == "false" ]]; then
+        SCALE_OPTS+=(--scale db-backup=0)
+        info "Database backups are disabled (BACKUP_ENABLED=false in .env) — skipping the db-backup service."
+    fi
+elif [[ -z "$(get_env_var .env DATABASE_URL)" ]]; then
+    backup_env_once
+    set_env_var .env BACKUP_ENABLED "true"
     if ! has_env_var .env BACKUP_DIR; then
-        backup_env_once
         set_env_var .env BACKUP_DIR "./backups"
         info "Added BACKUP_DIR=./backups to .env."
     fi
     if ! has_env_var .env BACKUP_RETENTION_DAYS; then
-        backup_env_once
         set_env_var .env BACKUP_RETENTION_DAYS "7"
         info "Added BACKUP_RETENTION_DAYS=7 to .env."
     fi
     if ! has_env_var .env BACKUP_CRON; then
-        backup_env_once
         set_env_var .env BACKUP_CRON "0 2 * * *"
         info "Added BACKUP_CRON=0 2 * * * to .env (runs daily at 02:00 UTC)."
     fi
     _BACKUP_DIR="$(get_env_var .env BACKUP_DIR)"
     _BACKUP_DIR="${_BACKUP_DIR:-./backups}"
     mkdir -p "$_BACKUP_DIR"
-    warn "A new db-backup service now writes a daily database dump to ${_BACKUP_DIR}. Disable with --scale db-backup=0 if you already back up this database elsewhere."
+    warn "A new db-backup service now writes a daily database dump to ${_BACKUP_DIR}. Disable with --scale db-backup=0 if you already back up this database elsewhere, or set BACKUP_ENABLED=false in .env to keep it off on future upgrades."
 else
+    backup_env_once
+    set_env_var .env BACKUP_ENABLED "false"
     SCALE_OPTS+=(--scale db-backup=0)
     info "Using an external database (DATABASE_URL is set) — skipping the automated db-backup service."
 fi


### PR DESCRIPTION
## Summary

Adds automated, scheduled PostgreSQL backups to the deploy stack.

- **`db-backup` service** (`docker-compose.dev.yml`, `docker-compose.prod.yml`) — a `postgres:16-alpine` container that runs a gzip-compressed `pg_dump` on a cron schedule (`BACKUP_CRON`, standard 5-field syntax) via `crond`, pruning dumps older than `BACKUP_RETENTION_DAYS` from `BACKUP_DIR`. Works against the bundled `postgres` container or an external `DATABASE_URL`. Prod caps it at 0.5 CPU / 256MB; either compose file can skip it with `--scale db-backup=0`.
- **`install.sh`** — new "Database backups" prompt: enable/disable, backup directory, cron schedule (validated to 5 fields), retention days. Skipped automatically (backups disabled) when an external database is configured, since a managed database is assumed to already have its own backup story.
- **`upgrade.sh`** — backfills `BACKUP_DIR`/`BACKUP_CRON`/`BACKUP_RETENTION_DAYS` into `.env` for installs created before this change, and applies the same external-database skip logic so existing installs pointed at `DATABASE_URL` don't unexpectedly start dumping a database they don't own.
- **Docs** (`deploy/README.md`, `.env.production.example`, `.env.dev.example`) — configuration reference, restore commands for both the bundled-postgres and external-`DATABASE_URL` cases, and dev-only instructions for triggering a backup on demand, testing retention pruning, and watching the cron schedule fire.
- **`ROADMAP.md`** — checks off "Backup and restore tooling for PostgreSQL data".
- **`.gitignore`** — ignores the dev stack's local dump directory (`deploy/backups/`).

## Test plan

- [x] CI: build, lint, unit tests, and CodeQL analysis pass
- [x] `docker compose -f deploy/docker-compose.dev.yml up -d` starts `db-backup` alongside the rest of the dev stack
- [x] On-demand trigger: `docker compose -f deploy/docker-compose.dev.yml exec db-backup run-backup.sh` writes a `.sql.gz` dump to `deploy/backups/`
- [x] Retention pruning: backdating a dump past `BACKUP_RETENTION_DAYS` and re-running `run-backup.sh` deletes it
- [x] Cron firing: overriding `BACKUP_CRON` (e.g. every 2 minutes) and tailing logs shows the schedule firing on its own
- [x] Restore: `gunzip -c <dump> | docker compose exec -T postgres psql -U paca -d paca` round-trips a dump back into Postgres
- [x] `install.sh` interactive flow (backup prompts, cron validation, external-DB skip path)
- [x] `upgrade.sh` run against a pre-migration install correctly backfills `BACKUP_DIR`/`BACKUP_CRON`/`BACKUP_RETENTION_DAYS`