### PR TITLE
fix: blocknote content validation

### DIFF
--- a/apps/web/src/components/projects/docs/doc-editor.tsx
+++ b/apps/web/src/components/projects/docs/doc-editor.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import { CustomSideMenu } from "@/components/shared/blocknote-custom-side-menu";
 import { customSchema } from "@/components/shared/blocknote-schema";
+import { normalizeBlockContent } from "@/components/shared/comment-blocknote";
 import { MentionSuggestionMenus } from "@/components/shared/mention-suggestion-menus";
 import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
 import { useThemeMode } from "@/hooks/use-theme-mode";
@@ -88,8 +89,13 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 
 		// Populate / re-populate editor from server content
 		useEffect(() => {
-			const normalized = content ?? null;
-			const cleanedNormalized = cleanBlocks(normalized);
+			// Normalize whatever the server returned (including legacy/invalid
+			// content that isn't a block array, e.g. a plain string) into a safe
+			// block array so BlockNote never receives data it can't render.
+			const displayBlocks = normalizeBlockContent(content ?? null);
+			const cleanedNormalized = cleanBlocks(
+				displayBlocks.length > 0 ? displayBlocks : null,
+			);
 			const normalizedStr = cleanedNormalized
 				? JSON.stringify(cleanedNormalized)
 				: null;
@@ -108,11 +114,10 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 			readyRef.current = false;
 			dirtyRef.current = false;
 
-			let blocks: Parameters<typeof editor.replaceBlocks>[1] | undefined;
-			if (normalized && Array.isArray(normalized) && normalized.length > 0) {
-				blocks = normalized as Parameters<typeof editor.replaceBlocks>[1];
-			}
-			editor.replaceBlocks(editor.document, blocks ?? []);
+			editor.replaceBlocks(
+				editor.document,
+				displayBlocks as Parameters<typeof editor.replaceBlocks>[1],
+			);
 			queueMicrotask(() => {
 				readyRef.current = true;
 			});

--- a/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/description-section.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CustomSideMenu } from "@/components/shared/blocknote-custom-side-menu";
 import { customSchema } from "@/components/shared/blocknote-schema";
+import { normalizeBlockContent } from "@/components/shared/comment-blocknote";
 import { MentionSuggestionMenus } from "@/components/shared/mention-suggestion-menus";
 import { Button } from "@/components/ui/button";
 import {
@@ -127,8 +128,13 @@ export function DescriptionSection({
 	// Populate the editor from BlockNote JSON whenever description changes
 	// externally (initial load or server refetch that differs from what we saved).
 	useEffect(() => {
-		const normalized = description ?? null;
-		const cleanedNormalized = cleanBlocks(normalized);
+		// Normalize whatever the API returned (including legacy/invalid content
+		// that isn't a block array, e.g. a plain string) into a safe block array
+		// so BlockNote never receives data it can't render.
+		const displayBlocks = normalizeBlockContent(description ?? null);
+		const cleanedNormalized = cleanBlocks(
+			displayBlocks.length > 0 ? displayBlocks : null,
+		);
 		// Stringify for stable comparison (array identity changes on every response)
 		const normalizedStr = cleanedNormalized
 			? JSON.stringify(cleanedNormalized)
@@ -139,11 +145,10 @@ export function DescriptionSection({
 		lastSavedRef.current = normalizedStr;
 		readyRef.current = false;
 
-		let blocks: Parameters<typeof editor.replaceBlocks>[1] | undefined;
-		if (normalized && Array.isArray(normalized) && normalized.length > 0) {
-			blocks = normalized as Parameters<typeof editor.replaceBlocks>[1];
-		}
-		editor.replaceBlocks(editor.document, blocks ?? []);
+		editor.replaceBlocks(
+			editor.document,
+			displayBlocks as Parameters<typeof editor.replaceBlocks>[1],
+		);
 		queueMicrotask(() => {
 			readyRef.current = true;
 		});

--- a/apps/web/src/components/shared/comment-blocknote.test.ts
+++ b/apps/web/src/components/shared/comment-blocknote.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeBlockContent } from "./comment-blocknote";
+
+describe("normalizeBlockContent", () => {
+	it("returns the array unchanged when content is already a block array", () => {
+		const blocks = [{ type: "paragraph", content: [] }];
+		expect(normalizeBlockContent(blocks)).toBe(blocks);
+	});
+
+	it("wraps a plain string into a paragraph block instead of dropping it", () => {
+		// This is the exact shape reported in GitHub issue #233: a plain string
+		// stored as description/comment content, which used to crash BlockNote's
+		// `.map()` calls over blocks.
+		const result = normalizeBlockContent("just a plain string") as Array<{
+			type: string;
+			content: Array<{ text: string }>;
+		}>;
+		expect(result).toHaveLength(1);
+		expect(result[0].type).toBe("paragraph");
+		expect(result[0].content[0].text).toBe("just a plain string");
+	});
+
+	it("returns an empty array for null, undefined, empty string, or other scalars", () => {
+		expect(normalizeBlockContent(null)).toEqual([]);
+		expect(normalizeBlockContent(undefined)).toEqual([]);
+		expect(normalizeBlockContent("")).toEqual([]);
+		expect(normalizeBlockContent(42)).toEqual([]);
+		expect(normalizeBlockContent({ type: "paragraph" })).toEqual([]);
+	});
+});

--- a/apps/web/src/components/shared/comment-blocknote.tsx
+++ b/apps/web/src/components/shared/comment-blocknote.tsx
@@ -154,6 +154,21 @@ export function isBlocksContent(content: unknown): content is unknown[] {
 	return Array.isArray(content);
 }
 
+/**
+ * Normalizes arbitrary stored content into a BlockNote block array so
+ * editors/viewers never receive non-array data (which crashes BlockNote's
+ * internal `.map()` calls over blocks). Legacy plain-text content — e.g.
+ * data saved before content validation existed — is wrapped into a single
+ * paragraph block so it stays visible instead of silently disappearing.
+ */
+export function normalizeBlockContent(content: unknown): unknown[] {
+	if (Array.isArray(content)) return content;
+	if (typeof content === "string" && content.trim().length > 0) {
+		return textToBlocks(content);
+	}
+	return [];
+}
+
 function stripTrailingEmptyBlocks(blocks: unknown[]): unknown[] {
 	if (!Array.isArray(blocks) || blocks.length === 0) return blocks;
 	const lastBlock = blocks[blocks.length - 1] as { content?: unknown[] };

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -18,6 +18,12 @@ describe("cleanBlocks", () => {
 		expect(cleanBlocks(null)).toBeNull();
 	});
 
+	it("returns null when blocks is not an array (e.g. a plain string)", () => {
+		expect(
+			cleanBlocks("just a plain string" as unknown as unknown[]),
+		).toBeNull();
+	});
+
 	it("strips id field recursively and preserves other properties", () => {
 		const input = [
 			{

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -8,7 +8,7 @@ export function cn(...inputs: ClassValue[]) {
 export function cleanBlocks(
 	blocks: unknown[] | null | undefined,
 ): unknown[] | null {
-	if (!blocks) return null;
+	if (!blocks || !Array.isArray(blocks)) return null;
 	const strip = (arr: unknown[]): unknown[] => {
 		return arr.map((item) => {
 			if (!item || typeof item !== "object") return item;

--- a/services/api/internal/transport/http/dto/blocknote_content.go
+++ b/services/api/internal/transport/http/dto/blocknote_content.go
@@ -1,0 +1,34 @@
+package dto
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// ValidateBlockNoteContent checks that raw is either absent, JSON null, or a
+// JSON array of BlockNote block objects (each a JSON object with a "type"
+// string field). Task descriptions and document content are stored as
+// BlockNote documents and rendered client-side with block-array assumptions
+// (e.g. `.map()` over the blocks); accepting anything else (a bare string, a
+// single object, a number, ...) would store data the web app cannot render
+// and crashes on. Activity/doc comment content has its own, more permissive
+// validation in the task/doc activity services (it also allows a legacy
+// {"text": "..."} shape), so this validator is not used for comments.
+func ValidateBlockNoteContent(raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+
+	var blocks []map[string]any
+	if err := json.Unmarshal(trimmed, &blocks); err != nil {
+		return fmt.Errorf("content must be a BlockNote document (a JSON array of blocks)")
+	}
+	for i, block := range blocks {
+		if _, ok := block["type"].(string); !ok {
+			return fmt.Errorf("content block at index %d is missing a \"type\" field", i)
+		}
+	}
+	return nil
+}

--- a/services/api/internal/transport/http/dto/blocknote_content_test.go
+++ b/services/api/internal/transport/http/dto/blocknote_content_test.go
@@ -1,0 +1,56 @@
+package dto_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Paca-AI/api/internal/transport/http/dto"
+)
+
+func TestValidateBlockNoteContent_AcceptsAbsentOrNull(t *testing.T) {
+	if err := dto.ValidateBlockNoteContent(nil); err != nil {
+		t.Fatalf("expected nil raw to be accepted, got %v", err)
+	}
+	if err := dto.ValidateBlockNoteContent(json.RawMessage("null")); err != nil {
+		t.Fatalf("expected JSON null to be accepted, got %v", err)
+	}
+}
+
+func TestValidateBlockNoteContent_AcceptsValidBlockArray(t *testing.T) {
+	raw := json.RawMessage(`[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]`)
+	if err := dto.ValidateBlockNoteContent(raw); err != nil {
+		t.Fatalf("expected valid block array to be accepted, got %v", err)
+	}
+}
+
+func TestValidateBlockNoteContent_AcceptsEmptyArray(t *testing.T) {
+	if err := dto.ValidateBlockNoteContent(json.RawMessage(`[]`)); err != nil {
+		t.Fatalf("expected empty array to be accepted, got %v", err)
+	}
+}
+
+func TestValidateBlockNoteContent_RejectsPlainString(t *testing.T) {
+	// This is the exact shape reported in GitHub issue #233: a plain string
+	// sent as the description, which crashes the web app's block renderers.
+	if err := dto.ValidateBlockNoteContent(json.RawMessage(`"just a plain string"`)); err == nil {
+		t.Fatal("expected a plain string to be rejected")
+	}
+}
+
+func TestValidateBlockNoteContent_RejectsObject(t *testing.T) {
+	if err := dto.ValidateBlockNoteContent(json.RawMessage(`{"type":"paragraph"}`)); err == nil {
+		t.Fatal("expected a bare object (not wrapped in an array) to be rejected")
+	}
+}
+
+func TestValidateBlockNoteContent_RejectsNumber(t *testing.T) {
+	if err := dto.ValidateBlockNoteContent(json.RawMessage(`42`)); err == nil {
+		t.Fatal("expected a number to be rejected")
+	}
+}
+
+func TestValidateBlockNoteContent_RejectsBlockMissingType(t *testing.T) {
+	if err := dto.ValidateBlockNoteContent(json.RawMessage(`[{"content":[]}]`)); err == nil {
+		t.Fatal("expected a block without a type field to be rejected")
+	}
+}

--- a/services/api/internal/transport/http/handler/document_handler.go
+++ b/services/api/internal/transport/http/handler/document_handler.go
@@ -206,6 +206,10 @@ func (h *DocumentHandler) CreateDocument(w http.ResponseWriter, r *http.Request)
 	if !middleware.BindJSON(w, r, &req) {
 		return
 	}
+	if err := dto.ValidateBlockNoteContent(req.Content); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "content: "+err.Error()))
+		return
+	}
 
 	var createdBy *uuid.UUID
 	var createdByAgent *uuid.UUID
@@ -255,6 +259,12 @@ func (h *DocumentHandler) UpdateDocument(w http.ResponseWriter, r *http.Request)
 	var req dto.UpdateDocumentRequest
 	if !middleware.BindJSON(w, r, &req) {
 		return
+	}
+	if req.Content.Set && req.Content.Value != nil {
+		if err := dto.ValidateBlockNoteContent(req.Content.Value); err != nil {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "content: "+err.Error()))
+			return
+		}
 	}
 
 	var updatedBy *uuid.UUID

--- a/services/api/internal/transport/http/handler/document_handler_test.go
+++ b/services/api/internal/transport/http/handler/document_handler_test.go
@@ -84,7 +84,9 @@ func newDocumentRouter() chi.Router {
 	r := chi.NewRouter()
 	r.Route("/projects/{projectId}", func(r chi.Router) {
 		r.Post("/docs/folders", h.CreateFolder)
+		r.Post("/docs", h.CreateDocument)
 		r.Route("/docs/{docId}", func(r chi.Router) {
+			r.Patch("/", h.UpdateDocument)
 			r.Post("/comments", h.AddComment)
 			r.Patch("/comments/{commentId}", h.UpdateComment)
 		})
@@ -164,5 +166,38 @@ func TestDocUpdateComment_EmptyContent_Returns400(t *testing.T) {
 	)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for empty content, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateDocument_StringContent_Returns400 guards against GitHub issue
+// #233: document content must be a BlockNote block array, not a plain string.
+func TestCreateDocument_StringContent_Returns400(t *testing.T) {
+	r := newDocumentRouter()
+	projectID := uuid.New()
+
+	w := doDocRequest(t, r, http.MethodPost,
+		"/projects/"+projectID.String()+"/docs",
+		map[string]any{"title": "Doc", "content": "just a plain string"},
+		nil,
+	)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for string content, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestUpdateDocument_StringContent_Returns400 mirrors the create case above
+// for PATCH /projects/:projectId/docs/:docId.
+func TestUpdateDocument_StringContent_Returns400(t *testing.T) {
+	r := newDocumentRouter()
+	projectID := uuid.New()
+	docID := uuid.New()
+
+	w := doDocRequest(t, r, http.MethodPatch,
+		"/projects/"+projectID.String()+"/docs/"+docID.String(),
+		map[string]any{"content": "just a plain string"},
+		nil,
+	)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for string content, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -607,6 +607,12 @@ func (h *TaskHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 	if !middleware.BindJSON(w, r, &req) {
 		return
 	}
+	if req.Description != nil {
+		if err := dto.ValidateBlockNoteContent(*req.Description); err != nil {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "description: "+err.Error()))
+			return
+		}
+	}
 
 	t, err := h.svc.CreateTask(r.Context(), taskdom.CreateTaskInput{
 		ProjectID:    projectID,
@@ -678,6 +684,12 @@ func (h *TaskHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 	var req dto.UpdateTaskRequest
 	if !middleware.BindJSON(w, r, &req) {
 		return
+	}
+	if req.Description.Set && req.Description.Value != nil {
+		if err := dto.ValidateBlockNoteContent(req.Description.Value); err != nil {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "description: "+err.Error()))
+			return
+		}
 	}
 
 	// Fetch old state before mutating so we can record before/after values.

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -664,6 +664,45 @@ func TestTaskHandler_CreateTask_EmptyTitleReturns400(t *testing.T) {
 	}
 }
 
+// TestTaskHandler_CreateTask_StringDescriptionReturns400 guards against
+// GitHub issue #233: a plain string description (instead of a BlockNote
+// block array) must be rejected up front, not stored and later crash the
+// web app's `.map()`-based block renderers.
+func TestTaskHandler_CreateTask_StringDescriptionReturns400(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+	w := doTaskRequest(r, http.MethodPost,
+		fmt.Sprintf("/projects/%s/tasks", projectID),
+		map[string]any{"title": "New Task", "description": "just a plain string"},
+	)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestTaskHandler_UpdateTask_StringDescriptionReturns400 mirrors the create
+// case above for PATCH /projects/:projectId/tasks/:taskId.
+func TestTaskHandler_UpdateTask_StringDescriptionReturns400(t *testing.T) {
+	svc := newFakeTaskSvc()
+	r := buildTaskHandlerRouter(svc)
+	projectID := uuid.New()
+
+	createW := doTaskRequest(r, http.MethodPost,
+		fmt.Sprintf("/projects/%s/tasks", projectID),
+		map[string]any{"title": "New Task"},
+	)
+	taskID := decodeTaskID(t, createW.Body.Bytes())
+
+	w := doTaskRequest(r, http.MethodPatch,
+		fmt.Sprintf("/projects/%s/tasks/%s", projectID, taskID),
+		map[string]any{"description": "just a plain string"},
+	)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestTaskHandler_GetTask_Returns200(t *testing.T) {
 	svc := newFakeTaskSvc()
 	r := buildTaskHandlerRouter(svc)

--- a/services/api/test/integration/document_test.go
+++ b/services/api/test/integration/document_test.go
@@ -508,7 +508,7 @@ func TestIntegrationDocuments_CRUD(t *testing.T) {
 	// Create document
 	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
 		"title":   "Getting Started",
-		"content": json.RawMessage(`{"type":"doc","content":[]}`),
+		"content": json.RawMessage(`[]`),
 	}))
 	if createW.Code != http.StatusCreated {
 		t.Fatalf("create document: expected 201, got %d (%s)", createW.Code, createW.Body.String())
@@ -690,7 +690,7 @@ func TestIntegrationDocuments_Snapshots(t *testing.T) {
 	// Create document with initial content
 	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{
 		"title":   "API Reference",
-		"content": json.RawMessage(`{"type":"doc","v":1}`),
+		"content": json.RawMessage(`[{"type":"paragraph","content":[{"type":"text","text":"v1"}]}]`),
 	}))
 	if createW.Code != http.StatusCreated {
 		t.Fatalf("create: expected 201, got %d", createW.Code)
@@ -709,7 +709,7 @@ func TestIntegrationDocuments_Snapshots(t *testing.T) {
 
 	// Update content — triggers snapshot creation
 	patchW := serve(r, authedJSONReq(t.Context(), http.MethodPatch, base+"/"+docID, tok, map[string]any{
-		"content": json.RawMessage(`{"type":"doc","v":2}`),
+		"content": json.RawMessage(`[{"type":"paragraph","content":[{"type":"text","text":"v2"}]}]`),
 	}))
 	if patchW.Code != http.StatusOK {
 		t.Fatalf("update: expected 200, got %d (%s)", patchW.Code, patchW.Body.String())
@@ -860,6 +860,38 @@ func TestIntegrationDocuments_AddEmptyCommentReturns400(t *testing.T) {
 
 	w := serve(r, authedJSONReq(t.Context(), http.MethodPost,
 		base+"/"+docID+"/comments", tok, map[string]any{"content": "   "}))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	if code := decodeErrorCode(t, w); code != "DOC_COMMENT_CONTENT_INVALID" {
+		t.Errorf("expected DOC_COMMENT_CONTENT_INVALID, got %q", code)
+	}
+}
+
+// TestIntegrationDocuments_AddStringCommentReturns400 guards against GitHub
+// issue #233: a bare JSON string (not a BlockNote block array, and not the
+// legacy {"text": "..."} shape) must be rejected rather than stored, since
+// the web app's block renderers crash on it.
+func TestIntegrationDocuments_AddStringCommentReturns400(t *testing.T) {
+	docRepo := newFakeDocRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionDocsRead, authz.PermissionDocsWrite},
+		},
+	}
+	r := buildDocTestRouter(docRepo, store)
+	tok := issueDocToken(t, uuid.NewString())
+	base := fmt.Sprintf("/api/v1/projects/%s/docs", projectID)
+
+	createW := serve(r, authedJSONReq(t.Context(), http.MethodPost, base, tok, map[string]any{"title": "Doc"}))
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d", createW.Code)
+	}
+	docID := docIDFrom(t, "document", createW.Body.Bytes())
+
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		base+"/"+docID+"/comments", tok, map[string]any{"content": "just a plain string"}))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d (%s)", w.Code, w.Body.String())
 	}

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -3141,6 +3141,42 @@ func TestActivities_AddAndListComment(t *testing.T) {
 	}
 }
 
+// TestActivities_AddComment_StringContentReturns400 guards against GitHub
+// issue #233: a bare JSON string (not a BlockNote block array, and not the
+// legacy {"text": "..."} shape) must be rejected rather than stored, since
+// the web app's block renderers crash on it.
+func TestActivities_AddComment_StringContentReturns400(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	projectID := uuid.New()
+	store := &projectPermStore{
+		projectPerms: map[uuid.UUID][]authz.Permission{
+			projectID: {authz.PermissionTasksRead, authz.PermissionTasksWrite},
+		},
+	}
+	r := buildTaskTestRouter(taskRepo, store)
+	tok := issueTaskToken(t, uuid.NewString())
+
+	w := serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks", projectID), tok,
+		map[string]any{"title": "Activity Test Task"},
+	))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create task: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	taskID := taskIDFrom(t, "task", w.Body.Bytes())
+
+	w = serve(r, authedJSONReq(t.Context(), http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/tasks/%s/activities/comments", projectID, taskID), tok,
+		map[string]any{"content": "just a plain string"},
+	))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if code := decodeErrorCode(t, w); code != "ACTIVITY_COMMENT_CONTENT_INVALID" {
+		t.Errorf("expected ACTIVITY_COMMENT_CONTENT_INVALID, got %q", code)
+	}
+}
+
 func TestActivities_AddComment_RequiresAuth(t *testing.T) {
 	taskRepo := newFakeTaskRepoIT()
 	projectID := uuid.New()


### PR DESCRIPTION
## Summary

Fixes #233 — `TypeError: e.map is not a function` when opening a task detail panel.

**Root cause:** task descriptions, comments, and document content are stored as BlockNote block arrays and rendered client-side with array assumptions (`.map()` over blocks). `cleanBlocks()` in `apps/web/src/lib/utils.ts` called `.map()` on its argument without checking it was actually an array. If a task's `description` (or a document's `content`) was ever saved as something other than a block array — e.g. a plain string sent directly via the API, bypassing the web editor — the task detail panel crashed before it could render anything.

**API validation** (`services/api`):
- Added `dto.ValidateBlockNoteContent`, which rejects any `description`/`content` value that isn't `null`/absent or a JSON array of block objects (each with a `type` field).
- Wired into `CreateTask`/`UpdateTask` (description) and `CreateDocument`/`UpdateDocument` (content), returning `400 Bad Request` instead of persisting malformed data.
- Left comment endpoints (task & doc) untouched — the activity services already have their own `isContentTypeValid`/`isContentEmpty` checks that intentionally also accept a legacy `{"text": "..."}` shape, so adding a stricter check there would have broken that behavior.

**Web resilience** (`apps/web`):
- `cleanBlocks()` now guards `Array.isArray` and returns `null` for non-array input instead of throwing.
- Added `normalizeBlockContent()` so non-array content (e.g. a legacy plain string from data saved before this validation existed) is converted into a paragraph block and still shown, rather than crashing or silently disappearing. Used in `description-section.tsx` and `doc-editor.tsx`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass (added unit tests in `dto`, `handler`, and new integration tests covering string descriptions/content returning 400)
- [x] `npx vitest run` passes (265 tests, incl. new `cleanBlocks`/`normalizeBlockContent` cases)
- [x] `tsc --noEmit` and `biome check .` clean