### PR TITLE
fix: update dependencies and improve Dockerfile configurations

### DIFF
--- a/.github/workflows/ai-agent-pr-ci.yml
+++ b/.github/workflows/ai-agent-pr-ci.yml
@@ -42,14 +42,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
-          cache-dependency-glob: "services/ai-agent/pyproject.toml"
+          cache-dependency-glob: "services/ai-agent/uv.lock"
 
       - name: Install dev dependencies
-        env:
-          VIRTUAL_ENV: ""
-        run: |
-          uv venv
-          uv pip install --group dev -e .
+        run: uv sync --locked
 
       - name: Run ruff (lint)
         run: uv run ruff check src/
@@ -80,14 +76,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
-          cache-dependency-glob: "services/ai-agent/pyproject.toml"
+          cache-dependency-glob: "services/ai-agent/uv.lock"
 
       - name: Install dev dependencies
-        env:
-          VIRTUAL_ENV: ""
-        run: |
-          uv venv
-          uv pip install --group dev -e .
+        run: uv sync --locked
 
       - name: Run pytest
         run: uv run pytest --tb=short
@@ -146,14 +138,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
-          cache-dependency-glob: "services/ai-agent/pyproject.toml"
+          cache-dependency-glob: "services/ai-agent/uv.lock"
 
       - name: Install dev dependencies
-        env:
-          VIRTUAL_ENV: ""
-        run: |
-          uv venv
-          uv pip install --group dev -e .
+        run: uv sync --locked
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -296,6 +296,7 @@ services:
       DEV_MCP_PATH: /mcp/build/index.js
     volumes:
       - ../services/ai-agent:/app
+      - ai_agent_venv:/app/.venv
       - ../apps/mcp:/mcp:ro
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
@@ -316,3 +317,4 @@ volumes:
   bun_cache:
   minio_data:
   realtime_node_modules:
+  ai_agent_venv:

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -201,6 +201,7 @@ services:
       LOG_LEVEL: INFO
     volumes:
       - ../services/ai-agent:/app
+      - ai_agent_venv:/app/.venv
       - ../apps/mcp:/mcp:ro
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
@@ -215,3 +216,4 @@ volumes:
   postgres_data:
   valkey_data:
   minio_data:
+  ai_agent_venv:

--- a/services/agent-server/Dockerfile
+++ b/services/agent-server/Dockerfile
@@ -2,7 +2,7 @@
 # resolves from the local install instead of downloading the package on
 # every ephemeral sandbox container boot.
 #
-# Pinned to the commit tagged v1.30.0 upstream — NOT `:latest-python`. That
+# Pinned to the commit tagged v1.34.0 upstream — NOT `:latest-python`. That
 # floating tag tracks upstream's main branch continuously (built on every
 # commit), which runs ahead of their tagged PyPI releases: it was already
 # serving events with a `parent_id` field before openhands-sdk on PyPI even
@@ -13,7 +13,7 @@
 # When bumping openhands-sdk/openhands-tools in services/ai-agent's
 # pyproject.toml, bump this to the matching `<short-sha>-python` tag for that
 # same version's git tag in the same change — never independently.
-FROM ghcr.io/openhands/agent-server:d1595f7-python
+FROM ghcr.io/openhands/agent-server:2eff609-python
 
 # The base image runs as the unprivileged `openhands` user, which doesn't own
 # npm's global install dir — switch to root for the install, then drop back

--- a/services/ai-agent/Dockerfile
+++ b/services/ai-agent/Dockerfile
@@ -5,11 +5,12 @@ RUN pip install uv
 
 WORKDIR /app
 
-COPY pyproject.toml .
-RUN uv pip install --system -e .
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
 
 COPY src/ ./src/
 COPY data/ ./data/
 
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/ai-agent/Dockerfile.dev
+++ b/services/ai-agent/Dockerfile.dev
@@ -5,8 +5,9 @@ RUN pip install uv watchfiles
 
 WORKDIR /app
 
-COPY pyproject.toml .
-RUN uv pip install --system -e .
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
 
+ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080", "--reload"]

--- a/services/ai-agent/pyproject.toml
+++ b/services/ai-agent/pyproject.toml
@@ -6,8 +6,8 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.138.0",
     "uvicorn[standard]>=0.30.0",
-    "openhands-sdk>=1.30.0",
-    "openhands-tools>=1.30.0",
+    "openhands-sdk>=1.34.0",
+    "openhands-tools>=1.34.0",
     "docker>=7.0.0",
     "redis[hiredis]>=5.0.0",
     "asyncpg>=0.29.0",

--- a/services/ai-agent/src/agent/builder.py
+++ b/services/ai-agent/src/agent/builder.py
@@ -106,6 +106,9 @@ def build_mcp_config(
 ) -> dict:
     """Build the MCP server configuration dict for the OpenHands SDK.
 
+    Returns a flat ``{server_name: server_config}`` map — the shape
+    ``Agent(mcp_config=...)`` expects directly (no ``mcpServers`` wrapper).
+
     User-configured servers come first; the built-in Paca MCP server is always
     appended last so it cannot be overridden by user entries.
     """
@@ -123,7 +126,7 @@ def build_mcp_config(
         else:
             servers[row.server_name] = {
                 "url": row.url,
-                **({"auth": "oauth"} if row.transport == "oauth" else {}),
+                **({"auth": {"strategy": "oauth2"}} if row.transport == "oauth" else {}),
             }
 
     if settings.paca_api_key:
@@ -143,4 +146,4 @@ def build_mcp_config(
             },
         }
 
-    return {"mcpServers": servers}
+    return servers

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -582,7 +582,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
 
             try:
                 agent_kwargs: dict = {"llm": llm, "agent_context": agent_context}
-                if mcp_config.get("mcpServers"):
+                if mcp_config:
                     agent_kwargs["mcp_config"] = mcp_config
 
                 if has_repos:

--- a/services/ai-agent/tests/test_builder.py
+++ b/services/ai-agent/tests/test_builder.py
@@ -242,7 +242,7 @@ def test_load_default_skills_is_cached():
 def test_stdio_server_fields(no_paca_key):
     server = _server(command="node", args=["index.js"], env={"KEY": "VAL"})
     cfg = build_mcp_config([server], "agent-1", "proj-1")
-    entry = cfg["mcpServers"]["my-server"]
+    entry = cfg["my-server"]
     assert entry["command"] == "node"
     assert entry["args"] == ["index.js"]
     assert entry["env"] == {"KEY": "VAL"}
@@ -251,7 +251,7 @@ def test_stdio_server_fields(no_paca_key):
 def test_http_server_has_url_no_auth(no_paca_key):
     server = _server(transport="http", url="https://mcp.example.com")
     cfg = build_mcp_config([server], "a", "p")
-    entry = cfg["mcpServers"]["my-server"]
+    entry = cfg["my-server"]
     assert entry["url"] == "https://mcp.example.com"
     assert "auth" not in entry
 
@@ -259,19 +259,19 @@ def test_http_server_has_url_no_auth(no_paca_key):
 def test_oauth_server_has_auth_field(no_paca_key):
     server = _server(transport="oauth", url="https://mcp.example.com")
     cfg = build_mcp_config([server], "a", "p")
-    assert cfg["mcpServers"]["my-server"]["auth"] == "oauth"
+    assert cfg["my-server"]["auth"] == {"strategy": "oauth2"}
 
 
 def test_disabled_server_excluded(no_paca_key):
     server = _server(enabled=False)
     cfg = build_mcp_config([server], "a", "p")
-    assert "my-server" not in cfg["mcpServers"]
+    assert "my-server" not in cfg
 
 
 def test_paca_server_injected_when_key_set(with_paca_key):
     cfg = build_mcp_config([], "agent-99", "proj-42")
-    assert "paca" in cfg["mcpServers"]
-    paca = cfg["mcpServers"]["paca"]
+    assert "paca" in cfg
+    paca = cfg["paca"]
     assert paca["command"] == "npx"
     assert paca["args"] == ["-y", "@paca-ai/paca-mcp"]
     assert paca["env"]["PACA_AGENT_ID"] == "agent-99"
@@ -282,30 +282,30 @@ def test_paca_server_injected_when_key_set(with_paca_key):
 def test_paca_server_uses_local_build_when_dev_mcp_path_set(with_paca_key):
     with_paca_key.dev_mcp_path = "/mcp/build/index.js"
     cfg = build_mcp_config([], "agent-99", "proj-42")
-    paca = cfg["mcpServers"]["paca"]
+    paca = cfg["paca"]
     assert paca["command"] == "node"
     assert paca["args"] == ["/mcp/build/index.js"]
 
 
 def test_paca_server_omitted_when_no_key(no_paca_key):
     cfg = build_mcp_config([], "a", "p")
-    assert "paca" not in cfg["mcpServers"]
+    assert "paca" not in cfg
 
 
 def test_user_servers_appear_before_paca(with_paca_key):
     servers = [_server(name="custom")]
     cfg = build_mcp_config(servers, "a", "p")
-    keys = list(cfg["mcpServers"])
+    keys = list(cfg)
     assert keys.index("custom") < keys.index("paca")
 
 
 def test_multiple_servers_all_included(no_paca_key):
     servers = [_server(name="srv1"), _server(name="srv2")]
     cfg = build_mcp_config(servers, "a", "p")
-    assert "srv1" in cfg["mcpServers"]
-    assert "srv2" in cfg["mcpServers"]
+    assert "srv1" in cfg
+    assert "srv2" in cfg
 
 
-def test_empty_servers_returns_only_mcpservers_key(no_paca_key):
+def test_empty_servers_returns_empty_dict(no_paca_key):
     cfg = build_mcp_config([], "a", "p")
-    assert cfg == {"mcpServers": {}}
+    assert cfg == {}

--- a/services/ai-agent/uv.lock
+++ b/services/ai-agent/uv.lock
@@ -2282,7 +2282,7 @@ wheels = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.30.0"
+version = "1.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2303,14 +2303,14 @@ dependencies = [
     { name = "tree-sitter-bash" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/32/a8fc01eefe1a9857ef9432c833841beb216ddd85ee8d6c2968013be267c1/openhands_sdk-1.30.0.tar.gz", hash = "sha256:b48a75adb8d2c48d6a53d0022e3521d63caeb5931b99d5a56906a24a4eec3e72", size = 588645, upload-time = "2026-07-01T10:29:58.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/28/a7bcd9f288d44dbd20d81b3de63aa03ff127232aacb3853fb24992587f99/openhands_sdk-1.34.0.tar.gz", hash = "sha256:baea605a8532bde6bde63afa7c80f762d40c28c412325958423c86e26128fad5", size = 611764, upload-time = "2026-07-09T10:09:55.953Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/e9/330fa562f63732c545d7fa0c8b68b8575cd39c952c605150bf41134932f3/openhands_sdk-1.30.0-py3-none-any.whl", hash = "sha256:53423bd4916c578ccb8f8f488dfcc16669343f2a3ac0c3db955793e704f734a2", size = 708572, upload-time = "2026-07-01T10:29:53.107Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6f/d66c4175a553211e49913db228f1a220f2dfb1d762c7fffde47d5f01750f/openhands_sdk-1.34.0-py3-none-any.whl", hash = "sha256:35f7012f1e09c9edd6c5be3797daea4ed9f23751b2b802107ce2f3b069aef85b", size = 733932, upload-time = "2026-07-09T10:09:51.818Z" },
 ]
 
 [[package]]
 name = "openhands-tools"
-version = "1.30.0"
+version = "1.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "binaryornot" },
@@ -2324,9 +2324,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/f5/017a969303eeb3c614d924e744b07e75540dc93e6786c8e1486654e0b74d/openhands_tools-1.30.0.tar.gz", hash = "sha256:8762808cb481a7d5805c0f66ac62228dc25ce2baf336ab2d446ca772c761c864", size = 145603, upload-time = "2026-07-01T10:29:59.418Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/10/68c5d72699d0b40cf07e8c41e8aaa4454065082ab32e7293b5e2c8e8b403/openhands_tools-1.34.0.tar.gz", hash = "sha256:918da1ce3bdc2e5c6a0759af9ba2762da9c772d18253260940c1743ce2e911bc", size = 145909, upload-time = "2026-07-09T10:09:57.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/3d/c3a754c1f010f3d4b100357b83b306c9efdcaca69742cc45ad1d2b386305/openhands_tools-1.30.0-py3-none-any.whl", hash = "sha256:349af6c15b7d9808edc529d52e0e06efea064187662bef0d2e6c3a0d219f6cfa", size = 190947, upload-time = "2026-07-01T10:29:54.436Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e2/81fbae73473ec90c1e6fda28a6480d9c7f326dacf6d77057524d0abfe638/openhands_tools-1.34.0-py3-none-any.whl", hash = "sha256:1ecf40185eebd3a2ac87d2764f7e74c4d8eebea9a96315343e890957acff6524", size = 191220, upload-time = "2026-07-09T10:09:53.192Z" },
 ]
 
 [[package]]
@@ -2555,8 +2555,8 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "openhands-sdk", specifier = ">=1.30.0" },
-    { name = "openhands-tools", specifier = ">=1.30.0" },
+    { name = "openhands-sdk", specifier = ">=1.34.0" },
+    { name = "openhands-tools", specifier = ">=1.34.0" },
     { name = "pydantic", specifier = ">=2.13.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-multipart", specifier = ">=0.0.32" },


### PR DESCRIPTION
## Summary

Fixes the AI agent crashing on startup with an OpenHands SDK MCP config error, and brings the supporting dependency/CI/Docker setup along for the ride.

- **Root cause fix**: `build_mcp_config()` in [builder.py](services/ai-agent/src/agent/builder.py) was wrapping the server map in `{"mcpServers": servers}`, but `Agent(mcp_config=...)` expects the flat `{server_name: server_config}` map directly. Now returns the flat dict, and [executor.py](services/ai-agent/src/agent/executor.py) checks `if mcp_config` instead of `if mcp_config.get("mcpServers")`.
- Bump `openhands-sdk`/`openhands-tools` from `1.30.0` → `1.34.0` in [pyproject.toml](services/ai-agent/pyproject.toml), and the pinned `agent-server` base image tag from `d1595f7-python` → `2eff609-python` to match.
- Update the oauth server auth field to match the new SDK shape: `"auth": "oauth"` → `"auth": {"strategy": "oauth2"}`.
- Switch both `ai-agent` Dockerfiles from `uv pip install --system -e .` to `uv sync --frozen --no-dev --no-install-project` against the committed `uv.lock`, so builds are reproducible instead of re-resolving on every build.
- Mount a named `ai_agent_venv` volume over `/app/.venv` in `docker-compose.dev.yml` and `docker-compose.e2e.yml` so the container's synced venv isn't shadowed by the host bind-mount of `services/ai-agent`.
- Bump CI Node.js from 20 → 24 for the mcp server, and pin `npm@11` (down from `@latest`) in `cd.yml` — npm 12.0.0 has a packaging bug where `libnpmpublish` requires `sigstore` but the published tarball is missing it, breaking `npm publish --provenance` (see [npm/cli#9722](https://github.com/npm/cli/issues/9722)).
- CI now installs Python deps via `uv sync --locked` (keyed on `uv.lock`) instead of `uv venv && uv pip install --group dev -e .` (keyed on `pyproject.toml`), for the same reproducibility reason.

## Test plan
- [x] `uv run pytest --tb=short` in `services/ai-agent` (updated `test_builder.py` assertions for the flat `mcp_config` shape)
- [x] `uv run ruff check src/`
- [ ] Verify agent sandbox boots and successfully connects to configured MCP servers end-to-end
