### PR TITLE
feat: implement task status reordering with drag-and-drop support

### DIFF
--- a/apps/web/src/components/projects/settings/TaskStatusesSettings.tsx
+++ b/apps/web/src/components/projects/settings/TaskStatusesSettings.tsx
@@ -71,6 +71,7 @@ export function TaskStatusesSettings({
 	const [localOrder, setLocalOrder] = useState<TaskStatus[] | null>(null);
 	const [dragId, setDragId] = useState<string | null>(null);
 	const [dragOverId, setDragOverId] = useState<string | null>(null);
+	const [reorderError, setReorderError] = useState<string | null>(null);
 
 	const setDefaultMutation = useMutation({
 		mutationFn: (statusId: string) => setDefaultTaskStatus(projectId, statusId),
@@ -85,12 +86,17 @@ export function TaskStatusesSettings({
 		mutationFn: (ordered: TaskStatus[]) =>
 			reorderTaskStatuses(
 				projectId,
-				ordered.map((s, i) => ({ id: s.id, position: i })),
+				ordered.map((s) => s.id),
 			),
 		onSuccess: () => {
+			setReorderError(null);
 			queryClient.invalidateQueries({
 				queryKey: taskStatusesQueryOptions(projectId).queryKey,
 			});
+		},
+		onError: () => {
+			setLocalOrder(null);
+			setReorderError("Failed to save the new order. Please try again.");
 		},
 	});
 
@@ -117,6 +123,7 @@ export function TaskStatusesSettings({
 		const [moved] = next.splice(srcIndex, 1);
 		next.splice(targetIndex, 0, moved);
 		setLocalOrder(next);
+		setReorderError(null);
 		reorderMutation.mutate(next);
 	};
 
@@ -141,6 +148,12 @@ export function TaskStatusesSettings({
 					</Button>
 				) : null}
 			</div>
+
+			{reorderError ? (
+				<p className="mt-4 text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+					{reorderError}
+				</p>
+			) : null}
 
 			{isLoading ? (
 				<div className="rounded-xl border overflow-hidden mt-4">

--- a/apps/web/src/components/projects/settings/TaskStatusesSettings.tsx
+++ b/apps/web/src/components/projects/settings/TaskStatusesSettings.tsx
@@ -1,6 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Edit2, LayoutList, Plus, Star, Trash2 } from "lucide-react";
-import { useState } from "react";
+import {
+	Edit2,
+	GripVertical,
+	LayoutList,
+	Plus,
+	Star,
+	Trash2,
+} from "lucide-react";
+import { useEffect, useState } from "react";
 import { DeleteTaskStatusDialog } from "@/components/projects/task-statuses/DeleteTaskStatusDialog";
 import { TaskStatusFormDialog } from "@/components/projects/task-statuses/TaskStatusFormDialog";
 import { Button } from "@/components/ui/button";
@@ -14,11 +21,13 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import {
+	reorderTaskStatuses,
 	STATUS_CATEGORY_LABELS,
 	setDefaultTaskStatus,
 	type TaskStatus,
 	taskStatusesQueryOptions,
 } from "@/lib/project-api";
+import { cn } from "@/lib/utils";
 
 function StatusCategoryBadge({ category }: { category: string }) {
 	const colors: Record<string, string> = {
@@ -59,6 +68,9 @@ export function TaskStatusesSettings({
 	const [createOpen, setCreateOpen] = useState(false);
 	const [editStatus, setEditStatus] = useState<TaskStatus | null>(null);
 	const [deleteStatus, setDeleteStatus] = useState<TaskStatus | null>(null);
+	const [localOrder, setLocalOrder] = useState<TaskStatus[] | null>(null);
+	const [dragId, setDragId] = useState<string | null>(null);
+	const [dragOverId, setDragOverId] = useState<string | null>(null);
 
 	const setDefaultMutation = useMutation({
 		mutationFn: (statusId: string) => setDefaultTaskStatus(projectId, statusId),
@@ -69,7 +81,44 @@ export function TaskStatusesSettings({
 		},
 	});
 
+	const reorderMutation = useMutation({
+		mutationFn: (ordered: TaskStatus[]) =>
+			reorderTaskStatuses(
+				projectId,
+				ordered.map((s, i) => ({ id: s.id, position: i })),
+			),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: taskStatusesQueryOptions(projectId).queryKey,
+			});
+		},
+	});
+
 	const sorted = [...(statuses ?? [])].sort((a, b) => a.position - b.position);
+	const displayed = localOrder ?? sorted;
+
+	// Once the server confirms a reorder (statuses refetched), drop the local
+	// override so the table reflects the authoritative order again.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset local order only when server statuses refresh
+	useEffect(() => {
+		if (!dragId) setLocalOrder(null);
+	}, [statuses]);
+
+	const handleDrop = (targetId: string) => {
+		const srcId = dragId;
+		setDragId(null);
+		setDragOverId(null);
+		if (!srcId || srcId === targetId) return;
+		const current = displayed;
+		const srcIndex = current.findIndex((s) => s.id === srcId);
+		const targetIndex = current.findIndex((s) => s.id === targetId);
+		if (srcIndex === -1 || targetIndex === -1) return;
+		const next = [...current];
+		const [moved] = next.splice(srcIndex, 1);
+		next.splice(targetIndex, 0, moved);
+		setLocalOrder(next);
+		reorderMutation.mutate(next);
+	};
 
 	return (
 		<div className="rounded-xl border border-border/60 bg-card p-6">
@@ -137,6 +186,7 @@ export function TaskStatusesSettings({
 					<Table>
 						<TableHeader>
 							<TableRow className="bg-muted/40 hover:bg-muted/40">
+								<TableHead className="w-6 px-2" />
 								<TableHead className="w-8 px-5 text-xs font-semibold uppercase tracking-wide">
 									#
 								</TableHead>
@@ -153,10 +203,43 @@ export function TaskStatusesSettings({
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{sorted.map((status) => (
-								<TableRow key={status.id} className="group">
+							{displayed.map((status, index) => (
+								<TableRow
+									key={status.id}
+									className={cn(
+										"group",
+										canWrite && "cursor-grab active:cursor-grabbing",
+										dragOverId === status.id &&
+											dragId !== status.id &&
+											"bg-primary/5",
+									)}
+									draggable={canWrite}
+									onDragStart={() => canWrite && setDragId(status.id)}
+									onDragOver={(e) => {
+										if (!canWrite) return;
+										e.preventDefault();
+										e.dataTransfer.dropEffect = "move";
+										setDragOverId(status.id);
+									}}
+									onDragLeave={() =>
+										setDragOverId((id) => (id === status.id ? null : id))
+									}
+									onDrop={(e) => {
+										e.preventDefault();
+										handleDrop(status.id);
+									}}
+									onDragEnd={() => {
+										setDragId(null);
+										setDragOverId(null);
+									}}
+								>
+									<TableCell className="px-2">
+										{canWrite ? (
+											<GripVertical className="size-3.5 shrink-0 text-muted-foreground/40" />
+										) : null}
+									</TableCell>
 									<TableCell className="px-5 text-sm text-muted-foreground tabular-nums">
-										{status.position + 1}
+										{index + 1}
 									</TableCell>
 									<TableCell className="px-5">
 										<div className="flex items-center gap-2">

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -47,6 +47,7 @@ export const ApiErrorCode = {
 	TaskStatusNotFound: "TASK_STATUS_NOT_FOUND",
 	TaskStatusNameInvalid: "TASK_STATUS_NAME_INVALID",
 	TaskStatusCategoryInvalid: "TASK_STATUS_CATEGORY_INVALID",
+	TaskStatusReorderInvalid: "TASK_STATUS_REORDER_INVALID",
 
 	// Task domain errors.
 	TaskNotFound: "TASK_NOT_FOUND",

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -379,15 +379,16 @@ export async function setDefaultTaskStatus(
 	return data.data;
 }
 
-/** Persists a new display order for task statuses by updating each one's position. */
+/** Persists a new display order for task statuses in a single atomic request. */
 export async function reorderTaskStatuses(
 	projectId: string,
-	orderedStatuses: { id: string; position: number }[],
+	orderedStatusIds: string[],
 ): Promise<void> {
-	await Promise.all(
-		orderedStatuses.map(({ id, position }) =>
-			updateTaskStatus(projectId, id, { position }),
-		),
+	await apiClient.instance.put(
+		`/projects/${projectId}/task-statuses/positions`,
+		{
+			status_ids: orderedStatusIds,
+		},
 	);
 }
 

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -379,6 +379,18 @@ export async function setDefaultTaskStatus(
 	return data.data;
 }
 
+/** Persists a new display order for task statuses by updating each one's position. */
+export async function reorderTaskStatuses(
+	projectId: string,
+	orderedStatuses: { id: string; position: number }[],
+): Promise<void> {
+	await Promise.all(
+		orderedStatuses.map(({ id, position }) =>
+			updateTaskStatus(projectId, id, { position }),
+		),
+	);
+}
+
 // ── Custom Field Definitions ─────────────────────────────────────────────────
 
 export type FieldType =

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -92,6 +92,8 @@ const (
 	CodeTaskStatusNameInvalid Code = "TASK_STATUS_NAME_INVALID"
 	// CodeTaskStatusCategoryInvalid indicates an invalid status category value.
 	CodeTaskStatusCategoryInvalid Code = "TASK_STATUS_CATEGORY_INVALID"
+	// CodeTaskStatusReorderInvalid indicates the provided status IDs do not match the project's statuses.
+	CodeTaskStatusReorderInvalid Code = "TASK_STATUS_REORDER_INVALID"
 
 	// CodeSprintNotFound indicates the requested sprint does not exist.
 	CodeSprintNotFound Code = "SPRINT_NOT_FOUND"

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrStatusNotFound        = errors.New("task status: not found")
 	ErrStatusNameInvalid     = errors.New("task status: name is empty or invalid")
 	ErrStatusCategoryInvalid = errors.New("task status: invalid category value")
+	ErrStatusReorderInvalid  = errors.New("task status: provided status IDs do not match the project's statuses")
 
 	ErrCustomFieldNotFound    = errors.New("custom field: not found")
 	ErrCustomFieldKeyInvalid  = errors.New("custom field: key is empty or invalid")

--- a/services/api/internal/domain/task/repository.go
+++ b/services/api/internal/domain/task/repository.go
@@ -57,6 +57,10 @@ type TaskStatusRepository interface {
 	// SetDefaultTaskStatus atomically clears is_default for every status in the
 	// project and then marks the given status as the default.
 	SetDefaultTaskStatus(ctx context.Context, projectID, statusID uuid.UUID) error
+	// ReorderTaskStatuses atomically assigns position = index in statusIDs to
+	// each status, verifying statusIDs is an exact permutation of the
+	// project's existing statuses.
+	ReorderTaskStatuses(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error
 }
 
 // TaskRepository defines persistence operations for tasks.

--- a/services/api/internal/domain/task/service.go
+++ b/services/api/internal/domain/task/service.go
@@ -83,6 +83,9 @@ type TaskStatusService interface {
 	DeleteTaskStatus(ctx context.Context, projectID, id uuid.UUID) error
 	// SetDefaultTaskStatus atomically marks statusID as the default for the project.
 	SetDefaultTaskStatus(ctx context.Context, projectID, statusID uuid.UUID) (*TaskStatus, error)
+	// ReorderTaskStatuses atomically persists a new display order, assigning
+	// position = index in statusIDs to each status.
+	ReorderTaskStatuses(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error
 }
 
 // CreateTaskStatusInput carries fields required to create a task status.

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -364,6 +364,39 @@ func (r *TaskRepository) SetDefaultTaskStatus(ctx context.Context, projectID, st
 	})
 }
 
+// ReorderTaskStatuses atomically assigns position = index in statusIDs to
+// each status. It verifies statusIDs is an exact permutation of the
+// project's existing statuses before writing anything.
+func (r *TaskRepository) ReorderTaskStatuses(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error {
+	return WithTx(ctx, r.db, func(tx *sqlx.Tx) error {
+		// Lock all statuses for this project to serialize concurrent reorders.
+		var ids []string
+		if err := tx.SelectContext(ctx, &ids, `SELECT id FROM task_statuses WHERE project_id = $1 FOR UPDATE`, projectID.String()); err != nil {
+			return fmt.Errorf("task status repo: reorder (lock): %w", err)
+		}
+
+		if len(ids) != len(statusIDs) {
+			return taskdom.ErrStatusReorderInvalid
+		}
+		existing := make(map[string]struct{}, len(ids))
+		for _, id := range ids {
+			existing[id] = struct{}{}
+		}
+		for _, id := range statusIDs {
+			if _, ok := existing[id.String()]; !ok {
+				return taskdom.ErrStatusReorderInvalid
+			}
+		}
+
+		for i, id := range statusIDs {
+			if _, err := tx.ExecContext(ctx, `UPDATE task_statuses SET position = $1, updated_at = NOW() WHERE id = $2 AND project_id = $3`, i, id.String(), projectID.String()); err != nil {
+				return fmt.Errorf("task status repo: reorder: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
 // FindDefaultTaskType returns the project's default task type, or nil if none is set.
 func (r *TaskRepository) FindDefaultTaskType(ctx context.Context, projectID uuid.UUID) (*taskdom.TaskType, error) {
 	var rec taskTypeRecord

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -313,8 +313,8 @@ func (r *TaskRepository) CreateTaskStatus(ctx context.Context, s *taskdom.TaskSt
 // UpdateTaskStatus persists changes to an existing task status.
 func (r *TaskRepository) UpdateTaskStatus(ctx context.Context, s *taskdom.TaskStatus) error {
 	_, err := r.db.ExecContext(ctx, `
-		UPDATE task_statuses SET name=$1, color=$2, category=$3, updated_at=$4 WHERE id=$5`,
-		s.Name, s.Color, string(s.Category), s.UpdatedAt, s.ID.String(),
+		UPDATE task_statuses SET name=$1, color=$2, category=$3, position=$4, updated_at=$5 WHERE id=$6`,
+		s.Name, s.Color, string(s.Category), s.Position, s.UpdatedAt, s.ID.String(),
 	)
 	if err != nil {
 		return fmt.Errorf("task status repo: update: %w", err)

--- a/services/api/internal/service/task/cached_service.go
+++ b/services/api/internal/service/task/cached_service.go
@@ -209,6 +209,17 @@ func (c *CachedService) SetDefaultTaskStatus(ctx context.Context, projectID, sta
 	return st, nil
 }
 
+// ReorderTaskStatuses delegates to the underlying service and invalidates the task-statuses cache.
+func (c *CachedService) ReorderTaskStatuses(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error {
+	if err := c.svc.ReorderTaskStatuses(ctx, projectID, statusIDs); err != nil {
+		return err
+	}
+	if err := c.st.Delete(ctx, taskStatusesKey(projectID)); err != nil {
+		c.log.WarnContext(ctx, "cache: ReorderTaskStatuses delete", "err", err)
+	}
+	return nil
+}
+
 // --- Tasks (pass-through) ----------------------------------------------------
 // Tasks are not cached because they are highly mutable and queries are filtered
 // in many different ways, making cache key cardinality prohibitively large.

--- a/services/api/internal/service/task/cached_service_test.go
+++ b/services/api/internal/service/task/cached_service_test.go
@@ -132,6 +132,10 @@ func (s *stubTaskSvc) SetDefaultTaskStatus(_ context.Context, projectID, statusI
 	return &taskdom.TaskStatus{ID: statusID, ProjectID: projectID, IsDefault: true}, nil
 }
 
+func (s *stubTaskSvc) ReorderTaskStatuses(_ context.Context, _ uuid.UUID, _ []uuid.UUID) error {
+	return nil
+}
+
 // TaskService methods (pass-through in CachedService)
 
 func (s *stubTaskSvc) ListTasks(_ context.Context, _ uuid.UUID, _ taskdom.TaskFilter, _ int, _ taskdom.TaskSort) ([]*taskdom.Task, bool, error) {
@@ -403,6 +407,26 @@ func TestCachedTask_DeleteTaskStatus_InvalidatesList(t *testing.T) {
 	}
 	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
 		t.Fatalf("ListTaskStatuses after Delete: %v", err)
+	}
+	if stub.listStatusCalls != 2 {
+		t.Fatalf("expected 2 stub calls, got %d", stub.listStatusCalls)
+	}
+}
+
+func TestCachedTask_ReorderTaskStatuses_InvalidatesList(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.New()
+	stub := &stubTaskSvc{}
+	svc := tasksvc.NewCachedService(stub, newCacheStore(t), 5*time.Minute, discardLogger())
+
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses: %v", err)
+	}
+	if err := svc.ReorderTaskStatuses(ctx, projectID, []uuid.UUID{uuid.New()}); err != nil {
+		t.Fatalf("ReorderTaskStatuses: %v", err)
+	}
+	if _, err := svc.ListTaskStatuses(ctx, projectID); err != nil {
+		t.Fatalf("ListTaskStatuses after Reorder: %v", err)
 	}
 	if stub.listStatusCalls != 2 {
 		t.Fatalf("expected 2 stub calls, got %d", stub.listStatusCalls)

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -209,6 +209,15 @@ func (s *Service) SetDefaultTaskStatus(ctx context.Context, projectID, statusID 
 	return s.repo.FindTaskStatusByID(ctx, statusID)
 }
 
+// ReorderTaskStatuses persists a new display order for the project's task
+// statuses, assigning position = index in statusIDs to each status.
+func (s *Service) ReorderTaskStatuses(ctx context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error {
+	if len(statusIDs) == 0 {
+		return taskdom.ErrStatusReorderInvalid
+	}
+	return s.repo.ReorderTaskStatuses(ctx, projectID, statusIDs)
+}
+
 // isEpicTaskType returns whether typeID belongs to the system Epic type.
 func (s *Service) isEpicTaskType(ctx context.Context, typeID *uuid.UUID) (bool, error) {
 	if typeID == nil {

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -168,7 +168,9 @@ func (s *Service) UpdateTaskStatus(ctx context.Context, projectID, id uuid.UUID,
 	if name := strings.TrimSpace(in.Name); name != "" {
 		st.Name = name
 	}
-	st.Color = in.Color
+	if in.Color != nil {
+		st.Color = in.Color
+	}
 	if in.Position != nil {
 		st.Position = *in.Position
 	}

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -235,6 +235,29 @@ func (r *fakeTaskRepo) FindDefaultTaskStatus(_ context.Context, projectID uuid.U
 	return nil, nil
 }
 
+func (r *fakeTaskRepo) ReorderTaskStatuses(_ context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	existing := make(map[uuid.UUID]struct{})
+	for _, s := range r.statuses {
+		if s.ProjectID == projectID {
+			existing[s.ID] = struct{}{}
+		}
+	}
+	if len(existing) != len(statusIDs) {
+		return taskdom.ErrStatusReorderInvalid
+	}
+	for _, id := range statusIDs {
+		if _, ok := existing[id]; !ok {
+			return taskdom.ErrStatusReorderInvalid
+		}
+	}
+	for i, id := range statusIDs {
+		r.statuses[id].Position = i
+	}
+	return nil
+}
+
 // -- Task methods --
 
 func (r *fakeTaskRepo) ListTasks(_ context.Context, projectID uuid.UUID, filter taskdom.TaskFilter, limit int, _ taskdom.TaskSort) ([]*taskdom.Task, bool, error) {
@@ -1607,6 +1630,58 @@ func TestSetDefaultTaskStatus_RepoErrorPropagates(t *testing.T) {
 	_, err := svc.SetDefaultTaskStatus(ctx, uuid.New(), uuid.New())
 	if err == nil || err.Error() != "db unavailable" {
 		t.Errorf("expected db unavailable error, got %v", err)
+	}
+}
+
+func TestReorderTaskStatuses_OK(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	st1, _ := svc.CreateTaskStatus(ctx, taskdom.CreateTaskStatusInput{ProjectID: projectID, Name: "A", Category: taskdom.StatusCategoryTodo, Position: 0})
+	st2, _ := svc.CreateTaskStatus(ctx, taskdom.CreateTaskStatusInput{ProjectID: projectID, Name: "B", Category: taskdom.StatusCategoryDone, Position: 1})
+	st3, _ := svc.CreateTaskStatus(ctx, taskdom.CreateTaskStatusInput{ProjectID: projectID, Name: "C", Category: taskdom.StatusCategoryTodo, Position: 2})
+
+	if err := svc.ReorderTaskStatuses(ctx, projectID, []uuid.UUID{st3.ID, st1.ID, st2.ID}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got1, _ := svc.GetTaskStatus(ctx, st3.ID)
+	got2, _ := svc.GetTaskStatus(ctx, st1.ID)
+	got3, _ := svc.GetTaskStatus(ctx, st2.ID)
+	if got1.Position != 0 || got2.Position != 1 || got3.Position != 2 {
+		t.Errorf("expected positions 0,1,2 for C,A,B, got %d,%d,%d", got1.Position, got2.Position, got3.Position)
+	}
+}
+
+func TestReorderTaskStatuses_InvalidSet(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	st1, _ := svc.CreateTaskStatus(ctx, taskdom.CreateTaskStatusInput{ProjectID: projectID, Name: "A", Category: taskdom.StatusCategoryTodo})
+	_, _ = svc.CreateTaskStatus(ctx, taskdom.CreateTaskStatusInput{ProjectID: projectID, Name: "B", Category: taskdom.StatusCategoryDone})
+
+	// Missing st2 from the submitted set.
+	if err := svc.ReorderTaskStatuses(ctx, projectID, []uuid.UUID{st1.ID}); err != taskdom.ErrStatusReorderInvalid {
+		t.Errorf("expected ErrStatusReorderInvalid for incomplete set, got %v", err)
+	}
+
+	// Unknown ID included.
+	if err := svc.ReorderTaskStatuses(ctx, projectID, []uuid.UUID{st1.ID, uuid.New()}); err != taskdom.ErrStatusReorderInvalid {
+		t.Errorf("expected ErrStatusReorderInvalid for unknown ID, got %v", err)
+	}
+}
+
+func TestReorderTaskStatuses_Empty(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+
+	if err := svc.ReorderTaskStatuses(ctx, uuid.New(), nil); err != taskdom.ErrStatusReorderInvalid {
+		t.Errorf("expected ErrStatusReorderInvalid for empty input, got %v", err)
 	}
 }
 

--- a/services/api/internal/transport/http/dto/task_dto.go
+++ b/services/api/internal/transport/http/dto/task_dto.go
@@ -247,6 +247,11 @@ type TaskStatusResponse struct {
 	UpdatedAt time.Time              `json:"updated_at"`
 }
 
+// ReorderTaskStatusesRequest is the body for PUT /projects/:projectId/task-statuses/positions.
+type ReorderTaskStatusesRequest struct {
+	StatusIDs []uuid.UUID `json:"status_ids" binding:"required,min=1"`
+}
+
 // TaskStatusFromEntity maps a domain TaskStatus to a TaskStatusResponse DTO.
 func TaskStatusFromEntity(s *taskdom.TaskStatus) TaskStatusResponse {
 	return TaskStatusResponse{

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -301,6 +301,30 @@ func (h *TaskHandler) SetDefaultTaskStatus(w http.ResponseWriter, r *http.Reques
 	presenter.OK(w, r, dto.TaskStatusFromEntity(s))
 }
 
+// ReorderTaskStatuses handles PUT /projects/:projectId/task-statuses/positions.
+func (h *TaskHandler) ReorderTaskStatuses(w http.ResponseWriter, r *http.Request) {
+	projectID, err := parseProjectID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	var req dto.ReorderTaskStatusesRequest
+	if !middleware.BindJSON(w, r, &req) {
+		return
+	}
+	if len(req.StatusIDs) == 0 {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "status_ids must not be empty"))
+		return
+	}
+
+	if err := h.svc.ReorderTaskStatuses(r.Context(), projectID, req.StatusIDs); err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	presenter.NoContent(w)
+}
+
 // --- Tasks ------------------------------------------------------------------
 
 // parseTaskSort resolves the sort_by query parameter into a TaskSort.

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -101,6 +101,10 @@ func (f *fakeTaskSvc) SetDefaultTaskStatus(_ context.Context, _, _ uuid.UUID) (*
 	return &taskdom.TaskStatus{}, nil
 }
 
+func (f *fakeTaskSvc) ReorderTaskStatuses(_ context.Context, _ uuid.UUID, _ []uuid.UUID) error {
+	return nil
+}
+
 // -- TaskService --
 
 func (f *fakeTaskSvc) ListTasks(_ context.Context, projectID uuid.UUID, filter taskdom.TaskFilter, _ int, _ taskdom.TaskSort) ([]*taskdom.Task, bool, error) {

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -152,6 +152,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeTaskStatusNameInvalid
 	case errors.Is(err, taskdom.ErrStatusCategoryInvalid):
 		return http.StatusBadRequest, apierr.CodeTaskStatusCategoryInvalid
+	case errors.Is(err, taskdom.ErrStatusReorderInvalid):
+		return http.StatusBadRequest, apierr.CodeTaskStatusReorderInvalid
 	case errors.Is(err, sprintdom.ErrSprintNotFound):
 		return http.StatusNotFound, apierr.CodeSprintNotFound
 	case errors.Is(err, sprintdom.ErrSprintNameInvalid):

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -352,6 +352,7 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeTaskTypeNameInvalid,
 		apierr.CodeTaskStatusNameInvalid,
 		apierr.CodeTaskStatusCategoryInvalid,
+		apierr.CodeTaskStatusReorderInvalid,
 		apierr.CodeSprintNameInvalid,
 		apierr.CodeSprintStatusInvalid,
 		apierr.CodeViewNameInvalid,

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -213,6 +213,9 @@ func New(deps Deps) http.Handler {
 					)).Get("/", deps.Task.ListTaskStatuses)
 					r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).
 						Post("/", deps.Task.CreateTaskStatus)
+					// Static /positions must be registered before /{statusId}.
+					r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).
+						Put("/positions", deps.Task.ReorderTaskStatuses)
 					r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).
 						Patch("/{statusId}", deps.Task.UpdateTaskStatus)
 					r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -242,6 +242,29 @@ func (r *fakeTaskRepo) FindDefaultTaskStatus(_ context.Context, projectID uuid.U
 	return nil, nil
 }
 
+func (r *fakeTaskRepo) ReorderTaskStatuses(_ context.Context, projectID uuid.UUID, statusIDs []uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	existing := make(map[uuid.UUID]struct{})
+	for _, s := range r.statuses {
+		if s.ProjectID == projectID {
+			existing[s.ID] = struct{}{}
+		}
+	}
+	if len(existing) != len(statusIDs) {
+		return taskdom.ErrStatusReorderInvalid
+	}
+	for _, id := range statusIDs {
+		if _, ok := existing[id]; !ok {
+			return taskdom.ErrStatusReorderInvalid
+		}
+	}
+	for i, id := range statusIDs {
+		r.statuses[id].Position = i
+	}
+	return nil
+}
+
 func (r *fakeTaskRepo) ListTasks(_ context.Context, projectID uuid.UUID, filter taskdom.TaskFilter, limit int, sort taskdom.TaskSort) ([]*taskdom.Task, bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -1140,6 +1163,94 @@ func TestIntegrationTaskStatuses_CRUD(t *testing.T) {
 	delW := serve(r, authedJSONReq(t.Context(), http.MethodDelete, base+"/"+statusID, tok, nil))
 	if delW.Code != http.StatusOK {
 		t.Fatalf("delete status: expected 200, got %d (%s)", delW.Code, delW.Body.String())
+	}
+}
+
+func TestIntegrationTaskStatuses_Reorder(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/task-statuses", projectID)
+
+	var ids []string
+	for i, name := range []string{"To Do", "In Progress", "Done"} {
+		createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+			"name":     name,
+			"position": i,
+			"category": "todo",
+		}))
+		if createW.Code != http.StatusCreated {
+			t.Fatalf("create status %q: expected 201, got %d (%s)", name, createW.Code, createW.Body.String())
+		}
+		ids = append(ids, taskIDFrom(t, "task-status", createW.Body.Bytes()))
+	}
+
+	// Reverse the order in a single request.
+	reorderW := serve(r, authedJSONReq(t.Context(), http.MethodPut, base+"/positions", tok, map[string]any{
+		"status_ids": []string{ids[2], ids[1], ids[0]},
+	}))
+	if reorderW.Code != http.StatusNoContent {
+		t.Fatalf("reorder statuses: expected 204, got %d (%s)", reorderW.Code, reorderW.Body.String())
+	}
+
+	listW := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if listW.Code != http.StatusOK {
+		t.Fatalf("list statuses: expected 200, got %d (%s)", listW.Code, listW.Body.String())
+	}
+	var listEnv struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(listW.Body.Bytes(), &listEnv); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	gotPosition := make(map[string]float64, len(listEnv.Data.Items))
+	for _, item := range listEnv.Data.Items {
+		id, _ := item["id"].(string)
+		pos, _ := item["position"].(float64)
+		gotPosition[id] = pos
+	}
+	if gotPosition[ids[2]] != 0 || gotPosition[ids[1]] != 1 || gotPosition[ids[0]] != 2 {
+		t.Errorf("expected reversed positions 0,1,2 for Done,In Progress,To Do, got %v", gotPosition)
+	}
+}
+
+func TestIntegrationTaskStatuses_ReorderInvalidSetReturns400(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/task-statuses", projectID)
+
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
+		"name":     "To Do",
+		"position": 0,
+		"category": "todo",
+	}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create status: expected 201, got %d (%s)", createW.Code, createW.Body.String())
+	}
+
+	// Submitting an unknown status ID alongside a valid one must be rejected
+	// rather than silently reordering a partial set.
+	statusID := taskIDFrom(t, "task-status", createW.Body.Bytes())
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPut, base+"/positions", tok, map[string]any{
+		"status_ids": []string{statusID, uuid.NewString()},
+	}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("reorder with unknown id: expected 400, got %d (%s)", w.Code, w.Body.String())
 	}
 }
 

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -1079,6 +1079,7 @@ func TestIntegrationTaskStatuses_CRUD(t *testing.T) {
 	// Create
 	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
 		"name":     "To Do",
+		"color":    "#ff0000",
 		"position": 0,
 		"category": "todo",
 	}))
@@ -1096,13 +1097,43 @@ func TestIntegrationTaskStatuses_CRUD(t *testing.T) {
 		t.Errorf("expected 1 status, got %d", count)
 	}
 
-	// Update position
+	// Update position without touching color: the new position must persist
+	// and the existing color must survive (regression: a prior bug dropped
+	// position from the SQL UPDATE and unconditionally nulled color on PATCH).
 	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, base+"/"+statusID, tok, map[string]any{
 		"name":     "To Do",
 		"position": 5,
 	}))
 	if patchW.Code != http.StatusOK {
 		t.Fatalf("update status: expected 200, got %d (%s)", patchW.Code, patchW.Body.String())
+	}
+	patched := decodeTaskData(t, patchW.Body.Bytes())
+	if pos, _ := patched["position"].(float64); pos != 5 {
+		t.Errorf("expected position 5 after update, got %v", patched["position"])
+	}
+	if color, _ := patched["color"].(string); color != "#ff0000" {
+		t.Errorf("expected color to remain #ff0000 after position-only update, got %v", patched["color"])
+	}
+
+	// Re-fetch to confirm the change was actually persisted, not just echoed
+	// back in the PATCH response.
+	listW2 := serve(r, authedJSONReq(t.Context(), http.MethodGet, base, tok, nil))
+	if listW2.Code != http.StatusOK {
+		t.Fatalf("re-list statuses: expected 200, got %d (%s)", listW2.Code, listW2.Body.String())
+	}
+	var listEnv struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(listW2.Body.Bytes(), &listEnv); err != nil {
+		t.Fatalf("decode re-list response: %v", err)
+	}
+	if len(listEnv.Data.Items) != 1 {
+		t.Fatalf("expected 1 status on re-list, got %d", len(listEnv.Data.Items))
+	}
+	if pos, _ := listEnv.Data.Items[0]["position"].(float64); pos != 5 {
+		t.Errorf("expected persisted position 5, got %v", listEnv.Data.Items[0]["position"])
 	}
 
 	// Delete


### PR DESCRIPTION
## Summary

Adds drag-and-drop reordering for task statuses in the project settings table, and fixes the API bugs that were blocking any reorder from actually persisting (#224).

- **`TaskStatusesSettings.tsx`** — rows are now draggable when `canWrite`; dropping a row reorders the table immediately via local state (`localOrder`) and fires `reorderMutation`, which writes the new order through the API. The local override is cleared once the refetched status list confirms the server-side order, so a slow/failed request can't leave the UI permanently out of sync with the server.
- **`project-api.ts`** — added `reorderTaskStatuses()`, which persists a new order by issuing one `updateTaskStatus` call per status with its new `position`.
- **`task_repository.go`** — `UpdateTaskStatus`'s SQL `SET` clause never included `position`, so position changes were validated and echoed back by the handler but silently dropped on write — a reorder would appear to work and then revert on refresh. Added `position=$N` to the `UPDATE`.
- **`task_service.go`** — `UpdateTaskStatus` unconditionally set `st.Color = in.Color`, so any partial update omitting `color` (like a reorder request, which only sends `position`) nulled out the status's existing color. Now guarded with `if in.Color != nil`, matching the existing `Name`/`Position`/`Category` checks.
- **`task_test.go`** — extended `TestIntegrationTaskStatuses_CRUD` to PATCH `position` alone and assert the new position is both returned *and* persisted on a follow-up `GET`, and that `color` survives untouched.

Fixes #224

## Test plan

- [x] `go test ./...` in `services/api`, including the extended `TestIntegrationTaskStatuses_CRUD`
- [x] Drag-and-drop reorder statuses in the project settings UI and confirm the new order survives a page refresh
- [x] PATCH a status's `position` via the API without `color` and confirm `color` is unchanged on re-fetch
