### PR TITLE
fix: ensure live REST read for conversation state to prevent staleness in execution status

### DIFF
--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -89,10 +89,22 @@ def _wait_for_done_or_stop(
             return False, False
 
         try:
+            # RemoteState caches execution_status from WebSocket events and only
+            # ever re-fetches over REST if the cache is still empty (see
+            # RemoteState._get_conversation_info). openhands-sdk's WS client
+            # thread permanently stops reconnecting after any ConnectionClosed
+            # (upstream bug, still present as of openhands-sdk 1.31.0 — see
+            # OpenHands/software-agent-sdk#1532), which would otherwise freeze
+            # this loop on a stale "running" status until the timeout above.
+            # Force a live REST read every poll so a dead socket can't wedge us.
+            conversation.state.refresh_from_server()
             status = conversation.state.execution_status
             if status in _DONE_STATUSES:
                 errored = status in _ERROR_STATUSES
                 if errored:
+                    # Same staleness risk applies to the cached event list used
+                    # for the error detail — reconcile before reading it.
+                    conversation.state.events.reconcile()
                     detail = _get_conversation_error_detail(conversation)
                     logger.error(
                         "Conversation ended with status %s — %s",


### PR DESCRIPTION
**Summary**

Fixes conversations getting stuck ("cannot continue") after the ai-agent service's internal WebSocket to the sandbox agent-server disconnects.

**Root cause:** `openhands-sdk`'s `WebSocketCallbackClient._client_loop()` permanently exits its reconnect loop on any `websockets.exceptions.ConnectionClosed` instead of retrying. This is a confirmed upstream bug ([OpenHands/software-agent-sdk#1532](https://github.com/OpenHands/software-agent-sdk/issues/1532)) still present in the latest release (1.31.0) — the linked upstream fix (#1832) only patched the SDK's own blocking `run()` wait path, not this underlying thread death.

`executor.py` uses `run(blocking=False)` plus its own polling loop (`_wait_for_done_or_stop`) so a "stop" request can interrupt a run — but that loop read `conversation.state.execution_status`, a property cached from WebSocket events that only falls back to REST if the cache is still empty. Once the WebSocket thread died, the loop kept reading the same stale "running" status for up to the full 3600s timeout, so the conversation looked hung.

**Changes**
- `services/ai-agent/src/agent/executor.py`: `_wait_for_done_or_stop` now calls `conversation.state.refresh_from_server()` every poll instead of trusting the WebSocket-cached state, and reconciles the event list before reading error details on a terminal status — so a dead socket can no longer wedge the polling loop.

**Test plan**
- [x] Unit tests: `pytest tests/ --ignore=tests/e2e` — 85 passed
- [x] E2E: `PACA_E2E=1 pytest tests/e2e -v` against a real sandbox container — 3 passed (agent reply persistence, tool-call flow, LLM-failure path)