### PR TITLE
feat: update PATCH operations to preserve omitted fields for sprint a…

### DIFF
--- a/services/api/internal/domain/sprint/service.go
+++ b/services/api/internal/domain/sprint/service.go
@@ -39,12 +39,17 @@ type CreateSprintInput struct {
 	Status    SprintStatus
 }
 
-// UpdateSprintInput carries mutable sprint fields.
+// UpdateSprintInput carries mutable sprint fields for a PATCH operation.
+// Name is applied when non-empty. For StartDate, EndDate, and Goal, the
+// double pointer encodes three states:
+//   - nil outer pointer  → field was absent in the request; do NOT overwrite
+//   - non-nil outer pointer, inner pointer nil  → explicitly set to null (clear)
+//   - non-nil outer pointer, inner pointer non-nil  → set to the given value
 type UpdateSprintInput struct {
 	Name      string
-	StartDate *time.Time
-	EndDate   *time.Time
-	Goal      *string
+	StartDate **time.Time
+	EndDate   **time.Time
+	Goal      **string
 	Status    *SprintStatus
 }
 

--- a/services/api/internal/domain/task/service.go
+++ b/services/api/internal/domain/task/service.go
@@ -62,12 +62,17 @@ type CreateTaskTypeInput struct {
 	Description *string
 }
 
-// UpdateTaskTypeInput carries mutable task-type fields.
+// UpdateTaskTypeInput carries mutable task-type fields for a PATCH operation.
+// Name is applied when non-empty. For Icon, Color, and Description, the
+// double pointer encodes three states:
+//   - nil outer pointer  → field was absent in the request; do NOT overwrite
+//   - non-nil outer pointer, inner pointer nil  → explicitly set to null (clear)
+//   - non-nil outer pointer, inner pointer non-nil  → set to the given value
 type UpdateTaskTypeInput struct {
 	Name        string
-	Icon        *string
-	Color       *string
-	Description *string
+	Icon        **string
+	Color       **string
+	Description **string
 }
 
 // --- Task Status Service ---------------------------------------------------

--- a/services/api/internal/service/sprint/sprint_service.go
+++ b/services/api/internal/service/sprint/sprint_service.go
@@ -87,9 +87,15 @@ func (s *Service) UpdateSprint(ctx context.Context, projectID, id uuid.UUID, in 
 	if name := strings.TrimSpace(in.Name); name != "" {
 		sp.Name = name
 	}
-	sp.StartDate = in.StartDate
-	sp.EndDate = in.EndDate
-	sp.Goal = in.Goal
+	if in.StartDate != nil {
+		sp.StartDate = *in.StartDate
+	}
+	if in.EndDate != nil {
+		sp.EndDate = *in.EndDate
+	}
+	if in.Goal != nil {
+		sp.Goal = *in.Goal
+	}
 	if in.Status != nil {
 		if !sprintdom.ValidSprintStatuses[*in.Status] {
 			return nil, sprintdom.ErrSprintStatusInvalid

--- a/services/api/internal/service/sprint/sprint_service_test.go
+++ b/services/api/internal/service/sprint/sprint_service_test.go
@@ -329,6 +329,80 @@ func TestUpdateSprint_InvalidStatus(t *testing.T) {
 	}
 }
 
+// TestUpdateSprint_OmittedFieldsUnchanged guards against regressing to
+// unconditionally overwriting StartDate/EndDate/Goal on every PATCH, even
+// when the request omits them (nil outer pointer = absent, not "clear").
+func TestUpdateSprint_OmittedFieldsUnchanged(t *testing.T) {
+	ctx := context.Background()
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	projectID := uuid.New()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	goal := "Ship the thing"
+	sp, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
+		ProjectID: projectID,
+		Name:      "Sprint 1",
+		StartDate: &start,
+		EndDate:   &end,
+		Goal:      &goal,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only Name is set; StartDate/EndDate/Goal are absent (nil outer pointer)
+	// and must survive the update untouched.
+	updated, err := svc.UpdateSprint(ctx, projectID, sp.ID, sprintdom.UpdateSprintInput{
+		Name: "Renamed Sprint",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Name != "Renamed Sprint" {
+		t.Errorf("expected Name to update, got %q", updated.Name)
+	}
+	if updated.StartDate == nil || !updated.StartDate.Equal(start) {
+		t.Errorf("expected StartDate to remain %v, got %v", start, updated.StartDate)
+	}
+	if updated.EndDate == nil || !updated.EndDate.Equal(end) {
+		t.Errorf("expected EndDate to remain %v, got %v", end, updated.EndDate)
+	}
+	if updated.Goal == nil || *updated.Goal != goal {
+		t.Errorf("expected Goal to remain %q, got %v", goal, updated.Goal)
+	}
+}
+
+// TestUpdateSprint_ExplicitNullClearsGoal verifies the other half of the
+// three-state contract: an explicit null (non-nil outer pointer, nil inner
+// pointer) clears the field rather than being ignored.
+func TestUpdateSprint_ExplicitNullClearsGoal(t *testing.T) {
+	ctx := context.Background()
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	projectID := uuid.New()
+
+	goal := "Ship the thing"
+	sp, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
+		ProjectID: projectID,
+		Name:      "Sprint 1",
+		Goal:      &goal,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var clearedGoal *string
+	updated, err := svc.UpdateSprint(ctx, projectID, sp.ID, sprintdom.UpdateSprintInput{
+		Goal: &clearedGoal,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Goal != nil {
+		t.Errorf("expected Goal to be cleared, got %q", *updated.Goal)
+	}
+}
+
 func TestDeleteSprint_OK(t *testing.T) {
 	ctx := context.Background()
 	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -95,9 +95,15 @@ func (s *Service) UpdateTaskType(ctx context.Context, projectID, id uuid.UUID, i
 	if name := strings.TrimSpace(in.Name); name != "" {
 		t.Name = name
 	}
-	t.Icon = in.Icon
-	t.Color = in.Color
-	t.Description = in.Description
+	if in.Icon != nil {
+		t.Icon = *in.Icon
+	}
+	if in.Color != nil {
+		t.Color = *in.Color
+	}
+	if in.Description != nil {
+		t.Description = *in.Description
+	}
 	t.UpdatedAt = time.Now()
 
 	if err := s.repo.UpdateTaskType(ctx, t); err != nil {

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -513,6 +513,82 @@ func TestUpdateTaskType_OK(t *testing.T) {
 	}
 }
 
+// TestUpdateTaskType_OmittedFieldsUnchanged guards against regressing to
+// unconditionally overwriting Icon/Color/Description on every PATCH, even
+// when the request omits them (nil outer pointer = absent, not "clear").
+func TestUpdateTaskType_OmittedFieldsUnchanged(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	icon := "rocket"
+	color := "#ff0000"
+	desc := "A feature request"
+	existing, err := svc.CreateTaskType(ctx, taskdom.CreateTaskTypeInput{
+		ProjectID:   projectID,
+		Name:        "Feature",
+		Icon:        &icon,
+		Color:       &color,
+		Description: &desc,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only Name is set; Icon/Color/Description are absent (nil outer pointer)
+	// and must survive the update untouched.
+	updated, err := svc.UpdateTaskType(ctx, existing.ProjectID, existing.ID, taskdom.UpdateTaskTypeInput{
+		Name: "Feature Request",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Name != "Feature Request" {
+		t.Errorf("expected Name=Feature Request, got %q", updated.Name)
+	}
+	if updated.Icon == nil || *updated.Icon != icon {
+		t.Errorf("expected Icon to remain %q, got %v", icon, updated.Icon)
+	}
+	if updated.Color == nil || *updated.Color != color {
+		t.Errorf("expected Color to remain %q, got %v", color, updated.Color)
+	}
+	if updated.Description == nil || *updated.Description != desc {
+		t.Errorf("expected Description to remain %q, got %v", desc, updated.Description)
+	}
+}
+
+// TestUpdateTaskType_ExplicitNullClearsIcon verifies the other half of the
+// three-state contract: an explicit null (non-nil outer pointer, nil inner
+// pointer) clears the field rather than being ignored.
+func TestUpdateTaskType_ExplicitNullClearsIcon(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeTaskRepo()
+	svc := tasksvc.New(repo)
+	projectID := uuid.New()
+
+	icon := "rocket"
+	existing, err := svc.CreateTaskType(ctx, taskdom.CreateTaskTypeInput{
+		ProjectID: projectID,
+		Name:      "Feature",
+		Icon:      &icon,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var clearedIcon *string
+	updated, err := svc.UpdateTaskType(ctx, existing.ProjectID, existing.ID, taskdom.UpdateTaskTypeInput{
+		Icon: &clearedIcon,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.Icon != nil {
+		t.Errorf("expected Icon to be cleared, got %q", *updated.Icon)
+	}
+}
+
 func TestUpdateTaskType_NotFound(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeTaskRepo()

--- a/services/api/internal/transport/http/dto/sprint_dto.go
+++ b/services/api/internal/transport/http/dto/sprint_dto.go
@@ -19,11 +19,14 @@ type CreateSprintRequest struct {
 }
 
 // UpdateSprintRequest is the body for PATCH /projects/:projectId/sprints/:sprintId.
+// StartDate, EndDate, and Goal use the Optional* wrapper types so that an
+// absent field leaves the stored value unchanged, distinct from an explicit
+// JSON null (which clears it).
 type UpdateSprintRequest struct {
 	Name      string                  `json:"name"`
-	StartDate *time.Time              `json:"start_date"`
-	EndDate   *time.Time              `json:"end_date"`
-	Goal      *string                 `json:"goal"`
+	StartDate OptionalTime            `json:"start_date"`
+	EndDate   OptionalTime            `json:"end_date"`
+	Goal      OptionalString          `json:"goal"`
 	Status    *sprintdom.SprintStatus `json:"status"`
 }
 

--- a/services/api/internal/transport/http/dto/task_dto.go
+++ b/services/api/internal/transport/http/dto/task_dto.go
@@ -179,11 +179,13 @@ type CreateTaskTypeRequest struct {
 }
 
 // UpdateTaskTypeRequest is the body for PATCH /projects/:projectId/task-types/:typeId.
+// Icon, Color, and Description use the Optional* wrapper types so an absent
+// field leaves the stored value unchanged, distinct from an explicit JSON null.
 type UpdateTaskTypeRequest struct {
-	Name        string  `json:"name"`
-	Icon        *string `json:"icon"`
-	Color       *string `json:"color"`
-	Description *string `json:"description"`
+	Name        string         `json:"name"`
+	Icon        OptionalString `json:"icon"`
+	Color       OptionalString `json:"color"`
+	Description OptionalString `json:"description"`
 }
 
 // TaskTypeResponse is the public representation of a task type.

--- a/services/api/internal/transport/http/handler/sprint_handler.go
+++ b/services/api/internal/transport/http/handler/sprint_handler.go
@@ -129,9 +129,9 @@ func (h *SprintHandler) UpdateSprint(w http.ResponseWriter, r *http.Request) {
 
 	s, err := h.svc.UpdateSprint(r.Context(), projectID, sprintID, sprintdom.UpdateSprintInput{
 		Name:      req.Name,
-		StartDate: req.StartDate,
-		EndDate:   req.EndDate,
-		Goal:      req.Goal,
+		StartDate: req.StartDate.Ptr(),
+		EndDate:   req.EndDate.Ptr(),
+		Goal:      req.Goal.Ptr(),
 		Status:    req.Status,
 	})
 	if err != nil {

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -125,9 +125,9 @@ func (h *TaskHandler) UpdateTaskType(w http.ResponseWriter, r *http.Request) {
 
 	t, err := h.svc.UpdateTaskType(r.Context(), projectID, typeID, taskdom.UpdateTaskTypeInput{
 		Name:        req.Name,
-		Icon:        req.Icon,
-		Color:       req.Color,
-		Description: req.Description,
+		Icon:        req.Icon.Ptr(),
+		Color:       req.Color.Ptr(),
+		Description: req.Description.Ptr(),
 	})
 	if err != nil {
 		presenter.Error(w, r, err)

--- a/services/api/test/e2e/task_management_test.go
+++ b/services/api/test/e2e/task_management_test.go
@@ -151,6 +151,204 @@ func TestE2ESprintManagement_CRUD(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Sprint partial-update semantics
+//
+// Regression coverage: PATCH /sprints/:sprintId used to unconditionally
+// overwrite start_date/end_date/goal with whatever the request carried, even
+// when the client omitted those fields entirely — silently wiping them on
+// any PATCH that only meant to change e.g. the name. See UpdateSprintInput
+// in internal/domain/sprint/service.go.
+// ---------------------------------------------------------------------------
+
+func TestE2ESprintManagement_PartialUpdatePreservesFields(t *testing.T) {
+	env := newE2EEnv(t)
+	seedTaskMemberUser(t, env, "sprint-patch-user", "sprintpatchpass1")
+	client, token := taskMemberLogin(t, env, "sprint-patch-user", "sprintpatchpass1")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+
+	sprintsURL := fmt.Sprintf("%s/api/v1/projects/%s/sprints", env.base, projID)
+
+	const (
+		startDate = "2026-01-01T00:00:00Z"
+		endDate   = "2026-01-15T00:00:00Z"
+		goal      = "Ship the thing"
+	)
+	var sprintID string
+
+	t.Run("create_sprint_with_dates_and_goal", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"name":       "Sprint With Dates",
+			"status":     "planned",
+			"start_date": startDate,
+			"end_date":   endDate,
+			"goal":       goal,
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost, sprintsURL, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		sprintID, _ = data["id"].(string)
+		if sprintID == "" {
+			t.Fatal("expected non-empty sprint id")
+		}
+		if g, _ := data["goal"].(string); g != goal {
+			t.Fatalf("expected goal %q at creation, got %v", goal, data["goal"])
+		}
+	})
+
+	t.Run("patch_name_only_preserves_dates_and_goal", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "Sprint With Dates Renamed"})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			fmt.Sprintf("%s/%s", sprintsURL, sprintID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+
+		if name, _ := data["name"].(string); name != "Sprint With Dates Renamed" {
+			t.Errorf("expected renamed sprint, got %q", name)
+		}
+		if g, _ := data["goal"].(string); g != goal {
+			t.Errorf("expected goal to remain %q after a name-only PATCH, got %v", goal, data["goal"])
+		}
+		if gotStart, _ := data["start_date"].(string); gotStart == "" {
+			t.Error("expected start_date to remain set after a name-only PATCH, got empty")
+		}
+		if gotEnd, _ := data["end_date"].(string); gotEnd == "" {
+			t.Error("expected end_date to remain set after a name-only PATCH, got empty")
+		}
+	})
+
+	t.Run("explicit_null_clears_goal_without_touching_dates", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"goal": nil})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			fmt.Sprintf("%s/%s", sprintsURL, sprintID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+
+		if g := data["goal"]; g != nil {
+			t.Errorf("expected goal to be cleared, got %v", g)
+		}
+		if gotStart, _ := data["start_date"].(string); gotStart == "" {
+			t.Error("expected start_date to remain set after clearing goal")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Task type partial-update semantics
+//
+// Regression coverage: PATCH /task-types/:typeId used to unconditionally
+// overwrite icon/color/description with whatever the request carried, even
+// when the client omitted those fields entirely. See UpdateTaskTypeInput in
+// internal/domain/task/service.go.
+// ---------------------------------------------------------------------------
+
+func TestE2ETaskTypeManagement_PartialUpdatePreservesFields(t *testing.T) {
+	env := newE2EEnv(t)
+	seedTaskMemberUser(t, env, "task-type-patch-user", "tasktypepass1")
+	client, token := taskMemberLogin(t, env, "task-type-patch-user", "tasktypepass1")
+	projID := createProjectForTasksViaAPI(t, env, client, token)
+
+	taskTypesURL := fmt.Sprintf("%s/api/v1/projects/%s/task-types", env.base, projID)
+
+	const (
+		icon        = "rocket"
+		color       = "#ff0000"
+		description = "A feature request"
+	)
+	var typeID string
+
+	t.Run("create_task_type_with_icon_color_description", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{
+			"name":        "Feature",
+			"icon":        icon,
+			"color":       color,
+			"description": description,
+		})
+		req := mustRequest(env.ctx, t, http.MethodPost, taskTypesURL, body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusCreated)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+		typeID, _ = data["id"].(string)
+		if typeID == "" {
+			t.Fatal("expected non-empty task type id")
+		}
+	})
+
+	t.Run("patch_name_only_preserves_icon_color_description", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"name": "Feature Request"})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			fmt.Sprintf("%s/%s", taskTypesURL, typeID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+
+		if name, _ := data["name"].(string); name != "Feature Request" {
+			t.Errorf("expected renamed task type, got %q", name)
+		}
+		if i, _ := data["icon"].(string); i != icon {
+			t.Errorf("expected icon to remain %q after a name-only PATCH, got %v", icon, data["icon"])
+		}
+		if c, _ := data["color"].(string); c != color {
+			t.Errorf("expected color to remain %q after a name-only PATCH, got %v", color, data["color"])
+		}
+		if d, _ := data["description"].(string); d != description {
+			t.Errorf("expected description to remain %q after a name-only PATCH, got %v", description, data["description"])
+		}
+	})
+
+	t.Run("explicit_null_clears_icon_without_touching_color_or_description", func(t *testing.T) {
+		body := jsonBody(t, map[string]any{"icon": nil})
+		req := mustRequest(env.ctx, t, http.MethodPatch,
+			fmt.Sprintf("%s/%s", taskTypesURL, typeID), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var env2 envelope
+		decodeJSON(t, resp, &env2)
+		data := assertDataMap(t, env2)
+
+		if icon := data["icon"]; icon != nil {
+			t.Errorf("expected icon to be cleared, got %v", icon)
+		}
+		if c, _ := data["color"].(string); c != color {
+			t.Errorf("expected color to remain %q, got %v", color, data["color"])
+		}
+		if d, _ := data["description"].(string); d != description {
+			t.Errorf("expected description to remain %q, got %v", description, data["description"])
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Task CRUD
 // ---------------------------------------------------------------------------
 

--- a/services/api/test/e2e/taskstatus_cache_test.go
+++ b/services/api/test/e2e/taskstatus_cache_test.go
@@ -1,0 +1,96 @@
+package e2e_test
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	"github.com/Paca-AI/api/internal/platform/cache"
+	tasksvc "github.com/Paca-AI/api/internal/service/task"
+	"github.com/google/uuid"
+)
+
+// TestE2ETaskStatus_CachedUpdatePreservesPositionAndCategory exercises the
+// exact production wiring from bootstrap/app.go -- tasksvc.NewCachedService
+// wrapping tasksvc.New(taskRepo) over real Postgres + real Redis -- which the
+// shared e2e harness (common_env_test.go) does not: it wires the plain,
+// uncached service directly. Filed as a regression check for GitHub issue
+// #252, which claimed a PATCH to a task-status that omits position reverts
+// it to a default under this cached path; that does not reproduce against
+// the current code (both the direct return and a subsequent cached-list
+// read correctly preserve position/category), but there was previously no
+// test exercising UpdateTaskStatus through the cache decorator at all.
+func TestE2ETaskStatus_CachedUpdatePreservesPositionAndCategory(t *testing.T) {
+	env := newE2EEnv(t)
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cacheStore := cache.NewStore(env.redisClient, "paca:")
+
+	svc := tasksvc.NewCachedService(tasksvc.New(env.taskRepo), cacheStore, 5*time.Minute, log)
+
+	var projectID string
+	if err := env.db.QueryRowContext(env.ctx, `INSERT INTO projects (name) VALUES ($1) RETURNING id`,
+		"taskstatus-cache-project").Scan(&projectID); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	pid, err := uuid.Parse(projectID)
+	if err != nil {
+		t.Fatalf("parse project id: %v", err)
+	}
+
+	created, err := svc.CreateTaskStatus(env.ctx, taskdom.CreateTaskStatusInput{
+		ProjectID: pid,
+		Name:      "In Progress",
+		Position:  7,
+		Category:  taskdom.StatusCategoryInProgress,
+	})
+	if err != nil {
+		t.Fatalf("create task status: %v", err)
+	}
+
+	// Populate the list cache, mirroring a GET /task-statuses right after creation.
+	if _, err := svc.ListTaskStatuses(env.ctx, pid); err != nil {
+		t.Fatalf("list task statuses (populate cache): %v", err)
+	}
+
+	// PATCH only the name; position/color/category are omitted and must survive.
+	updated, err := svc.UpdateTaskStatus(env.ctx, pid, created.ID, taskdom.UpdateTaskStatusInput{
+		Name: "In Progress (renamed)",
+	})
+	if err != nil {
+		t.Fatalf("update task status: %v", err)
+	}
+	if updated.Position != 7 {
+		t.Errorf("expected position to remain 7 after a name-only PATCH, got %d", updated.Position)
+	}
+	if updated.Category != taskdom.StatusCategoryInProgress {
+		t.Errorf("expected category to remain %q, got %q", taskdom.StatusCategoryInProgress, updated.Category)
+	}
+
+	// Read back through the LIST path: proves UpdateTaskStatus's cache
+	// invalidation actually clears the stale pre-update snapshot rather than
+	// leaving readers to see it until TTL expiry.
+	listedAfter, err := svc.ListTaskStatuses(env.ctx, pid)
+	if err != nil {
+		t.Fatalf("list task statuses (after patch): %v", err)
+	}
+	var found *taskdom.TaskStatus
+	for _, s := range listedAfter {
+		if s.ID == created.ID {
+			found = s
+		}
+	}
+	if found == nil {
+		t.Fatalf("status not found in list after patch")
+	}
+	if found.Name != "In Progress (renamed)" {
+		t.Errorf("expected cached list to reflect the rename, got %q (stale cache not invalidated?)", found.Name)
+	}
+	if found.Position != 7 {
+		t.Errorf("expected position to remain 7 via the cached list read, got %d", found.Position)
+	}
+	if found.Category != taskdom.StatusCategoryInProgress {
+		t.Errorf("expected category to remain %q via the cached list read, got %q", taskdom.StatusCategoryInProgress, found.Category)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two `PATCH` endpoints that behaved as a full-object replace instead of a true partial update — fields omitted from the request body were silently reset instead of left untouched.

- **`PATCH /projects/:projectId/sprints/:sprintId`** — `start_date`, `end_date`, and `goal` were unconditionally overwritten from the request body every time, even when the client omitted them. A PATCH containing only `{"name": "..."}` would wipe an existing sprint's dates and goal.
- **`PATCH /projects/:projectId/task-types/:typeId`** — `icon`, `color`, and `description` had the same bug.

Both now use the `Optional*` wrapper types (`OptionalTime`, `OptionalString`) already established elsewhere in this codebase (see `UpdateTaskRequest`) to correctly distinguish three states:
- field absent → leave the stored value unchanged
- field explicitly `null` → clear it
- field present with a value → set it

## Changes

- `domain/sprint/service.go`, `domain/task/service.go` — `UpdateSprintInput`/`UpdateTaskTypeInput` fields changed from single to double pointers to carry the three-state signal through to the service layer.
- `dto/sprint_dto.go`, `dto/task_dto.go` — DTO fields switched to `OptionalTime`/`OptionalString`.
- `handler/sprint_handler.go`, `handler/task_handler.go` — wire `.Ptr()` through to the domain input.
- `service/sprint/sprint_service.go`, `service/task/task_service.go` — guard each field with a nil check instead of unconditional assignment.

## Testing

- Unit tests (`sprint_service_test.go`, `task_service_test.go`) covering both the "omitted field survives" and "explicit null clears" cases.
- E2E tests (`test/e2e/task_management_test.go`) for full HTTP round-trip coverage of both endpoints.
- `test/e2e/taskstatus_cache_test.go` (new) — regression coverage for `UpdateTaskStatus` through the cached-service wiring used in production (`bootstrap/app.go`'s `tasksvc.NewCachedService`), which the standard e2e harness didn't previously exercise.