### PR TITLE
feat(i18n): add Brazilian Portuguese (pt-BR) locale

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,7 +7,7 @@
     <title>Paca</title>
     <script>(()=> {try{const stored=window.localStorage.getItem('theme');const mode=(stored==='light'||stored==='dark'||stored==='auto')?stored:'auto';const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;const resolved=mode==='auto'?(prefersDark?'dark':'light'):mode;const root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);if(mode==='auto'){root.removeAttribute('data-theme')}else{root.setAttribute('data-theme',mode)}root.style.colorScheme=resolved;}catch(_e){}})();</script>
     <!-- Keep this list in sync with SUPPORTED_LANGUAGES in src/i18n/config.ts. Sets `lang` before first paint so locale-specific font rules (e.g. Vietnamese) apply immediately, avoiding a flash of the wrong font. -->
-    <script>(()=> {try{const supported=['en','vi','ko','zh-CN','ja','es','fr'];const stored=window.localStorage.getItem('locale');let locale=supported.includes(stored)?stored:null;if(!locale){const nav=navigator.language||'';const base=nav.split('-')[0];locale=supported.includes(nav)?nav:(supported.includes(base)?base:null);}document.documentElement.lang=locale||'en';}catch(_e){}})();</script>
+    <script>(()=> {try{const supported=['en','vi','ko','zh-CN','ja','es','fr','pt-BR'];const stored=window.localStorage.getItem('locale');let locale=supported.includes(stored)?stored:null;if(!locale){const nav=navigator.language||'';const base=nav.split('-')[0];locale=supported.includes(nav)?nav:(supported.includes(base)?base:null);}document.documentElement.lang=locale||'en';}catch(_e){}})();</script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/i18n/config.ts
+++ b/apps/web/src/i18n/config.ts
@@ -11,6 +11,7 @@ export const SUPPORTED_LANGUAGES = [
 	"ja",
 	"es",
 	"fr",
+	"pt-BR",
 ] as const;
 
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
@@ -23,6 +24,7 @@ export const LOCALE_LABELS: Record<SupportedLanguage, string> = {
 	ja: "日本語",
 	es: "Español",
 	fr: "Français",
+	"pt-BR": "Português (Brasil)",
 };
 
 export const LOCALE_STORAGE_KEY = "locale";

--- a/apps/web/src/i18n/locales/pt-BR/admin.json
+++ b/apps/web/src/i18n/locales/pt-BR/admin.json
@@ -1,0 +1,264 @@
+{
+	"users": {
+		"header": {
+			"title": "Gerenciamento de Usuários",
+			"description": "Visualize e gerencie contas de usuários e as funções atribuídas a eles.",
+			"newUser": "Novo Usuário"
+		},
+		"stats": {
+			"userCount_one": "{{count}} usuário",
+			"userCount_other": "{{count}} usuários",
+			"inSystem": "no sistema",
+			"mustChangePassword": "devem alterar a senha"
+		},
+		"empty": {
+			"title": "Nenhum usuário encontrado",
+			"description": "Crie seu primeiro usuário para começar.",
+			"createUser": "Criar usuário"
+		},
+		"errors": {
+			"loadFailed": "Falha ao carregar usuários",
+			"tryAgain": "Atualize a página e tente novamente."
+		},
+		"noPermission": {
+			"title": "Você não tem permissão para visualizar usuários",
+			"description": "Você ainda pode criar novos usuários usando o botão acima."
+		},
+		"table": {
+			"columnUsername": "Usuário",
+			"columnFullName": "Nome Completo",
+			"columnRole": "Função",
+			"columnCreated": "Criado em",
+			"pwdResetBadge": "senha redefinida",
+			"youBadge": "você",
+			"noFullName": "—",
+			"resetPasswordAction": "Redefinir senha",
+			"editAction": "Editar usuário",
+			"deleteAction": "Excluir usuário"
+		},
+		"formDialog": {
+			"createdTitle": "Usuário criado",
+			"createdDescriptionSuffix": "foi criado. Compartilhe a senha temporária abaixo — será solicitado ao usuário que a altere no primeiro login.",
+			"temporaryPasswordLabel": "Senha temporária",
+			"hidePassword": "Ocultar senha",
+			"showPassword": "Mostrar senha",
+			"copyPassword": "Copiar senha",
+			"passwordNotShownAgain": "Esta senha não será exibida novamente. Certifique-se de copiá-la agora.",
+			"done": "Concluído",
+			"editTitle": "Editar Usuário",
+			"createTitle": "Criar Usuário",
+			"editDescription": "Atualize o nome de exibição e a atribuição de função do usuário.",
+			"createDescription": "Uma senha temporária segura será gerada automaticamente. Será solicitado ao usuário que a altere no primeiro login.",
+			"usernameLabel": "Usuário",
+			"usernamePlaceholder": "ex.: joao.silva",
+			"fullNameLabel": "Nome Completo",
+			"fullNamePlaceholder": "ex.: João Silva",
+			"roleLabel": "Função",
+			"roleOptionalHint": "(opcional — o padrão é USER)",
+			"rolePlaceholder": "Selecione uma função…",
+			"cancel": "Cancelar",
+			"saving": "Salvando…",
+			"creating": "Criando…",
+			"saveChanges": "Salvar alterações",
+			"createUser": "Criar usuário",
+			"errors": {
+				"fullNameRequired": "O nome completo é obrigatório.",
+				"usernameTaken": "Este nome de usuário já está em uso.",
+				"userNotFound": "Usuário não encontrado. Ele pode já ter sido excluído.",
+				"forbidden": "Você não tem permissão para executar esta ação.",
+				"internalError": "Algo deu errado no servidor. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		},
+		"resetPasswordDialog": {
+			"title": "Redefinir senha",
+			"descriptionSuccessPrefix": "A senha de",
+			"descriptionSuccessSuffix": "foi redefinida. Compartilhe a senha temporária abaixo — ela não será exibida novamente.",
+			"descriptionConfirmPrefix": "Uma senha temporária forte será gerada e atribuída a",
+			"descriptionConfirmSuffix": "Será solicitado a ele que a altere no próximo login.",
+			"temporaryPasswordLabel": "Senha Temporária",
+			"hidePassword": "Ocultar senha",
+			"showPassword": "Mostrar senha",
+			"copyPassword": "Copiar senha",
+			"notShownAgain": "⚠ Esta senha não será exibida novamente após o fechamento.",
+			"done": "Concluído",
+			"cancel": "Cancelar",
+			"resetting": "Redefinindo…",
+			"resetButton": "Redefinir senha",
+			"errors": {
+				"userNotFound": "Este usuário não existe mais.",
+				"forbidden": "Você não tem permissão para redefinir a senha deste usuário.",
+				"internalError": "Algo deu errado. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		},
+		"deleteDialog": {
+			"title": "Excluir usuário",
+			"confirmTextPrefix": "Tem certeza de que deseja excluir",
+			"confirmTextSuffix": "? A conta dele será removida permanentemente.",
+			"cannotBeUndone": "Esta ação não pode ser desfeita.",
+			"cancel": "Cancelar",
+			"deleting": "Excluindo…",
+			"confirmButton": "Excluir usuário",
+			"errors": {
+				"userNotFound": "Este usuário não existe mais.",
+				"forbidden": "Você não tem permissão para excluir este usuário.",
+				"internalError": "Algo deu errado. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		}
+	},
+	"globalRoles": {
+		"header": {
+			"title": "Funções Globais",
+			"description": "Gerencie funções de todo o sistema e as permissões que elas concedem aos usuários.",
+			"newRole": "Nova Função"
+		},
+		"stats": {
+			"roleCount_one": "{{count}} função",
+			"roleCount_other": "{{count}} funções",
+			"defined": "definidas",
+			"permissionGrants": "concessões de permissão em todas as funções"
+		},
+		"empty": {
+			"title": "Nenhuma função definida ainda",
+			"description": "Crie sua primeira função para começar a gerenciar as permissões dos usuários.",
+			"createRole": "Criar função"
+		},
+		"errors": {
+			"loadFailed": "Falha ao carregar funções",
+			"tryAgain": "Atualize a página e tente novamente."
+		},
+		"noPermission": {
+			"title": "Você não tem permissão para visualizar funções",
+			"description": "Você ainda pode criar novas funções usando o botão acima."
+		},
+		"table": {
+			"columnName": "Nome",
+			"columnPermissions": "Permissões",
+			"columnCreated": "Criado em",
+			"noPermissionsAssigned": "Nenhuma permissão atribuída",
+			"editAction": "Editar função",
+			"deleteAction": "Excluir função"
+		},
+		"formDialog": {
+			"editTitle": "Editar Função",
+			"createTitle": "Criar Função",
+			"editDescription": "Atualize o nome da função e suas concessões de permissão.",
+			"createDescription": "Defina uma nova função de todo o sistema e configure suas permissões.",
+			"roleNameLabel": "Nome da Função",
+			"roleNamePlaceholder": "ex.: SECURITY_ADMIN",
+			"permissionsLabel": "Permissões",
+			"enabledCount_one": "{{count}} ativada",
+			"enabledCount_other": "{{count}} ativadas",
+			"cancel": "Cancelar",
+			"saving": "Salvando…",
+			"saveChanges": "Salvar alterações",
+			"createRole": "Criar função",
+			"errors": {
+				"roleNameRequired": "O nome da função é obrigatório.",
+				"nameTaken": "Já existe uma função com este nome.",
+				"nameInvalid": "O nome da função deve conter apenas letras maiúsculas, números e sublinhados.",
+				"roleNotFound": "Esta função não existe mais. Ela pode já ter sido excluída.",
+				"forbidden": "Você não tem permissão para executar esta ação.",
+				"internalError": "Algo deu errado no servidor. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		},
+		"deleteDialog": {
+			"title": "Excluir função",
+			"confirmTextPrefix": "Tem certeza de que deseja excluir",
+			"confirmTextSuffix": "? Isso também removerá todas as atribuições de usuários para esta função.",
+			"cannotBeUndone": "Esta ação não pode ser desfeita.",
+			"cancel": "Cancelar",
+			"deleting": "Excluindo…",
+			"confirmButton": "Excluir função",
+			"errors": {
+				"roleNotFound": "Esta função não existe mais.",
+				"hasUsersWarning": "Esta função não pode ser excluída porque ainda está atribuída a um ou mais usuários.",
+				"forbidden": "Você não tem permissão para excluir esta função.",
+				"internalError": "Algo deu errado. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		},
+		"permissions": {
+			"globalRolesRead": {
+				"label": "Ler Funções Globais",
+				"description": "Visualizar definições de funções globais"
+			},
+			"globalRolesWrite": {
+				"label": "Escrever Funções Globais",
+				"description": "Criar e atualizar definições de funções globais"
+			},
+			"globalRolesAssign": {
+				"label": "Atribuir Funções Globais",
+				"description": "Atribuir funções globais a usuários"
+			},
+			"usersRead": {
+				"label": "Ler Usuários",
+				"description": "Visualizar perfis e lista de usuários"
+			},
+			"usersWrite": {
+				"label": "Escrever Usuários",
+				"description": "Criar e atualizar contas de usuários"
+			},
+			"usersDelete": {
+				"label": "Excluir Usuários",
+				"description": "Remover contas de usuários"
+			},
+			"projectsRead": {
+				"label": "Ler Todos os Projetos",
+				"description": "Visualizar todos os projetos no workspace"
+			},
+			"projectsCreate": {
+				"label": "Criar Projetos",
+				"description": "Criar novos projetos"
+			},
+			"projectsWrite": {
+				"label": "Escrever Projetos",
+				"description": "Atualizar detalhes do projeto"
+			},
+			"projectsDelete": {
+				"label": "Excluir Projetos",
+				"description": "Excluir projetos permanentemente"
+			},
+			"projectMembersRead": {
+				"label": "Ler Membros do Projeto",
+				"description": "Visualizar membros de qualquer projeto"
+			},
+			"projectMembersWrite": {
+				"label": "Escrever Membros do Projeto",
+				"description": "Adicionar, remover e atualizar membros em qualquer projeto"
+			},
+			"projectRolesRead": {
+				"label": "Ler Funções do Projeto",
+				"description": "Visualizar funções definidas em qualquer projeto"
+			},
+			"projectRolesWrite": {
+				"label": "Escrever Funções do Projeto",
+				"description": "Criar e atualizar funções em qualquer projeto"
+			}
+		},
+		"permissionGroups": {
+			"globalRoles": "Funções Globais",
+			"users": "Usuários",
+			"projects": "Projetos"
+		}
+	},
+	"plugins": {
+		"title": "Configurações de Plugins",
+		"description": "Gerencie a ordenação e a visibilidade dos painéis de plugins de todo o sistema para todos os usuários.",
+		"tabs": {
+			"marketplace": "Marketplace",
+			"layout": "Layout de Pontos de Extensão"
+		},
+		"marketplace": {
+			"title": "Marketplace",
+			"description": "Instale ou desinstale plugins do catálogo público paca-plugins."
+		},
+		"layout": {
+			"title": "Layout de Pontos de Extensão",
+			"description": "Arraste para reordenar os painéis de plugins dentro de cada ponto de extensão. Alterne a visibilidade para mostrar ou ocultar painéis para todos os usuários."
+		}
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/appShell.json
+++ b/apps/web/src/i18n/locales/pt-BR/appShell.json
@@ -1,0 +1,71 @@
+{
+	"language": {
+		"label": "Idioma",
+		"toggleTooltip": "Idioma: {{language}} — clique para alterar"
+	},
+	"brand": {
+		"logoAlt": "Logo Paca"
+	},
+	"theme": {
+		"label": "Tema",
+		"light": "Claro",
+		"dark": "Escuro",
+		"auto": "Automático",
+		"cycleTooltip": "Tema: {{mode}} — clique para alternar",
+		"modeAutoTooltip": "Modo do tema: automático (sistema). Clique para mudar para o modo claro.",
+		"modeTooltip": "Modo do tema: {{mode}}. Clique para mudar de modo."
+	},
+	"nav": {
+		"home": "Início",
+		"administration": "Administração",
+		"globalRoles": "Funções Globais",
+		"users": "Usuários",
+		"plugins": "Plugins",
+		"allProjects": "Todos os Projetos",
+		"project": "Projeto",
+		"agents": "Agentes",
+		"automation": "Automação",
+		"team": "Equipe",
+		"settings": "Configurações"
+	},
+	"projectSwitcher": {
+		"projects": "Projetos",
+		"yourProjects": "Seus Projetos",
+		"noProjectsYet": "Nenhum projeto ainda",
+		"newProject": "Novo projeto"
+	},
+	"interactions": {
+		"title": "Interações",
+		"timeline": "Linha do tempo",
+		"productBacklog": "Backlog do Produto"
+	},
+	"docs": {
+		"documentation": "Documentação",
+		"noDocumentsYet": "Nenhum documento ainda",
+		"emptyFolder": "Pasta vazia",
+		"add": "Adicionar",
+		"newDocument": "Novo Documento",
+		"newFolder": "Nova Pasta",
+		"newFolderDefaultName": "Nova Pasta",
+		"newSubfolder": "Nova Subpasta",
+		"rename": "Renomear",
+		"delete": "Excluir",
+		"untitled": "Sem título"
+	},
+	"notifications": {
+		"title": "Notificações",
+		"empty": "Nenhuma notificação ainda",
+		"markAllAsRead": "Marcar todas como lidas",
+		"text": {
+			"assigned": "{{actor}} atribuiu você à tarefa #{{taskNumber}} — {{taskTitle}}",
+			"mentioned": "{{actor}} mencionou você em #{{taskNumber}} — {{taskTitle}}"
+		}
+	},
+	"userMenu": {
+		"signIn": "Entrar",
+		"myProfile": "Meu Perfil",
+		"apiKeys": "Chaves de API",
+		"logOut": "Sair",
+		"loggingOut": "Saindo…"
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/auth.json
+++ b/apps/web/src/i18n/locales/pt-BR/auth.json
@@ -1,0 +1,63 @@
+{
+	"brand": {
+		"logoAlt": "Logo Paca",
+		"ossBadge": "OSS",
+		"headingPrefix": "Um time, um quadro,",
+		"headingHighlight": "humanos e IA.",
+		"tagline": "Gestão de projetos de código aberto onde agentes de IA e humanos colaboram como colegas de time Scrum em pé de igualdade — auto-hospedado, totalmente personalizável.",
+		"viewOnGitHub": "Ver no GitHub",
+		"licenseLine": "Apache-2.0 · Código Aberto",
+		"features": {
+			"sandboxedAgents": {
+				"title": "Agentes de IA isolados",
+				"desc": "Cada agente é executado em um contêiner isolado — escolhendo tarefas do quadro sem tocar no seu ambiente host."
+			},
+			"bddSddHub": {
+				"title": "Central de BDD e SDD",
+				"desc": "Escreva em conjunto cenários Gherkin e Documentos de Design de Sistema com todo o seu time — humanos e IA."
+			},
+			"pluginMarketplace": {
+				"title": "Marketplace de plugins",
+				"desc": "Navegue e instale plugins pela interface. Personalize tudo via configuração e plugins WASM."
+			}
+		}
+	},
+	"login": {
+		"title": "Bem-vindo de volta",
+		"subtitle": "Entre no seu workspace para continuar.",
+		"usernameLabel": "Usuário",
+		"usernamePlaceholder": "Digite seu usuário",
+		"passwordLabel": "Senha",
+		"showPassword": "Mostrar senha",
+		"hidePassword": "Ocultar senha",
+		"rememberMe": "Manter-me conectado",
+		"signIn": "Entrar",
+		"signingIn": "Entrando…",
+		"adminManagedNote": "O acesso à conta e as redefinições de senha são gerenciados pelo seu administrador.",
+		"footerCopyright": "© {{year}} Paca",
+		"footerGitHub": "GitHub",
+		"footerDocs": "Docs",
+		"footerLicense": "Apache-2.0",
+		"errors": {
+			"invalidCredentials": "Usuário ou senha inválidos.",
+			"sessionExpired": "Sessão expirada. Entre novamente.",
+			"genericError": "Algo deu errado. Tente novamente."
+		}
+	},
+	"changePassword": {
+		"actionRequiredBadge": "Ação necessária",
+		"secureAccountTitle": "Proteja sua conta",
+		"secureAccountDesc": "Seu administrador atribuiu a você uma senha temporária. Você precisa definir uma nova senha pessoal antes de acessar o workspace.",
+		"steps": {
+			"enterTemporaryPassword": "Digite a senha temporária que você recebeu",
+			"chooseStrongPassword": "Escolha uma nova senha forte",
+			"signInAgain": "Entre novamente com sua nova senha"
+		},
+		"passwordChangeRequiredBadge": "Alteração de senha necessária",
+		"setNewPasswordTitle": "Definir nova senha",
+		"setNewPasswordSubtitle": "Digite sua senha temporária e escolha uma nova para desbloquear sua conta.",
+		"signOut": "Sair",
+		"signingOut": "Saindo…",
+		"footerCopyright": "© {{year}} Paca. Todos os direitos reservados."
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/common.json
+++ b/apps/web/src/i18n/locales/pt-BR/common.json
@@ -1,0 +1,31 @@
+{
+	"dialog": {
+		"closeLabel": "Fechar",
+		"closeButton": "Fechar"
+	},
+	"sidebar": {
+		"title": "Barra lateral",
+		"description": "Exibe a barra lateral no celular.",
+		"toggleLabel": "Alternar barra lateral"
+	},
+	"validation": {
+		"usernameRequired": "O nome de usuário é obrigatório.",
+		"usernameMinLength": "O nome de usuário deve ter pelo menos {{min}} caracteres.",
+		"passwordRequired": "A senha é obrigatória.",
+		"passwordMinLength": "A senha deve ter pelo menos {{min}} caracteres.",
+		"newPasswordRequired": "A nova senha é obrigatória.",
+		"newPasswordMinLength": "A nova senha deve ter pelo menos {{min}} caracteres.",
+		"newPasswordMustDiffer": "A nova senha deve ser diferente da senha atual.",
+		"confirmPasswordRequired": "Confirme sua nova senha.",
+		"passwordsDoNotMatch": "As senhas não coincidem."
+	},
+	"timeAgo": {
+		"justNow": "agora mesmo",
+		"minutes_one": "há {{count}}min",
+		"minutes_other": "há {{count}}min",
+		"hours_one": "há {{count}}h",
+		"hours_other": "há {{count}}h",
+		"days_one": "há {{count}}d",
+		"days_other": "há {{count}}d"
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/errors.json
+++ b/apps/web/src/i18n/locales/pt-BR/errors.json
@@ -1,0 +1,4 @@
+{
+	"pluginLoadFailedPrefix": "O plugin",
+	"pluginLoadFailedSuffix": "falhou ao carregar"
+}

--- a/apps/web/src/i18n/locales/pt-BR/plugins.json
+++ b/apps/web/src/i18n/locales/pt-BR/plugins.json
@@ -1,0 +1,38 @@
+{
+	"marketplace": {
+		"loading": "Carregando marketplace...",
+		"searchPlaceholder": "Buscar plugins",
+		"empty": "Nenhum plugin do marketplace encontrado.",
+		"card": {
+			"installed": "Instalado",
+			"updateAvailable": "Atualização disponível",
+			"source": "Origem",
+			"upgrading": "Atualizando...",
+			"upgradeTo": "Atualizar para {{version}}",
+			"uninstalling": "Desinstalando...",
+			"uninstall": "Desinstalar",
+			"installing": "Instalando...",
+			"install": "Instalar",
+			"features": {
+				"backend": "Backend",
+				"frontend": "Frontend",
+				"migrations": "Migrações",
+				"mcp": "MCP"
+			}
+		}
+	},
+	"preferences": {
+		"empty": "Nenhum plugin com pontos de extensão está instalado.",
+		"actions": {
+			"show": "Mostrar",
+			"hide": "Ocultar"
+		},
+		"extensionPoints": {
+			"sidebarGeneral": "Barra lateral — Geral",
+			"sidebarProject": "Barra lateral — Projeto",
+			"taskDetail": "Detalhes da tarefa",
+			"projectSettingsTab": "Aba de configurações do projeto",
+			"customView": "Visualização personalizada"
+		}
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/profile.json
+++ b/apps/web/src/i18n/locales/pt-BR/profile.json
@@ -1,0 +1,106 @@
+{
+	"page": {
+		"title": "Meu Perfil",
+		"subtitle": "Visualize e atualize as informações da sua conta."
+	},
+	"fields": {
+		"fullName": "Nome completo",
+		"fullNamePlaceholder": "Digite seu nome completo",
+		"notSet": "Não definido",
+		"username": "Usuário"
+	},
+	"actions": {
+		"editProfile": "Editar perfil",
+		"saveChanges": "Salvar alterações",
+		"saving": "Salvando…",
+		"cancel": "Cancelar"
+	},
+	"errors": {
+		"updateFailed": "Falha ao atualizar o perfil. Tente novamente."
+	},
+	"joinedOn": "Ingressou em {{date}}",
+	"changePassword": {
+		"title": "Alterar Senha",
+		"description": "Atualize a senha da sua conta.",
+		"descriptionMustChange": "Você precisa definir uma nova senha antes de continuar.",
+		"temporaryPasswordNotice": "Uma senha temporária foi definida para sua conta. Altere-a agora.",
+		"success": "Senha alterada com sucesso.",
+		"fields": {
+			"currentPassword": "Senha atual",
+			"newPassword": "Nova senha",
+			"confirmPassword": "Confirmar nova senha",
+			"passwordPlaceholder": "••••••••",
+			"newPasswordHint": "Use pelo menos 8 caracteres e escolha algo diferente da sua senha atual."
+		},
+		"aria": {
+			"showCurrentPassword": "Mostrar senha atual",
+			"hideCurrentPassword": "Ocultar senha atual",
+			"showNewPassword": "Mostrar nova senha",
+			"hideNewPassword": "Ocultar nova senha",
+			"showConfirmPassword": "Mostrar confirmação da senha",
+			"hideConfirmPassword": "Ocultar confirmação da senha"
+		},
+		"actions": {
+			"submit": "Alterar senha",
+			"updating": "Atualizando…"
+		},
+		"errors": {
+			"currentPasswordRequired": "A senha atual é obrigatória.",
+			"currentPasswordIncorrect": "A senha atual está incorreta.",
+			"sessionExpired": "Sua sessão expirou. Entre novamente.",
+			"serverError": "Algo deu errado no servidor. Tente novamente.",
+			"changeFailed": "Falha ao alterar a senha."
+		}
+	},
+	"apiKeys": {
+		"title": "Chaves de API",
+		"subtitle": "As chaves de API permitem autenticar requisições de API sem usar os cookies da sua sessão. Trate-as como senhas — nunca as compartilhe.",
+		"empty": "Nenhuma chave de API ainda. Crie uma para começar.",
+		"yourKeys": {
+			"title": "Suas chaves",
+			"description": "As chaves são exibidas apenas com os 8 primeiros caracteres para identificação."
+		},
+		"table": {
+			"name": "Nome",
+			"prefix": "Prefixo",
+			"created": "Criada",
+			"expires": "Expira",
+			"lastUsed": "Último uso"
+		},
+		"actions": {
+			"newKey": "Nova chave",
+			"cancel": "Cancelar",
+			"creating": "Criando…",
+			"createKey": "Criar chave",
+			"done": "Concluído",
+			"revoking": "Revogando…",
+			"revokeKey": "Revogar chave",
+			"revokeKeyAria": "Revogar chave",
+			"copyKeyAria": "Copiar chave"
+		},
+		"createDialog": {
+			"title": "Criar chave de API",
+			"description": "Dê um nome descritivo à sua chave para poder identificá-la depois.",
+			"nameLabel": "Nome",
+			"namePlaceholder": "ex.: Pipeline de CI, Dev local",
+			"expiryLabel": "Data de expiração",
+			"expiryOptional": "(opcional)"
+		},
+		"revealDialog": {
+			"title": "Chave de API criada",
+			"description": "Copie sua nova chave agora. Você não poderá vê-la novamente.",
+			"copied": "Copiada para a área de transferência!"
+		},
+		"revokeDialog": {
+			"title": "Revogar chave de API",
+			"confirmPrefix": "Tem certeza de que deseja revogar",
+			"confirmSuffix": "? Qualquer requisição que use esta chave deixará de funcionar imediatamente."
+		},
+		"errors": {
+			"nameRequired": "O nome não pode ficar vazio.",
+			"nameTooLong": "O nome deve ter no máximo 100 caracteres.",
+			"createFailed": "Falha ao criar a chave. Tente novamente.",
+			"copyFailed": "Falha ao copiar. Copie a chave manualmente."
+		}
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -1,0 +1,1193 @@
+{
+	"project": {
+		"notFound": "Projeto não encontrado ou acesso negado.",
+		"settingsPage": {
+			"title": "Configurações",
+			"subtitle": "Configure as opções, papéis e permissões do projeto",
+			"nav": {
+				"general": "Geral",
+				"roles": "Papéis",
+				"taskStatuses": "Status de tarefas",
+				"taskTypes": "Tipos de tarefa",
+				"customFields": "Campos personalizados",
+				"dangerZone": "Zona de perigo",
+				"plugins": "Plugins"
+			}
+		}
+	},
+	"agents": {
+		"createDialog": {
+			"title": "Criar agente",
+			"step1Description": "Defina a identidade e o papel do seu agente",
+			"step2Description": "Configure o modelo de IA que alimenta seu agente",
+			"stepIndicator": "{{step}} / 2",
+			"startFromPreset": "Começar a partir de um preset",
+			"nameLabel": "Nome",
+			"handleLabel": "Identificador",
+			"handleHint": "Derivado automaticamente do nome. Usado para @menções em comentários.",
+			"projectRoleLabel": "Papel no projeto",
+			"projectRolePlaceholder": "Selecione um papel no projeto…",
+			"projectRoleHint": "Controla o que o agente pode ler e modificar neste projeto.",
+			"modelSection": "Modelo",
+			"providerLabel": "Provedor",
+			"modelLabel": "Modelo",
+			"customOption": "Personalizado…",
+			"apiKeyLabel": "Chave de API",
+			"hideApiKey": "Ocultar chave de API",
+			"showApiKey": "Mostrar chave de API",
+			"apiKeyHint": "Armazenada de forma criptografada — nunca exposta nas respostas da API.",
+			"baseUrlLabel": "URL base",
+			"systemPromptLabel": "Prompt de sistema",
+			"optional": "(opcional)",
+			"charsCount": "{{count}} caracteres",
+			"createFailed": "Falha ao criar o agente. Tente novamente.",
+			"cancel": "Cancelar",
+			"continue": "Continuar",
+			"back": "Voltar",
+			"creating": "Criando…",
+			"createAgent": "Criar agente",
+			"namePlaceholder": "Dev Bot",
+			"systemPromptPlaceholder": "Você é um engenheiro de software sênior…"
+		},
+		"card": {
+			"configure": "Configurar",
+			"delete": "Excluir",
+			"deleteDialog": {
+				"title": "Excluir {{name}}?",
+				"description": "Isso exclui permanentemente o agente e o remove do projeto. As conversas em andamento serão interrompidas.",
+				"cancel": "Cancelar",
+				"delete": "Excluir"
+			}
+		},
+		"page": {
+			"title": "Agentes de IA",
+			"subtitle": "Agentes autônomos que trabalham em tarefas e conversam com sua equipe",
+			"newAgent": "Novo agente",
+			"empty": {
+				"title": "Nenhum agente ainda",
+				"description": "Adicione um agente de IA para automatizar tarefas, revisar código, escrever documentação e muito mais.",
+				"createFirstAgent": "Crie seu primeiro agente"
+			}
+		},
+		"detail": {
+			"tabs": {
+				"overview": "Visão geral",
+				"mcpServers": "Servidores MCP",
+				"skills": "Skills",
+				"envVars": "Ambiente",
+				"conversations": "Conversas"
+			},
+			"overview": {
+				"nameLabel": "Nome",
+				"llmConfiguration": "Configuração do LLM",
+				"providerLabel": "Provedor",
+				"modelLabel": "Modelo",
+				"customOption": "Personalizado…",
+				"apiKeyUpdateLabel": "Atualizar chave de API",
+				"apiKeyUpdateHint": "(deixe em branco para manter a atual)",
+				"baseUrlLabel": "URL base",
+				"gitCommitterIdentity": "Identidade de committer do Git",
+				"gitCommitterHint": "Nome e e-mail usados nos commits feitos por este agente.",
+				"committerNameLabel": "Nome do committer",
+				"committerEmailLabel": "E-mail do committer",
+				"saveChanges": "Salvar alterações",
+				"saved": "Salvo",
+				"saveFailed": "Falha ao salvar. Tente novamente.",
+				"systemPromptLabel": "Prompt de sistema"
+			},
+			"mcp": {
+				"serverCount_one": "{{count}} servidor configurado",
+				"serverCount_other": "{{count}} servidores configurados",
+				"addServer": "Adicionar servidor",
+				"empty": {
+					"title": "Nenhum servidor MCP adicionado",
+					"addFirstServer": "Adicione seu primeiro servidor"
+				},
+				"addDialog": {
+					"title": "Adicionar servidor MCP",
+					"description": "Conecte um servidor MCP para ampliar as capacidades do agente.",
+					"serverNameLabel": "Nome do servidor",
+					"transportLabel": "Transporte",
+					"commandLabel": "Comando",
+					"argsLabel": "Argumentos",
+					"argsHint": "(separados por espaço)",
+					"urlLabel": "URL",
+					"cancel": "Cancelar",
+					"addServer": "Adicionar servidor"
+				}
+			},
+			"envVars": {
+				"count_one": "{{count}} variável configurada",
+				"count_other": "{{count}} variáveis configuradas",
+				"addVariable": "Adicionar variável",
+				"empty": {
+					"title": "Nenhuma variável de ambiente adicionada",
+					"addFirst": "Adicione sua primeira variável"
+				},
+				"addDialog": {
+					"title": "Adicionar variável de ambiente",
+					"description": "Valores secretos são criptografados em repouso e injetados no sandbox do agente em tempo de execução. Depois de salvo, um valor nunca mais pode ser visualizado.",
+					"keyLabel": "Chave",
+					"keyPlaceholder": "GITHUB_TOKEN",
+					"keyHint": "(letras, dígitos, underscores — deve começar com uma letra ou underscore)",
+					"valueLabel": "Valor",
+					"cancel": "Cancelar",
+					"addVariable": "Adicionar variável"
+				}
+			},
+			"skills": {
+				"skillCount_one": "{{count}} skill anexada",
+				"skillCount_other": "{{count}} skills anexadas",
+				"addSkill": "Adicionar skill",
+				"empty": {
+					"title": "Nenhuma skill ainda",
+					"addFirstSkill": "Adicionar primeira skill"
+				},
+				"addDialog": {
+					"title": "Adicionar skill",
+					"description": "Dê ao agente instruções ou capacidades especializadas.",
+					"skillNameLabel": "Nome da skill",
+					"sourceLabel": "Origem",
+					"sourceInline": "Inline (escreva o conteúdo aqui)",
+					"sourceMarketplace": "Marketplace",
+					"sourceGithubUrl": "URL do GitHub",
+					"skillContentLabel": "Conteúdo da skill (Markdown)",
+					"urlLabel": "URL",
+					"cancel": "Cancelar",
+					"addSkill": "Adicionar skill"
+				}
+			},
+			"conversations": {
+				"triggerChat": "Chat",
+				"triggerWriteDescription": "Escrever descrição",
+				"triggerTask": "Tarefa",
+				"iterations_one": "{{count}} iteração",
+				"iterations_other": "{{count}} iterações",
+				"prOpened": "PR aberto",
+				"empty": {
+					"title": "Nenhuma conversa ainda",
+					"description": "As conversas começam quando uma tarefa é atribuída a este agente ou quando alguém envia uma mensagem a ele."
+				}
+			}
+		},
+		"conversationView": {
+			"stop": "Parar",
+			"notFound": "Conversa não encontrada",
+			"chatSession": "Sessão de chat",
+			"taskSession": "Sessão de tarefa",
+			"pr": "PR",
+			"conversationEnded": "Esta conversa foi encerrada.",
+			"textOnlyMessage": "Apenas mensagens de texto são suportadas.",
+			"failed": "A conversa falhou",
+			"noOutput": "O agente não produziu nenhuma saída."
+		},
+		"thread": {
+			"composerPlaceholder": "Enviar mensagem ao agente…",
+			"welcomeHeading": "Como posso ajudar você hoje?",
+			"messageInputAriaLabel": "Campo de mensagem",
+			"voiceInput": "Entrada de voz",
+			"startVoiceInputAriaLabel": "Iniciar entrada de voz",
+			"stopDictation": "Parar ditado",
+			"stopVoiceInputAriaLabel": "Parar entrada de voz",
+			"sendMessage": "Enviar mensagem",
+			"stopGeneratingAriaLabel": "Parar geração",
+			"assistantWorkingAriaLabel": "O assistente está trabalhando",
+			"copy": "Copiar",
+			"refresh": "Atualizar",
+			"more": "Mais",
+			"edit": "Editar",
+			"previous": "Anterior",
+			"next": "Próximo",
+			"exportAsMarkdown": "Exportar como Markdown",
+			"scrollToBottom": "Rolar até o fim",
+			"cancel": "Cancelar",
+			"update": "Atualizar",
+			"reasoning": "Raciocínio",
+			"reasoningWithDuration": "Raciocínio ({{duration}}s)",
+			"toolCallCount_one": "{{count}} chamada de ferramenta",
+			"toolCallCount_other": "{{count}} chamadas de ferramenta",
+			"usedTool": "Ferramenta usada",
+			"cancelledTool": "Ferramenta cancelada",
+			"resultLabel": "Resultado:",
+			"errorLabel": "Erro:",
+			"cancelledReasonLabel": "Motivo do cancelamento:",
+			"approvedByUser": "Aprovado pelo usuário",
+			"deniedByUser": "O usuário negou a execução da ferramenta",
+			"allow": "Permitir",
+			"alwaysAllow": "Permitir sempre",
+			"deny": "Negar",
+			"alwaysDeny": "Negar sempre",
+			"confirm": "Confirmar",
+			"back": "Voltar",
+			"attachmentPreview": "Visualização do anexo",
+			"attachmentTypeImage": "Imagem",
+			"attachmentTypeDocument": "Documento",
+			"attachmentTypeFile": "Arquivo",
+			"removeFile": "Remover arquivo",
+			"imageAttachmentPreviewTitle": "Visualização do anexo de imagem",
+			"attachmentAriaLabel": "Anexo {{type}}",
+			"attachmentAriaLabelError": "Anexo {{type}}, falha no upload",
+			"attachmentAriaLabelUploading": "Anexo {{type}}, enviando"
+		}
+	},
+	"docs": {
+		"editorPage": {
+			"notFound": {
+				"title": "Documento não encontrado",
+				"description": "Este documento pode ter sido excluído ou o link é inválido."
+			},
+			"unsaved": "Não salvo",
+			"saving": "Salvando…",
+			"saved": "Salvo",
+			"commentsAndActivity": "Comentários e atividade"
+		},
+		"activity": {
+			"created": "criou este documento",
+			"updated": "atualizou o documento",
+			"updatedFields": "atualizou {{fields}}",
+			"deleted": "excluiu o documento",
+			"moved": "moveu o documento",
+			"contentChangeDiff": "Diferença de alteração de conteúdo"
+		}
+	},
+	"roles": {
+		"deleteDialog": {
+			"title": "Excluir papel",
+			"confirmTextPrefix": "Tem certeza de que deseja excluir",
+			"confirmTextSuffix": "? Todos os membros atualmente atribuídos a este papel perderão o acesso. Esta ação não pode ser desfeita.",
+			"cancel": "Cancelar",
+			"deleteRole": "Excluir papel",
+			"errors": {
+				"notFound": "Este papel não existe mais.",
+				"hasMembers": "Este papel não pode ser excluído porque ainda está atribuído a um ou mais membros.",
+				"forbidden": "Você não tem permissão para excluir este papel.",
+				"internalError": "Algo deu errado. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		},
+		"formDialog": {
+			"editTitle": "Editar papel",
+			"createTitle": "Novo papel",
+			"editDescription": "Atualize o nome do papel e configure suas permissões concedidas.",
+			"createDescription": "Defina um novo papel de projeto e configure quais permissões ele concede aos membros.",
+			"roleNameLabel": "Nome do papel",
+			"roleNamePlaceholder": "ex.: PROJECT_REVIEWER",
+			"permissionsLabel": "Permissões",
+			"enabledCount_one": "{{count}} ativada",
+			"enabledCount_other": "{{count}} ativadas",
+			"cancel": "Cancelar",
+			"saveChanges": "Salvar alterações",
+			"createRole": "Criar papel",
+			"errors": {
+				"nameTaken": "Já existe um papel com este nome.",
+				"nameInvalid": "O nome do papel deve usar letras maiúsculas, números e underscores.",
+				"notFound": "Este papel não existe mais. Ele pode já ter sido excluído.",
+				"forbidden": "Você não tem permissão para realizar esta ação.",
+				"internalError": "Algo deu errado no servidor. Tente novamente.",
+				"generic": "Algo deu errado."
+			}
+		},
+		"permissions": {
+			"projectsRead": {
+				"label": "Ler projeto",
+				"description": "Ver detalhes e configurações do projeto"
+			},
+			"projectsWrite": {
+				"label": "Editar projeto",
+				"description": "Atualizar nome, descrição e configurações do projeto"
+			},
+			"projectsDelete": {
+				"label": "Excluir projeto",
+				"description": "Excluir permanentemente este projeto"
+			},
+			"membersRead": {
+				"label": "Ver membros",
+				"description": "Listar e visualizar os membros do projeto"
+			},
+			"membersWrite": {
+				"label": "Gerenciar membros",
+				"description": "Adicionar, remover e reatribuir membros do projeto"
+			},
+			"rolesRead": {
+				"label": "Ver papéis",
+				"description": "Listar e visualizar as definições de papéis do projeto"
+			},
+			"rolesWrite": {
+				"label": "Gerenciar papéis",
+				"description": "Criar, editar e excluir papéis do projeto"
+			},
+			"tasksRead": {
+				"label": "Ver tarefas",
+				"description": "Navegar e ler as tarefas do projeto"
+			},
+			"tasksWrite": {
+				"label": "Editar tarefas",
+				"description": "Criar, atualizar e mover tarefas"
+			},
+			"sprintsRead": {
+				"label": "Ver sprints",
+				"description": "Navegar pelos quadros de sprint e backlogs"
+			},
+			"sprintsWrite": {
+				"label": "Gerenciar sprints",
+				"description": "Criar, atualizar e encerrar sprints"
+			},
+			"docsRead": {
+				"label": "Ver documentos",
+				"description": "Navegar e ler os documentos do projeto"
+			},
+			"docsWrite": {
+				"label": "Editar documentos",
+				"description": "Criar, atualizar e excluir documentos e pastas"
+			},
+			"agentsRead": {
+				"label": "Ver agentes",
+				"description": "Navegar pelos agentes de IA e ver suas configurações"
+			},
+			"agentsWrite": {
+				"label": "Gerenciar agentes",
+				"description": "Criar, configurar e excluir agentes de IA"
+			},
+			"workflowsRead": {
+				"label": "Ver workflows",
+				"description": "Navegar pelos workflows de automação e suas configurações"
+			},
+			"workflowsWrite": {
+				"label": "Gerenciar workflows",
+				"description": "Criar, editar, ativar e excluir workflows de automação"
+			}
+		},
+		"permissionGroups": {
+			"project": "Projeto",
+			"members": "Membros",
+			"roles": "Papéis",
+			"tasks": "Tarefas",
+			"sprints": "Sprints",
+			"documents": "Documentos",
+			"aiAgents": "Agentes de IA",
+			"workflows": "Automação"
+		}
+	},
+	"settings": {
+		"general": {
+			"title": "Geral",
+			"projectNameLabel": "Nome do projeto",
+			"projectNamePlaceholder": "Meu projeto incrível",
+			"taskIdPrefixLabel": "Prefixo de ID de tarefa",
+			"taskIdPrefixHint": "ex.: PACA → PACA-1, PACA-2…",
+			"taskIdPrefixPlaceholder": "PROJ",
+			"descriptionLabel": "Descrição",
+			"descriptionPlaceholder": "Descreva sobre o que é este projeto…",
+			"publicProjectLabel": "Projeto público",
+			"publicProjectHintPublic": "Qualquer pessoa com o link pode visualizar este projeto. Usuários anônimos têm acesso somente leitura.",
+			"publicProjectHintPrivate": "Apenas membros da equipe podem acessar este projeto.",
+			"saveChanges": "Salvar alterações",
+			"saved": "Salvo ✓",
+			"noPermission": "Você não tem permissão para editar este projeto.",
+			"errors": {
+				"nameTaken": "Já existe um projeto com este nome.",
+				"nameInvalid": "O nome do projeto está vazio ou inválido.",
+				"prefixInvalid": "O prefixo deve ter de 1 a 10 letras/dígitos maiúsculos (ex.: PACA).",
+				"updateFailed": "Falha ao atualizar o projeto. Tente novamente."
+			}
+		},
+		"roles": {
+			"title": "Papéis do projeto",
+			"description": "Gerencie os papéis e permissões dos membros deste projeto.",
+			"newRole": "Novo papel",
+			"noPermissionsAssigned": "Nenhuma permissão atribuída",
+			"editRole": "Editar papel",
+			"deleteRole": "Excluir papel",
+			"rolesDefined_one": "papel definido",
+			"rolesDefined_other": "papéis definidos",
+			"permissionGrants": "permissões concedidas em todos os papéis",
+			"empty": {
+				"title": "Nenhum papel definido ainda",
+				"description": "Crie seu primeiro papel para começar a atribuir permissões aos membros.",
+				"createRole": "Criar papel"
+			},
+			"table": {
+				"name": "Nome",
+				"permissions": "Permissões",
+				"created": "Criado em"
+			},
+			"systemRolesNote": "Papéis de sistema são modelos compartilhados e não podem ser editados ou excluídos."
+		},
+		"taskStatuses": {
+			"title": "Status de tarefas",
+			"description": "Defina os status de fluxo de trabalho pelos quais as tarefas passam neste projeto.",
+			"newStatus": "Novo status",
+			"reorderFailed": "Falha ao salvar a nova ordem. Tente novamente.",
+			"empty": {
+				"title": "Nenhum status definido",
+				"description": "Crie status para definir o fluxo de trabalho das tarefas neste projeto.",
+				"createStatus": "Criar status"
+			},
+			"table": {
+				"name": "Nome",
+				"category": "Categoria",
+				"default": "Padrão"
+			},
+			"default": "Padrão",
+			"setAsDefault": "Definir como status padrão",
+			"editStatus": "Editar status",
+			"deleteStatus": "Excluir status"
+		},
+		"taskTypes": {
+			"title": "Tipos de tarefa",
+			"description": "Categorize tarefas com tipos personalizados (ex.: Bug, Funcionalidade, História).",
+			"newType": "Novo tipo",
+			"empty": {
+				"title": "Nenhum tipo de tarefa definido",
+				"description": "Crie tipos para categorizar tarefas por natureza — ex.: Bug, Funcionalidade, História.",
+				"createType": "Criar tipo"
+			},
+			"table": {
+				"icon": "Ícone",
+				"name": "Nome",
+				"description": "Descrição",
+				"default": "Padrão"
+			},
+			"default": "Padrão",
+			"setAsDefault": "Definir como tipo padrão",
+			"editType": "Editar tipo",
+			"deleteType": "Excluir tipo"
+		},
+		"customFields": {
+			"title": "Campos personalizados",
+			"description": "Defina campos de tarefa personalizados no nível do projeto que estendem as tarefas com dados adicionais específicos do seu fluxo de trabalho.",
+			"newField": "Novo campo personalizado",
+			"empty": {
+				"title": "Nenhum campo personalizado ainda",
+				"description": "Campos personalizados permitem capturar dados específicos do seu fluxo de trabalho — sprints, níveis de severidade, tags de release e muito mais.",
+				"createFirstField": "Criar primeiro campo"
+			},
+			"table": {
+				"displayName": "Nome de exibição",
+				"fieldKey": "Chave do campo",
+				"type": "Tipo",
+				"required": "Obrigatório"
+			},
+			"yes": "Sim",
+			"no": "Não",
+			"editField": "Editar campo",
+			"deleteField": "Excluir campo",
+			"cancel": "Cancelar",
+			"saveChanges": "Salvar alterações",
+			"displayNameLabel": "Nome de exibição",
+			"displayNamePlaceholder": "ex.: Tag de release",
+			"fieldKeyLabel": "Chave do campo",
+			"fieldKeyHint": "Usada como identificador na API e nas exportações de dados.",
+			"fieldKeyImmutableHint": "A chave do campo não pode ser alterada após a criação.",
+			"fieldTypeLabel": "Tipo de campo",
+			"fieldTypeImmutableHint": "O tipo de campo não pode ser alterado após a criação.",
+			"optionsLabel": "Opções",
+			"addOptionPlaceholder": "Adicionar opção…",
+			"addOption": "Adicionar",
+			"requiredLabel": "Obrigatório",
+			"requiredHint": "Os usuários devem preencher este campo ao criar ou editar uma tarefa.",
+			"fieldTypes": {
+				"text": "Texto",
+				"number": "Número",
+				"date": "Data",
+				"checkbox": "Caixa de seleção",
+				"select": "Seleção",
+				"multiSelect": "Seleção múltipla",
+				"url": "URL"
+			},
+			"createDialog": {
+				"title": "Criar campo personalizado",
+				"description": "Defina um novo campo para capturar dados adicionais nas tarefas deste projeto.",
+				"createField": "Criar campo",
+				"errors": {
+					"keyTaken": "Já existe um campo com esta chave no projeto.",
+					"keyInvalid": "A chave do campo está vazia ou inválida.",
+					"nameInvalid": "O nome de exibição está vazio ou inválido.",
+					"createFailed": "Falha ao criar o campo. Tente novamente."
+				}
+			},
+			"editDialog": {
+				"title": "Editar campo personalizado",
+				"description": "Atualize as configurações do campo.",
+				"errors": {
+					"nameInvalid": "O nome de exibição está vazio ou inválido.",
+					"saveFailed": "Falha ao salvar as alterações. Tente novamente."
+				}
+			},
+			"deleteDialog": {
+				"title": "Excluir campo personalizado",
+				"confirmTextPrefix": "Excluir",
+				"confirmTextSuffix": "? Os dados de tarefa armazenados neste campo serão perdidos. Esta ação não pode ser desfeita.",
+				"deleteFailed": "Falha ao excluir o campo. Tente novamente.",
+				"deleteField": "Excluir campo"
+			}
+		},
+		"dangerZone": {
+			"title": "Zona de perigo",
+			"deleteProjectTitle": "Excluir este projeto",
+			"deleteProjectDescription": "Exclua permanentemente o projeto e todos os seus dados. Esta ação não pode ser desfeita.",
+			"deleteProjectButton": "Excluir projeto",
+			"deleteDialog": {
+				"title": "Excluir projeto",
+				"confirmTextPrefix": "Isso excluirá permanentemente",
+				"confirmTextSuffix": "e todos os seus dados, incluindo membros, papéis e interações. Esta ação não pode ser desfeita.",
+				"typeToConfirmPrefix": "Digite",
+				"typeToConfirmSuffix": "para confirmar",
+				"deleteFailed": "Falha ao excluir o projeto. Tente novamente.",
+				"cancel": "Cancelar",
+				"deletePermanently": "Excluir permanentemente"
+			}
+		}
+	},
+	"taskStatuses": {
+		"deleteDialog": {
+			"title": "Excluir status",
+			"confirmTextPrefix": "Excluir",
+			"confirmTextSuffix": "? As tarefas que usam este status perderão seu status. Esta ação não pode ser desfeita.",
+			"deleteFailed": "Falha ao excluir o status. Tente novamente.",
+			"cancel": "Cancelar",
+			"deleteStatus": "Excluir status"
+		},
+		"formDialog": {
+			"editTitle": "Editar status",
+			"createTitle": "Criar status",
+			"editDescription": "Atualize este status de fluxo de trabalho.",
+			"createDescription": "Adicione um novo status ao fluxo de trabalho do projeto.",
+			"nameLabel": "Nome",
+			"namePlaceholder": "ex.: Em revisão",
+			"categoryLabel": "Categoria",
+			"colorLabel": "Cor",
+			"customColorTitle": "Cor personalizada",
+			"cancel": "Cancelar",
+			"saveChanges": "Salvar alterações",
+			"createStatus": "Criar status",
+			"errors": {
+				"nameInvalid": "O nome do status está vazio ou inválido.",
+				"categoryInvalid": "Categoria selecionada inválida.",
+				"saveFailed": "Falha ao salvar o status. Tente novamente."
+			}
+		}
+	},
+	"team": {
+		"title": "Equipe",
+		"subtitle": "Gerencie os membros e papéis do projeto",
+		"addMember": "Adicionar membro",
+		"memberCount_one": "{{count}} membro",
+		"memberCount_other": "{{count}} membros",
+		"empty": {
+			"title": "Nenhum membro ainda",
+			"description": "Adicione colegas de equipe ou agentes de IA a este projeto para começar.",
+			"addFirstMember": "Adicionar primeiro membro"
+		},
+		"addMemberDialog": {
+			"title": "Adicionar membro",
+			"description": "Selecione um usuário e atribua um papel a ele neste projeto.",
+			"userLabel": "Usuário",
+			"change": "Alterar",
+			"searchPlaceholder": "Buscar por nome ou usuário…",
+			"noUsersMatch": "Nenhum usuário corresponde à sua busca.",
+			"noUsersAvailable": "Nenhum usuário disponível para adicionar.",
+			"roleLabel": "Papel",
+			"rolePlaceholder": "Selecione um papel…",
+			"cancel": "Cancelar",
+			"addMember": "Adicionar membro",
+			"errors": {
+				"addFailed": "Falha ao adicionar o membro. Tente novamente."
+			}
+		},
+		"roleChip": {
+			"changeRole": "Alterar papel",
+			"changeFailed": "Falha ao alterar o papel."
+		},
+		"memberRow": {
+			"removeMember": "Remover membro"
+		},
+		"removeDialog": {
+			"title": "Remover membro",
+			"removePrefix": "Remover",
+			"fromInfix": "de",
+			"confirmSuffix": "? Ele perderá o acesso imediatamente.",
+			"removeFailed": "Falha ao remover o membro. Tente novamente.",
+			"cancel": "Cancelar",
+			"remove": "Remover"
+		}
+	},
+	"aiChat": {
+		"chatWithAgent": "Conversar com o agente de IA",
+		"newConversation": "Nova conversa",
+		"agentLabel": "Agente",
+		"noAgentsConfigured": "Nenhum agente configurado para este projeto.",
+		"selectAgentPlaceholder": "Selecione um agente…",
+		"selectAgentFirst": "Selecione um agente primeiro."
+	},
+	"taskTypes": {
+		"deleteDialog": {
+			"title": "Excluir tipo de tarefa",
+			"confirmTextPrefix": "Excluir",
+			"confirmTextSuffix": "? As tarefas que usam este tipo perderão sua atribuição de tipo. Esta ação não pode ser desfeita.",
+			"deleteFailed": "Falha ao excluir o tipo de tarefa. Tente novamente.",
+			"cancel": "Cancelar",
+			"deleteType": "Excluir tipo"
+		},
+		"formDialog": {
+			"editTitle": "Editar tipo de tarefa",
+			"createTitle": "Criar tipo de tarefa",
+			"editDescription": "Atualize este tipo de tarefa.",
+			"createDescription": "Adicione um novo tipo para categorizar tarefas neste projeto.",
+			"nameLabel": "Nome",
+			"namePlaceholder": "ex.: Bug, Funcionalidade, História",
+			"iconLabel": "Ícone",
+			"optional": "(opcional)",
+			"clear": "Limpar",
+			"colorLabel": "Cor",
+			"customColorTitle": "Cor personalizada",
+			"descriptionLabel": "Descrição",
+			"descriptionPlaceholder": "Descreva quando usar este tipo…",
+			"cancel": "Cancelar",
+			"saveChanges": "Salvar alterações",
+			"createType": "Criar tipo",
+			"errors": {
+				"nameInvalid": "O nome do tipo está vazio ou inválido.",
+				"saveFailed": "Falha ao salvar o tipo de tarefa. Tente novamente."
+			}
+		}
+	},
+	"taskDetail": {
+		"common": {
+			"empty": "Vazio",
+			"dash": "—",
+			"unassigned": "Sem responsável"
+		},
+		"notFound": {
+			"title": "Tarefa não encontrada",
+			"description": "Esta tarefa pode ter sido excluída ou o link é inválido.",
+			"ariaLabel": "Detalhe da tarefa",
+			"backToProject": "Voltar ao projeto",
+			"projectFallback": "Projeto"
+		},
+		"header": {
+			"created": "Criada em {{date}}",
+			"copied": "Copiado!",
+			"share": "Compartilhar",
+			"taskActions": "Ações da tarefa",
+			"delete": "Excluir",
+			"closeTaskDetail": "Fechar detalhe da tarefa",
+			"deleteDialog": {
+				"title": "Excluir tarefa?",
+				"description": "Isso exclui permanentemente \"{{title}}\" e todos os seus dados. Esta ação não pode ser desfeita.",
+				"cancel": "Cancelar",
+				"delete": "Excluir"
+			}
+		},
+		"properties": {
+			"title": "Propriedades",
+			"status": "Status",
+			"dates": "Datas",
+			"trackTime": "Registrar tempo",
+			"addTime": "Adicionar tempo",
+			"type": "Tipo",
+			"relationships": "Relacionamentos",
+			"assignees": "Responsáveis",
+			"importance": "Importância",
+			"none": "Nenhum",
+			"storyPoints": "Story Points",
+			"tags": "Tags",
+			"reporter": "Relator",
+			"sprint": "Sprint",
+			"productBacklog": "Backlog do produto",
+			"epic": "Épico",
+			"viewEpic": "Ver épico",
+			"removeEpic": "Remover épico",
+			"parent": "Pai",
+			"viewParent": "Ver pai",
+			"removeParent": "Remover pai",
+			"addFields": "Adicionar campos"
+		},
+		"description": {
+			"title": "Descrição",
+			"writeWithAI": "Escrever com IA",
+			"writeWithAIDialog": {
+				"title": "Escrever com IA",
+				"description": "Selecione um agente para escrever a descrição da tarefa.",
+				"noAgents": "Nenhum agente configurado para este projeto.",
+				"cancel": "Cancelar",
+				"starting": "Iniciando...",
+				"writeButton": "Escrever descrição"
+			}
+		},
+		"subtasks": {
+			"title": "Subtarefas",
+			"addButton": "Adicionar subtarefa",
+			"titlePlaceholder": "Título da subtarefa…",
+			"empty": "Nenhuma subtarefa ainda"
+		},
+		"links": {
+			"title": "Tarefas vinculadas",
+			"addButton": "Adicionar vínculo",
+			"openTask": "Abrir tarefa",
+			"removeLink": "Remover vínculo",
+			"empty": "Nenhuma tarefa vinculada"
+		},
+		"workflows": {
+			"title": "Workflows",
+			"open": "Abrir workflow",
+			"empty": "Nenhum workflow ainda"
+		},
+		"attachments": {
+			"title": "Anexos",
+			"uploadLabel": "Enviar anexo",
+			"dropZoneTitle": "Solte seus arquivos aqui para enviar",
+			"dropZoneSubtitle": "ou clique para navegar",
+			"previewLabel": "Visualizar {{fileName}}",
+			"downloadLabel": "Baixar {{fileName}}",
+			"deleteLabel": "Excluir {{fileName}}",
+			"unitBytes_one": "{{count}} B",
+			"unitBytes_other": "{{count}} B",
+			"unitKilobytes": "{{value}} KB",
+			"unitMegabytes": "{{value}} MB"
+		},
+		"addFieldDialog": {
+			"title": "Criar campo personalizado",
+			"displayNameLabel": "Nome de exibição",
+			"displayNamePlaceholder": "ex.: Tag de release",
+			"fieldKeyLabel": "Chave do campo",
+			"fieldKeyPlaceholder": "release_tag",
+			"fieldTypeLabel": "Tipo de campo",
+			"requiredLabel": "Obrigatório",
+			"cancel": "Cancelar",
+			"creating": "Criando…",
+			"createField": "Criar campo",
+			"fieldTypes": {
+				"text": "Texto",
+				"number": "Número",
+				"date": "Data",
+				"checkbox": "Caixa de seleção",
+				"select": "Seleção",
+				"multiSelect": "Seleção múltipla",
+				"url": "URL"
+			}
+		},
+		"addTaskLinkModal": {
+			"title": "Vincular tarefa",
+			"relationship": "Relacionamento",
+			"searchPlaceholder": "Buscar tarefas por título ou número...",
+			"loadingTasks": "Carregando tarefas…",
+			"noTasksFound": "Nenhuma tarefa encontrada",
+			"linkTypes": {
+				"blocks": {
+					"label": "Bloqueia",
+					"description": "Esta tarefa deve ser concluída antes da outra"
+				},
+				"isBlockedBy": {
+					"label": "É bloqueada por",
+					"description": "Esta tarefa não pode começar até que a outra seja concluída"
+				},
+				"relatesTo": {
+					"label": "Relaciona-se com",
+					"description": "Estas tarefas são relacionadas, mas não dependentes"
+				},
+				"duplicates": {
+					"label": "Duplica",
+					"description": "Esta tarefa é uma duplicata da outra"
+				}
+			}
+		},
+		"propertyField": {
+			"dateEditor": {
+				"datePlaceholder": "Data",
+				"clearDate": "Limpar data",
+				"startDate": "Data de início",
+				"dueDate": "Data de entrega"
+			},
+			"storyPointsEditor": {
+				"decrease": "Diminuir story points",
+				"increase": "Aumentar story points"
+			},
+			"tagsEditor": {
+				"addTag": "Adicionar tag",
+				"addTagPlaceholder": "Adicionar tag..."
+			},
+			"multiSelectEditor": {
+				"addOption": "Adicionar opção"
+			}
+		},
+		"panel": {
+			"priority": "Prioridade",
+			"assignee": "Responsável",
+			"assigned": "Atribuída",
+			"sprint": "Sprint",
+			"created": "Criada",
+			"updated": "Atualizada"
+		},
+		"activity": {
+			"none": "nenhum",
+			"system": "Sistema",
+			"created": "criou esta tarefa",
+			"deleted": "excluiu esta tarefa",
+			"updated": "atualizou esta tarefa",
+			"changedStatus": "alterou o status de \"{{oldVal}}\" para \"{{newVal}}\"",
+			"setStatus": "definiu o status como \"{{newVal}}\"",
+			"clearedStatus": "limpou o status",
+			"changedType": "alterou o tipo de \"{{oldVal}}\" para \"{{newVal}}\"",
+			"setType": "definiu o tipo como \"{{newVal}}\"",
+			"clearedType": "limpou o tipo",
+			"renamed": "renomeou de \"{{oldVal}}\" para \"{{newVal}}\"",
+			"setTitle": "definiu o título como \"{{newVal}}\"",
+			"changedPriority": "alterou a prioridade de {{oldVal}} para {{newVal}}",
+			"setPriority": "definiu a prioridade como {{newVal}}",
+			"changedAssignee": "alterou o responsável de {{oldName}} para {{newName}}",
+			"assignedTo": "atribuída a {{newName}}",
+			"removedAssignee": "removeu o responsável {{oldName}}",
+			"changedReporter": "alterou o relator de {{oldName}} para {{newName}}",
+			"setReporter": "definiu o relator como {{newName}}",
+			"removedReporter": "removeu o relator {{oldName}}",
+			"movedSprint": "moveu do sprint \"{{oldSprint}}\" para \"{{newSprint}}\"",
+			"addedToSprint": "adicionada ao sprint \"{{newSprint}}\"",
+			"removedFromSprint": "removida do sprint \"{{oldSprint}}\"",
+			"setParentTask": "definiu a tarefa pai",
+			"removedParentTask": "removeu a tarefa pai",
+			"changedDueDate": "alterou a data de entrega de {{oldVal}} para {{newVal}}",
+			"setDueDate": "definiu a data de entrega como {{newVal}}",
+			"removedDueDate": "removeu a data de entrega",
+			"changedStartDate": "alterou a data de início de {{oldVal}} para {{newVal}}",
+			"setStartDate": "definiu a data de início como {{newVal}}",
+			"removedStartDate": "removeu a data de início",
+			"updatedDescription": "atualizou a descrição",
+			"updatedTags": "atualizou as tags",
+			"updatedCustomFields": "atualizou os campos personalizados",
+			"updatedField": "atualizou {{field}}",
+			"addedAttachment": "adicionou um anexo",
+			"addedAttachmentNamed": "adicionou anexo: {{fileName}}",
+			"removedAttachment": "removeu um anexo",
+			"removedAttachmentNamed": "removeu anexo: {{fileName}}",
+			"linkTypeBlocks": "bloqueia",
+			"linkTypeRelatedTo": "relacionada a",
+			"linkTypeDuplicates": "duplica",
+			"addedTaskLink": "adicionou vínculo de tarefa ({{linkType}})",
+			"removedTaskLink": "removeu vínculo de tarefa",
+			"startedAiSession": "iniciou uma sessão de IA",
+			"watchSession": "Assistir sessão",
+			"madeChange": "fez uma alteração",
+			"descriptionChangeDiff": "Diferença de alteração da descrição"
+		}
+	},
+	"board": {
+		"common": {
+			"none": "Nenhum"
+		},
+		"view": {
+			"noTasks": "Nenhuma tarefa",
+			"loading": "Carregando…",
+			"viewMore": "Ver mais",
+			"expandColumn": "Expandir coluna",
+			"collapseColumn": "Recolher coluna"
+		},
+		"taskCard": {
+			"unassigned": "Sem responsável",
+			"priorityLabel": "Prioridade",
+			"reporterTitle": "Relator",
+			"epicLabel": "Épico",
+			"noEpic": "Sem épico",
+			"storyPointsTitle": "Story Points"
+		},
+		"listGroup": {
+			"columnHeaders": {
+				"id": "ID",
+				"title": "Título"
+			},
+			"loading": "Carregando…",
+			"viewMore": "Ver mais",
+			"startSprint": "Iniciar sprint",
+			"newSprint": "Novo sprint",
+			"noTasks": "Nenhuma tarefa"
+		},
+		"taskRow": {
+			"columnHeaders": {
+				"type": "Tipo",
+				"importance": "Importância",
+				"storyPoints": "SP",
+				"status": "Status",
+				"assignee": "Responsável",
+				"reporter": "Relator",
+				"startDate": "Data de início",
+				"dueDate": "Data de entrega",
+				"epic": "Épico",
+				"created": "Criada"
+			},
+			"unassigned": "Sem responsável",
+			"noEpic": "Sem épico"
+		},
+		"addTaskRow": {
+			"addTask": "Adicionar tarefa",
+			"placeholder": "Título da tarefa…",
+			"cancel": "Cancelar",
+			"create": "Criar"
+		},
+		"taskTypeSelector": {
+			"noType": "—"
+		},
+		"backlog": {
+			"title": "Backlog do produto",
+			"description": "Todos os itens de trabalho não atribuídos a um sprint."
+		}
+	},
+	"layout": {
+		"shell": {
+			"newSprint": "Novo sprint",
+			"renameView": "Renomear visão",
+			"deleteView": "Excluir visão",
+			"searchTasksPlaceholder": "Buscar tarefas…",
+			"pluginNotAvailable": "Plugin não disponível"
+		},
+		"viewSettings": {
+			"viewSettingsAriaLabel": "Configurações da visão",
+			"title": "Configurações da visão",
+			"chooseFields": "Escolher campos",
+			"back": "← Voltar",
+			"clearFilters": "Limpar filtros",
+			"display": "Exibição",
+			"filters": "Filtros",
+			"noSelection": "—",
+			"titleField": "Título",
+			"fieldsLabel": "Campos",
+			"columnByLabel": "Coluna por",
+			"swimlanesLabel": "Raias",
+			"sortByLabel": "Ordenar por",
+			"fieldSumLabel": "Soma de campo",
+			"initialSizeLabel": "Tamanho inicial",
+			"perPageLabel": "Por página",
+			"sprintsLabel": "Sprints",
+			"statusesLabel": "Status",
+			"assigneesLabel": "Responsáveis",
+			"taskTypesLabel": "Tipos de tarefa",
+			"reset": "Redefinir",
+			"saving": "Salvando…",
+			"save": "Salvar",
+			"sprintFilter": {
+				"noSprints": "Nenhum sprint",
+				"allSprints": "Todos os sprints"
+			},
+			"statusFilter": {
+				"noStatuses": "Nenhum status",
+				"allStatuses": "Todos os status",
+				"clear": "Limpar",
+				"all": "Todos"
+			},
+			"assigneeFilter": {
+				"allAssignees": "Todos os responsáveis",
+				"noMembers": "Nenhum membro",
+				"unassigned": "Sem responsável"
+			},
+			"taskTypeFilter": {
+				"normalTypes": "Tipos normais",
+				"allNormalTypesDynamic": "Todos os tipos normais (dinâmico)",
+				"systemTypes": "Tipos de sistema",
+				"noTaskTypes": "Nenhum tipo de tarefa"
+			}
+		},
+		"roadmap": {
+			"taskColumnLabel": "Tarefa",
+			"noTasksToDisplay": "Nenhuma tarefa para exibir",
+			"noDatesSet": "Nenhuma data definida",
+			"dateRangeTooltip": "{{start}} → {{end}}",
+			"startDateTooltip": "Início: {{date}}",
+			"dueDateTooltip": "Entrega: {{date}}",
+			"loading": "Carregando…",
+			"viewMore": "Ver mais"
+		},
+		"newViewPopover": {
+			"addView": "Adicionar visão",
+			"addViewAriaLabel": "Adicionar visão",
+			"title": "Nova visão",
+			"viewNameLabel": "Nome da visão",
+			"defaultName": "Novo {{layout}}",
+			"layoutLabel": "Layout",
+			"creating": "Criando…",
+			"createView": "Criar visão",
+			"layouts": {
+				"board": "Quadro",
+				"table": "Tabela",
+				"roadmap": "Roadmap",
+				"plugin": "Plugin"
+			}
+		},
+		"renameViewDialog": {
+			"title": "Renomear visão",
+			"cancel": "Cancelar",
+			"renaming": "Renomeando…",
+			"rename": "Renomear"
+		},
+		"startSprintModal": {
+			"title": "Iniciar sprint",
+			"nameLabel": "Nome",
+			"goalLabel": "Objetivo",
+			"optional": "(opcional)",
+			"goalPlaceholder": "O que este sprint deve alcançar?",
+			"startDateLabel": "Data de início",
+			"endDateLabel": "Data de término",
+			"cancel": "Cancelar",
+			"starting": "Iniciando…",
+			"startSprint": "Iniciar sprint"
+		},
+		"timeline": {
+			"title": "Linha do tempo",
+			"description": "Épicos e planejamento de longo prazo em um roadmap."
+		},
+		"sprintDetail": {
+			"notFound": "Sprint não encontrado ou acesso negado.",
+			"statusActive": "Ativo",
+			"statusPlanned": "Planejado",
+			"statusCompleted": "Concluído",
+			"description": "Sprint {{status}}",
+			"descriptionWithStartDate": "Sprint {{status}} · iniciado em {{date}}",
+			"completeSprint": "Concluir sprint",
+			"completeSprintModal": {
+				"title": "Concluir sprint",
+				"willBeMovedTo_one": "{{count}} tarefa incompleta será movida para:",
+				"willBeMovedTo_other": "{{count}} tarefas incompletas serão movidas para:",
+				"noIncompleteTasks": "Não há tarefas incompletas neste sprint.",
+				"productBacklog": "Backlog do produto",
+				"unassignedHint": "As tarefas serão desatribuídas de qualquer sprint",
+				"cancel": "Cancelar",
+				"completing": "Concluindo…",
+				"completeSprint": "Concluir sprint"
+			}
+		},
+		"conversation": {
+			"agentsFallback": "Agentes"
+		}
+	},
+	"priority": {
+		"none": "Nenhuma",
+		"low": "Baixa",
+		"medium": "Média",
+		"high": "Alta",
+		"critical": "Crítica"
+	},
+	"viewUtils": {
+		"groups": {
+			"backlog": "Backlog",
+			"unassigned": "Sem responsável",
+			"noReporter": "Sem relator",
+			"noType": "Sem tipo",
+			"none": "Nenhum",
+			"yes": "Sim",
+			"no": "Não"
+		},
+		"columnBy": {
+			"status": "Status",
+			"sprint": "Sprint",
+			"assignee": "Responsável",
+			"importance": "Importância",
+			"type": "Tipo",
+			"reporter": "Relator"
+		},
+		"sortBy": {
+			"manual": "Manual",
+			"importance": "Importância",
+			"storyPoints": "Story Points",
+			"title": "Título",
+			"created": "Criada",
+			"startDate": "Data de início",
+			"dueDate": "Data de entrega"
+		},
+		"swimlanes": {
+			"none": "Nenhuma",
+			"assignee": "Responsável",
+			"importance": "Importância",
+			"type": "Tipo"
+		},
+		"fieldSum": {
+			"count": "Contagem",
+			"storyPoints": "Story Points"
+		},
+		"fields": {
+			"assignee": "Responsável",
+			"status": "Status",
+			"importance": "Importância",
+			"storyPoints": "Story Points",
+			"type": "Tipo",
+			"epic": "Épico",
+			"reporter": "Relator",
+			"startDate": "Data de início",
+			"dueDate": "Data de entrega",
+			"created": "Criada"
+		}
+	},
+	"automation": {
+		"list": {
+			"title": "Automação",
+			"subtitle": "Automatize repasses de tarefas conforme o trabalho avança pelo seu projeto",
+			"newWorkflow": "Novo workflow",
+			"empty": {
+				"title": "Nenhum workflow ainda",
+				"description": "Crie um workflow para automatizar repasses de tarefas conforme o trabalho avança pelo seu projeto.",
+				"createFirstWorkflow": "Crie seu primeiro workflow"
+			},
+			"noDescription": "Sem descrição",
+			"updated": "Atualizado {{time}}"
+		},
+		"status": {
+			"draft": "Rascunho",
+			"active": "Ativo",
+			"archived": "Arquivado"
+		},
+		"createDialog": {
+			"title": "Novo workflow de automação",
+			"nameLabel": "Nome",
+			"namePlaceholder": "ex.: Pipeline de release",
+			"descriptionLabel": "Descrição",
+			"descriptionPlaceholder": "Detalhes opcionais sobre este workflow…",
+			"cancel": "Cancelar",
+			"create": "Criar"
+		},
+		"deleteDialog": {
+			"title": "Excluir workflow",
+			"body": "Tem certeza de que deseja excluir \"{{name}}\"? Isso não pode ser desfeito.",
+			"cancel": "Cancelar",
+			"confirm": "Excluir"
+		},
+		"builder": {
+			"addTask": "Adicionar tarefa",
+			"activate": "Ativar",
+			"archive": "Arquivar",
+			"deactivate": "Desativar",
+			"readOnlyNoticeArchived": "Este workflow está arquivado e é somente leitura — workflows arquivados não podem ser editados.",
+			"genericError": "Algo deu errado. Tente novamente.",
+			"collapseSidebar": "Recolher barra lateral",
+			"expandSidebar": "Expandir barra lateral"
+		},
+		"canvas": {
+			"unknownTask": "Tarefa desconhecida",
+			"deleteEdge": "Excluir conexão"
+		},
+		"addNodeModal": {
+			"title": "Adicionar tarefa ao workflow",
+			"searchPlaceholder": "Buscar tarefas...",
+			"loadingTasks": "Carregando tarefas...",
+			"noTasksFound": "Nenhuma tarefa encontrada"
+		},
+		"nodePanel": {
+			"title": "Tarefa",
+			"removeNode": "Remover do workflow",
+			"removeConfirmTitle": "Remover tarefa do workflow",
+			"removeConfirmBody": "Isso remove a tarefa do grafo do workflow, junto com todas as suas conexões. A tarefa em si não é afetada.",
+			"cancel": "Cancelar",
+			"removeConfirmAction": "Remover"
+		},
+		"statusRules": {
+			"title": "Regras de status → responsável",
+			"hint": "Atribua automaticamente uma tarefa a um membro sempre que ela mudar para um destes status. Isso se aplica a qualquer tarefa neste workflow — quando alguém altera o status de uma tarefa diretamente, ou quando uma tarefa predecessora é concluída e uma tarefa subsequente é reavaliada no seu status atual.",
+			"noRules": "Nenhuma regra ainda",
+			"statusPlaceholder": "Status",
+			"memberPlaceholder": "Responsável"
+		},
+		"statusTransitions": {
+			"title": "Fluxo de status",
+			"hint": "Defina qual status vem em seguida assim que o trabalho em cada status é concluído. Isso desbloqueia tarefas subsequentes e informa a um agente de IA responsável exatamente qual status definir a seguir, em vez de adivinhar. Uma cadeia padrão é gerada automaticamente a partir dos status do seu projeto quando o workflow é criado.",
+			"nextStatusLabel": "Próximo status",
+			"terminalOption": "__END__",
+			"ambiguousWarning": "Exatamente um status não deve ter próximo status (este se torna o status __END__ do workflow). Atualmente: {{count}} configurados."
+		}
+	}
+}

--- a/apps/web/src/i18n/locales/pt-BR/shared.json
+++ b/apps/web/src/i18n/locales/pt-BR/shared.json
@@ -1,0 +1,142 @@
+{
+	"activityPane": {
+		"title": "Atividade",
+		"empty": "Nenhuma atividade ainda",
+		"editingComment": "Editando comentário...",
+		"cancel": "Cancelar",
+		"sendHint": "⌘↵ para enviar",
+		"systemActor": "Sistema",
+		"editing": "Editando",
+		"edit": "Editar",
+		"delete": "Excluir",
+		"viewDiff": "Ver diferenças",
+		"revert": "Reverter",
+		"errors": {
+			"revertFailed": "Falha ao reverter. Tente novamente."
+		}
+	},
+	"contentDiff": {
+		"emptyLine": "(linha vazia)",
+		"noDifferences": "Nenhuma diferença de texto",
+		"changeDiff": "Alterar diferenças",
+		"removed": "Removido",
+		"added": "Adicionado"
+	},
+	"home": {
+		"greeting": {
+			"morning": "Bom dia",
+			"afternoon": "Boa tarde",
+			"evening": "Boa noite",
+			"fallbackName": "olá"
+		},
+		"hero": {
+			"badge": "Workspace scrumban",
+			"subtitleWithProjects_one": "Você tem {{count}} projeto ativo. Continue de onde parou.",
+			"subtitleWithProjects_other": "Você tem {{count}} projetos ativos. Continue de onde parou.",
+			"subtitleEmpty": "Seu workspace está pronto. Crie um projeto, convide sua equipe e comece a entregar.",
+			"newProject": "Novo Projeto"
+		},
+		"stats": {
+			"projects": {
+				"label": "Projetos",
+				"subEmpty": "Nenhum projeto ainda",
+				"subActive": "{{count}} ativos"
+			},
+			"openTasks": {
+				"label": "Tarefas Abertas",
+				"sub": "Em todos os projetos"
+			},
+			"teamMembers": {
+				"label": "Membros da Equipe",
+				"sub": "Incluindo você"
+			},
+			"aiAgents": {
+				"label": "Agentes de IA",
+				"sub": "Nenhum configurado"
+			}
+		},
+		"projectsSection": {
+			"title": "Projetos",
+			"countInWorkspace_one": "{{count}} projeto no seu workspace",
+			"countInWorkspace_other": "{{count}} projetos no seu workspace",
+			"newShort": "Novo",
+			"newProjectCard": "Novo projeto"
+		},
+		"projectCard": {
+			"public": "Público",
+			"noDescription": "Sem descrição"
+		},
+		"gettingStarted": {
+			"title": "Comece agora",
+			"progress": "{{completed}} / {{total}}",
+			"subtitle": "Complete estas etapas para desbloquear todo o poder do Paca.",
+			"steps": {
+				"createProject": {
+					"title": "Crie seu primeiro projeto",
+					"description": "Configure um quadro scrumban para gerenciar o trabalho da sua equipe."
+				},
+				"inviteTeam": {
+					"title": "Convide sua equipe",
+					"description": "Adicione colaboradores humanos e atribua funções."
+				},
+				"configureAgent": {
+					"title": "Configure um agente de IA",
+					"description": "Conecte uma IA para lidar com tarefas de forma autônoma."
+				},
+				"runSprint": {
+					"title": "Execute seu primeiro sprint",
+					"description": "Mova tarefas pelo ciclo Planejar → Agir → Verificar → Adaptar."
+				}
+			}
+		},
+		"quickActions": {
+			"title": "Ações rápidas",
+			"newProject": {
+				"label": "Novo Projeto",
+				"description": "Criar um quadro scrumban"
+			},
+			"inviteTeam": {
+				"label": "Convidar Equipe",
+				"description": "Adicionar membros ou agentes"
+			},
+			"addAiAgent": {
+				"label": "Adicionar Agente de IA",
+				"description": "Configurar automação"
+			}
+		},
+		"about": {
+			"title": "Como o Paca funciona",
+			"descriptionLead": "Combine a criatividade humana com a velocidade da IA em um quadro scrumban compartilhado. As tarefas fluem por",
+			"workflow": "Planejar → Agir → Verificar → Adaptar",
+			"descriptionTrail": "com total transparência sobre quem — humano ou IA — fez o quê.",
+			"openSource": "Código aberto · Apache-2.0"
+		},
+		"createDialog": {
+			"title": "Novo projeto",
+			"description": "Crie um workspace scrumban para sua equipe. Você pode convidar membros e ajustar as configurações após a criação.",
+			"nameLabel": "Nome do projeto *",
+			"namePlaceholder": "ex.: Platform v3",
+			"prefixLabel": "Prefixo do ID da tarefa",
+			"prefixHint": "(ex.: PACA)",
+			"prefixPlaceholder": "PROJ",
+			"prefixExampleLead": "As tarefas serão rotuladas como",
+			"descriptionLabel": "Descrição",
+			"optionalHint": "(opcional)",
+			"descriptionPlaceholder": "Sobre o que é este projeto?",
+			"publicProject": {
+				"label": "Projeto público",
+				"publicHint": "Qualquer pessoa com o link pode visualizar este projeto. Usuários anônimos têm acesso somente leitura.",
+				"privateHint": "Apenas membros da equipe podem acessar este projeto."
+			},
+			"cancel": "Cancelar",
+			"submit": "Criar projeto",
+			"errors": {
+				"nameRequired": "O nome do projeto é obrigatório.",
+				"nameTaken": "Já existe um projeto com este nome.",
+				"nameInvalid": "O nome do projeto está vazio ou é inválido.",
+				"prefixInvalid": "O prefixo deve ter de 1 a 10 letras maiúsculas/dígitos (ex.: PACA).",
+				"generic": "Algo deu errado. Tente novamente."
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds **Brazilian Portuguese (pt-BR)** as a selectable UI language.

## Changes

- New locale files under `apps/web/src/i18n/locales/pt-BR/` covering all nine namespaces: `common`, `errors`, `shared`, `projects`, `appShell`, `auth`, `admin`, `profile`, `plugins`.
- Registers `pt-BR` in `SUPPORTED_LANGUAGES` and `LOCALE_LABELS` (`"Português (Brasil)"`) in `src/i18n/config.ts`.
- Adds `pt-BR` to the pre-paint language list in `index.html` (kept in sync with `SUPPORTED_LANGUAGES`, per the existing comment there).

## Scope / behavior

- **English remains the default.** `fallbackLng`, the detection order, and `<html lang>` are unchanged — pt-BR is fully opt-in through the existing language switcher and browser-language detection.
- Full translation-key parity with `en` for every namespace (same keys and structure; `{{interpolation}}` placeholders, plural suffixes, `$t(...)` references and tags preserved).

## Testing

- Verified every pt-BR JSON file parses and matches the `en` key set 1:1.
- Ran the app locally with the language set to pt-BR and confirmed login, home, sidebar and settings render translated.

Scoped to a single concern (adding one locale); no behavior change for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
