### PR TITLE
fix: fix missing sigstore error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -348,8 +348,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@paca-ai"
 
+      # npm 12.0.0 has a packaging bug: libnpmpublish still requires
+      # `sigstore`, but the published 12.0.0 tarball is missing that
+      # module, so `npm publish --provenance` crashes with "Cannot find
+      # module 'sigstore'". Pin to the 11.x line until a patched 12.x
+      # ships. See https://github.com/npm/cli/issues/9722.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       # For prerelease versions (e.g. 1.0.0-alpha.1), npm requires an explicit
       # --tag to avoid accidentally tagging as "latest".


### PR DESCRIPTION
## Problem

Release publishing to npm was failing on the `Publish to npm` step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
```

## Root cause

npm 12.0.0 has a packaging bug: `libnpmpublish` still requires `sigstore` for `--provenance` signing, but the published `npm-12.0.0.tgz` tarball is missing that module. Any `npm publish --provenance` (or provenance via trusted publishing) crashes on npm 12.0.0. See [npm/cli#9722](https://github.com/npm/cli/issues/9722).

## Fix

Pin npm to the 11.x line in the CD workflow's `Upgrade npm` step (`npm install -g npm@11` instead of `npm@latest`), which restores a working bundled `sigstore`.

## Follow-up

Once npm ships a patched 12.x, this pin should be removed/loosened back to `latest`.
