### PR TITLE
feat: refactor ai agent executor

### DIFF
--- a/scripts/install-local-plugin.sh
+++ b/scripts/install-local-plugin.sh
@@ -172,6 +172,7 @@ fi
 
 BACKEND_DIR="$PACA_DIR/plugins/local/backend/$PLUGIN_ID"
 FRONTEND_DIR="$PACA_DIR/plugins/local/frontend/$PLUGIN_ID"
+MCP_DIR="$PACA_DIR/plugins/local/mcp/$PLUGIN_ID"
 
 # Build backend
 if [[ "$SKIP_BUILD" = false ]]; then
@@ -246,6 +247,46 @@ if [[ "$SKIP_BUILD" = false ]]; then
 fi
 
 print_success "Frontend store populated"
+
+# Build and populate MCP bundle (optional — not every plugin has MCP tools)
+if [[ -d "$PLUGIN_DIR/mcp" ]]; then
+    if [[ "$SKIP_BUILD" = false ]]; then
+        print_step "Building MCP bundle..."
+        cd "$PLUGIN_DIR/mcp"
+
+        if [[ ! -f "package.json" ]]; then
+            print_error "package.json not found in mcp directory"
+            exit 1
+        fi
+
+        if [[ ! -d "node_modules" ]]; then
+            print_step "Installing MCP dependencies..."
+            bun install
+        fi
+
+        bun run build
+
+        if [[ ! -f "dist/mcp.js" ]]; then
+            print_error "MCP build failed - dist/mcp.js not found"
+            exit 1
+        fi
+
+        print_success "MCP bundle built successfully"
+    else
+        print_step "Skipping MCP build (--skip-build)"
+    fi
+
+    print_step "Populating MCP store..."
+    mkdir -p "$MCP_DIR"
+
+    if [[ "$SKIP_BUILD" = false ]]; then
+        cp "$PLUGIN_DIR/mcp/dist/mcp.js" "$MCP_DIR/mcp.js"
+    fi
+
+    print_success "MCP store populated"
+else
+    print_info "No mcp directory found — skipping MCP bundle (plugin has no MCP tools)"
+fi
 
 # Install plugin via API
 if [[ "$SKIP_INSTALL" = false ]]; then
@@ -385,4 +426,7 @@ echo ""
 print_success "Plugin $PLUGIN_ID v$PLUGIN_VERSION build and installation complete!"
 print_info "Backend artifacts: $BACKEND_DIR"
 print_info "Frontend artifacts: $FRONTEND_DIR"
+if [[ -d "$PLUGIN_DIR/mcp" ]]; then
+    print_info "MCP artifacts: $MCP_DIR"
+fi
 print_info "If the plugin is enabled, it will be available after restarting the Paca services"

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import threading
 import time
@@ -27,20 +26,20 @@ from .repo_tools import make_repository_tool_specs
 
 logger = logging.getLogger(__name__)
 
-_DONE_STATUSES = frozenset(
-    {
-        ConversationExecutionStatus.FINISHED,
-        ConversationExecutionStatus.ERROR,
-        ConversationExecutionStatus.STUCK,
-    }
-)
-
 _ERROR_STATUSES = frozenset(
     {
         ConversationExecutionStatus.ERROR,
         ConversationExecutionStatus.STUCK,
     }
 )
+
+# events.reconcile() re-walks the *entire* remote event history over REST
+# (openhands.sdk.conversation.impl.remote_conversation.RemoteEventsList has no
+# "since" cursor) — the SDK's own blocking run() only pays that cost once, at
+# completion, rather than on every status poll. We still need it more often
+# than that to bound the WS-dead-thread persistence gap (see
+# _wait_for_done_or_stop), but not on every 2s tick.
+_RECONCILE_INTERVAL = 10.0
 
 
 def _get_conversation_error_detail(conversation) -> str | None:
@@ -64,6 +63,7 @@ def _get_conversation_error_detail(conversation) -> str | None:
 def _wait_for_done_or_stop(
     conversation,
     stop_event: threading.Event,
+    reconcile,
     poll_interval: float = 2.0,
     timeout: float = 3600.0,
 ) -> tuple[bool, bool]:
@@ -74,6 +74,7 @@ def _wait_for_done_or_stop(
       errored  — True if the conversation ended with ERROR or STUCK status.
     """
     start = time.monotonic()
+    last_reconcile = start
     while True:
         # stop_event.wait() blocks for up to poll_interval seconds, returning
         # True immediately if the event is already set.
@@ -82,10 +83,15 @@ def _wait_for_done_or_stop(
                 conversation.pause()
             except Exception as exc:
                 logger.warning("Failed to pause conversation on stop request: %s", exc)
+            # Catch up on anything the dead WS thread missed before we stop
+            # watching this conversation entirely.
+            reconcile(conversation)
             return True, False
 
-        if time.monotonic() - start > timeout:
+        now = time.monotonic()
+        if now - start > timeout:
             logger.warning("Conversation polling timed out after %.0f seconds", timeout)
+            reconcile(conversation)
             return False, False
 
         try:
@@ -93,24 +99,34 @@ def _wait_for_done_or_stop(
             # ever re-fetches over REST if the cache is still empty (see
             # RemoteState._get_conversation_info). openhands-sdk's WS client
             # thread permanently stops reconnecting after any ConnectionClosed
-            # (upstream bug, still present as of openhands-sdk 1.31.0 — see
+            # (upstream bug, still present as of openhands-sdk 1.30.0 — see
             # OpenHands/software-agent-sdk#1532), which would otherwise freeze
             # this loop on a stale "running" status until the timeout above.
             # Force a live REST read every poll so a dead socket can't wedge us.
             conversation.state.refresh_from_server()
             status = conversation.state.execution_status
-            if status in _DONE_STATUSES:
+
+            # The same dead socket also stops new agent events from ever
+            # reaching our persistence callback (it only fires from inside the
+            # WS client thread). reconcile() is a full-history REST walk (see
+            # _RECONCILE_INTERVAL), so throttle it independently of the
+            # cheap poll_interval status check above.
+            if now - last_reconcile >= _RECONCILE_INTERVAL:
+                reconcile(conversation)
+                last_reconcile = now
+
+            if status.is_terminal():
                 errored = status in _ERROR_STATUSES
                 if errored:
-                    # Same staleness risk applies to the cached event list used
-                    # for the error detail — reconcile before reading it.
-                    conversation.state.events.reconcile()
                     detail = _get_conversation_error_detail(conversation)
                     logger.error(
                         "Conversation ended with status %s — %s",
                         status.value,
                         detail or "no detail available",
                     )
+                # Final catch-up so the run never ends with an un-persisted
+                # tail from the last reconcile_interval stretch.
+                reconcile(conversation)
                 return False, errored
         except Exception as exc:
             logger.debug("Failed to read conversation execution status: %s", exc)
@@ -124,7 +140,7 @@ class _QuietVisualizer(ConversationVisualizerBase):
 
     The SDK's DefaultConversationVisualizer emits a WARNING for every event
     type absent from its EVENT_VISUALIZATION_CONFIG (e.g. StreamingDeltaEvent).
-    Since this service handles all events via callbacks / token_callbacks, we
+    Since this service handles all events via the `callbacks` list, we
     replace the default visualizer with this no-op to eliminate the noise.
     """
 
@@ -179,7 +195,7 @@ def _gather_repo_sources(trigger: TriggerMessage) -> list[RepoInfoSource]:
 
 
 class _AtomicCounter:
-    """Thread-safe monotonic counter shared across event and token callbacks."""
+    """Thread-safe monotonic counter for ordering persisted events."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -192,203 +208,144 @@ class _AtomicCounter:
             return v
 
 
-class _TurnState:
-    """Tracks whether _make_token_callback already persisted the agent's
-    reply for the in-flight turn.
+class _SeenEvents:
+    """Thread-safe set of SDK event ids already routed to persistence.
 
-    openhands.sdk.conversation.impl.RemoteConversation accepts a
-    token_callbacks kwarg but never wires it to anything — Conversation()
-    always builds a RemoteConversation here since docker_sandbox() always
-    yields a RemoteWorkspace, so on_token is never actually invoked.
-    _make_event_callback consults this flag to fall back to persisting the
-    SDK's own MessageEvent instead, so the reply is never silently dropped.
-    See https://github.com/Paca-AI/paca/issues/211 and #214.
+    Shared between the live WebSocket callback and the reconciliation
+    fallback in `_wait_for_done_or_stop` so that an event is persisted
+    exactly once no matter which path first observes it.
     """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._token_persisted = False
+        self._ids: set[str] = set()
 
-    def mark_token_persisted(self) -> None:
+    def mark_new(self, event_id: str) -> bool:
+        """Return True and record the id if it hasn't been seen before."""
         with self._lock:
-            self._token_persisted = True
-
-    def consume(self) -> bool:
-        """Return True if the token callback persisted this turn, clearing
-        the flag for the next one."""
-        with self._lock:
-            was_persisted = self._token_persisted
-            self._token_persisted = False
-            return was_persisted
+            if event_id in self._ids:
+                return False
+            self._ids.add(event_id)
+            return True
 
 
 # ─── Event callback ───────────────────────────────────────────────────────────
+
+
+def _persist_event(
+    trigger: TriggerMessage,
+    loop: asyncio.AbstractEventLoop,
+    counter: _AtomicCounter,
+    event,
+) -> None:
+    """Filter, index, and persist a single SDK event to Postgres + Valkey.
+
+    Shared by the live WebSocket callback and the reconciliation fallback (see
+    `_make_reconciler`) so both paths apply identical filtering and write to
+    the same destinations, regardless of which one first observes an event.
+    """
+    event_type = type(event).__name__
+    event_source = str(getattr(event, "source", "agent"))
+
+    # Events the frontend never renders — skip to avoid wasting event_index
+    # slots and polluting the paginated events list.
+    if event_type in {
+        "StreamingDeltaEvent",  # raw streaming chunks — only the final message matters
+        "ConversationStateUpdateEvent",  # internal iteration bookkeeping
+        "SystemPromptEvent",  # system prompt echo — not shown to user
+        "ConversationErrorEvent",  # SDK error signal — surfaced via conversation status
+    }:
+        return
+
+    event_index = counter.next()
+    payload = event.model_dump_json() if hasattr(event, "model_dump_json") else "{}"
+
+    async def _persist():
+        await conversation_repository.insert_conversation_event(
+            conversation_id=trigger.conversation_id,
+            event_type=event_type,
+            event_source=event_source,
+            event_index=event_index,
+            payload=payload,
+        )
+        await stream_store.publish_event(
+            {
+                "conversation_id": trigger.conversation_id,
+                "project_id": trigger.project_id,
+                "event_type": event_type,
+                "event_source": event_source,
+                "event_index": str(event_index),
+                "payload": payload,
+                "status": "running",
+            }
+        )
+        await stream_store.publish_realtime(
+            project_id=trigger.project_id,
+            conversation_id=trigger.conversation_id,
+            event_type=f"agent.{event_type.lower()}",
+        )
+
+    future = asyncio.run_coroutine_threadsafe(_persist(), loop)
+    try:
+        future.result(timeout=10)
+    except Exception as exc:
+        logger.warning(
+            "Event persist failed for conversation %s: %s",
+            trigger.conversation_id,
+            exc,
+        )
 
 
 def _make_event_callback(
     trigger: TriggerMessage,
     loop: asyncio.AbstractEventLoop,
     counter: _AtomicCounter,
-    turn_state: _TurnState,
+    seen: _SeenEvents,
 ):
-    """Return a synchronous callback invoked by the OpenHands SDK on each complete event.
-
-    Agent MessageEvents are normally skipped here in favor of
-    _make_token_callback, which captures the LLM's text output directly from
-    the streaming response for cleaner content without SDK wrapper fields —
-    when on_token actually gets invoked (see _TurnState). All other events
-    (actions, observations, system messages) are saved normally.
-    """
+    """Return a synchronous callback invoked by the OpenHands SDK on each complete event."""
 
     def callback(event) -> None:
-        event_type = type(event).__name__
-        event_source = str(getattr(event, "source", "agent"))
-
-        # Events the frontend never renders — skip to avoid wasting event_index
-        # slots and polluting the paginated events list.
-        if event_type in {
-            "StreamingDeltaEvent",  # raw streaming chunks — only the final message matters
-            "ConversationStateUpdateEvent",  # internal iteration bookkeeping
-            "SystemPromptEvent",  # system prompt echo — not shown to user
-            "ConversationErrorEvent",  # SDK error signal — surfaced via conversation status
-        }:
+        event_id = getattr(event, "id", None)
+        if event_id is not None and not seen.mark_new(event_id):
             return
-        # Agent text responses are normally captured by token_callbacks with
-        # richer streaming data; skip them here to avoid duplicate DB rows —
-        # unless the token callback never actually persisted this turn (it
-        # never fires at all for RemoteConversation — see _TurnState), in
-        # which case fall through and persist this event instead of silently
-        # dropping the reply.
-        if event_type == "MessageEvent" and event_source == "agent" and turn_state.consume():
-            return
-
-        event_index = counter.next()
-        payload = event.model_dump_json() if hasattr(event, "model_dump_json") else "{}"
-
-        async def _persist():
-            await conversation_repository.insert_conversation_event(
-                conversation_id=trigger.conversation_id,
-                event_type=event_type,
-                event_source=event_source,
-                event_index=event_index,
-                payload=payload,
-            )
-            await stream_store.publish_event(
-                {
-                    "conversation_id": trigger.conversation_id,
-                    "project_id": trigger.project_id,
-                    "event_type": event_type,
-                    "event_source": event_source,
-                    "event_index": str(event_index),
-                    "payload": payload,
-                    "status": "running",
-                }
-            )
-            await stream_store.publish_realtime(
-                project_id=trigger.project_id,
-                conversation_id=trigger.conversation_id,
-                event_type=f"agent.{event_type.lower()}",
-            )
-
-        future = asyncio.run_coroutine_threadsafe(_persist(), loop)
-        try:
-            future.result(timeout=10)
-        except Exception as exc:
-            logger.warning(
-                "Event persist failed for conversation %s: %s",
-                trigger.conversation_id,
-                exc,
-            )
+        _persist_event(trigger, loop, counter, event)
 
     return callback
 
 
-# ─── Token (streaming) callback ───────────────────────────────────────────────
-
-
-def _make_token_callback(
+def _make_reconciler(
     trigger: TriggerMessage,
     loop: asyncio.AbstractEventLoop,
     counter: _AtomicCounter,
-    turn_state: _TurnState,
+    seen: _SeenEvents,
 ):
-    """Return a token callback that accumulates streaming LLM chunks into complete
-    messages and persists each finished message as a MessageEvent.
+    """Return a function that catches up on events the dead WS thread missed.
 
-    The OpenHands SDK calls this once per streaming chunk.  When finish_reason
-    is set the accumulated content is flushed to the database and a realtime
-    pub/sub notification is published so WebSocket clients update immediately.
+    openhands-sdk's WS client thread permanently stops reconnecting after any
+    ConnectionClosed (see the comment in `_wait_for_done_or_stop`), so the
+    composed event callback silently stops firing entirely — even though the
+    agent keeps running in its sandbox and producing events. `events.reconcile()`
+    re-fetches the full event history over REST and merges it straight into
+    the SDK's local cache, bypassing callbacks, so anything new it pulls in
+    has to be routed through `_persist_event` by hand here.
     """
-    lock = threading.Lock()
-    parts_content: list[str] = []
-    parts_reasoning: list[str] = []
 
-    def on_token(stream) -> None:
-        for choice in stream.choices:
-            delta = choice.delta
-            finish_reason = getattr(choice, "finish_reason", None)
+    def reconcile(conversation) -> None:
+        try:
+            conversation.state.events.reconcile()
+            for event in list(conversation.state.events):
+                event_id = getattr(event, "id", None)
+                if event_id is None or not seen.mark_new(event_id):
+                    continue
+                _persist_event(trigger, loop, counter, event)
+        except Exception as exc:
+            logger.debug(
+                "Event reconciliation failed for conversation %s: %s",
+                trigger.conversation_id,
+                exc,
+            )
 
-            content_chunk = getattr(delta, "content", None) or ""
-            reasoning_chunk = getattr(delta, "reasoning_content", None) or ""
-
-            with lock:
-                if content_chunk:
-                    parts_content.append(content_chunk)
-                if reasoning_chunk:
-                    parts_reasoning.append(reasoning_chunk)
-
-                if finish_reason:
-                    full_content = "".join(parts_content)
-                    full_reasoning = "".join(parts_reasoning)
-                    parts_content.clear()
-                    parts_reasoning.clear()
-
-                    if not full_content and not full_reasoning:
-                        return
-
-                    event_index = counter.next()
-                    payload_obj: dict = {"content": full_content, "source": "agent"}
-                    if full_reasoning:
-                        payload_obj["reasoning_content"] = full_reasoning
-                    payload_str = json.dumps(payload_obj)
-
-                    async def _persist(idx=event_index, p=payload_str):
-                        await conversation_repository.insert_conversation_event(
-                            conversation_id=trigger.conversation_id,
-                            event_type="MessageEvent",
-                            event_source="agent",
-                            event_index=idx,
-                            payload=p,
-                        )
-                        await stream_store.publish_event(
-                            {
-                                "conversation_id": trigger.conversation_id,
-                                "project_id": trigger.project_id,
-                                "event_type": "MessageEvent",
-                                "event_source": "agent",
-                                "event_index": str(idx),
-                                "payload": p,
-                                "status": "running",
-                            }
-                        )
-                        await stream_store.publish_realtime(
-                            project_id=trigger.project_id,
-                            conversation_id=trigger.conversation_id,
-                            event_type="agent.messageevent",
-                        )
-
-                    future = asyncio.run_coroutine_threadsafe(_persist(), loop)
-                    try:
-                        future.result(timeout=10)
-                        turn_state.mark_token_persisted()
-                    except Exception as exc:
-                        logger.warning(
-                            "Token callback persist failed for conversation %s: %s",
-                            trigger.conversation_id,
-                            exc,
-                        )
-
-    return on_token
+    return reconcile
 
 
 def _build_project_context_suffix(project_id: str) -> str:
@@ -408,7 +365,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
     """Execute a single agent conversation end-to-end."""
     loop = asyncio.get_event_loop()
     counter = _AtomicCounter()
-    turn_state = _TurnState()
+    seen_events = _SeenEvents()
     stop_event = threading.Event()
     logger.info("Starting conversation %s (agent=%s)", trigger.conversation_id, trigger.agent_id)
     await conversation_repository.update_conversation_status(trigger.conversation_id, "running")
@@ -468,10 +425,10 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 "4. Make your code changes, then commit them:\n"
                 "   git -C /workspace/repo add -A && git -C /workspace/repo commit -m '<message>'\n"
                 "5. Call push_branch with the plugin_id, repo_id,"
-                " and the branch name to publish the branch.\n"
-                "6. Call create_pull_request with the plugin_id, repo_id, a descriptive title, "
-                "the feature branch as head_branch, and the default branch as base_branch.\n\n"
-                "Do NOT skip steps 5 and 6 — always push your branch and open a PR when finished."
+                " and the branch name to publish the branch.\n\n"
+                "Do NOT skip step 5 — always push your branch when finished.\n\n"
+                "Creating, listing, reviewing, and commenting on pull/merge requests is "
+                "handled by the repository plugin's own tools. "
             )
 
         # Append the trigger-specific prompt last so it takes precedence.
@@ -513,7 +470,6 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                     agent_kwargs["tools"] = get_default_tools() + make_repository_tool_specs(
                         trigger.project_id,
                         trigger.repo_plugin_ids,
-                        trigger.task_id,
                         api_base_url=settings.api_base_url,
                         api_key=settings.paca_api_key,
                     )
@@ -530,8 +486,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 conversation = Conversation(
                     agent=agent,
                     workspace=workspace,
-                    callbacks=[_make_event_callback(trigger, loop, counter, turn_state)],
-                    token_callbacks=[_make_token_callback(trigger, loop, counter, turn_state)],
+                    callbacks=[_make_event_callback(trigger, loop, counter, seen_events)],
                     max_iteration_per_run=agent_config.max_iterations,
                     visualizer=_QuietVisualizer(),
                 )
@@ -565,7 +520,8 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                     # Use non-blocking run so our polling loop can be interrupted
                     # by a stop signal without waiting for the SDK timeout.
                     conversation.run(blocking=False)
-                    return _wait_for_done_or_stop(conversation, stop_event)
+                    reconcile = _make_reconciler(trigger, loop, counter, seen_events)
+                    return _wait_for_done_or_stop(conversation, stop_event, reconcile)
                 finally:
                     active_conversations.pop(trigger.conversation_id, None)
                     # Stop the SDK's WebSocket client thread so it does not

--- a/services/ai-agent/src/agent/repo_tools.py
+++ b/services/ai-agent/src/agent/repo_tools.py
@@ -334,93 +334,6 @@ class PushBranchExecutor(ToolExecutor[PushBranchAction, PushBranchObservation]):
             return PushBranchObservation(success=False, message=str(exc))
 
 
-# ─── Create Pull Request ──────────────────────────────────────────────────────
-
-
-class CreatePullRequestAction(Action):
-    """Action to create a pull request and link it to the current task."""
-
-    plugin_id: str = Field(description="The plugin ID (from list_repositories)")
-    repo_id: str = Field(description="The repository ID (from list_repositories)")
-    title: str = Field(description="Pull request title")
-    head_branch: str = Field(description="The feature branch to merge from")
-    base_branch: str = Field(description="The target branch to merge into (e.g. main)")
-    body: str = Field(default="", description="Pull request description (optional)")
-
-
-class CreatePullRequestObservation(Observation):
-    """Observation containing PR creation result."""
-
-    success: bool = False
-    pr_number: int = 0
-    pr_url: str = ""
-    message: str = ""
-
-    @property
-    def to_llm_content(self) -> Sequence[TextContent]:
-        if self.success:
-            lines = [
-                "Pull request created successfully!",
-                f"  PR number: #{self.pr_number}",
-                f"  URL: {self.pr_url}",
-            ]
-            return [TextContent(text="\n".join(lines))]
-        return [TextContent(text=f"Failed to create pull request: {self.message}")]
-
-
-class CreatePullRequestExecutor(
-    ToolExecutor[CreatePullRequestAction, CreatePullRequestObservation]
-):
-    def __init__(
-        self, project_id: str, task_id: str | None, api_base_url: str, api_key: str
-    ) -> None:
-        self.project_id = project_id
-        self.task_id = task_id
-        self.api_base_url = api_base_url
-        self.api_key = api_key
-
-    def __call__(
-        self, action: CreatePullRequestAction, conversation=None
-    ) -> CreatePullRequestObservation:
-        if not self.task_id:
-            return CreatePullRequestObservation(
-                success=False,
-                message="No task ID is associated with this conversation. Cannot create a PR.",
-            )
-        try:
-            url = (
-                f"{self.api_base_url}/api/v1/plugins/{action.plugin_id}"
-                f"/projects/{self.project_id}/tasks/{self.task_id}/pull-requests"
-            )
-            resp = httpx.post(
-                url,
-                headers={"X-API-Key": self.api_key, "Content-Type": "application/json"},
-                json={
-                    "repo_id": action.repo_id,
-                    "title": action.title,
-                    "head_branch": action.head_branch,
-                    "base_branch": action.base_branch,
-                    "body": action.body,
-                },
-                timeout=15,
-            )
-            resp.raise_for_status()
-            data = resp.json().get("data", {})
-            return CreatePullRequestObservation(
-                success=True,
-                pr_number=data.get("pr_number", 0),
-                pr_url=data.get("html_url", ""),
-            )
-        except httpx.HTTPStatusError as exc:
-            try:
-                err_msg = exc.response.json().get("error", str(exc))
-            except Exception:
-                err_msg = str(exc)
-            return CreatePullRequestObservation(success=False, message=err_msg)
-        except Exception as exc:
-            return CreatePullRequestObservation(success=False, message=str(exc))
-
-
 # ─── Tool Definitions ─────────────────────────────────────────────────────────
 
 _LIST_DESC = """\
@@ -456,23 +369,11 @@ Parameters:
 - branch_name: Branch name to push (leave empty to use the currently checked-out branch)
 - repo_dir: Path to the local repository (default: /workspace/repo)
 
-After a successful push, call create_pull_request to open a PR.
+After a successful push, use the repository plugin's own tools (if configured
+for this agent) to open, review, or comment on a pull/merge request. Pull
+request operations are plugin-specific, not built-in tools.
 """
 
-_CREATE_PR_DESC = """\
-Create a pull request on GitHub and link it to the current task.
-
-Call this after push_branch has succeeded. The PR will be linked to the
-task that triggered this conversation.
-
-Parameters:
-- plugin_id: The plugin UUID (from list_repositories)
-- repo_id: The repository UUID (from list_repositories)
-- title: A short, descriptive PR title
-- head_branch: The feature branch you pushed (source of changes)
-- base_branch: The branch to merge into (e.g. main, develop)
-- body: Optional PR description with details about the changes
-"""
 
 
 class ListRepositoriesTool(ToolDefinition[ListRepositoriesAction, ListRepositoriesObservation]):
@@ -541,38 +442,16 @@ class PushBranchTool(ToolDefinition[PushBranchAction, PushBranchObservation]):
         ]
 
 
-class CreatePullRequestTool(ToolDefinition[CreatePullRequestAction, CreatePullRequestObservation]):
-    @classmethod
-    def create(
-        cls,
-        conv_state=None,
-        *,
-        project_id: str,
-        task_id: str | None,
-        api_base_url: str,
-        api_key: str,
-    ) -> Sequence[ToolDefinition]:
-        return [
-            cls(
-                description=_CREATE_PR_DESC,
-                action_type=CreatePullRequestAction,
-                observation_type=CreatePullRequestObservation,
-                executor=CreatePullRequestExecutor(project_id, task_id, api_base_url, api_key),
-            )
-        ]
-
 
 # Register tool classes so Agent can resolve them via Tool(name=..., params={...})
 register_tool("list_repositories", ListRepositoriesTool)
 register_tool("clone_repository", CloneRepositoryTool)
 register_tool("push_branch", PushBranchTool)
-register_tool("create_pull_request", CreatePullRequestTool)
 
 
 def make_repository_tool_specs(
     project_id: str,
     repo_plugin_ids: list[str],
-    task_id: str | None = None,
     *,
     api_base_url: str,
     api_key: str,
@@ -595,8 +474,4 @@ def make_repository_tool_specs(
         ),
         Tool(name="clone_repository", params={"project_id": project_id, **common}),
         Tool(name="push_branch", params={"project_id": project_id, **common}),
-        Tool(
-            name="create_pull_request",
-            params={"project_id": project_id, "task_id": task_id, **common},
-        ),
     ]

--- a/services/ai-agent/src/agent/repo_tools.py
+++ b/services/ai-agent/src/agent/repo_tools.py
@@ -375,7 +375,6 @@ request operations are plugin-specific, not built-in tools.
 """
 
 
-
 class ListRepositoriesTool(ToolDefinition[ListRepositoriesAction, ListRepositoriesObservation]):
     @classmethod
     def create(
@@ -440,7 +439,6 @@ class PushBranchTool(ToolDefinition[PushBranchAction, PushBranchObservation]):
                 executor=PushBranchExecutor(project_id, terminal, api_base_url, api_key),
             )
         ]
-
 
 
 # Register tool classes so Agent can resolve them via Tool(name=..., params={...})

--- a/services/ai-agent/tests/e2e/test_run_conversation_e2e.py
+++ b/services/ai-agent/tests/e2e/test_run_conversation_e2e.py
@@ -169,8 +169,7 @@ async def test_agent_reply_is_persisted_through_real_sandbox(make_fake_llm, pers
 async def test_agent_tool_call_then_reply_persists_full_flow(make_fake_llm, persistence):
     """A tool call followed by a final text reply spans two agent.step()
     iterations. Confirms the action, its observation, AND the final reply
-    all persist — i.e. _TurnState correctly resets between turns in the
-    real pipeline, not just in the isolated unit test."""
+    all persist through the real pipeline, not just the isolated unit test."""
     base_url = make_fake_llm(
         script=[
             tool_call_reply("terminal", {"command": "echo hello-from-e2e"}),

--- a/services/ai-agent/tests/test_executor.py
+++ b/services/ai-agent/tests/test_executor.py
@@ -11,8 +11,8 @@ from src.agent.executor import (
     _AtomicCounter,
     _build_project_context_suffix,
     _make_event_callback,
-    _make_token_callback,
-    _TurnState,
+    _make_reconciler,
+    _SeenEvents,
 )
 from src.core import streams as stream_store
 from src.core.streams import TriggerMessage
@@ -38,36 +38,12 @@ def test_different_project_ids_produce_different_suffixes():
     assert _build_project_context_suffix("proj-1") != _build_project_context_suffix("proj-2")
 
 
-def test_turn_state_defaults_to_not_persisted():
-    """The event callback should fall back to persisting the raw MessageEvent
-    when the token callback never fired for this turn — which is always, for
-    RemoteConversation (see _TurnState's docstring in executor.py)."""
-    state = _TurnState()
-    assert state.consume() is False
-
-
-def test_turn_state_consume_reflects_token_persist():
-    state = _TurnState()
-    state.mark_token_persisted()
-    assert state.consume() is True
-
-
-def test_turn_state_consume_clears_flag_for_next_turn():
-    state = _TurnState()
-    state.mark_token_persisted()
-    assert state.consume() is True
-    # A second turn with no streaming output must not inherit the previous
-    # turn's flag — otherwise its reply would be silently dropped too.
-    assert state.consume() is False
-
-
-# ─── _make_event_callback / _make_token_callback integration ─────────────────
+# ─── _make_event_callback ─────────────────────────────────────────────────────
 #
-# These exercise the real closures together rather than just _TurnState in
-# isolation. They run a real asyncio loop on a background thread because the
-# callbacks call asyncio.run_coroutine_threadsafe(...).result(...) — exactly
-# how they're driven in production (the SDK invokes them synchronously from
-# the executor thread, while the main event loop runs separately).
+# These run a real asyncio loop on a background thread because the callbacks
+# call asyncio.run_coroutine_threadsafe(...).result(...) — exactly how they're
+# driven in production (the SDK invokes them synchronously from the executor
+# thread, while the main event loop runs separately).
 
 
 @pytest.fixture
@@ -92,24 +68,14 @@ def mock_persistence(monkeypatch):
 
 class MessageEvent:
     """Stand-in for openhands.sdk.event.MessageEvent — the callback only
-    relies on the class name, `.source`, and `.model_dump_json()`."""
+    relies on the class name, `.id`, `.source`, and `.model_dump_json()`."""
 
-    def __init__(self, source: str = "agent") -> None:
+    def __init__(self, source: str = "agent", id: str | None = None) -> None:
         self.source = source
+        self.id = id
 
     def model_dump_json(self) -> str:
         return json.dumps({"source": self.source})
-
-
-class _FakeChoice:
-    def __init__(self, content: str = "", finish_reason: str | None = None) -> None:
-        self.delta = type("Delta", (), {"content": content, "reasoning_content": ""})()
-        self.finish_reason = finish_reason
-
-
-class _FakeStreamChunk:
-    def __init__(self, *choices: _FakeChoice) -> None:
-        self.choices = choices
 
 
 def _trigger(conversation_id: str = "conv-1") -> TriggerMessage:
@@ -128,19 +94,16 @@ def _trigger(conversation_id: str = "conv-1") -> TriggerMessage:
     )
 
 
-def test_event_callback_persists_agent_reply_when_token_callback_never_fires(
-    bg_loop, mock_persistence
-):
-    """Mirrors production under openhands-sdk's RemoteConversation: on_token
-    is never invoked at all (token_callbacks isn't wired through for remote
-    workspaces — see openhands.sdk.conversation.impl.remote_conversation).
-    The event callback must persist the agent's reply itself rather than
-    silently dropping it."""
+def test_event_callback_persists_agent_reply(bg_loop, mock_persistence):
+    """Regression coverage for https://github.com/Paca-AI/paca/issues/211 and
+    #214: openhands-sdk's RemoteConversation never wires up token_callbacks
+    (confirmed by reading openhands.sdk.conversation.impl.remote_conversation
+    — the real constructor has no such parameter, it's swallowed by a
+    catch-all **kwargs), so the event callback is the only path that ever
+    persists the agent's reply."""
     trigger = _trigger()
-    turn_state = _TurnState()
-    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), turn_state)
+    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), _SeenEvents())
 
-    # on_token is intentionally never called here.
     event_callback(MessageEvent(source="agent"))
 
     mock_persistence.assert_awaited_once()
@@ -150,32 +113,76 @@ def test_event_callback_persists_agent_reply_when_token_callback_never_fires(
     assert kwargs["conversation_id"] == "conv-1"
 
 
-def test_event_callback_skips_duplicate_when_token_callback_already_persisted(
-    bg_loop, mock_persistence
-):
-    """When the token callback *does* manage to flush a finished message,
-    the event callback must not also persist the SDK's own MessageEvent —
-    that would duplicate the reply in the conversation."""
+def test_event_callback_skips_non_message_noise_events(bg_loop, mock_persistence):
+    """Internal bookkeeping events must be skipped."""
     trigger = _trigger()
-    turn_state = _TurnState()
-    on_token = _make_token_callback(trigger, bg_loop, _AtomicCounter(), turn_state)
-    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), turn_state)
-
-    on_token(_FakeStreamChunk(_FakeChoice(content="Hello", finish_reason="stop")))
-    mock_persistence.assert_awaited_once()
-    mock_persistence.reset_mock()
-
-    event_callback(MessageEvent(source="agent"))
-    mock_persistence.assert_not_awaited()
-
-
-def test_event_callback_still_skips_non_message_noise_events(bg_loop, mock_persistence):
-    """Unrelated to the fallback logic: internal bookkeeping events must
-    still be skipped regardless of turn_state."""
-    trigger = _trigger()
-    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), _TurnState())
+    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), _SeenEvents())
 
     noise = type("ConversationStateUpdateEvent", (), {"source": "agent"})()
     event_callback(noise)
 
     mock_persistence.assert_not_awaited()
+
+
+# ─── _make_reconciler ─────────────────────────────────────────────────────────
+
+
+class _FakeEventsList:
+    """Stand-in for RemoteEventsList — reconcile() + iteration only."""
+
+    def __init__(self, events: list) -> None:
+        self._events = events
+        self.reconcile_calls = 0
+
+    def reconcile(self) -> int:
+        self.reconcile_calls += 1
+        return 0
+
+    def __iter__(self):
+        return iter(self._events)
+
+
+class _FakeConversation:
+    def __init__(self, events: list) -> None:
+        self.state = type("State", (), {"events": _FakeEventsList(events)})()
+
+
+def test_reconciler_persists_events_missed_by_dead_ws_thread(bg_loop, mock_persistence):
+    """Simulates the openhands-sdk WS-thread-died scenario: events the agent
+    produced never reached the live callback (nothing called it), but they
+    are visible over REST via events.reconcile(). The reconciler must push
+    those through the normal persistence path exactly once."""
+    trigger = _trigger()
+    seen = _SeenEvents()
+    reconcile = _make_reconciler(trigger, bg_loop, _AtomicCounter(), seen)
+
+    conversation = _FakeConversation(
+        [MessageEvent(source="agent", id="evt-1"), MessageEvent(source="agent", id="evt-2")]
+    )
+
+    reconcile(conversation)
+
+    assert mock_persistence.await_count == 2
+    persisted_ids = {call.kwargs["event_index"] for call in mock_persistence.call_args_list}
+    assert len(persisted_ids) == 2  # each event got its own monotonic index
+
+
+def test_reconciler_does_not_reprocess_events_already_seen(bg_loop, mock_persistence):
+    """An event already delivered via the live WebSocket callback (and marked
+    seen there) must not be persisted again just because reconcile() also
+    surfaces it from the full REST history."""
+    trigger = _trigger()
+    seen = _SeenEvents()
+    event_callback = _make_event_callback(trigger, bg_loop, _AtomicCounter(), seen)
+    reconcile = _make_reconciler(trigger, bg_loop, _AtomicCounter(), seen)
+
+    live_event = MessageEvent(source="agent", id="evt-live")
+    event_callback(live_event)
+    mock_persistence.assert_awaited_once()
+    mock_persistence.reset_mock()
+
+    conversation = _FakeConversation([live_event, MessageEvent(source="agent", id="evt-new")])
+    reconcile(conversation)
+
+    mock_persistence.assert_awaited_once()
+    assert mock_persistence.call_args.kwargs["conversation_id"] == "conv-1"


### PR DESCRIPTION
## Summary

- **`services/ai-agent/src/agent/executor.py`** — refactored the conversation-run/event-persistence pipeline after reading the installed `openhands-sdk` 1.30.0 source directly:
  - Removed the dead `_make_token_callback` / `_TurnState` machinery. `RemoteConversation.__init__`'s real constructor has no `token_callbacks` parameter — it's silently absorbed by a `**_: object` catch-all (only the `Conversation` factory's type-checking overload claims to support it), so this code had never fired in production; every agent reply was always persisted through `_persist_event`'s fallback path anyway. Zero behavior change, ~90 fewer lines.
  - Throttled the `events.reconcile()` workaround (added to unblock the WS-client-thread-dies-permanently upstream bug, [OpenHands/software-agent-sdk#1532](https://github.com/OpenHands/software-agent-sdk/issues/1532)) from every 2s poll to every 10s. `reconcile()` re-walks the *entire* event history over REST with no incremental cursor, and the SDK's own internal blocking `run()` only pays that cost once, at completion — not on every tick. The cheap `execution_status` poll stays at 2s for stop-responsiveness; a final `reconcile()` is still guaranteed on every exit path (done/error/timeout/manual-stop) so a run can never end with an un-persisted tail.
  - Swapped the hand-maintained "done" status set for the SDK's own `ConversationExecutionStatus.is_terminal()`.
- **`services/ai-agent/src/agent/repo_tools.py`** — removed the built-in `create_pull_request` tool. PR/MR creation, review, and commenting is repository-plugin-specific and is handled entirely by each plugin's own tools now, not a built-in agent tool.
- **`scripts/install-local-plugin.sh`** — added support for building and installing a plugin's MCP bundle (`mcp/dist/mcp.js`) alongside the existing backend/frontend artifacts, for plugins that define an `mcp/` directory.

## Type of Change

- Other (refactor / internal cleanup)

## Test plan

- [x] `pytest tests/ --ignore=tests/e2e` — 83 passed
- [x] `ruff check` — clean
- [x] `PACA_E2E=1 pytest tests/e2e` — requires Docker; not run in this environment, recommend running before merge since it exercises the real sandbox + WebSocket path this PR touches

## Checklist

- The change is focused and scoped per area above.
- No behavior change intended in the executor beyond the reconcile-interval widening (2s → 10s), called out explicitly above.