### PR TITLE
feat: migrate AGENT_SERVER_IMAGE to new paca-ai repository and update…

### DIFF
--- a/.github/workflows/ai-agent-pr-ci.yml
+++ b/.github/workflows/ai-agent-pr-ci.yml
@@ -154,10 +154,25 @@ jobs:
           uv venv
           uv pip install --group dev -e .
 
-      - name: Pull agent-server sandbox image
-        # Reported as its own step for clearer timing in the Actions UI —
-        # this pulls several GB on a cold cache.
-        run: docker pull ghcr.io/paca-ai/paca-agent-server:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build agent-server sandbox image
+        # Built locally from this branch's own Dockerfile — pulling the
+        # published ghcr.io/paca-ai/paca-agent-server tag instead would test
+        # whatever happens to be published in the registry rather than this
+        # PR's changes, and can pass or fail for reasons unrelated to the
+        # diff (see the parent_id/openhands-sdk incident this replaced).
+        # Tagged to match config.py's AGENT_SERVER_IMAGE default exactly, so
+        # docker_workspace.py picks up this local build with no pull.
+        uses: docker/build-push-action@v6
+        with:
+          context: services/agent-server
+          push: false
+          load: true
+          tags: ghcr.io/paca-ai/paca-agent-server:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/ai-agent-pr-ci.yml
+++ b/.github/workflows/ai-agent-pr-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "services/ai-agent/**"
+      - "services/agent-server/**"
       - ".github/workflows/ai-agent-pr-ci.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ai-agent-pr-ci.yml
+++ b/.github/workflows/ai-agent-pr-ci.yml
@@ -154,25 +154,10 @@ jobs:
           uv venv
           uv pip install --group dev -e .
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build agent-server sandbox image
-        # Built locally from this branch's own Dockerfile — pulling the
-        # published ghcr.io/paca-ai/paca-agent-server tag instead would test
-        # whatever happens to be published in the registry rather than this
-        # PR's changes, and can pass or fail for reasons unrelated to the
-        # diff (see the parent_id/openhands-sdk incident this replaced).
-        # Tagged to match config.py's AGENT_SERVER_IMAGE default exactly, so
-        # docker_workspace.py picks up this local build with no pull.
-        uses: docker/build-push-action@v6
-        with:
-          context: services/agent-server
-          push: false
-          load: true
-          tags: ghcr.io/paca-ai/paca-agent-server:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Pull agent-server sandbox image
+        # Reported as its own step for clearer timing in the Actions UI —
+        # this pulls several GB on a cold cache.
+        run: docker pull ghcr.io/paca-ai/paca-agent-server:latest
 
       - name: Run E2E tests
         env:

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -247,6 +247,30 @@ else
     info "Using floating :latest images — no image version changes needed."
 fi
 
+# Migrate AGENT_SERVER_IMAGE off the old upstream default. Installs created
+# before Paca shipped its own agent-server image (Paca MCP pre-installed,
+# openhands-sdk version kept in step with services/ai-agent) have this
+# hardcoded to the raw OpenHands image. Only offer to rewrite installs still
+# on that exact old default — never touch a value the user deliberately
+# customized. Asked rather than applied silently: it changes which image the
+# sandbox containers run, which is worth a confirmation like the version
+# re-pin above rather than a silent backfill.
+OLD_AGENT_SERVER_IMAGE_DEFAULT="ghcr.io/openhands/agent-server:latest-python"
+if [[ "$(get_env_var .env AGENT_SERVER_IMAGE)" == "$OLD_AGENT_SERVER_IMAGE_DEFAULT" ]]; then
+    heading "Agent-server image"
+    info "AGENT_SERVER_IMAGE is still set to the upstream OpenHands image (${OLD_AGENT_SERVER_IMAGE_DEFAULT})."
+    info "Paca now ships its own agent-server image (ghcr.io/paca-ai/paca-agent-server:latest) with the Paca MCP server pre-installed, avoiding a cold npm download on every new sandbox."
+    UPDATE_AGENT_IMAGE="yes"
+    yes_no UPDATE_AGENT_IMAGE "Switch AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:latest?" "y"
+    if [[ "$UPDATE_AGENT_IMAGE" == "yes" ]]; then
+        backup_env_once
+        set_env_var .env AGENT_SERVER_IMAGE "ghcr.io/paca-ai/paca-agent-server:latest"
+        info "Updated AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:latest."
+    else
+        info "Keeping AGENT_SERVER_IMAGE unchanged."
+    fi
+fi
+
 # Backfill variables introduced by the nginx → Caddy gateway migration.
 # Installations from before that release have neither in .env. SITE_ADDRESS
 # defaults to the hostname already in PUBLIC_URL so Caddy requests a

--- a/services/agent-server/Dockerfile
+++ b/services/agent-server/Dockerfile
@@ -1,19 +1,7 @@
 # Pre-installs the Paca MCP server globally so `npx -y @paca-ai/paca-mcp`
 # resolves from the local install instead of downloading the package on
 # every ephemeral sandbox container boot.
-#
-# Pinned to the commit tagged v1.30.0 upstream — NOT `:latest-python`. That
-# floating tag tracks upstream's main branch continuously (built on every
-# commit), which runs ahead of their tagged PyPI releases: it was already
-# serving events with a `parent_id` field before openhands-sdk on PyPI even
-# had one, breaking every conversation against services/ai-agent's
-# pip-installed client (pydantic rejects the unrecognized field under
-# `extra="forbid"`). There is no way to keep a PyPI-installed client in sync
-# with a tag that isn't tracking PyPI releases, so this must stay pinned.
-# When bumping openhands-sdk/openhands-tools in services/ai-agent's
-# pyproject.toml, bump this to the matching `<short-sha>-python` tag for that
-# same version's git tag in the same change — never independently.
-FROM ghcr.io/openhands/agent-server:d1595f7-python
+FROM ghcr.io/openhands/agent-server:latest-python
 
 # The base image runs as the unprivileged `openhands` user, which doesn't own
 # npm's global install dir — switch to root for the install, then drop back

--- a/services/agent-server/Dockerfile
+++ b/services/agent-server/Dockerfile
@@ -1,7 +1,19 @@
 # Pre-installs the Paca MCP server globally so `npx -y @paca-ai/paca-mcp`
 # resolves from the local install instead of downloading the package on
 # every ephemeral sandbox container boot.
-FROM ghcr.io/openhands/agent-server:latest-python
+#
+# Pinned to the commit tagged v1.30.0 upstream — NOT `:latest-python`. That
+# floating tag tracks upstream's main branch continuously (built on every
+# commit), which runs ahead of their tagged PyPI releases: it was already
+# serving events with a `parent_id` field before openhands-sdk on PyPI even
+# had one, breaking every conversation against services/ai-agent's
+# pip-installed client (pydantic rejects the unrecognized field under
+# `extra="forbid"`). There is no way to keep a PyPI-installed client in sync
+# with a tag that isn't tracking PyPI releases, so this must stay pinned.
+# When bumping openhands-sdk/openhands-tools in services/ai-agent's
+# pyproject.toml, bump this to the matching `<short-sha>-python` tag for that
+# same version's git tag in the same change — never independently.
+FROM ghcr.io/openhands/agent-server:d1595f7-python
 
 # The base image runs as the unprivileged `openhands` user, which doesn't own
 # npm's global install dir — switch to root for the install, then drop back

--- a/services/ai-agent/pyproject.toml
+++ b/services/ai-agent/pyproject.toml
@@ -6,8 +6,8 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.138.0",
     "uvicorn[standard]>=0.30.0",
-    "openhands-sdk>=1.29.0",
-    "openhands-tools>=1.29.0",
+    "openhands-sdk>=1.30.0",
+    "openhands-tools>=1.30.0",
     "docker>=7.0.0",
     "redis[hiredis]>=5.0.0",
     "asyncpg>=0.29.0",

--- a/services/ai-agent/tests/e2e/fake_llm_server.py
+++ b/services/ai-agent/tests/e2e/fake_llm_server.py
@@ -28,6 +28,20 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 REPLY_TEXT = "Hello! This is a canned reply from the fake LLM server."
 
+# openhands-sdk's AutoTitleSubscriber (autotitle=True by default) fires
+# title_utils.generate_title_with_llm() asynchronously on the first user
+# message — a separate /v1/chat/completions call racing the real
+# conversation turn for whichever scripted reply comes next. Recognized by
+# its distinctive system prompt and answered directly below, without
+# consuming a script slot, so scripted multi-turn tests stay deterministic
+# regardless of which call actually reaches the server first.
+_SDK_INTERNAL_CALL_MARKER = "descriptive titles for conversations with OpenHands"
+
+
+def _is_sdk_internal_call(payload: dict) -> bool:
+    messages = payload.get("messages") or []
+    return any(_SDK_INTERNAL_CALL_MARKER in json.dumps(m) for m in messages)
+
 
 @dataclass(frozen=True)
 class ToolCall:
@@ -80,6 +94,10 @@ class _Handler(BaseHTTPRequestHandler):
             payload = json.loads(body or b"{}")
         except json.JSONDecodeError:
             payload = {}
+
+        if _is_sdk_internal_call(payload):
+            self._send_non_streaming_reply(text_reply("untitled"))
+            return
 
         reply = self.server.next_reply()
         if reply.error_status is not None:

--- a/services/ai-agent/uv.lock
+++ b/services/ai-agent/uv.lock
@@ -2282,7 +2282,7 @@ wheels = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.29.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2303,14 +2303,14 @@ dependencies = [
     { name = "tree-sitter-bash" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/d7/03c75453aa50e016e10989bb11e6fe5015db659c3d6d541a38aa60ec7920/openhands_sdk-1.29.0.tar.gz", hash = "sha256:2b38dec04858535ff78fdc961ffc44cee338aca6947c0ddb70c6926e5ac883af", size = 588347, upload-time = "2026-06-18T16:10:58.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/32/a8fc01eefe1a9857ef9432c833841beb216ddd85ee8d6c2968013be267c1/openhands_sdk-1.30.0.tar.gz", hash = "sha256:b48a75adb8d2c48d6a53d0022e3521d63caeb5931b99d5a56906a24a4eec3e72", size = 588645, upload-time = "2026-07-01T10:29:58.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/7d/faacecdc314f1deb85f7f123147c4522a77200c8b744496269b830dded36/openhands_sdk-1.29.0-py3-none-any.whl", hash = "sha256:ae9f4ec0b1fd86e3fd4c74682a9ee477614e790457ed06c675ad6caf9eef5194", size = 710013, upload-time = "2026-06-18T16:10:59.683Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e9/330fa562f63732c545d7fa0c8b68b8575cd39c952c605150bf41134932f3/openhands_sdk-1.30.0-py3-none-any.whl", hash = "sha256:53423bd4916c578ccb8f8f488dfcc16669343f2a3ac0c3db955793e704f734a2", size = 708572, upload-time = "2026-07-01T10:29:53.107Z" },
 ]
 
 [[package]]
 name = "openhands-tools"
-version = "1.29.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "binaryornot" },
@@ -2324,9 +2324,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/31/95c9575bca5124dec2e603b32ebf15363b6a3e70f7d8becfa1e025c1df5e/openhands_tools-1.29.0.tar.gz", hash = "sha256:3427966f5cb21cc64932dde73173772ccf384ba25f4f599501d540b3f2dd7d01", size = 144895, upload-time = "2026-06-18T16:10:54.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/f5/017a969303eeb3c614d924e744b07e75540dc93e6786c8e1486654e0b74d/openhands_tools-1.30.0.tar.gz", hash = "sha256:8762808cb481a7d5805c0f66ac62228dc25ce2baf336ab2d446ca772c761c864", size = 145603, upload-time = "2026-07-01T10:29:59.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/49/0375502eb628d5df7e4dab08bfedcdbd5caec8c81d6dc2176ead1c7f9423/openhands_tools-1.29.0-py3-none-any.whl", hash = "sha256:bb50b62a1929958e4fd8991fd8dbd6b8269c87da74286a925c066d0ac3dd915f", size = 190143, upload-time = "2026-06-18T16:10:55.842Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3d/c3a754c1f010f3d4b100357b83b306c9efdcaca69742cc45ad1d2b386305/openhands_tools-1.30.0-py3-none-any.whl", hash = "sha256:349af6c15b7d9808edc529d52e0e06efea064187662bef0d2e6c3a0d219f6cfa", size = 190947, upload-time = "2026-07-01T10:29:54.436Z" },
 ]
 
 [[package]]
@@ -2555,8 +2555,8 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "openhands-sdk", specifier = ">=1.29.0" },
-    { name = "openhands-tools", specifier = ">=1.29.0" },
+    { name = "openhands-sdk", specifier = ">=1.30.0" },
+    { name = "openhands-tools", specifier = ">=1.30.0" },
     { name = "pydantic", specifier = ">=2.13.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-multipart", specifier = ">=0.0.32" },


### PR DESCRIPTION
## Summary

Fixes a production incident on v0.7.1 where every agent conversation failed with:

```
ValidationError: 1 validation error for Event
parent_id
  Extra inputs are not permitted [type=extra_forbidden]
```
followed by `WebSocketConnectionError: WebSocket subscription did not complete within 30.0 seconds`.

Root cause: `services/ai-agent` was locked to `openhands-sdk==1.29.0`, while the sandbox's `agent-server` image was still resolving to raw upstream `ghcr.io/openhands/agent-server:latest-python` — which had moved to SDK **v1.30.0**. That version added a `parent_id` field to `Event`; the 1.29.0 client's `Event` model has `extra="forbid"`, so it rejected every event the sandbox sent over the WebSocket, and the conversation died once the subscription timed out.

This was compounded by an operational gap from [#238](https://github.com/Paca-AI/paca/pull/238): that PR pointed the *default* `AGENT_SERVER_IMAGE` at our own `ghcr.io/paca-ai/paca-agent-server`, but `upgrade.sh` never rewrote installs that already had the old upstream value hardcoded in `.env` — so upgrading to v0.7.1 silently kept production on the raw upstream image instead of ours.

- Bump `openhands-sdk` / `openhands-tools` to `1.30.0` in `services/ai-agent` (`pyproject.toml` + re-locked `uv.lock`), matching upstream's current `latest-python`. Confirmed safe in this direction: `Event.parent_id` defaults to `None`, so a 1.30.0 client validating an older server's events (which simply omit the field) doesn't error — only the reverse direction (older client, newer server) breaks.
- Add a migration step to `upgrade.sh`: if `AGENT_SERVER_IMAGE` is still set to exactly the old upstream default, prompt to switch it to `ghcr.io/paca-ai/paca-agent-server:latest` (defaults to yes, skippable, never touches a value someone deliberately customized to something else).

## Test plan

- [ ] `uv lock --check` passes in `services/ai-agent` (lockfile matches `pyproject.toml`)
- [ ] Rebuild and publish the `ai-agent` service image with the bumped SDK version
- [ ] Run `upgrade.sh` against a `.env` with the old `AGENT_SERVER_IMAGE` default — confirm the prompt appears and updates it on "yes"
- [ ] Run `upgrade.sh` against a `.env` with a custom `AGENT_SERVER_IMAGE` — confirm it's left untouched (prompt doesn't appear)
- [ ] After deploying, start a fresh conversation and confirm no `parent_id` validation error / WebSocket timeout
