### PR TITLE
feat: add MultiSelect and Url custom field types with corresponding editors

### DIFF
--- a/apps/web/src/components/projects/interactions/task-detail/add-field-dialog.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/add-field-dialog.tsx
@@ -10,13 +10,22 @@ import { cn } from "@/lib/utils";
 import { mapApiFieldToUi, mapUiFieldTypeToApi, slugify } from "./helpers";
 import type { CustomFieldDef } from "./types";
 
-type UiFieldType = "Text" | "Number" | "Date" | "Checkbox" | "Select";
+type UiFieldType =
+	| "Text"
+	| "Number"
+	| "Date"
+	| "Checkbox"
+	| "Select"
+	| "MultiSelect"
+	| "Url";
 const FIELD_TYPES: UiFieldType[] = [
 	"Text",
 	"Number",
 	"Date",
 	"Checkbox",
 	"Select",
+	"MultiSelect",
+	"Url",
 ];
 
 const FIELD_TYPE_LABEL_KEYS = {
@@ -25,6 +34,8 @@ const FIELD_TYPE_LABEL_KEYS = {
 	Date: "taskDetail.addFieldDialog.fieldTypes.date",
 	Checkbox: "taskDetail.addFieldDialog.fieldTypes.checkbox",
 	Select: "taskDetail.addFieldDialog.fieldTypes.select",
+	MultiSelect: "taskDetail.addFieldDialog.fieldTypes.multiSelect",
+	Url: "taskDetail.addFieldDialog.fieldTypes.url",
 } as const satisfies Record<UiFieldType, string>;
 
 interface AddFieldDialogProps {
@@ -73,7 +84,10 @@ export function AddFieldDialog({
 					field_key: key,
 					field_type: apiFieldType,
 					is_required: required,
-					options: fieldType === "Select" ? [] : undefined,
+					options:
+						fieldType === "Select" || fieldType === "MultiSelect"
+							? []
+							: undefined,
 				});
 				const mapped = mapApiFieldToUi(created);
 				onAdd(mapped);

--- a/apps/web/src/components/projects/interactions/task-detail/helpers.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/helpers.ts
@@ -31,8 +31,8 @@ const API_TO_UI_FIELD_TYPE: Record<FieldType, CustomFieldDef["field_type"]> = {
 	date: "Date",
 	boolean: "Checkbox",
 	select: "Select",
-	multi_select: "Select",
-	url: "Text",
+	multi_select: "MultiSelect",
+	url: "Url",
 };
 
 const UI_TO_API_FIELD_TYPE: Record<CustomFieldDef["field_type"], FieldType> = {
@@ -41,6 +41,8 @@ const UI_TO_API_FIELD_TYPE: Record<CustomFieldDef["field_type"], FieldType> = {
 	Date: "date",
 	Checkbox: "boolean",
 	Select: "select",
+	MultiSelect: "multi_select",
+	Url: "url",
 };
 
 export function mapApiFieldToUi(

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/chip-field.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/chip-field.tsx
@@ -1,0 +1,64 @@
+import { Plus, X } from "lucide-react";
+import type { ReactNode } from "react";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+
+export function ChipField({
+	chips,
+	onRemoveChip,
+	canEdit,
+	addLabel,
+	popoverContentClassName = "w-52 p-1 rounded-xl border border-border/40 shadow-lg",
+	popoverAlign = "start",
+	children,
+}: {
+	chips: { key: string; label: ReactNode }[];
+	onRemoveChip: (key: string) => void;
+	canEdit: boolean;
+	addLabel: string;
+	popoverContentClassName?: string;
+	popoverAlign?: "start" | "end" | "center";
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex flex-wrap items-center gap-1.5 min-h-7">
+			{chips.map((chip) => (
+				<span
+					key={chip.key}
+					className="inline-flex items-center gap-1 rounded-md bg-muted/50 px-2 py-0.5 text-xs font-medium text-foreground/80 border border-border/20 hover:border-border/40 transition-colors duration-150"
+				>
+					{chip.label}
+					{canEdit && (
+						<button
+							type="button"
+							onClick={() => onRemoveChip(chip.key)}
+							className="text-muted-foreground/60 hover:text-destructive transition-colors duration-150"
+						>
+							<X className="size-2.5" />
+						</button>
+					)}
+				</span>
+			))}
+			{canEdit && (
+				<Popover>
+					<PopoverTrigger
+						type="button"
+						className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/30 px-2 py-0.5 text-xs text-muted-foreground/60 hover:border-border/60 hover:text-muted-foreground transition-all duration-150"
+					>
+						<Plus className="size-2.5" />
+						{addLabel}
+					</PopoverTrigger>
+					<PopoverContent
+						className={popoverContentClassName}
+						align={popoverAlign}
+					>
+						{children}
+					</PopoverContent>
+				</Popover>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/custom-field-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/custom-field-editor.tsx
@@ -101,7 +101,9 @@ export function CustomFieldEditor({
 			}));
 			const currentVal = Array.isArray(rawValue)
 				? rawValue.filter((v): v is string => typeof v === "string")
-				: [];
+				: typeof rawValue === "string" && rawValue
+					? [rawValue]
+					: [];
 			return (
 				<MultiSelectEditor
 					value={currentVal}

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/custom-field-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/custom-field-editor.tsx
@@ -4,10 +4,12 @@ import { FieldValue } from "../primitives";
 import { CheckboxEditor } from "./checkbox-editor";
 import { SingleDateEditor } from "./date-editor";
 import { displayDate } from "./helpers";
+import { MultiSelectEditor } from "./multi-select-editor";
 import { NumberEditor } from "./number-editor";
 import { SelectEditor } from "./select-editor";
 import { TextEditor } from "./text-editor";
 import type { SelectOption } from "./types";
+import { UrlEditor } from "./url-editor";
 
 export function CustomFieldEditor({
 	customType,
@@ -16,7 +18,14 @@ export function CustomFieldEditor({
 	options = [],
 	onChange,
 }: {
-	customType: "Text" | "Number" | "Date" | "Checkbox" | "Select";
+	customType:
+		| "Text"
+		| "Number"
+		| "Date"
+		| "Checkbox"
+		| "Select"
+		| "MultiSelect"
+		| "Url";
 	rawValue: unknown;
 	canEdit: boolean;
 	options?: string[];
@@ -85,5 +94,30 @@ export function CustomFieldEditor({
 				/>
 			);
 		}
+		case "MultiSelect": {
+			const selectOptions: SelectOption[] = options.map((o) => ({
+				value: o,
+				label: o,
+			}));
+			const currentVal = Array.isArray(rawValue)
+				? rawValue.filter((v): v is string => typeof v === "string")
+				: [];
+			return (
+				<MultiSelectEditor
+					value={currentVal}
+					options={selectOptions}
+					canEdit={canEdit}
+					onChange={(v) => onChange?.(v)}
+				/>
+			);
+		}
+		case "Url":
+			return (
+				<UrlEditor
+					value={rawValue != null ? String(rawValue) : null}
+					canEdit={canEdit}
+					onChange={(v) => onChange?.(v)}
+				/>
+			);
 	}
 }

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/multi-select-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/multi-select-editor.tsx
@@ -1,0 +1,108 @@
+import { Check, Plus, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { FieldValue } from "../primitives";
+import type { SelectOption } from "./types";
+
+export function MultiSelectEditor({
+	value = [],
+	options,
+	canEdit,
+	onChange,
+}: {
+	value?: string[];
+	options: SelectOption[];
+	canEdit: boolean;
+	onChange?: (values: string[]) => void;
+}) {
+	const { t } = useTranslation("projects");
+	const selected = options.filter((o) => value.includes(o.value));
+
+	function toggle(optValue: string) {
+		onChange?.(
+			value.includes(optValue)
+				? value.filter((v) => v !== optValue)
+				: [...value, optValue],
+		);
+	}
+
+	if (!canEdit) {
+		if (selected.length === 0) return <FieldValue empty />;
+		return (
+			<div className="flex flex-wrap items-center gap-1.5">
+				{selected.map((opt) => (
+					<span
+						key={opt.value}
+						className="inline-flex items-center gap-1.5 rounded-full border border-border/30 bg-muted/30 px-2.5 py-0.5 text-xs font-semibold text-muted-foreground"
+					>
+						{opt.colorDot && (
+							<span
+								className="size-1.75 rounded-full shrink-0"
+								style={{ background: opt.colorDot }}
+							/>
+						)}
+						{opt.label}
+					</span>
+				))}
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-wrap items-center gap-1.5 min-h-7">
+			{selected.map((opt) => (
+				<span
+					key={opt.value}
+					className="inline-flex items-center gap-1 rounded-md bg-muted/50 px-2 py-0.5 text-xs font-medium text-foreground/80 border border-border/20 hover:border-border/40 transition-colors duration-150"
+				>
+					{opt.label}
+					<button
+						type="button"
+						onClick={() => toggle(opt.value)}
+						className="text-muted-foreground/60 hover:text-destructive transition-colors duration-150"
+					>
+						<X className="size-2.5" />
+					</button>
+				</span>
+			))}
+			<Popover>
+				<PopoverTrigger
+					type="button"
+					className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/30 px-2 py-0.5 text-xs text-muted-foreground/60 hover:border-border/60 hover:text-muted-foreground transition-all duration-150"
+				>
+					<Plus className="size-2.5" />
+					{t("taskDetail.propertyField.multiSelectEditor.addOption")}
+				</PopoverTrigger>
+				<PopoverContent
+					className="w-52 p-1 rounded-xl border border-border/40 shadow-lg"
+					align="start"
+				>
+					{options.map((opt) => {
+						const isSelected = value.includes(opt.value);
+						return (
+							<button
+								key={opt.value}
+								type="button"
+								className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-muted/60 transition-colors duration-100"
+								onClick={() => toggle(opt.value)}
+							>
+								{opt.colorDot && (
+									<span
+										className="size-2 rounded-full shrink-0"
+										style={{ background: opt.colorDot }}
+									/>
+								)}
+								<span className="flex-1 text-left">{opt.label}</span>
+								{isSelected && <Check className="size-3.5 text-primary" />}
+							</button>
+						);
+					})}
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/multi-select-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/multi-select-editor.tsx
@@ -1,11 +1,7 @@
-import { Check, Plus, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
 import { FieldValue } from "../primitives";
+import { ChipField } from "./chip-field";
+import { OptionListButton } from "./option-list-button";
 import type { SelectOption } from "./types";
 
 export function MultiSelectEditor({
@@ -53,56 +49,20 @@ export function MultiSelectEditor({
 	}
 
 	return (
-		<div className="flex flex-wrap items-center gap-1.5 min-h-7">
-			{selected.map((opt) => (
-				<span
+		<ChipField
+			chips={selected.map((opt) => ({ key: opt.value, label: opt.label }))}
+			onRemoveChip={toggle}
+			canEdit={canEdit}
+			addLabel={t("taskDetail.propertyField.multiSelectEditor.addOption")}
+		>
+			{options.map((opt) => (
+				<OptionListButton
 					key={opt.value}
-					className="inline-flex items-center gap-1 rounded-md bg-muted/50 px-2 py-0.5 text-xs font-medium text-foreground/80 border border-border/20 hover:border-border/40 transition-colors duration-150"
-				>
-					{opt.label}
-					<button
-						type="button"
-						onClick={() => toggle(opt.value)}
-						className="text-muted-foreground/60 hover:text-destructive transition-colors duration-150"
-					>
-						<X className="size-2.5" />
-					</button>
-				</span>
+					option={opt}
+					isSelected={value.includes(opt.value)}
+					onClick={() => toggle(opt.value)}
+				/>
 			))}
-			<Popover>
-				<PopoverTrigger
-					type="button"
-					className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/30 px-2 py-0.5 text-xs text-muted-foreground/60 hover:border-border/60 hover:text-muted-foreground transition-all duration-150"
-				>
-					<Plus className="size-2.5" />
-					{t("taskDetail.propertyField.multiSelectEditor.addOption")}
-				</PopoverTrigger>
-				<PopoverContent
-					className="w-52 p-1 rounded-xl border border-border/40 shadow-lg"
-					align="start"
-				>
-					{options.map((opt) => {
-						const isSelected = value.includes(opt.value);
-						return (
-							<button
-								key={opt.value}
-								type="button"
-								className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-muted/60 transition-colors duration-100"
-								onClick={() => toggle(opt.value)}
-							>
-								{opt.colorDot && (
-									<span
-										className="size-2 rounded-full shrink-0"
-										style={{ background: opt.colorDot }}
-									/>
-								)}
-								<span className="flex-1 text-left">{opt.label}</span>
-								{isSelected && <Check className="size-3.5 text-primary" />}
-							</button>
-						);
-					})}
-				</PopoverContent>
-			</Popover>
-		</div>
+		</ChipField>
 	);
 }

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/option-list-button.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/option-list-button.tsx
@@ -1,0 +1,31 @@
+import { Check } from "lucide-react";
+import type { SelectOption } from "./types";
+
+export function OptionListButton({
+	option,
+	isSelected,
+	onClick,
+}: {
+	option: SelectOption;
+	isSelected: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-muted/60 transition-colors duration-100"
+			onClick={onClick}
+		>
+			{option.colorDot ? (
+				<span
+					className="size-2 rounded-full shrink-0"
+					style={{ background: option.colorDot }}
+				/>
+			) : option.icon ? (
+				<span className="shrink-0">{option.icon}</span>
+			) : null}
+			<span className="flex-1 text-left">{option.label}</span>
+			{isSelected && <Check className="size-3.5 text-primary" />}
+		</button>
+	);
+}

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/select-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/select-editor.tsx
@@ -1,10 +1,10 @@
-import { Check } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import { OptionListButton } from "./option-list-button";
 import type { SelectOption } from "./types";
 
 export function SelectEditor({
@@ -57,23 +57,12 @@ export function SelectEditor({
 				{options.map((opt) => {
 					const isSelected = selectedArr.includes(opt.value);
 					return (
-						<button
+						<OptionListButton
 							key={opt.value}
-							type="button"
-							className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-muted/60 transition-colors duration-100"
+							option={opt}
+							isSelected={isSelected}
 							onClick={() => onChange(isSelected ? null : opt.value)}
-						>
-							{opt.colorDot ? (
-								<span
-									className="size-2 rounded-full shrink-0"
-									style={{ background: opt.colorDot }}
-								/>
-							) : opt.icon ? (
-								<span className="shrink-0">{opt.icon}</span>
-							) : null}
-							<span className="flex-1 text-left">{opt.label}</span>
-							{isSelected && <Check className="size-3.5 text-primary" />}
-						</button>
+						/>
 					);
 				})}
 			</PopoverContent>

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/tags-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/tags-editor.tsx
@@ -1,11 +1,6 @@
-import { Plus, X } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
+import { ChipField } from "./chip-field";
 
 export function TagsEditor({
 	tags = [],
@@ -31,64 +26,37 @@ export function TagsEditor({
 	}
 
 	return (
-		<div className="flex flex-wrap items-center gap-1.5 min-h-7">
-			{tags.map((tag) => (
-				<span
-					key={tag}
-					className="inline-flex items-center gap-1 rounded-md bg-muted/50 px-2 py-0.5 text-xs font-medium text-foreground/80 border border-border/20 hover:border-border/40 transition-colors duration-150"
-				>
-					{tag}
-					{canEdit && (
-						<button
-							type="button"
-							onClick={() => handleRemove(tag)}
-							className="text-muted-foreground/60 hover:text-destructive transition-colors duration-150"
-						>
-							<X className="size-2.5" />
-						</button>
+		<ChipField
+			chips={tags.map((tag) => ({ key: tag, label: tag }))}
+			onRemoveChip={handleRemove}
+			canEdit={canEdit}
+			addLabel={t("taskDetail.propertyField.tagsEditor.addTag")}
+			popoverContentClassName="w-52 p-2 rounded-xl border border-border/40 shadow-lg"
+		>
+			<form
+				onSubmit={(e) => {
+					e.preventDefault();
+					handleAdd(input);
+				}}
+			>
+				<input
+					// biome-ignore lint/a11y/noAutofocus: intentional for popover
+					autoFocus
+					type="text"
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					placeholder={t(
+						"taskDetail.propertyField.tagsEditor.addTagPlaceholder",
 					)}
-				</span>
-			))}
-			{canEdit && (
-				<Popover>
-					<PopoverTrigger
-						type="button"
-						className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/30 px-2 py-0.5 text-xs text-muted-foreground/60 hover:border-border/60 hover:text-muted-foreground transition-all duration-150"
-					>
-						<Plus className="size-2.5" />
-						{t("taskDetail.propertyField.tagsEditor.addTag")}
-					</PopoverTrigger>
-					<PopoverContent
-						className="w-52 p-2 rounded-xl border border-border/40 shadow-lg"
-						align="start"
-					>
-						<form
-							onSubmit={(e) => {
-								e.preventDefault();
-								handleAdd(input);
-							}}
-						>
-							<input
-								// biome-ignore lint/a11y/noAutofocus: intentional for popover
-								autoFocus
-								type="text"
-								value={input}
-								onChange={(e) => setInput(e.target.value)}
-								placeholder={t(
-									"taskDetail.propertyField.tagsEditor.addTagPlaceholder",
-								)}
-								className="w-full rounded-lg border border-border/30 bg-muted/25 px-3 py-2 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all duration-150"
-								onKeyDown={(e) => {
-									if (e.key === "Enter") {
-										e.preventDefault();
-										handleAdd(input);
-									}
-								}}
-							/>
-						</form>
-					</PopoverContent>
-				</Popover>
-			)}
-		</div>
+					className="w-full rounded-lg border border-border/30 bg-muted/25 px-3 py-2 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-all duration-150"
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							handleAdd(input);
+						}
+					}}
+				/>
+			</form>
+		</ChipField>
 	);
 }

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/types.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/types.ts
@@ -65,7 +65,14 @@ export interface PropertyFieldProps {
 	linkValue?: string;
 	onLinkClick?: () => void;
 
-	customType?: "Text" | "Number" | "Date" | "Checkbox" | "Select";
+	customType?:
+		| "Text"
+		| "Number"
+		| "Date"
+		| "Checkbox"
+		| "Select"
+		| "MultiSelect"
+		| "Url";
 	customRawValue?: unknown;
 	onCustomChange?: (value: unknown) => void;
 	customOptions?: string[];

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/url-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/url-editor.tsx
@@ -1,0 +1,30 @@
+import { ExternalLink } from "lucide-react";
+import { FieldValue } from "../primitives";
+import { TextEditor } from "./text-editor";
+
+export function UrlEditor({
+	value,
+	canEdit,
+	onChange,
+}: {
+	value: string | null;
+	canEdit: boolean;
+	onChange?: (value: string) => void;
+}) {
+	if (!canEdit) {
+		if (!value) return <FieldValue empty />;
+		if (!/^https?:\/\//i.test(value)) return <FieldValue>{value}</FieldValue>;
+		return (
+			<a
+				href={value}
+				target="_blank"
+				rel="noreferrer"
+				className="inline-flex items-center gap-1.5 text-sm font-medium text-primary/80 hover:text-primary hover:underline underline-offset-2 transition-colors duration-150 truncate max-w-full"
+			>
+				<ExternalLink className="size-3 shrink-0" />
+				<span className="truncate">{value}</span>
+			</a>
+		);
+	}
+	return <TextEditor value={value} canEdit={canEdit} onChange={onChange} />;
+}

--- a/apps/web/src/components/projects/interactions/task-detail/types.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/types.ts
@@ -7,7 +7,14 @@ export interface CustomFieldDef {
 	id: string;
 	display_name: string;
 	field_key: string;
-	field_type: "Text" | "Number" | "Date" | "Checkbox" | "Select";
+	field_type:
+		| "Text"
+		| "Number"
+		| "Date"
+		| "Checkbox"
+		| "Select"
+		| "MultiSelect"
+		| "Url";
 	required?: boolean;
 	options?: string[];
 }

--- a/apps/web/src/components/projects/settings/CustomFieldsSettings.tsx
+++ b/apps/web/src/components/projects/settings/CustomFieldsSettings.tsx
@@ -43,6 +43,8 @@ const UI_FIELD_TYPES = [
 	"Date",
 	"Checkbox",
 	"Select",
+	"MultiSelect",
+	"Url",
 ] as const;
 type UIFieldType = (typeof UI_FIELD_TYPES)[number];
 
@@ -52,6 +54,8 @@ const UI_TO_API_FIELD_TYPE: Record<UIFieldType, FieldType> = {
 	Date: "date",
 	Checkbox: "boolean",
 	Select: "select",
+	MultiSelect: "multi_select",
+	Url: "url",
 };
 
 const UI_FIELD_TYPE_LABEL_KEYS = {
@@ -60,6 +64,8 @@ const UI_FIELD_TYPE_LABEL_KEYS = {
 	Date: "settings.customFields.fieldTypes.date",
 	Checkbox: "settings.customFields.fieldTypes.checkbox",
 	Select: "settings.customFields.fieldTypes.select",
+	MultiSelect: "settings.customFields.fieldTypes.multiSelect",
+	Url: "settings.customFields.fieldTypes.url",
 } as const satisfies Record<UIFieldType, string>;
 
 const API_TO_UI_FIELD_TYPE_LABEL_KEY = {
@@ -133,7 +139,8 @@ function CreateCustomFieldDialog({
 				display_name: displayName.trim(),
 				field_key: fieldKey || slugify(displayName),
 				field_type: UI_TO_API_FIELD_TYPE[fieldType],
-				options: fieldType === "Select" ? options : [],
+				options:
+					fieldType === "Select" || fieldType === "MultiSelect" ? options : [],
 				is_required: required,
 			}),
 		onSuccess: () => {
@@ -237,8 +244,8 @@ function CreateCustomFieldDialog({
 						</div>
 					</div>
 
-					{/* Options editor — only for Select type */}
-					{fieldType === "Select" && (
+					{/* Options editor — only for Select / MultiSelect types */}
+					{(fieldType === "Select" || fieldType === "MultiSelect") && (
 						<div className="space-y-1.5">
 							<Label>{t("settings.customFields.optionsLabel")}</Label>
 							<div className="space-y-1">
@@ -402,7 +409,10 @@ function EditCustomFieldDialog({
 				return Promise.resolve(field as unknown as CustomFieldDefinition);
 			return updateCustomFieldDefinition(projectId, field.id, {
 				display_name: displayName.trim(),
-				options: field.field_type === "select" ? options : undefined,
+				options:
+					field.field_type === "select" || field.field_type === "multi_select"
+						? options
+						: undefined,
 				is_required: required,
 			});
 		},
@@ -483,7 +493,8 @@ function EditCustomFieldDialog({
 						</p>
 					</div>
 
-					{field.field_type === "select" && (
+					{(field.field_type === "select" ||
+						field.field_type === "multi_select") && (
 						<div className="space-y-1.5">
 							<Label>{t("settings.customFields.optionsLabel")}</Label>
 							<div className="space-y-1">

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -699,7 +699,9 @@
 				"number": "Number",
 				"date": "Date",
 				"checkbox": "Checkbox",
-				"select": "Select"
+				"select": "Select",
+				"multiSelect": "Multi-Select",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "Add tag",
 				"addTagPlaceholder": "Add tag..."
+			},
+			"multiSelectEditor": {
+				"addOption": "Add option"
 			}
 		},
 		"panel": {

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -699,7 +699,9 @@
 				"number": "Número",
 				"date": "Fecha",
 				"checkbox": "Casilla de verificación",
-				"select": "Selección"
+				"select": "Selección",
+				"multiSelect": "Selección múltiple",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "Añadir etiqueta",
 				"addTagPlaceholder": "Añadir etiqueta..."
+			},
+			"multiSelectEditor": {
+				"addOption": "Añadir opción"
 			}
 		},
 		"panel": {

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -699,7 +699,9 @@
 				"number": "Nombre",
 				"date": "Date",
 				"checkbox": "Case à cocher",
-				"select": "Liste déroulante"
+				"select": "Liste déroulante",
+				"multiSelect": "Sélection multiple",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "Ajouter un tag",
 				"addTagPlaceholder": "Ajouter un tag..."
+			},
+			"multiSelectEditor": {
+				"addOption": "Ajouter une option"
 			}
 		},
 		"panel": {

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -699,7 +699,9 @@
 				"number": "数値",
 				"date": "日付",
 				"checkbox": "チェックボックス",
-				"select": "選択"
+				"select": "選択",
+				"multiSelect": "複数選択",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "タグを追加",
 				"addTagPlaceholder": "タグを追加..."
+			},
+			"multiSelectEditor": {
+				"addOption": "オプションを追加"
 			}
 		},
 		"panel": {

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -699,7 +699,9 @@
 				"number": "숫자",
 				"date": "날짜",
 				"checkbox": "체크박스",
-				"select": "선택"
+				"select": "선택",
+				"multiSelect": "다중 선택",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "태그 추가",
 				"addTagPlaceholder": "태그 추가..."
+			},
+			"multiSelectEditor": {
+				"addOption": "옵션 추가"
 			}
 		},
 		"panel": {

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -699,7 +699,9 @@
 				"number": "Số",
 				"date": "Ngày",
 				"checkbox": "Checkbox",
-				"select": "Chọn"
+				"select": "Chọn",
+				"multiSelect": "Chọn nhiều",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "Thêm thẻ",
 				"addTagPlaceholder": "Thêm thẻ..."
+			},
+			"multiSelectEditor": {
+				"addOption": "Thêm tùy chọn"
 			}
 		},
 		"panel": {

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -699,7 +699,9 @@
 				"number": "数字",
 				"date": "日期",
 				"checkbox": "复选框",
-				"select": "单选"
+				"select": "单选",
+				"multiSelect": "多选",
+				"url": "URL"
 			}
 		},
 		"addTaskLinkModal": {
@@ -741,6 +743,9 @@
 			"tagsEditor": {
 				"addTag": "添加标签",
 				"addTagPlaceholder": "添加标签..."
+			},
+			"multiSelectEditor": {
+				"addOption": "添加选项"
 			}
 		},
 		"panel": {


### PR DESCRIPTION
## Summary

The backend's `FieldType` enum supports 7 custom field types (`text`, `number`, `date`, `select`, `multi_select`, `boolean`, `url`), but the web app only had editors for 5. `multi_select` and `url` fields could only be created by calling the API directly — there was no UI path to create them — and once created, their values were silently mangled (a `multi_select` array like `["backend", "bug"]` got passed through `String()` and rendered as `"backend,bug"`).

This PR adds full UI support for both types, end to end: creation, display, and editing.

## Changes

- **New editors**: `MultiSelectEditor` (chip-based multi-pick over fixed options) and `UrlEditor` (renders as a clickable external link when read-only, falls back to plain text if the value isn't a real `http(s)://` URL)
- **Type mapping**: `helpers.ts`'s `API_TO_UI_FIELD_TYPE` / `UI_TO_API_FIELD_TYPE` are now a lossless 1:1 mapping instead of collapsing `multi_select → Select` and `url → Text`
- **Field creation**: both the in-task-detail "Add field" dialog and the project settings custom fields manager can now create `MultiSelect`/`Url` fields, including an options editor for `MultiSelect` (reusing the existing `Select` options UI)
- **i18n**: added `multiSelect`/`url` labels and a `multiSelectEditor.addOption` string to all 7 locales

## Testing

- `tsc -b` and `biome check` pass clean across `apps/web`
- Manually created a `multi_select` field, set values via the new editor, confirmed display/edit round-trips correctly