### PR TITLE
fix: avoid litellm provider-name collision for custom OpenAI-compatib…

### DIFF
--- a/services/ai-agent/src/agent/builder.py
+++ b/services/ai-agent/src/agent/builder.py
@@ -8,6 +8,7 @@ from openhands.sdk import LLM
 from openhands.sdk.context import KeywordTrigger, Skill
 from pydantic import SecretStr
 
+from .. import llm_catalog
 from ..config import settings
 from ..models.agent import AgentConfig, AgentMCPServerRow, AgentSkillRow
 
@@ -16,14 +17,16 @@ logger = logging.getLogger(__name__)
 
 def build_llm(agent_config: AgentConfig) -> LLM:
     """Construct an OpenHands SDK LLM instance from agent configuration."""
-    import litellm  # noqa: PLC0415
-
     provider = agent_config.llm_provider
     llm_base_url = agent_config.llm_base_url or None
 
-    # For providers not natively known to LiteLLM, route through the OpenAI-compatible
-    # client by prefixing with "openai/" — LiteLLM uses base_url to reach the endpoint.
-    if llm_base_url and provider not in litellm.provider_list:
+    # For providers outside our own catalog (freeform "Custom…" entries), route
+    # through the OpenAI-compatible client by prefixing with "openai/". Checking
+    # against our catalog rather than litellm.provider_list matters: litellm
+    # reserves names like "custom"/"vllm"/"huggingface" for its own non-chat,
+    # non-OpenAI-compatible handlers, and a user typing one of those by
+    # coincidence would otherwise get silently misrouted into them.
+    if llm_base_url and provider not in llm_catalog.load():
         model_str = (
             agent_config.llm_model
             if agent_config.llm_model.startswith("openai/")

--- a/services/ai-agent/src/llm_catalog.py
+++ b/services/ai-agent/src/llm_catalog.py
@@ -1,0 +1,28 @@
+"""Loads the pre-generated LLM provider/model catalog (data/llm_models.json).
+
+Shared by the `/llm/models` route (frontend provider dropdown) and
+`agent.builder.build_llm` (decides whether a provider needs OpenAI-compatible
+passthrough routing). Both must agree on what counts as a "known" provider.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_DATA_FILE = Path(__file__).parent.parent / "data" / "llm_models.json"
+
+# Loaded once on first request, then cached for the lifetime of the process.
+_cache: dict | None = None
+
+
+def load() -> dict:
+    global _cache
+    if _cache is None:
+        if not _DATA_FILE.exists():
+            raise FileNotFoundError(
+                f"Model list not found at {_DATA_FILE}. "
+                "Run scripts/generate_llm_models.py to generate it."
+            )
+        _cache = json.loads(_DATA_FILE.read_text())
+    return _cache

--- a/services/ai-agent/src/routes/llm.py
+++ b/services/ai-agent/src/routes/llm.py
@@ -2,29 +2,11 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 from fastapi import APIRouter, HTTPException
 
+from .. import llm_catalog
+
 router = APIRouter(prefix="/llm")
-
-_DATA_FILE = Path(__file__).parent.parent.parent / "data" / "llm_models.json"
-
-# Loaded once on first request, then cached for the lifetime of the process.
-_cache: dict | None = None
-
-
-def _load() -> dict:
-    global _cache
-    if _cache is None:
-        if not _DATA_FILE.exists():
-            raise FileNotFoundError(
-                f"Model list not found at {_DATA_FILE}. "
-                "Run scripts/generate_llm_models.py to generate it."
-            )
-        _cache = json.loads(_DATA_FILE.read_text())
-    return _cache
 
 
 @router.get("/models")
@@ -35,6 +17,6 @@ async def list_llm_models() -> dict[str, dict]:
     the service (or simply redeploying the updated data/llm_models.json).
     """
     try:
-        return _load()
+        return llm_catalog.load()
     except FileNotFoundError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/services/ai-agent/tests/test_builder.py
+++ b/services/ai-agent/tests/test_builder.py
@@ -4,11 +4,40 @@ from unittest.mock import patch
 
 import pytest
 
-from src.agent.builder import build_mcp_config, build_skills
-from src.models.agent import AgentMCPServerRow, AgentSkillRow
-
+from src.agent.builder import build_llm, build_mcp_config, build_skills
+from src.models.agent import AgentConfig, AgentMCPServerRow, AgentSkillRow
 
 # ─── Fixtures / helpers ───────────────────────────────────────────────────────
+
+
+def _agent_config(
+    provider: str = "anthropic",
+    model: str = "claude-sonnet-4-6",
+    base_url: str = "",
+) -> AgentConfig:
+    return AgentConfig(
+        agent_id="agent-1",
+        project_id="proj-1",
+        system_prompt=None,
+        task_trigger_prompt="",
+        doc_comment_trigger_prompt="",
+        chat_trigger_prompt="",
+        description_write_trigger_prompt="",
+        llm_provider=provider,
+        llm_model=model,
+        llm_api_key_secret_ref="secret-ref",
+        llm_base_url=base_url,
+        max_iterations=10,
+        can_clone_repos=False,
+    )
+
+
+@pytest.fixture
+def catalog():
+    """Stub Paca's known-provider catalog so tests don't depend on data/llm_models.json."""
+    with patch("src.agent.builder.llm_catalog.load") as m:
+        m.return_value = {"anthropic": {}, "openai": {}}
+        yield m
 
 
 def _skill(
@@ -60,6 +89,63 @@ def with_paca_key():
         m.gateway_base_url = "http://gateway"
         m.dev_mcp_path = ""
         yield m
+
+
+# ─── build_llm ────────────────────────────────────────────────────────────────
+
+
+def test_known_provider_with_base_url_uses_native_routing(catalog):
+    config = _agent_config(
+        provider="anthropic", model="claude-sonnet-4-6", base_url="https://api.anthropic.com"
+    )
+    llm = build_llm(config)
+    assert llm.model == "anthropic/claude-sonnet-4-6"
+
+
+def test_custom_literal_provider_does_not_collide_with_litellm_builtin(catalog):
+    # Regression test for #221: litellm has its own built-in "custom" provider
+    # with an incompatible non-chat wire format. A user typing "custom" into the
+    # freeform provider field (the obvious choice for "a custom provider") must
+    # still get routed through the OpenAI-compatible passthrough, not litellm's
+    # native "custom" handler.
+    config = _agent_config(
+        provider="custom", model="llama-3.1-70b", base_url="http://self-hosted:8000/v1"
+    )
+    llm = build_llm(config)
+    assert llm.model == "openai/llama-3.1-70b"
+
+
+def test_unknown_freeform_provider_routes_through_openai_passthrough(catalog):
+    config = _agent_config(
+        provider="my-vllm-box", model="mixtral", base_url="http://10.0.0.5:8000/v1"
+    )
+    llm = build_llm(config)
+    assert llm.model == "openai/mixtral"
+
+
+def test_model_already_openai_prefixed_is_not_double_prefixed(catalog):
+    config = _agent_config(
+        provider="custom",
+        model="openai/already-prefixed",
+        base_url="http://self-hosted:8000/v1",
+    )
+    llm = build_llm(config)
+    assert llm.model == "openai/already-prefixed"
+
+
+def test_no_base_url_uses_raw_provider_string(catalog):
+    config = _agent_config(provider="custom", model="some-model", base_url="")
+    llm = build_llm(config)
+    assert llm.model == "custom/some-model"
+
+
+def test_llm_uses_configured_base_url_and_stream(catalog):
+    config = _agent_config(
+        provider="custom", model="some-model", base_url="http://self-hosted:8000/v1"
+    )
+    llm = build_llm(config)
+    assert llm.base_url == "http://self-hosted:8000/v1"
+    assert llm.stream is True
 
 
 # ─── build_skills ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Agents configured with a freeform/self-hosted LLM provider name crashed on every real invocation with:

```
litellm.APIConnectionError: sequence item 0: expected str instance, list found
```

Reported in #221, but the upstream-litellm `default_pt()` theory in that issue doesn't hold up — I reproduced the call path locally and the `openai/<model>` passthrough handles multi-block message content fine.

## Root cause

`build_llm()` decided whether to route a provider through the OpenAI-compatible passthrough by checking `provider not in litellm.provider_list`. That list is litellm's *internal* provider registry, which reserves generic-sounding names — `custom`, `vllm`, `huggingface`, `petals`, etc. — for its own non-chat, non-OpenAI-compatible handlers.

A user setting up a self-hosted endpoint naturally types `"custom"` into Paca's freeform "Custom…" provider field. Since `"custom"` is already a registered litellm provider, `build_llm()` skipped the OpenAI passthrough and built `model_str = "custom/<model>"`. litellm's native `custom` handler then does:

```python
prompt = " ".join([message["content"] for message in messages])
```

which throws exactly the reported `TypeError` once any message has multi-block `content` (the normal shape once there's a system prompt + skills).

## Fix

Route based on Paca's own provider catalog (`data/llm_models.json`, the same list backing the frontend provider dropdown) instead of litellm's internal `provider_list`. Any provider name outside that catalog — regardless of whether it happens to collide with a litellm-reserved name — now always gets the OpenAI-compatible passthrough.

- Extracted the catalog loader into `src/llm_catalog.py`, shared by `routes/llm.py` and `agent/builder.py` so both agree on what counts as "known."
- Added regression tests for `build_llm()` (previously untested), including the exact `"custom"` collision from #221.

Fixes #221

## Test plan

- [x] `pytest` — 85 passed, 3 skipped (unrelated e2e)
- [x] `ruff check` clean
- [x] Reproduced the original crash locally with `litellm.completion(model="custom/...", ...)` and confirmed the fix routes it through `openai/...` instead