### PR TITLE
feat: implement plugin event consumer to dispatch activity events to …

### DIFF
--- a/scripts/install-local-plugin.sh
+++ b/scripts/install-local-plugin.sh
@@ -359,7 +359,7 @@ if [[ "$SKIP_INSTALL" = false ]]; then
         MANIFEST=$(cat "$PLUGIN_DIR/plugin.json")
         
         # Install the plugin
-        INSTALL_RESPONSE=$(curl -s -X POST "${API_ENDPOINT}/plugins" \
+        INSTALL_RESPONSE=$(curl -s -X POST "${API_ENDPOINT}/admin/plugins" \
             -H "${AUTH_HEADER}" \
             -H "Content-Type: application/json" \
             -d "{\"name\":\"${PLUGIN_ID}\",\"version\":\"${PLUGIN_VERSION}\",\"manifest\":${MANIFEST},\"enabled\":true}" \

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -60,6 +60,7 @@ type App struct {
 	activityConsumer     *worker.ActivityConsumer
 	docActivityConsumer  *worker.DocActivityConsumer
 	notificationConsumer *worker.NotificationConsumer
+	pluginEventConsumer  *worker.PluginEventConsumer
 	log                  *slog.Logger
 }
 
@@ -242,6 +243,13 @@ func New(cfg *config.Config) (*App, error) {
 		log.Error("plugin: some plugins failed to load", "error", err)
 	}
 
+	// Forward every recorded activity (task created/updated/deleted, comments,
+	// links, etc.) to subscribed plugins. ActivitySvc appends to the
+	// StreamPluginEvents Valkey stream; this consumer reads it back and
+	// dispatches to the plugin runtime — the API never calls into the plugin
+	// runtime directly when recording an activity.
+	pluginEventConsumer := worker.NewPluginEventConsumer(redisClient, pluginRuntime, log)
+
 	pluginHandler := handler.NewPluginHandler(pluginService, pluginRuntime, projectRepo).
 		WithRouteAuth(tokenManager, apiKeyService, authorizer).
 		WithMarketplace(marketplaceClient, pluginInstaller, pluginMigrationRunner)
@@ -296,7 +304,7 @@ func New(cfg *config.Config) (*App, error) {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	return &App{server: srv, publisher: publisher, activityConsumer: activityConsumer, docActivityConsumer: docActivityConsumer, notificationConsumer: notificationConsumer, log: log}, nil
+	return &App{server: srv, publisher: publisher, activityConsumer: activityConsumer, docActivityConsumer: docActivityConsumer, notificationConsumer: notificationConsumer, pluginEventConsumer: pluginEventConsumer, log: log}, nil
 }
 
 // Run starts the activity consumers and the HTTP server.
@@ -306,6 +314,7 @@ func (a *App) Run() error {
 	a.activityConsumer.Start(context.Background())
 	a.docActivityConsumer.Start(context.Background())
 	a.notificationConsumer.Start(context.Background())
+	a.pluginEventConsumer.Start(context.Background())
 	return a.server.ListenAndServe()
 }
 
@@ -315,6 +324,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	a.activityConsumer.Stop()
 	a.docActivityConsumer.Stop()
 	a.notificationConsumer.Stop()
+	a.pluginEventConsumer.Stop()
 	if a.publisher != nil {
 		a.publisher.Close()
 	}

--- a/services/api/internal/domain/plugin/entity.go
+++ b/services/api/internal/domain/plugin/entity.go
@@ -64,8 +64,10 @@ type BackendManifest struct {
 	// EventSubscriptions lists the event topics the plugin subscribes to.
 	EventSubscriptions []string `json:"eventSubscriptions,omitempty"`
 	// AllowedOutboundDomains is the list of hostnames the plugin is permitted to
-	// contact via paca.fetch. Matching is exact, case-insensitive hostname match
-	// only (no wildcard support). Requests to unlisted domains are rejected.
+	// contact via paca.fetch. Matching is exact, case-insensitive hostname match,
+	// except for the literal entry "*" which permits any HTTPS host (still
+	// subject to the private/internal IP block). Requests to unlisted domains
+	// are rejected.
 	AllowedOutboundDomains []string `json:"allowedOutboundDomains,omitempty"`
 	// AllowedConfigKeys is the list of host config keys the plugin may read via
 	// paca.config_get. Keys not listed here are not exposed to the plugin.

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -26,6 +26,14 @@ const StreamDocActivities = "paca.doc_activities"
 // publishes real-time push events.
 const StreamTaskAssignments = "paca.task_assignments"
 
+// StreamPluginEvents is the Valkey Stream key every activity event (task
+// activities, comments, links, etc.) is appended to so that the plugin
+// runtime can dispatch them to subscribed plugins via PluginEventConsumer.
+// The plugin runtime is just another stream subscriber here — the API
+// service that records an activity never calls into the plugin runtime
+// directly.
+const StreamPluginEvents = "paca.plugin_events"
+
 // Event type constants used in both Pub/Sub messages and Stream entries.
 const (
 	// --- Auth events --------------------------------------------------------

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -615,6 +615,19 @@ func (r *Runtime) execQuery(ctx context.Context, schema, sqlStr, paramsJSON stri
 	if err != nil {
 		return nil, err
 	}
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, err
+	}
+	// The driver returns text/json/jsonb columns as []byte; encoding/json would
+	// otherwise base64-encode those when marshaling the result across the WASM
+	// boundary, corrupting the value for the plugin. Convert those columns to
+	// string so plugins receive the raw text. Genuinely binary columns (bytea)
+	// are left as []byte so they keep going through the safe base64 path.
+	isTextColumn := make([]bool, len(colTypes))
+	for i, ct := range colTypes {
+		isTextColumn[i] = strings.ToUpper(ct.DatabaseTypeName()) != "BYTEA"
+	}
 	result := &dbQueryResult{Columns: cols}
 	for rows.Next() {
 		vals := make([]any, len(cols))
@@ -625,12 +638,8 @@ func (r *Runtime) execQuery(ctx context.Context, schema, sqlStr, paramsJSON stri
 		if err := rows.Scan(ptrs...); err != nil {
 			return nil, err
 		}
-		// Postgres driver returns text/json/jsonb columns as []byte; encoding/json
-		// would otherwise base64-encode those when marshaling the result across
-		// the WASM boundary, corrupting the value for the plugin. Convert to
-		// string so plugins receive the raw text.
 		for i, v := range vals {
-			if b, ok := v.([]byte); ok {
+			if b, ok := v.([]byte); ok && isTextColumn[i] {
 				vals[i] = string(b)
 			}
 		}

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -625,6 +625,15 @@ func (r *Runtime) execQuery(ctx context.Context, schema, sqlStr, paramsJSON stri
 		if err := rows.Scan(ptrs...); err != nil {
 			return nil, err
 		}
+		// Postgres driver returns text/json/jsonb columns as []byte; encoding/json
+		// would otherwise base64-encode those when marshaling the result across
+		// the WASM boundary, corrupting the value for the plugin. Convert to
+		// string so plugins receive the raw text.
+		for i, v := range vals {
+			if b, ok := v.([]byte); ok {
+				vals[i] = string(b)
+			}
+		}
 		result.Rows = append(result.Rows, vals)
 	}
 	if err := rows.Err(); err != nil {
@@ -1233,7 +1242,10 @@ func (r *Runtime) registerFetchFunction(b wazero.HostModuleBuilder, p plugindom.
 }
 
 // isAllowedFetchDomain reports whether rawURL's host is in the allowlist.
-// An empty allowlist means no outbound requests are permitted.
+// An empty allowlist means no outbound requests are permitted. A literal "*"
+// entry allows any HTTPS host (used by plugins like webhook integrations that
+// must call user-supplied URLs); the scheme, hostname, and private/internal IP
+// checks below still apply in that case.
 func isAllowedFetchDomain(ctx context.Context, rawURL string, allowed []string) bool {
 	if len(allowed) == 0 {
 		return false
@@ -1254,7 +1266,8 @@ func isAllowedFetchDomain(ctx context.Context, rawURL string, allowed []string) 
 
 	hostAllowed := false
 	for _, a := range allowed {
-		if strings.EqualFold(host, strings.TrimSpace(a)) {
+		a = strings.TrimSpace(a)
+		if a == "*" || strings.EqualFold(host, a) {
 			hostAllowed = true
 			break
 		}

--- a/services/api/internal/service/task/activity_service.go
+++ b/services/api/internal/service/task/activity_service.go
@@ -208,7 +208,7 @@ func (s *ActivitySvc) UpdateComment(ctx context.Context, id uuid.UUID, projectID
 	if err := s.repo.UpdateActivity(ctx, a); err != nil {
 		return nil, err
 	}
-	s.publishRealtimeOnly(ctx, events.TopicTaskCommentUpdated, activityPayload(a, uuid.Nil))
+	s.publishRealtimeOnly(ctx, events.TopicTaskCommentUpdated, activityPayload(a, projectID))
 	return a, nil
 }
 
@@ -233,9 +233,10 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 		return err
 	}
 	s.publishRealtimeOnly(ctx, events.TopicTaskCommentDeleted, map[string]any{
-		"id":       id,
-		"task_id":  a.TaskID,
-		"actor_id": actorID,
+		"id":         id,
+		"task_id":    a.TaskID,
+		"project_id": projectID,
+		"actor_id":   actorID,
 	})
 	return nil
 }
@@ -265,30 +266,44 @@ func activityPayload(a *taskdom.Activity, projectID uuid.UUID) map[string]any {
 // Valkey stream and also broadcasts a real-time pub/sub notification.
 // agentID, when non-nil, is embedded so the consumer can resolve the actor as
 // an agent member instead of a user member.
-// Errors are intentionally swallowed — a messaging failure must not block
-// the primary HTTP response.
 func (s *ActivitySvc) publishToActivityStream(ctx context.Context, a *taskdom.Activity, projectID uuid.UUID, agentID *uuid.UUID) {
-	if s.publisher == nil {
-		return
-	}
 	payload := activityPayload(a, projectID)
 	if agentID != nil {
 		payload["actor_agent_id"] = agentID.String()
 	}
-	_ = s.publisher.Append(ctx, events.StreamTaskActivities, string(a.ActivityType), payload)
-	_ = s.publisher.Publish(ctx, events.ChannelRealtime, map[string]any{
-		"type":    string(a.ActivityType),
-		"payload": payload,
-	})
+	s.fanout(ctx, string(a.ActivityType), payload, true)
 }
 
 // publishRealtimeOnly sends a real-time pub/sub notification without writing
-// to any stream.  Used for comment operations that already write to the DB
-// directly and don't need the consumer-persistence path.
+// to the activity-persistence stream. Used for comment operations that
+// already write to the DB directly and don't need the consumer-persistence
+// path.
 func (s *ActivitySvc) publishRealtimeOnly(ctx context.Context, topic string, payload any) {
+	s.fanout(ctx, topic, payload, false)
+}
+
+// fanout is the single dispatch point for an activity event. It writes the
+// event into Valkey exactly once per destination, and every listener —
+// ActivityConsumer (DB persistence), PluginEventConsumer (plugin dispatch),
+// and services/realtime (live UI updates) — reads it back out as a
+// subscriber. ActivitySvc never calls into the plugin runtime, or any other
+// listener, directly: Valkey is the only fan-out point. To add a new
+// listener, give it its own stream/consumer rather than adding another call
+// here.
+// appendToActivityStream controls whether the event is also durably appended
+// to StreamTaskActivities (skipped for events whose owning write path
+// persists to Postgres directly, e.g. comments); StreamPluginEvents and
+// ChannelRealtime always receive every event regardless.
+// Errors are intentionally swallowed — a messaging failure must not block
+// the primary HTTP response.
+func (s *ActivitySvc) fanout(ctx context.Context, topic string, payload any, appendToActivityStream bool) {
 	if s.publisher == nil {
 		return
 	}
+	if appendToActivityStream {
+		_ = s.publisher.Append(ctx, events.StreamTaskActivities, topic, payload)
+	}
+	_ = s.publisher.Append(ctx, events.StreamPluginEvents, topic, payload)
 	_ = s.publisher.Publish(ctx, events.ChannelRealtime, map[string]any{
 		"type":    topic,
 		"payload": payload,

--- a/services/api/internal/transport/http/handler/plugin_handler.go
+++ b/services/api/internal/transport/http/handler/plugin_handler.go
@@ -122,23 +122,36 @@ func (h *PluginHandler) InstallPlugin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	onFailure := func() { _ = h.svc.DeletePlugin(r.Context(), plugin.ID) }
+	if !h.runMigrationsAndLoad(w, r, plugin, onFailure) {
+		return
+	}
+
+	presenter.Created(w, r, dto.PluginResponseFromEntity(plugin))
+}
+
+// runMigrationsAndLoad runs any pending migrations for plugin and, if it is
+// enabled, loads it into the WASM runtime. On failure it invokes onFailure
+// (used by callers to roll back whatever they just persisted), writes the
+// error response, and returns false; returns true on success.
+func (h *PluginHandler) runMigrationsAndLoad(w http.ResponseWriter, r *http.Request, plugin *plugindom.Plugin, onFailure func()) bool {
 	if h.migrationRunner != nil {
 		if err := h.migrationRunner.Run(r.Context(), plugin.Name); err != nil {
-			_ = h.svc.DeletePlugin(r.Context(), plugin.ID)
+			onFailure()
 			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to run plugin migrations: "+err.Error()))
-			return
+			return false
 		}
 	}
 
 	if plugin.Enabled && h.runtime != nil {
 		if err := h.runtime.Load(r.Context(), *plugin); err != nil {
-			_ = h.svc.DeletePlugin(r.Context(), plugin.ID)
+			onFailure()
 			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to load plugin runtime: "+err.Error()))
-			return
+			return false
 		}
 	}
 
-	presenter.Created(w, r, dto.PluginResponseFromEntity(plugin))
+	return true
 }
 
 // ListMarketplacePlugins handles GET /api/v1/admin/plugins/marketplace.
@@ -213,20 +226,9 @@ func (h *PluginHandler) InstallMarketplacePlugin(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if h.migrationRunner != nil {
-		if err := h.migrationRunner.Run(r.Context(), pl.Name); err != nil {
-			_ = h.svc.DeletePlugin(r.Context(), pl.ID)
-			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to run plugin migrations: "+err.Error()))
-			return
-		}
-	}
-
-	if pl.Enabled && h.runtime != nil {
-		if err := h.runtime.Load(r.Context(), *pl); err != nil {
-			_ = h.svc.DeletePlugin(r.Context(), pl.ID)
-			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to load plugin runtime: "+err.Error()))
-			return
-		}
+	onFailure := func() { _ = h.svc.DeletePlugin(r.Context(), pl.ID) }
+	if !h.runMigrationsAndLoad(w, r, pl, onFailure) {
+		return
 	}
 
 	success = true
@@ -245,6 +247,26 @@ func (h *PluginHandler) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
 		return
 	}
+
+	// Capture the pre-update state so we can roll the DB record back if
+	// migrations or the runtime reload fail below.
+	plugins, err := h.svc.ListPlugins(r.Context())
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	var previous *plugindom.Plugin
+	for _, p := range plugins {
+		if p.ID == id {
+			previous = p
+			break
+		}
+	}
+	if previous == nil {
+		presenter.Error(w, r, apierr.New(apierr.CodePluginNotFound, "plugin not found"))
+		return
+	}
+
 	plugin, err := h.svc.UpdatePlugin(r.Context(), id, plugindom.UpdateInput{
 		Version:  req.Version,
 		Manifest: req.Manifest,
@@ -255,9 +277,20 @@ func (h *PluginHandler) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rollback := func(reason, msg string) {
+		if _, rollbackErr := h.svc.UpdatePlugin(r.Context(), id, plugindom.UpdateInput{
+			Version:  &previous.Version,
+			Manifest: &previous.Manifest,
+			Enabled:  &previous.Enabled,
+		}); rollbackErr != nil {
+			slog.Error("plugin update: failed to roll back DB record", "name", previous.Name, "reason", reason, "error", rollbackErr)
+		}
+		presenter.Error(w, r, apierr.New(apierr.CodeInternalError, msg))
+	}
+
 	if h.migrationRunner != nil {
 		if err := h.migrationRunner.Run(r.Context(), plugin.Name); err != nil {
-			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to run plugin migrations: "+err.Error()))
+			rollback("migration failure", "failed to run plugin migrations: "+err.Error())
 			return
 		}
 	}
@@ -265,7 +298,16 @@ func (h *PluginHandler) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 	if h.runtime != nil {
 		if plugin.Enabled {
 			if err := h.runtime.Load(r.Context(), *plugin); err != nil {
-				presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to reload plugin runtime: "+err.Error()))
+				// Best-effort: restore the previously-loaded version/state in the
+				// runtime so it doesn't keep serving the now-rolled-back plugin.
+				if previous.Enabled {
+					if rollbackErr := h.runtime.Load(r.Context(), *previous); rollbackErr != nil {
+						slog.Error("plugin update: failed to roll back runtime", "name", previous.Name, "error", rollbackErr)
+					}
+				} else {
+					h.runtime.Unload(r.Context(), previous.Name)
+				}
+				rollback("runtime reload failure", "failed to reload plugin runtime: "+err.Error())
 				return
 			}
 		} else {

--- a/services/api/internal/transport/http/handler/plugin_handler.go
+++ b/services/api/internal/transport/http/handler/plugin_handler.go
@@ -121,6 +121,23 @@ func (h *PluginHandler) InstallPlugin(w http.ResponseWriter, r *http.Request) {
 		presenter.Error(w, r, err)
 		return
 	}
+
+	if h.migrationRunner != nil {
+		if err := h.migrationRunner.Run(r.Context(), plugin.Name); err != nil {
+			_ = h.svc.DeletePlugin(r.Context(), plugin.ID)
+			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to run plugin migrations: "+err.Error()))
+			return
+		}
+	}
+
+	if plugin.Enabled && h.runtime != nil {
+		if err := h.runtime.Load(r.Context(), *plugin); err != nil {
+			_ = h.svc.DeletePlugin(r.Context(), plugin.ID)
+			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to load plugin runtime: "+err.Error()))
+			return
+		}
+	}
+
 	presenter.Created(w, r, dto.PluginResponseFromEntity(plugin))
 }
 
@@ -237,6 +254,25 @@ func (h *PluginHandler) UpdatePlugin(w http.ResponseWriter, r *http.Request) {
 		presenter.Error(w, r, err)
 		return
 	}
+
+	if h.migrationRunner != nil {
+		if err := h.migrationRunner.Run(r.Context(), plugin.Name); err != nil {
+			presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to run plugin migrations: "+err.Error()))
+			return
+		}
+	}
+
+	if h.runtime != nil {
+		if plugin.Enabled {
+			if err := h.runtime.Load(r.Context(), *plugin); err != nil {
+				presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to reload plugin runtime: "+err.Error()))
+				return
+			}
+		} else {
+			h.runtime.Unload(r.Context(), plugin.Name)
+		}
+	}
+
 	presenter.OK(w, r, dto.PluginResponseFromEntity(plugin))
 }
 

--- a/services/api/internal/worker/plugin_event_consumer.go
+++ b/services/api/internal/worker/plugin_event_consumer.go
@@ -1,0 +1,172 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/Paca-AI/api/internal/events"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	pluginEventConsumerGroup = "api.plugin_dispatcher"
+	pluginEventReadBlock     = 5 * time.Second
+	pluginEventReadCount     = 50
+)
+
+// PluginEventEmitter dispatches a topic+payload to every loaded plugin that
+// has subscribed to it. Implemented by *plugin.Runtime; kept as a narrow
+// interface here to avoid a dependency from the worker package onto the
+// plugin platform package.
+type PluginEventEmitter interface {
+	EmitEvent(ctx context.Context, topic string, payload any)
+}
+
+// PluginEventConsumer reads every activity event (task activities, comments,
+// links, etc.) from the StreamPluginEvents Valkey stream — written by
+// ActivitySvc.fanout — and dispatches each one to the plugin runtime.
+//
+// The plugin runtime is intentionally just another stream subscriber here,
+// on equal footing with ActivityConsumer (DB persistence) and
+// services/realtime (live UI updates): the API never calls into the plugin
+// runtime directly when recording an activity.
+type PluginEventConsumer struct {
+	client       *redis.Client
+	emitter      PluginEventEmitter
+	log          *slog.Logger
+	consumerName string // unique per instance, derived from hostname
+	stopCh       chan struct{}
+	doneCh       chan struct{}
+}
+
+// NewPluginEventConsumer creates a consumer that is ready to be started.
+// The consumer name is derived from the hostname so it is unique per pod/instance.
+// If hostname retrieval fails, a random UUID suffix is used as fallback.
+func NewPluginEventConsumer(client *redis.Client, emitter PluginEventEmitter, log *slog.Logger) *PluginEventConsumer {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = uuid.New().String()
+	}
+	return &PluginEventConsumer{
+		client:       client,
+		emitter:      emitter,
+		log:          log,
+		consumerName: fmt.Sprintf("%s.%s", pluginEventConsumerGroup, hostname),
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+	}
+}
+
+// Start creates the consumer group if needed, then begins reading from the
+// stream in a background goroutine. Call Stop to drain and exit cleanly.
+func (c *PluginEventConsumer) Start(ctx context.Context) {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamPluginEvents, pluginEventConsumerGroup, "0").Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		c.log.Warn("plugin event consumer: could not create consumer group", "err", err)
+		// Non-fatal — we still attempt to read below.
+	}
+
+	go c.run()
+}
+
+// Stop signals the consumer to stop and waits for the goroutine to exit.
+func (c *PluginEventConsumer) Stop() {
+	close(c.stopCh)
+	<-c.doneCh
+}
+
+// run is the main loop executed in a goroutine by Start.
+func (c *PluginEventConsumer) run() {
+	defer close(c.doneCh)
+	c.log.Info("plugin event consumer: started", "stream", events.StreamPluginEvents)
+
+	// On startup, replay any pending messages (PEL) that were delivered but
+	// never acknowledged (e.g. after a crash). "0" fetches the backlog.
+	c.processPending(context.Background())
+
+	for {
+		select {
+		case <-c.stopCh:
+			c.log.Info("plugin event consumer: stopping")
+			return
+		default:
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), pluginEventReadBlock+time.Second)
+		msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    pluginEventConsumerGroup,
+			Consumer: c.consumerName,
+			Streams:  []string{events.StreamPluginEvents, ">"},
+			Count:    pluginEventReadCount,
+			Block:    pluginEventReadBlock,
+		}).Result()
+		cancel()
+
+		if err != nil {
+			if err == redis.Nil {
+				// Timeout with no new messages — loop and check stopCh.
+				continue
+			}
+			c.log.Error("plugin event consumer: xreadgroup error", "err", err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		for _, stream := range msgs {
+			for _, msg := range stream.Messages {
+				c.handle(msg)
+			}
+		}
+	}
+}
+
+// processPending re-delivers and acknowledges any messages in the PEL that
+// were not acked during a previous run.
+func (c *PluginEventConsumer) processPending(ctx context.Context) {
+	msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    pluginEventConsumerGroup,
+		Consumer: c.consumerName,
+		Streams:  []string{events.StreamPluginEvents, "0"},
+		Count:    pluginEventReadCount,
+	}).Result()
+	if err != nil && err != redis.Nil {
+		c.log.Warn("plugin event consumer: could not read pending messages", "err", err)
+		return
+	}
+	for _, stream := range msgs {
+		for _, msg := range stream.Messages {
+			c.handle(msg)
+		}
+	}
+}
+
+// handle dispatches one stream message to the plugin runtime.
+func (c *PluginEventConsumer) handle(msg redis.XMessage) {
+	ctx := context.Background()
+
+	eventType, _ := msg.Values["type"].(string)
+	if eventType == "" {
+		c.log.Warn("plugin event consumer: message has no type field", "id", msg.ID)
+		c.ack(ctx, msg.ID)
+		return
+	}
+
+	// The Publisher.Append method stores the body in a "payload" field as a
+	// JSON-encoded string. Passing it through as json.RawMessage lets
+	// Runtime.EmitEvent re-marshal it verbatim instead of double-encoding it.
+	raw, _ := msg.Values["payload"].(string)
+	c.emitter.EmitEvent(ctx, eventType, json.RawMessage(raw))
+
+	c.ack(ctx, msg.ID)
+}
+
+func (c *PluginEventConsumer) ack(ctx context.Context, id string) {
+	if err := c.client.XAck(ctx, events.StreamPluginEvents, pluginEventConsumerGroup, id).Err(); err != nil {
+		c.log.Warn("plugin event consumer: xack failed", "id", id, "err", err)
+	}
+}


### PR DESCRIPTION
## Summary

Plugins can now react to activity events (task created/updated/deleted, comments, links, etc.) instead of only being invoked synchronously from request handlers.

- Added `PluginEventConsumer`, a Valkey Stream consumer group reader that subscribes to a new `paca.plugin_events` stream and dispatches each event to the plugin runtime (`Runtime.EmitEvent`). Replays unacked messages from the PEL on startup so a crash doesn't drop events.
- `ActivitySvc` now fans every activity event out through a single `fanout` method that writes to Valkey once per destination (`StreamTaskActivities` when applicable, `StreamPluginEvents` always, `ChannelRealtime` always). `ActivitySvc` never calls into the plugin runtime directly — Valkey stream/pubsub is the only fan-out point, matching how `ActivityConsumer` and the realtime channel already work.
- Fixed `UpdateComment`/`DeleteComment` payloads to include `project_id` (was previously `uuid.Nil`/missing), which plugins and the realtime channel need to scope events correctly.
- `PluginHandler.InstallPlugin`/`UpdatePlugin` now run pending migrations and load/unload the plugin into the runtime as part of install/update, instead of requiring a separate step. Failures roll back the plugin record.
- `Runtime.isAllowedFetchDomain` now supports a literal `"*"` entry in `allowedOutboundDomains` to permit any HTTPS host (still subject to the private/internal IP block) — needed for plugins like webhook integrations that call user-supplied URLs.
- Fixed `Runtime.execQuery` to convert `[]byte` column values (e.g. text/json/jsonb) to `string` before marshaling across the WASM boundary; otherwise `encoding/json` base64-encodes them, corrupting the value seen by the plugin.
- `scripts/install-local-plugin.sh`: plugin install now goes through `/admin/plugins` instead of `/plugins`.

## Test plan

- [x] Verify plugin subscribed to a topic in `eventSubscriptions` receives dispatched events end-to-end (task created/updated, comment added/updated/deleted)
- [x] Kill the API mid-flight and confirm pending plugin events are redelivered on restart (PEL replay)
- [x] Install/update a plugin via the API and confirm migrations run and the plugin loads/unloads in the runtime automatically
- [x] Confirm a plugin with `allowedOutboundDomains: ["*"]` can fetch an arbitrary HTTPS host but is still blocked from private/internal IPs
- [x] Confirm a SQL query plugin gets correct (non-base64) text/json column values
