### PR TITLE
feat: add support for secret environment variables per agent

### DIFF
--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -78,6 +78,7 @@
 				"overview": "Overview",
 				"mcpServers": "MCP Servers",
 				"skills": "Skills",
+				"envVars": "Environment",
 				"conversations": "Conversations"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "Cancel",
 					"addServer": "Add server"
+				}
+			},
+			"envVars": {
+				"count_one": "{{count}} variable configured",
+				"count_other": "{{count}} variables configured",
+				"addVariable": "Add variable",
+				"empty": {
+					"title": "No environment variables added",
+					"addFirst": "Add your first variable"
+				},
+				"addDialog": {
+					"title": "Add Environment Variable",
+					"description": "Secret values are encrypted at rest and injected into the agent's sandbox at run time. Once saved, a value can never be viewed again.",
+					"keyLabel": "Key",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "(letters, digits, underscores — must start with a letter or underscore)",
+					"valueLabel": "Value",
+					"cancel": "Cancel",
+					"addVariable": "Add variable"
 				}
 			},
 			"skills": {

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -78,6 +78,7 @@
 				"overview": "Resumen",
 				"mcpServers": "Servidores MCP",
 				"skills": "Skills",
+				"envVars": "Entorno",
 				"conversations": "Conversaciones"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "Cancelar",
 					"addServer": "Añadir servidor"
+				}
+			},
+			"envVars": {
+				"count_one": "{{count}} variable configurada",
+				"count_other": "{{count}} variables configuradas",
+				"addVariable": "Añadir variable",
+				"empty": {
+					"title": "No se han añadido variables de entorno",
+					"addFirst": "Añade tu primera variable"
+				},
+				"addDialog": {
+					"title": "Añadir variable de entorno",
+					"description": "Los valores secretos se cifran en reposo y se inyectan en el sandbox del agente en tiempo de ejecución. Una vez guardado, un valor nunca podrá volver a verse.",
+					"keyLabel": "Clave",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "(letras, números, guiones bajos — debe empezar por una letra o guión bajo)",
+					"valueLabel": "Valor",
+					"cancel": "Cancelar",
+					"addVariable": "Añadir variable"
 				}
 			},
 			"skills": {

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -78,6 +78,7 @@
 				"overview": "Aperçu",
 				"mcpServers": "Serveurs MCP",
 				"skills": "Compétences",
+				"envVars": "Environnement",
 				"conversations": "Conversations"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "Annuler",
 					"addServer": "Ajouter le serveur"
+				}
+			},
+			"envVars": {
+				"count_one": "{{count}} variable configurée",
+				"count_other": "{{count}} variables configurées",
+				"addVariable": "Ajouter une variable",
+				"empty": {
+					"title": "Aucune variable d'environnement ajoutée",
+					"addFirst": "Ajouter votre première variable"
+				},
+				"addDialog": {
+					"title": "Ajouter une variable d'environnement",
+					"description": "Les valeurs secrètes sont chiffrées au repos et injectées dans le sandbox de l'agent à l'exécution. Une fois enregistrée, une valeur ne peut plus jamais être consultée.",
+					"keyLabel": "Clé",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "(lettres, chiffres, underscores — doit commencer par une lettre ou un underscore)",
+					"valueLabel": "Valeur",
+					"cancel": "Annuler",
+					"addVariable": "Ajouter la variable"
 				}
 			},
 			"skills": {

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -78,6 +78,7 @@
 				"overview": "概要",
 				"mcpServers": "MCPサーバー",
 				"skills": "スキル",
+				"envVars": "環境変数",
 				"conversations": "会話"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "キャンセル",
 					"addServer": "サーバーを追加"
+				}
+			},
+			"envVars": {
+				"count_one": "{{count}}件の変数を設定済み",
+				"count_other": "{{count}}件の変数を設定済み",
+				"addVariable": "変数を追加",
+				"empty": {
+					"title": "環境変数が追加されていません",
+					"addFirst": "最初の変数を追加"
+				},
+				"addDialog": {
+					"title": "環境変数を追加",
+					"description": "シークレット値は保存時に暗号化され、実行時にエージェントのサンドボックスに注入されます。保存後は値を再度表示することはできません。",
+					"keyLabel": "キー",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "（英字・数字・アンダースコア。英字またはアンダースコアで始まる必要があります）",
+					"valueLabel": "値",
+					"cancel": "キャンセル",
+					"addVariable": "変数を追加"
 				}
 			},
 			"skills": {

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -78,6 +78,7 @@
 				"overview": "개요",
 				"mcpServers": "MCP 서버",
 				"skills": "스킬",
+				"envVars": "환경 변수",
 				"conversations": "대화"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "취소",
 					"addServer": "서버 추가"
+				}
+			},
+			"envVars": {
+				"count_one": "변수 {{count}}개 구성됨",
+				"count_other": "변수 {{count}}개 구성됨",
+				"addVariable": "변수 추가",
+				"empty": {
+					"title": "추가된 환경 변수가 없습니다",
+					"addFirst": "첫 변수 추가"
+				},
+				"addDialog": {
+					"title": "환경 변수 추가",
+					"description": "비밀 값은 저장 시 암호화되며 실행 시 에이전트의 샌드박스에 주입됩니다. 저장 후에는 값을 다시 볼 수 없습니다.",
+					"keyLabel": "키",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "(영문, 숫자, 밑줄 — 영문 또는 밑줄로 시작해야 함)",
+					"valueLabel": "값",
+					"cancel": "취소",
+					"addVariable": "변수 추가"
 				}
 			},
 			"skills": {

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -78,6 +78,7 @@
 				"overview": "Tổng quan",
 				"mcpServers": "Máy chủ MCP",
 				"skills": "Skill",
+				"envVars": "Môi trường",
 				"conversations": "Hội thoại"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "Hủy",
 					"addServer": "Thêm máy chủ"
+				}
+			},
+			"envVars": {
+				"count_one": "{{count}} biến đã cấu hình",
+				"count_other": "{{count}} biến đã cấu hình",
+				"addVariable": "Thêm biến",
+				"empty": {
+					"title": "Chưa thêm biến môi trường nào",
+					"addFirst": "Thêm biến đầu tiên của bạn"
+				},
+				"addDialog": {
+					"title": "Thêm biến môi trường",
+					"description": "Giá trị bí mật được mã hóa khi lưu trữ và được đưa vào sandbox của agent khi chạy. Sau khi lưu, giá trị sẽ không thể xem lại được nữa.",
+					"keyLabel": "Khóa",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "(chữ cái, chữ số, dấu gạch dưới — phải bắt đầu bằng chữ cái hoặc dấu gạch dưới)",
+					"valueLabel": "Giá trị",
+					"cancel": "Hủy",
+					"addVariable": "Thêm biến"
 				}
 			},
 			"skills": {

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -78,6 +78,7 @@
 				"overview": "概览",
 				"mcpServers": "MCP 服务器",
 				"skills": "技能",
+				"envVars": "环境变量",
 				"conversations": "对话"
 			},
 			"overview": {
@@ -128,6 +129,25 @@
 					"urlLabel": "URL",
 					"cancel": "取消",
 					"addServer": "添加服务器"
+				}
+			},
+			"envVars": {
+				"count_one": "已配置 {{count}} 个变量",
+				"count_other": "已配置 {{count}} 个变量",
+				"addVariable": "添加变量",
+				"empty": {
+					"title": "尚未添加环境变量",
+					"addFirst": "添加您的第一个变量"
+				},
+				"addDialog": {
+					"title": "添加环境变量",
+					"description": "密钥值在静态存储时会被加密，并在运行时注入到智能体的沙箱环境中。保存后将无法再次查看该值。",
+					"keyLabel": "键",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "（字母、数字、下划线，必须以字母或下划线开头）",
+					"valueLabel": "值",
+					"cancel": "取消",
+					"addVariable": "添加变量"
 				}
 			},
 			"skills": {

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -115,6 +115,15 @@ export interface AgentSkill {
 	updated_at: string;
 }
 
+export interface AgentEnvVar {
+	id: string;
+	agent_id: string;
+	key: string;
+	// Always "***" — the plaintext value is never returned by the API.
+	value: string;
+	created_at: string;
+}
+
 export interface Agent {
 	id: string;
 	project_id: string;
@@ -135,6 +144,7 @@ export interface Agent {
 	member_id?: string | null;
 	mcp_servers?: AgentMCPServer[];
 	skills?: AgentSkill[];
+	env_vars?: AgentEnvVar[];
 	created_at: string;
 	updated_at: string;
 }
@@ -401,6 +411,53 @@ export async function deleteSkill(
 	);
 }
 
+// ── Environment Variables ────────────────────────────────────────────────────
+
+export async function listEnvVars(
+	projectId: string,
+	agentId: string,
+): Promise<AgentEnvVar[]> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<{ items: AgentEnvVar[] }>
+	>(`/projects/${projectId}/agents/${agentId}/env-vars`);
+	return data.data.items;
+}
+
+export async function addEnvVar(
+	projectId: string,
+	agentId: string,
+	payload: { key: string; value: string },
+): Promise<AgentEnvVar> {
+	const { data } = await apiClient.instance.post<SuccessEnvelope<AgentEnvVar>>(
+		`/projects/${projectId}/agents/${agentId}/env-vars`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function updateEnvVar(
+	projectId: string,
+	agentId: string,
+	envVarId: string,
+	payload: { value: string },
+): Promise<AgentEnvVar> {
+	const { data } = await apiClient.instance.patch<SuccessEnvelope<AgentEnvVar>>(
+		`/projects/${projectId}/agents/${agentId}/env-vars/${envVarId}`,
+		payload,
+	);
+	return data.data;
+}
+
+export async function deleteEnvVar(
+	projectId: string,
+	agentId: string,
+	envVarId: string,
+): Promise<void> {
+	await apiClient.instance.delete(
+		`/projects/${projectId}/agents/${agentId}/env-vars/${envVarId}`,
+	);
+}
+
 // ── Conversations ─────────────────────────────────────────────────────────────
 
 export async function listConversations(
@@ -516,6 +573,12 @@ export const agentSkillsQueryOptions = (projectId: string, agentId: string) =>
 	queryOptions({
 		queryKey: ["projects", projectId, "agents", agentId, "skills"],
 		queryFn: () => listSkills(projectId, agentId),
+	});
+
+export const agentEnvVarsQueryOptions = (projectId: string, agentId: string) =>
+	queryOptions({
+		queryKey: ["projects", projectId, "agents", agentId, "env-vars"],
+		queryFn: () => listEnvVars(projectId, agentId),
 	});
 
 export const conversationsQueryOptions = (

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
@@ -7,6 +7,7 @@ import {
 	Code2,
 	GitBranch,
 	GitPullRequest,
+	KeyRound,
 	Loader2,
 	MessageSquare,
 	Plus,
@@ -51,14 +52,17 @@ import {
 	type AgentConversation,
 	type AgentMCPServer,
 	type AgentSkill,
+	addEnvVar,
 	addMCPServer,
 	addSkill,
+	agentEnvVarsQueryOptions,
 	agentMCPServersQueryOptions,
 	agentQueryOptions,
 	agentSkillsQueryOptions,
 	CONVERSATION_STATUS_COLORS,
 	CONVERSATION_STATUS_LABELS,
 	conversationsQueryOptions,
+	deleteEnvVar,
 	deleteMCPServer,
 	deleteSkill,
 	llmModelsQueryOptions,
@@ -80,6 +84,7 @@ export const Route = createFileRoute(
 				agentMCPServersQueryOptions(projectId, agentId),
 			),
 			queryClient.ensureQueryData(agentSkillsQueryOptions(projectId, agentId)),
+			queryClient.ensureQueryData(agentEnvVarsQueryOptions(projectId, agentId)),
 			queryClient.ensureQueryData(
 				conversationsQueryOptions(projectId, agentId),
 			),
@@ -89,7 +94,7 @@ export const Route = createFileRoute(
 	component: AgentDetailPage,
 });
 
-type Tab = "overview" | "mcp-servers" | "skills" | "conversations";
+type Tab = "overview" | "mcp-servers" | "skills" | "env-vars" | "conversations";
 
 const CUSTOM = "__custom__";
 
@@ -1003,6 +1008,196 @@ function SkillsTab({
 	);
 }
 
+// ── Environment Variables Tab ────────────────────────────────────────────────
+
+const ENV_VAR_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function AddEnvVarDialog({
+	projectId,
+	agentId,
+	open,
+	onOpenChange,
+}: {
+	projectId: string;
+	agentId: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const { t } = useTranslation("projects");
+	const qc = useQueryClient();
+	const [key, setKey] = useState("");
+	const [value, setValue] = useState("");
+
+	const isKeyValid = ENV_VAR_KEY_PATTERN.test(key.trim());
+
+	const addMutation = useMutation({
+		mutationFn: () => addEnvVar(projectId, agentId, { key: key.trim(), value }),
+		onSuccess: () => {
+			qc.invalidateQueries({
+				queryKey: ["projects", projectId, "agents", agentId, "env-vars"],
+			});
+			onOpenChange(false);
+			setKey("");
+			setValue("");
+		},
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<KeyRound className="size-4 text-primary" />
+						{t("agents.detail.envVars.addDialog.title")}
+					</DialogTitle>
+					<DialogDescription>
+						{t("agents.detail.envVars.addDialog.description")}
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-4 py-2">
+					<div className="space-y-1.5">
+						<Label>{t("agents.detail.envVars.addDialog.keyLabel")}</Label>
+						<Input
+							placeholder={t("agents.detail.envVars.addDialog.keyPlaceholder")}
+							className="font-mono"
+							value={key}
+							onChange={(e) => setKey(e.target.value)}
+						/>
+						<p className="text-xs text-muted-foreground">
+							{t("agents.detail.envVars.addDialog.keyHint")}
+						</p>
+					</div>
+					<div className="space-y-1.5">
+						<Label>{t("agents.detail.envVars.addDialog.valueLabel")}</Label>
+						<Input
+							type="password"
+							autoComplete="off"
+							className="font-mono"
+							value={value}
+							onChange={(e) => setValue(e.target.value)}
+						/>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						{t("agents.detail.envVars.addDialog.cancel")}
+					</Button>
+					<Button
+						onClick={() => addMutation.mutate()}
+						disabled={!isKeyValid || !value || addMutation.isPending}
+					>
+						{addMutation.isPending ? (
+							<Loader2 className="size-4 animate-spin" />
+						) : (
+							t("agents.detail.envVars.addDialog.addVariable")
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function EnvVarsTab({
+	projectId,
+	agentId,
+	canWrite,
+}: {
+	projectId: string;
+	agentId: string;
+	canWrite: boolean;
+}) {
+	const { t } = useTranslation("projects");
+	const qc = useQueryClient();
+	const { data: envVars = [] } = useQuery(
+		agentEnvVarsQueryOptions(projectId, agentId),
+	);
+	const [addOpen, setAddOpen] = useState(false);
+
+	const deleteMutation = useMutation({
+		mutationFn: (id: string) => deleteEnvVar(projectId, agentId, id),
+		onSuccess: () => {
+			qc.invalidateQueries({
+				queryKey: ["projects", projectId, "agents", agentId, "env-vars"],
+			});
+		},
+	});
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<p className="text-sm text-muted-foreground">
+					{t("agents.detail.envVars.count", { count: envVars.length })}
+				</p>
+				{canWrite && (
+					<Button size="sm" onClick={() => setAddOpen(true)}>
+						<Plus className="size-4 mr-1.5" />
+						{t("agents.detail.envVars.addVariable")}
+					</Button>
+				)}
+			</div>
+
+			{envVars.length === 0 ? (
+				<div className="flex flex-col items-center justify-center gap-3 py-14 rounded-xl border border-dashed border-border">
+					<KeyRound className="size-8 text-muted-foreground/40" />
+					<p className="text-sm text-muted-foreground">
+						{t("agents.detail.envVars.empty.title")}
+					</p>
+					{canWrite && (
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => setAddOpen(true)}
+						>
+							<Plus className="size-3.5 mr-1" />
+							{t("agents.detail.envVars.empty.addFirst")}
+						</Button>
+					)}
+				</div>
+			) : (
+				<div className="space-y-2">
+					{envVars.map((v) => (
+						<div
+							key={v.id}
+							className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-card px-4 py-3"
+						>
+							<div className="flex items-center gap-3 min-w-0">
+								<KeyRound className="size-4 text-muted-foreground shrink-0" />
+								<div className="min-w-0">
+									<p className="text-sm font-medium font-mono truncate">
+										{v.key}
+									</p>
+									<p className="text-xs text-muted-foreground font-mono truncate">
+										{v.value}
+									</p>
+								</div>
+							</div>
+							{canWrite && (
+								<Button
+									variant="ghost"
+									size="icon"
+									className="size-7 text-muted-foreground hover:text-destructive shrink-0"
+									onClick={() => deleteMutation.mutate(v.id)}
+									disabled={deleteMutation.isPending}
+								>
+									<Trash2 className="size-3.5" />
+								</Button>
+							)}
+						</div>
+					))}
+				</div>
+			)}
+
+			<AddEnvVarDialog
+				projectId={projectId}
+				agentId={agentId}
+				open={addOpen}
+				onOpenChange={setAddOpen}
+			/>
+		</div>
+	);
+}
+
 // ── Conversations Tab ─────────────────────────────────────────────────────────
 
 function ConversationRow({
@@ -1176,6 +1371,11 @@ const TABS = [
 	},
 	{ id: "skills", labelKey: "agents.detail.tabs.skills", icon: Wand2 },
 	{
+		id: "env-vars",
+		labelKey: "agents.detail.tabs.envVars",
+		icon: KeyRound,
+	},
+	{
 		id: "conversations",
 		labelKey: "agents.detail.tabs.conversations",
 		icon: MessageSquare,
@@ -1279,6 +1479,13 @@ function AgentDetailPage() {
 				)}
 				{activeTab === "skills" && (
 					<SkillsTab
+						projectId={projectId}
+						agentId={agentId}
+						canWrite={canWrite}
+					/>
+				)}
+				{activeTab === "env-vars" && (
+					<EnvVarsTab
 						projectId={projectId}
 						agentId={agentId}
 						canWrite={canWrite}

--- a/services/ai-agent/src/agent/docker_workspace.py
+++ b/services/ai-agent/src/agent/docker_workspace.py
@@ -174,6 +174,7 @@ def docker_sandbox(
     conversation_id: str,
     git_committer_name: str = "paca-agent",
     git_committer_email: str = "280579135+paca-agent@users.noreply.github.com",
+    env: dict[str, str] | None = None,
 ) -> Iterator[RemoteWorkspace]:
     """Spin up an isolated agent-server container and yield a RemoteWorkspace.
 
@@ -244,7 +245,11 @@ def docker_sandbox(
                 )
 
         # ── Environment ───────────────────────────────────────────────────────
+        # User-configured secret env vars are spread first so that the
+        # hardcoded infra keys below always win on name collision — a
+        # misconfigured agent variable can never shadow sandbox internals.
         environment: dict = {
+            **(env or {}),
             # OH_SECRET_KEY is required by the agent server to encrypt persisted
             # secrets.  Each container is ephemeral so a fresh key per run is fine.
             "OH_SECRET_KEY": secrets.token_hex(32),

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -503,6 +503,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 trigger.conversation_id,
                 git_committer_name=agent_config.git_committer_name,
                 git_committer_email=agent_config.git_committer_email,
+                env=agent_config.env_vars,
             ) as workspace:
                 agent_kwargs: dict = {"llm": llm, "agent_context": agent_context}
                 if mcp_config.get("mcpServers"):

--- a/services/ai-agent/src/models/agent.py
+++ b/services/ai-agent/src/models/agent.py
@@ -43,3 +43,4 @@ class AgentConfig:
     git_committer_email: str = "280579135+paca-agent@users.noreply.github.com"
     mcp_servers: list[AgentMCPServerRow] = field(default_factory=list)
     skills: list[AgentSkillRow] = field(default_factory=list)
+    env_vars: dict[str, str] = field(default_factory=dict)

--- a/services/ai-agent/src/repositories/agent_repository.py
+++ b/services/ai-agent/src/repositories/agent_repository.py
@@ -129,10 +129,16 @@ async def load_agent_config(agent_id: str) -> AgentConfig | None:
         )
         for r in skill_rows
     ]
-    env_vars = {
-        r["key"]: _decrypt_secret(r["encrypted_value"], label=f"environment variable {r['key']}")
-        for r in env_var_rows
-    }
+    # A key is omitted rather than injected with an empty value on decrypt
+    # failure — a missing env var is unambiguous, while an empty one can be
+    # mistaken for a deliberately blank secret by downstream tooling (e.g.
+    # git treating an empty GITHUB_TOKEN as "no auth" vs "broken auth").
+    env_vars: dict[str, str] = {}
+    for r in env_var_rows:
+        key = r["key"]
+        value = _decrypt_secret(r["encrypted_value"], label=f"environment variable {key}")
+        if value:
+            env_vars[key] = value
 
     return AgentConfig(
         agent_id=str(row["id"]),

--- a/services/ai-agent/src/repositories/agent_repository.py
+++ b/services/ai-agent/src/repositories/agent_repository.py
@@ -13,22 +13,24 @@ from ..models.agent import AgentConfig, AgentMCPServerRow, AgentSkillRow
 logger = logging.getLogger(__name__)
 
 
-def _decrypt_secret(ciphertext: str) -> str:
+def _decrypt_secret(ciphertext: str, label: str = "LLM API key") -> str:
     """Decrypt an AES-256-GCM ciphertext produced by the Go API's secret.Encryptor.
 
     If ENCRYPTION_KEY is not configured the value is returned as-is (plaintext
     backward-compat mode).  Any decryption error returns an empty string so
     that a clear "missing API key" error surfaces at the LLM call rather than
     the misleading "token expired / incorrect" that results from forwarding the
-    raw ciphertext to the provider.
+    raw ciphertext to the provider. `label` is used only to identify the field
+    being decrypted in log messages (e.g. "LLM API key", "environment variable").
     """
     if not ciphertext:
         return ciphertext
     if not settings.encryption_key:
         logger.warning(
-            "ENCRYPTION_KEY is not set — LLM API key will be used as-is from the "
+            "ENCRYPTION_KEY is not set — %s will be used as-is from the "
             "database. If the api service encrypts secrets, set ENCRYPTION_KEY in "
-            "the ai-agent environment to the same value."
+            "the ai-agent environment to the same value.",
+            label,
         )
         return ciphertext
     try:
@@ -43,9 +45,10 @@ def _decrypt_secret(ciphertext: str) -> str:
         return plaintext.decode()
     except Exception as exc:
         logger.error(
-            "Failed to decrypt LLM API key secret — the LLM will receive an empty "
-            "key. Verify that ENCRYPTION_KEY in the ai-agent service matches the "
-            "api service. Error: %s",
+            "Failed to decrypt %s — the value will be treated as empty. Verify "
+            "that ENCRYPTION_KEY in the ai-agent service matches the api "
+            "service. Error: %s",
+            label,
             exc,
         )
         return ""
@@ -96,6 +99,14 @@ async def load_agent_config(agent_id: str) -> AgentConfig | None:
         """,
         agent_id,
     )
+    env_var_rows = await pool.fetch(
+        """
+        SELECT key, encrypted_value
+        FROM agent_environment_variables
+        WHERE agent_id = $1
+        """,
+        agent_id,
+    )
 
     mcp_servers = [
         AgentMCPServerRow(
@@ -118,6 +129,10 @@ async def load_agent_config(agent_id: str) -> AgentConfig | None:
         )
         for r in skill_rows
     ]
+    env_vars = {
+        r["key"]: _decrypt_secret(r["encrypted_value"], label=f"environment variable {r['key']}")
+        for r in env_var_rows
+    }
 
     return AgentConfig(
         agent_id=str(row["id"]),
@@ -138,4 +153,5 @@ async def load_agent_config(agent_id: str) -> AgentConfig | None:
         or "280579135+paca-agent@users.noreply.github.com",
         mcp_servers=mcp_servers,
         skills=skills,
+        env_vars=env_vars,
     )

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -270,6 +270,14 @@ const (
 	CodeAgentConversationAlreadyStopped Code = "AGENT_CONVERSATION_ALREADY_STOPPED"
 	// CodeAgentChatSessionNotFound indicates the requested chat session does not exist.
 	CodeAgentChatSessionNotFound Code = "AGENT_CHAT_SESSION_NOT_FOUND"
+	// CodeAgentEnvVarNotFound indicates the requested environment variable does not exist.
+	CodeAgentEnvVarNotFound Code = "AGENT_ENV_VAR_NOT_FOUND"
+	// CodeAgentEnvVarKeyTaken indicates the environment variable key is already in use on this agent.
+	CodeAgentEnvVarKeyTaken Code = "AGENT_ENV_VAR_KEY_TAKEN"
+	// CodeAgentEnvVarKeyInvalid indicates the environment variable key is malformed.
+	CodeAgentEnvVarKeyInvalid Code = "AGENT_ENV_VAR_KEY_INVALID"
+	// CodeAgentEnvVarKeyReserved indicates the environment variable key collides with an internal sandbox variable.
+	CodeAgentEnvVarKeyReserved Code = "AGENT_ENV_VAR_KEY_RESERVED"
 )
 
 // Error carries a machine-readable Code alongside a human-readable Message.

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -37,6 +37,7 @@ type Agent struct {
 	MemberID   *uuid.UUID
 	MCPServers []*AgentMCPServer
 	Skills     []*AgentSkill
+	EnvVars    []*AgentEnvironmentVariable
 }
 
 // AgentMCPServer is a custom MCP server configuration attached to an agent.
@@ -52,6 +53,19 @@ type AgentMCPServer struct {
 	IsEnabled  bool
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
+}
+
+// AgentEnvironmentVariable is a secret environment variable injected into an
+// agent's sandbox container at run time. Value is always stored encrypted;
+// the plaintext is never persisted on this struct once it round-trips
+// through the repository.
+type AgentEnvironmentVariable struct {
+	ID             uuid.UUID
+	AgentID        uuid.UUID
+	Key            string
+	EncryptedValue string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // AgentSkill is a skill associated with an agent.

--- a/services/api/internal/domain/agent/errors.go
+++ b/services/api/internal/domain/agent/errors.go
@@ -23,6 +23,14 @@ var (
 	ErrSkillNameTaken = errors.New("skill name already in use on this agent")
 )
 
+// Environment variable errors
+var (
+	ErrEnvVarNotFound    = errors.New("environment variable not found")
+	ErrEnvVarKeyTaken    = errors.New("environment variable key already in use on this agent")
+	ErrEnvVarKeyInvalid  = errors.New("environment variable key must start with a letter or underscore and contain only letters, digits, and underscores")
+	ErrEnvVarKeyReserved = errors.New("environment variable key is reserved for internal sandbox configuration")
+)
+
 // Conversation errors
 var (
 	ErrConversationNotFound       = errors.New("conversation not found")

--- a/services/api/internal/domain/agent/repository.go
+++ b/services/api/internal/domain/agent/repository.go
@@ -11,6 +11,7 @@ type Repository interface {
 	AgentRepository
 	MCPServerRepository
 	SkillRepository
+	EnvVarRepository
 	ConversationRepository
 	ChatSessionRepository
 }
@@ -49,6 +50,16 @@ type SkillRepository interface {
 	CreateSkill(ctx context.Context, s *AgentSkill) error
 	UpdateSkill(ctx context.Context, s *AgentSkill) error
 	DeleteSkill(ctx context.Context, id uuid.UUID) error
+}
+
+// EnvVarRepository defines storage for agent secret environment variables.
+type EnvVarRepository interface {
+	ListEnvVars(ctx context.Context, agentID uuid.UUID) ([]*AgentEnvironmentVariable, error)
+	FindEnvVarByID(ctx context.Context, id uuid.UUID) (*AgentEnvironmentVariable, error)
+	FindEnvVarByKey(ctx context.Context, agentID uuid.UUID, key string) (*AgentEnvironmentVariable, error)
+	CreateEnvVar(ctx context.Context, v *AgentEnvironmentVariable) error
+	UpdateEnvVar(ctx context.Context, v *AgentEnvironmentVariable) error
+	DeleteEnvVar(ctx context.Context, id uuid.UUID) error
 }
 
 // ConversationRepository defines storage for agent conversations.

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -11,6 +11,7 @@ type Service interface {
 	AgentService
 	MCPServerService
 	SkillService
+	EnvVarService
 	ConversationService
 	ChatSessionService
 }
@@ -39,6 +40,14 @@ type SkillService interface {
 	AddSkill(ctx context.Context, agentID uuid.UUID, in AddSkillInput) (*AgentSkill, error)
 	UpdateSkill(ctx context.Context, agentID, skillID uuid.UUID, in UpdateSkillInput) (*AgentSkill, error)
 	DeleteSkill(ctx context.Context, agentID, skillID uuid.UUID) error
+}
+
+// EnvVarService defines secret environment variable CRUD use cases.
+type EnvVarService interface {
+	ListEnvVars(ctx context.Context, agentID uuid.UUID) ([]*AgentEnvironmentVariable, error)
+	AddEnvVar(ctx context.Context, agentID uuid.UUID, in AddEnvVarInput) (*AgentEnvironmentVariable, error)
+	UpdateEnvVar(ctx context.Context, agentID, envVarID uuid.UUID, in UpdateEnvVarInput) (*AgentEnvironmentVariable, error)
+	DeleteEnvVar(ctx context.Context, agentID, envVarID uuid.UUID) error
 }
 
 // ConversationService defines conversation management use cases.
@@ -121,6 +130,17 @@ type UpdateMCPServerInput struct {
 	URL       *string
 	Env       map[string]string
 	IsEnabled *bool
+}
+
+// AddEnvVarInput carries fields to add a secret environment variable.
+type AddEnvVarInput struct {
+	Key   string
+	Value string // plain text; encrypted by the service before storage
+}
+
+// UpdateEnvVarInput carries the new value for an existing environment variable.
+type UpdateEnvVarInput struct {
+	Value string // plain text; encrypted by the service before storage
 }
 
 // AddSkillInput carries fields to add a skill.

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -525,7 +525,13 @@ func (r *AgentRepository) CreateEnvVar(ctx context.Context, v *agentdom.AgentEnv
 		VALUES ($1,$2,$3,$4,$5,$6)`,
 		v.ID.String(), v.AgentID.String(), v.Key, v.EncryptedValue, v.CreatedAt, v.UpdatedAt,
 	)
-	return err
+	if err != nil {
+		if isUniqueViolation(err) {
+			return agentdom.ErrEnvVarKeyTaken
+		}
+		return err
+	}
+	return nil
 }
 
 // UpdateEnvVar saves the full environment variable record.

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -59,6 +59,15 @@ type agentMCPServerRecord struct {
 	UpdatedAt  time.Time `db:"updated_at"`
 }
 
+type agentEnvVarRecord struct {
+	ID             string    `db:"id"`
+	AgentID        string    `db:"agent_id"`
+	Key            string    `db:"key"`
+	EncryptedValue string    `db:"encrypted_value"`
+	CreatedAt      time.Time `db:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at"`
+}
+
 type agentSkillRecord struct {
 	ID           string    `db:"id"`
 	AgentID      string    `db:"agent_id"`
@@ -186,8 +195,13 @@ func (r *AgentRepository) FindAgentByID(ctx context.Context, id uuid.UUID) (*age
 	if err != nil {
 		return nil, err
 	}
+	envVars, err := r.ListEnvVars(ctx, id)
+	if err != nil {
+		return nil, err
+	}
 	agent.MCPServers = mcpServers
 	agent.Skills = skills
+	agent.EnvVars = envVars
 	return agent, nil
 }
 
@@ -458,6 +472,75 @@ func (r *AgentRepository) UpdateSkill(ctx context.Context, s *agentdom.AgentSkil
 // DeleteSkill permanently removes a skill record.
 func (r *AgentRepository) DeleteSkill(ctx context.Context, id uuid.UUID) error {
 	_, err := r.db.ExecContext(ctx, `DELETE FROM agent_skills WHERE id = $1`, id.String())
+	return err
+}
+
+// -------------------------------------------------------------------------
+// Environment Variables
+// -------------------------------------------------------------------------
+
+const envVarCols = `id, agent_id, key, encrypted_value, created_at, updated_at`
+
+// ListEnvVars returns all environment variable records for the given agent.
+func (r *AgentRepository) ListEnvVars(ctx context.Context, agentID uuid.UUID) ([]*agentdom.AgentEnvironmentVariable, error) {
+	var recs []agentEnvVarRecord
+	if err := r.db.SelectContext(ctx, &recs, `SELECT `+envVarCols+` FROM agent_environment_variables WHERE agent_id = $1 ORDER BY key`, agentID.String()); err != nil {
+		return nil, err
+	}
+	result := make([]*agentdom.AgentEnvironmentVariable, 0, len(recs))
+	for _, rec := range recs {
+		result = append(result, envVarFromRecord(rec))
+	}
+	return result, nil
+}
+
+// FindEnvVarByID returns a single environment variable by its primary key.
+func (r *AgentRepository) FindEnvVarByID(ctx context.Context, id uuid.UUID) (*agentdom.AgentEnvironmentVariable, error) {
+	var rec agentEnvVarRecord
+	if err := r.db.GetContext(ctx, &rec, `SELECT `+envVarCols+` FROM agent_environment_variables WHERE id = $1`, id.String()); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, agentdom.ErrEnvVarNotFound
+		}
+		return nil, err
+	}
+	return envVarFromRecord(rec), nil
+}
+
+// FindEnvVarByKey returns a single environment variable by agent and key.
+func (r *AgentRepository) FindEnvVarByKey(ctx context.Context, agentID uuid.UUID, key string) (*agentdom.AgentEnvironmentVariable, error) {
+	var rec agentEnvVarRecord
+	if err := r.db.GetContext(ctx, &rec, `SELECT `+envVarCols+` FROM agent_environment_variables WHERE agent_id = $1 AND key = $2`, agentID.String(), key); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, agentdom.ErrEnvVarNotFound
+		}
+		return nil, err
+	}
+	return envVarFromRecord(rec), nil
+}
+
+// CreateEnvVar inserts a new environment variable record.
+func (r *AgentRepository) CreateEnvVar(ctx context.Context, v *agentdom.AgentEnvironmentVariable) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO agent_environment_variables (id, agent_id, key, encrypted_value, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6)`,
+		v.ID.String(), v.AgentID.String(), v.Key, v.EncryptedValue, v.CreatedAt, v.UpdatedAt,
+	)
+	return err
+}
+
+// UpdateEnvVar saves the full environment variable record.
+func (r *AgentRepository) UpdateEnvVar(ctx context.Context, v *agentdom.AgentEnvironmentVariable) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE agent_environment_variables SET encrypted_value=$1, updated_at=$2
+		WHERE id=$3`,
+		v.EncryptedValue, v.UpdatedAt, v.ID.String(),
+	)
+	return err
+}
+
+// DeleteEnvVar permanently removes an environment variable record.
+func (r *AgentRepository) DeleteEnvVar(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM agent_environment_variables WHERE id = $1`, id.String())
 	return err
 }
 
@@ -827,6 +910,17 @@ func skillToRecord(s *agentdom.AgentSkill) (agentSkillRecord, error) {
 		CreatedAt:    s.CreatedAt,
 		UpdatedAt:    s.UpdatedAt,
 	}, nil
+}
+
+func envVarFromRecord(rec agentEnvVarRecord) *agentdom.AgentEnvironmentVariable {
+	return &agentdom.AgentEnvironmentVariable{
+		ID:             mustParseUUID(rec.ID),
+		AgentID:        mustParseUUID(rec.AgentID),
+		Key:            rec.Key,
+		EncryptedValue: rec.EncryptedValue,
+		CreatedAt:      rec.CreatedAt,
+		UpdatedAt:      rec.UpdatedAt,
+	}
 }
 
 func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversation {

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -440,12 +440,15 @@ var reservedEnvVarKeys = map[string]bool{
 }
 
 // validateEnvVarKey checks that key is a well-formed, non-reserved shell
-// environment variable name.
+// environment variable name. The reserved-name check is case-insensitive so
+// a lookalike like "oh_secret_key" can't sit alongside the real uppercase
+// infra variable and confuse anyone inspecting the container's environment.
 func validateEnvVarKey(key string) error {
 	if !envVarKeyPattern.MatchString(key) {
 		return agentdom.ErrEnvVarKeyInvalid
 	}
-	if reservedEnvVarKeys[key] || strings.HasPrefix(key, "PACA_") {
+	upperKey := strings.ToUpper(key)
+	if reservedEnvVarKeys[upperKey] || strings.HasPrefix(upperKey, "PACA_") {
 		return agentdom.ErrEnvVarKeyReserved
 	}
 	return nil

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -4,6 +4,7 @@ package agentsvc
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -414,6 +415,106 @@ func (s *Service) DeleteSkill(ctx context.Context, agentID, skillID uuid.UUID) e
 		return agentdom.ErrSkillNotFound
 	}
 	return s.repo.DeleteSkill(ctx, skillID)
+}
+
+// -------------------------------------------------------------------------
+// Environment Variables
+// -------------------------------------------------------------------------
+
+// envVarKeyPattern matches valid shell environment variable names.
+var envVarKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// reservedEnvVarKeys are names the sandbox container already sets for its own
+// operation (git identity, MCP wiring, secrets). User-supplied variables may
+// not use these names, so a misconfigured agent can never shadow them.
+// Keep in sync with services/ai-agent/src/agent/docker_workspace.py and
+// services/ai-agent/src/agent/builder.py.
+var reservedEnvVarKeys = map[string]bool{
+	"OH_SECRET_KEY":             true,
+	"OPENHANDS_SUPPRESS_BANNER": true,
+	"GIT_AUTHOR_NAME":           true,
+	"GIT_AUTHOR_EMAIL":          true,
+	"GIT_COMMITTER_NAME":        true,
+	"GIT_COMMITTER_EMAIL":       true,
+	"OH_EXTRA_PYTHON_PATH":      true,
+}
+
+// validateEnvVarKey checks that key is a well-formed, non-reserved shell
+// environment variable name.
+func validateEnvVarKey(key string) error {
+	if !envVarKeyPattern.MatchString(key) {
+		return agentdom.ErrEnvVarKeyInvalid
+	}
+	if reservedEnvVarKeys[key] || strings.HasPrefix(key, "PACA_") {
+		return agentdom.ErrEnvVarKeyReserved
+	}
+	return nil
+}
+
+// ListEnvVars returns all secret environment variables for the given agent.
+func (s *Service) ListEnvVars(ctx context.Context, agentID uuid.UUID) ([]*agentdom.AgentEnvironmentVariable, error) {
+	return s.repo.ListEnvVars(ctx, agentID)
+}
+
+// AddEnvVar creates a new secret environment variable for the given agent.
+func (s *Service) AddEnvVar(ctx context.Context, agentID uuid.UUID, in agentdom.AddEnvVarInput) (*agentdom.AgentEnvironmentVariable, error) {
+	key := strings.TrimSpace(in.Key)
+	if err := validateEnvVarKey(key); err != nil {
+		return nil, err
+	}
+	if existing, err := s.repo.FindEnvVarByKey(ctx, agentID, key); err == nil && existing != nil {
+		return nil, agentdom.ErrEnvVarKeyTaken
+	}
+	encryptedValue, err := s.encryptKey(in.Value)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt environment variable value: %w", err)
+	}
+	now := time.Now()
+	v := &agentdom.AgentEnvironmentVariable{
+		ID:             uuid.New(),
+		AgentID:        agentID,
+		Key:            key,
+		EncryptedValue: encryptedValue,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := s.repo.CreateEnvVar(ctx, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// UpdateEnvVar replaces the value of an existing environment variable.
+func (s *Service) UpdateEnvVar(ctx context.Context, agentID, envVarID uuid.UUID, in agentdom.UpdateEnvVarInput) (*agentdom.AgentEnvironmentVariable, error) {
+	v, err := s.repo.FindEnvVarByID(ctx, envVarID)
+	if err != nil {
+		return nil, err
+	}
+	if v.AgentID != agentID {
+		return nil, agentdom.ErrEnvVarNotFound
+	}
+	encryptedValue, err := s.encryptKey(in.Value)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt environment variable value: %w", err)
+	}
+	v.EncryptedValue = encryptedValue
+	v.UpdatedAt = time.Now()
+	if err := s.repo.UpdateEnvVar(ctx, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// DeleteEnvVar removes an environment variable after verifying ownership.
+func (s *Service) DeleteEnvVar(ctx context.Context, agentID, envVarID uuid.UUID) error {
+	v, err := s.repo.FindEnvVarByID(ctx, envVarID)
+	if err != nil {
+		return err
+	}
+	if v.AgentID != agentID {
+		return agentdom.ErrEnvVarNotFound
+	}
+	return s.repo.DeleteEnvVar(ctx, envVarID)
 }
 
 // -------------------------------------------------------------------------

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -30,6 +30,12 @@ type mockAgentRepo struct {
 	createSkill                   func(ctx context.Context, skill *agentdom.AgentSkill) error
 	updateSkill                   func(ctx context.Context, skill *agentdom.AgentSkill) error
 	deleteSkill                   func(ctx context.Context, id uuid.UUID) error
+	listEnvVars                   func(ctx context.Context, agentID uuid.UUID) ([]*agentdom.AgentEnvironmentVariable, error)
+	findEnvVarByID                func(ctx context.Context, id uuid.UUID) (*agentdom.AgentEnvironmentVariable, error)
+	findEnvVarByKey               func(ctx context.Context, agentID uuid.UUID, key string) (*agentdom.AgentEnvironmentVariable, error)
+	createEnvVar                  func(ctx context.Context, v *agentdom.AgentEnvironmentVariable) error
+	updateEnvVar                  func(ctx context.Context, v *agentdom.AgentEnvironmentVariable) error
+	deleteEnvVar                  func(ctx context.Context, id uuid.UUID) error
 	listConversations             func(ctx context.Context, filter agentdom.ListConversationsFilter) ([]*agentdom.AgentConversation, int64, error)
 	findConversationByID          func(ctx context.Context, id uuid.UUID) (*agentdom.AgentConversation, error)
 	createConversation            func(ctx context.Context, conv *agentdom.AgentConversation) error
@@ -172,6 +178,48 @@ func (m *mockAgentRepo) UpdateSkill(ctx context.Context, skill *agentdom.AgentSk
 func (m *mockAgentRepo) DeleteSkill(ctx context.Context, id uuid.UUID) error {
 	if m.deleteSkill != nil {
 		return m.deleteSkill(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockAgentRepo) ListEnvVars(ctx context.Context, agentID uuid.UUID) ([]*agentdom.AgentEnvironmentVariable, error) {
+	if m.listEnvVars != nil {
+		return m.listEnvVars(ctx, agentID)
+	}
+	return nil, nil
+}
+
+func (m *mockAgentRepo) FindEnvVarByID(ctx context.Context, id uuid.UUID) (*agentdom.AgentEnvironmentVariable, error) {
+	if m.findEnvVarByID != nil {
+		return m.findEnvVarByID(ctx, id)
+	}
+	return nil, agentdom.ErrEnvVarNotFound
+}
+
+func (m *mockAgentRepo) FindEnvVarByKey(ctx context.Context, agentID uuid.UUID, key string) (*agentdom.AgentEnvironmentVariable, error) {
+	if m.findEnvVarByKey != nil {
+		return m.findEnvVarByKey(ctx, agentID, key)
+	}
+	return nil, agentdom.ErrEnvVarNotFound
+}
+
+func (m *mockAgentRepo) CreateEnvVar(ctx context.Context, v *agentdom.AgentEnvironmentVariable) error {
+	if m.createEnvVar != nil {
+		return m.createEnvVar(ctx, v)
+	}
+	return nil
+}
+
+func (m *mockAgentRepo) UpdateEnvVar(ctx context.Context, v *agentdom.AgentEnvironmentVariable) error {
+	if m.updateEnvVar != nil {
+		return m.updateEnvVar(ctx, v)
+	}
+	return nil
+}
+
+func (m *mockAgentRepo) DeleteEnvVar(ctx context.Context, id uuid.UUID) error {
+	if m.deleteEnvVar != nil {
+		return m.deleteEnvVar(ctx, id)
 	}
 	return nil
 }

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -39,6 +39,7 @@ type AgentResponse struct {
 	UpdatedAt                     time.Time                `json:"updated_at"`
 	MCPServers                    []AgentMCPServerResponse `json:"mcp_servers,omitempty"`
 	Skills                        []AgentSkillResponse     `json:"skills,omitempty"`
+	EnvVars                       []AgentEnvVarResponse    `json:"env_vars,omitempty"`
 }
 
 // CreateAgentRequest is the body for POST /projects/:projectId/agents.
@@ -121,6 +122,12 @@ func AgentFromEntity(a *agentdom.Agent) AgentResponse {
 		resp.Skills = make([]AgentSkillResponse, 0, len(a.Skills))
 		for _, s := range a.Skills {
 			resp.Skills = append(resp.Skills, SkillFromEntity(s))
+		}
+	}
+	if len(a.EnvVars) > 0 {
+		resp.EnvVars = make([]AgentEnvVarResponse, 0, len(a.EnvVars))
+		for _, v := range a.EnvVars {
+			resp.EnvVars = append(resp.EnvVars, EnvVarFromEntity(v))
 		}
 	}
 	return resp
@@ -260,6 +267,43 @@ func SkillFromEntity(s *agentdom.AgentSkill) AgentSkillResponse {
 		Triggers:     triggers,
 		IsEnabled:    s.IsEnabled,
 		CreatedAt:    s.CreatedAt,
+	}
+}
+
+// =========================================================================
+// Environment Variable DTOs
+// =========================================================================
+
+// AgentEnvVarResponse is the public view of a secret environment variable.
+// Value is always redacted — the plaintext is never returned once set.
+type AgentEnvVarResponse struct {
+	ID        uuid.UUID `json:"id"`
+	AgentID   uuid.UUID `json:"agent_id"`
+	Key       string    `json:"key"`
+	Value     string    `json:"value"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// AddEnvVarRequest is the body for POST /agents/:agentId/env-vars.
+type AddEnvVarRequest struct {
+	Key   string `json:"key" binding:"required"`
+	Value string `json:"value" binding:"required"`
+}
+
+// UpdateEnvVarRequest is the body for PATCH /agents/:agentId/env-vars/:envVarId.
+type UpdateEnvVarRequest struct {
+	Value string `json:"value" binding:"required"`
+}
+
+// EnvVarFromEntity maps an AgentEnvironmentVariable entity to its DTO. The
+// value is always masked; it is never decrypted for API responses.
+func EnvVarFromEntity(v *agentdom.AgentEnvironmentVariable) AgentEnvVarResponse {
+	return AgentEnvVarResponse{
+		ID:        v.ID,
+		AgentID:   v.AgentID,
+		Key:       v.Key,
+		Value:     "***",
+		CreatedAt: v.CreatedAt,
 	}
 }
 

--- a/services/api/internal/transport/http/handler/agent_handler.go
+++ b/services/api/internal/transport/http/handler/agent_handler.go
@@ -448,6 +448,108 @@ func (h *AgentHandler) DeleteSkill(w http.ResponseWriter, r *http.Request) {
 	presenter.OK(w, r, map[string]any{"message": "skill deleted"})
 }
 
+// --- Environment Variables ---------------------------------------------------
+
+// ListEnvVars handles GET /projects/:projectId/agents/:agentId/env-vars.
+func (h *AgentHandler) ListEnvVars(w http.ResponseWriter, r *http.Request) {
+	_, agentID, err := h.parseAgentForProject(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	envVars, err := h.svc.ListEnvVars(r.Context(), agentID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	resp := make([]dto.AgentEnvVarResponse, 0, len(envVars))
+	for _, v := range envVars {
+		resp = append(resp, dto.EnvVarFromEntity(v))
+	}
+	presenter.OK(w, r, map[string]any{"items": resp})
+}
+
+// AddEnvVar handles POST /projects/:projectId/agents/:agentId/env-vars.
+func (h *AgentHandler) AddEnvVar(w http.ResponseWriter, r *http.Request) {
+	_, agentID, err := h.parseAgentForProject(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	var req dto.AddEnvVarRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if req.Key == "" {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "key is required"))
+		return
+	}
+	if req.Value == "" {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "value is required"))
+		return
+	}
+	envVar, err := h.svc.AddEnvVar(r.Context(), agentID, agentdom.AddEnvVarInput{
+		Key:   req.Key,
+		Value: req.Value,
+	})
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	presenter.OK(w, r, dto.EnvVarFromEntity(envVar))
+}
+
+// UpdateEnvVar handles PATCH /projects/:projectId/agents/:agentId/env-vars/:envVarId.
+func (h *AgentHandler) UpdateEnvVar(w http.ResponseWriter, r *http.Request) {
+	_, agentID, err := h.parseAgentForProject(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	envVarID, err := parseParamUUID(r, "envVarId")
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	var req dto.UpdateEnvVarRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if req.Value == "" {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "value is required"))
+		return
+	}
+	envVar, err := h.svc.UpdateEnvVar(r.Context(), agentID, envVarID, agentdom.UpdateEnvVarInput{
+		Value: req.Value,
+	})
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	presenter.OK(w, r, dto.EnvVarFromEntity(envVar))
+}
+
+// DeleteEnvVar handles DELETE /projects/:projectId/agents/:agentId/env-vars/:envVarId.
+func (h *AgentHandler) DeleteEnvVar(w http.ResponseWriter, r *http.Request) {
+	_, agentID, err := h.parseAgentForProject(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	envVarID, err := parseParamUUID(r, "envVarId")
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if err := h.svc.DeleteEnvVar(r.Context(), agentID, envVarID); err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	presenter.OK(w, r, map[string]any{"message": "environment variable deleted"})
+}
+
 // --- Chat Sessions ----------------------------------------------------------
 
 // ListChatSessions handles GET /projects/:projectId/agents/:agentId/chat-sessions.

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -68,6 +68,16 @@ func (m *mockAgentSvc) UpdateSkill(_ context.Context, _, _ uuid.UUID, _ agentdom
 	return nil, errors.New("not found")
 }
 func (m *mockAgentSvc) DeleteSkill(_ context.Context, _, _ uuid.UUID) error { return nil }
+func (m *mockAgentSvc) ListEnvVars(_ context.Context, _ uuid.UUID) ([]*agentdom.AgentEnvironmentVariable, error) {
+	return nil, nil
+}
+func (m *mockAgentSvc) AddEnvVar(_ context.Context, _ uuid.UUID, _ agentdom.AddEnvVarInput) (*agentdom.AgentEnvironmentVariable, error) {
+	return &agentdom.AgentEnvironmentVariable{ID: uuid.New()}, nil
+}
+func (m *mockAgentSvc) UpdateEnvVar(_ context.Context, _, _ uuid.UUID, _ agentdom.UpdateEnvVarInput) (*agentdom.AgentEnvironmentVariable, error) {
+	return nil, errors.New("not found")
+}
+func (m *mockAgentSvc) DeleteEnvVar(_ context.Context, _, _ uuid.UUID) error { return nil }
 func (m *mockAgentSvc) ListConversations(_ context.Context, _ agentdom.ListConversationsFilter) ([]*agentdom.AgentConversation, int64, error) {
 	return nil, 0, nil
 }

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -441,13 +441,18 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeAgentMCPServerNotFound,
 		apierr.CodeAgentSkillNotFound,
 		apierr.CodeAgentConversationNotFound,
-		apierr.CodeAgentChatSessionNotFound:
+		apierr.CodeAgentChatSessionNotFound,
+		apierr.CodeAgentEnvVarNotFound:
 		return http.StatusNotFound
 	case apierr.CodeAgentHandleTaken,
 		apierr.CodeAgentConversationNotRunning,
-		apierr.CodeAgentConversationAlreadyStopped:
+		apierr.CodeAgentConversationAlreadyStopped,
+		apierr.CodeAgentEnvVarKeyTaken:
 		return http.StatusConflict
-	case apierr.CodeAgentHandleInvalid, apierr.CodeAgentNameInvalid:
+	case apierr.CodeAgentHandleInvalid,
+		apierr.CodeAgentNameInvalid,
+		apierr.CodeAgentEnvVarKeyInvalid,
+		apierr.CodeAgentEnvVarKeyReserved:
 		return http.StatusBadRequest
 	case apierr.CodeBadRequest:
 		return http.StatusBadRequest

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -281,6 +281,14 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusConflict, apierr.CodeAgentConversationAlreadyStopped
 	case errors.Is(err, agentdom.ErrChatSessionNotFound):
 		return http.StatusNotFound, apierr.CodeAgentChatSessionNotFound
+	case errors.Is(err, agentdom.ErrEnvVarNotFound):
+		return http.StatusNotFound, apierr.CodeAgentEnvVarNotFound
+	case errors.Is(err, agentdom.ErrEnvVarKeyTaken):
+		return http.StatusConflict, apierr.CodeAgentEnvVarKeyTaken
+	case errors.Is(err, agentdom.ErrEnvVarKeyInvalid):
+		return http.StatusBadRequest, apierr.CodeAgentEnvVarKeyInvalid
+	case errors.Is(err, agentdom.ErrEnvVarKeyReserved):
+		return http.StatusBadRequest, apierr.CodeAgentEnvVarKeyReserved
 	default:
 		return http.StatusInternalServerError, apierr.CodeInternalError
 	}

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -471,6 +471,16 @@ func New(deps Deps) http.Handler {
 						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsWrite)).
 							Delete("/{agentId}/skills/{skillId}", deps.Agent.DeleteSkill)
 
+						// Environment variables
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsRead)).
+							Get("/{agentId}/env-vars", deps.Agent.ListEnvVars)
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsWrite)).
+							Post("/{agentId}/env-vars", deps.Agent.AddEnvVar)
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsWrite)).
+							Patch("/{agentId}/env-vars/{envVarId}", deps.Agent.UpdateEnvVar)
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsWrite)).
+							Delete("/{agentId}/env-vars/{envVarId}", deps.Agent.DeleteEnvVar)
+
 						// Chat sessions
 						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsRead)).
 							Get("/{agentId}/chat-sessions", deps.Agent.ListChatSessions)

--- a/services/api/migrations/000017_add_agent_environment_variables.sql
+++ b/services/api/migrations/000017_add_agent_environment_variables.sql
@@ -1,0 +1,23 @@
+-- 000017_add_agent_environment_variables.sql
+-- Adds per-agent secret environment variables, encrypted at rest, injected
+-- into the agent's sandbox container at run time (see issues #240, #241).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_environment_variables (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id        UUID        NOT NULL,
+    key             TEXT        NOT NULL,
+    encrypted_value TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_agent_environment_variables_agent
+        FOREIGN KEY (agent_id)
+        REFERENCES agents(id)
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_environment_variables_key
+    ON agent_environment_variables (agent_id, key);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds per-agent secret environment variables, encrypted at rest and injected into the agent's sandbox container at run time. This addresses two related requests: #240 asked for a way to keep secret config (`.env`-style values) encrypted, and #241 needs a `GITHUB_TOKEN`-style credential reachable by `git clone` inside the sandbox — this is the "configuring environment variables directly for the agent container" approach the maintainer described in the #241 discussion.

This PR only covers the credential-delivery half of #241 (getting a token into the sandbox so cloning works). The other half — letting the agent review or update an existing pull request — is tracked as a separate follow-up and is not part of this PR, so #241 stays open until that lands too.

## Changes

**Backend (`services/api`)**
- New `agent_environment_variables` table (migration `000017`), values encrypted with the existing AES-256-GCM `secret.Encryptor` — the same mechanism already used for `llm_api_key_secret`.
- Full CRUD (list/add/update/delete) across domain, postgres repository, service, DTO, handler, and router layers, mirroring the existing `agent_mcp_servers` slice.
- Key validation: must match `^[A-Za-z_][A-Za-z0-9_]*$` and can't collide with reserved sandbox-internal variable names (`GIT_AUTHOR_*`, `GIT_COMMITTER_*`, `OH_SECRET_KEY`, `OH_EXTRA_PYTHON_PATH`, `PACA_*`), checked case-insensitively so a lowercase lookalike can't bypass it.
- Creating a duplicate key on the same agent now returns a proper `409` (`ErrEnvVarKeyTaken`) instead of a raw database error.
- API responses never return the plaintext value — always masked as `"***"`, even immediately after creation.

**Runtime (`services/ai-agent`)**
- `AgentConfig` now carries decrypted `env_vars`, loaded the same way as the LLM API key. A variable that fails to decrypt is omitted entirely rather than injected as an empty string, so it fails clearly (missing) instead of ambiguously (blank).
- `docker_sandbox()` injects them as real container environment variables, so they're usable by `git clone`, build tools, and deploy scripts — not scoped to a single MCP server subprocess. Reserved infra vars always win on name collision as defense-in-depth alongside the backend-side validation.

**Frontend (`apps/web`)**
- New "Environment" tab on the agent detail page to add, list, and delete secret variables — masked values, no reveal affordance once saved.
- Translated into all supported locales (en, fr, ja, zh-CN, ko, vi, es).

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` (services/api)
- [x] `pytest` (services/ai-agent)
- [x] `tsc -b && biome check . && vitest run && npm run build` (apps/web)
- [ ] Manual smoke test against a live Postgres + Docker sandbox: add a `GITHUB_TOKEN` variable on an agent, trigger a private-repo clone, confirm the token reaches the container.

Closes #240
