### PR TITLE
fix: fix error when set default task type

### DIFF
--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -249,21 +249,34 @@ func (r *TaskRepository) DeleteTaskType(ctx context.Context, id uuid.UUID) error
 // SetDefaultTaskType atomically marks typeID as the project's default task type,
 // clearing is_default on all other types in the same project.
 func (r *TaskRepository) SetDefaultTaskType(ctx context.Context, projectID, typeID uuid.UUID) error {
-	result, err := r.db.ExecContext(ctx, `
-		UPDATE task_types
-		SET is_default = (id = $1), updated_at = NOW()
-		WHERE project_id = $2
-		  AND EXISTS (SELECT 1 FROM task_types WHERE id = $1 AND project_id = $2)`,
-		typeID.String(), projectID.String(),
-	)
-	if err != nil {
-		return fmt.Errorf("task type repo: set default: %w", err)
-	}
-	n, _ := result.RowsAffected()
-	if n == 0 {
-		return taskdom.ErrTypeNotFound
-	}
-	return nil
+	return WithTx(ctx, r.db, func(tx *sqlx.Tx) error {
+		// Lock all types for this project to serialize concurrent calls.
+		var ids []string
+		if err := tx.SelectContext(ctx, &ids, `SELECT id FROM task_types WHERE project_id = $1 FOR UPDATE`, projectID.String()); err != nil {
+			return fmt.Errorf("task type repo: set default (lock): %w", err)
+		}
+
+		found := false
+		for _, id := range ids {
+			if id == typeID.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return taskdom.ErrTypeNotFound
+		}
+
+		if _, err := tx.ExecContext(ctx, `UPDATE task_types SET is_default = false, updated_at = NOW() WHERE project_id = $1 AND is_default = true`, projectID.String()); err != nil {
+			return fmt.Errorf("task type repo: set default (clear): %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, `UPDATE task_types SET is_default = true, updated_at = NOW() WHERE id = $1 AND project_id = $2`, typeID.String(), projectID.String()); err != nil {
+			return fmt.Errorf("task type repo: set default (set): %w", err)
+		}
+
+		return nil
+	})
 }
 
 // --- Task Statuses ---------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR fixes an issue that occurs when users attempt to set the default task type. The fix addresses error handling and ensures the operation completes successfully, improving the overall user experience and system stability.

## Motivation
Previously, when users tried to set the default task type, they would encounter an error that prevented the operation from completing successfully. This created friction in the workflow and required manual intervention or workarounds.

## Changes

### Files Modified
- 7 files changed
- 73 lines added
- 46 lines deleted

### Key Improvements
- Enhanced error handling for task type selection operations
- Improved validation when setting default task types
- Added proper error messaging and user feedback
- Ensures proper state management during the operation

## Testing
### Test Cases
- [x] Successfully set default task type through the UI
- [x] Verify error handling when invalid task type is selected
- [x] Test with network errors or API failures
- [x] Verify concurrent requests to set task type
- [x] Ensure permissions are properly checked