### PR TITLE
feat: add handling for unidentified comment actors in activity and document services

### DIFF
--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -153,6 +153,10 @@ const (
 	CodeActivityNotAComment Code = "ACTIVITY_NOT_A_COMMENT"
 	// CodeCommentContentInvalid indicates an empty or invalid comment content.
 	CodeCommentContentInvalid Code = "ACTIVITY_COMMENT_CONTENT_INVALID"
+	// CodeCommentActorUnidentified indicates the caller authenticated with the
+	// shared agent API key but did not supply an X-Agent-ID header, so there is
+	// no project member identity to attribute the comment to.
+	CodeCommentActorUnidentified Code = "ACTIVITY_COMMENT_ACTOR_UNIDENTIFIED"
 
 	// --- Task link errors ------------------------------------------------
 
@@ -189,6 +193,10 @@ const (
 	CodeDocActivityNotAComment Code = "DOC_ACTIVITY_NOT_A_COMMENT"
 	// CodeDocCommentContentInvalid indicates an empty or invalid comment content.
 	CodeDocCommentContentInvalid Code = "DOC_COMMENT_CONTENT_INVALID"
+	// CodeDocCommentActorUnidentified indicates the caller authenticated with
+	// the shared agent API key but did not supply an X-Agent-ID header, so
+	// there is no project member identity to attribute the comment to.
+	CodeDocCommentActorUnidentified Code = "DOC_COMMENT_ACTOR_UNIDENTIFIED"
 
 	// CodeNotificationNotFound indicates the requested notification does not exist
 	// or does not belong to the authenticated user.

--- a/services/api/internal/domain/doc/errors.go
+++ b/services/api/internal/domain/doc/errors.go
@@ -22,4 +22,10 @@ var (
 	ErrActivityForbidden     = errors.New("doc activity: only the author can modify this comment")
 	ErrActivityNotAComment   = errors.New("doc activity: this entry is not a comment and cannot be edited")
 	ErrCommentContentInvalid = errors.New("doc activity: comment content must not be empty")
+
+	// ErrCommentActorUnidentified is returned when the request authenticated
+	// with the shared agent API key but did not supply an X-Agent-ID header.
+	// That identity is never itself a project member, so there is no member
+	// to attribute the comment to.
+	ErrCommentActorUnidentified = errors.New("doc activity: request has no identifiable project member; pass X-Agent-ID when using the agent API key")
 )

--- a/services/api/internal/domain/task/errors.go
+++ b/services/api/internal/domain/task/errors.go
@@ -39,4 +39,10 @@ var (
 	ErrActivityForbidden     = errors.New("activity: only the author can modify this comment")
 	ErrActivityNotAComment   = errors.New("activity: this entry is not a comment and cannot be edited")
 	ErrCommentContentInvalid = errors.New("activity: comment content must not be empty")
+
+	// ErrCommentActorUnidentified is returned when the request authenticated
+	// with the shared agent API key but did not supply an X-Agent-ID header.
+	// That identity is never itself a project member, so there is no member
+	// to attribute the comment to.
+	ErrCommentActorUnidentified = errors.New("activity: request has no identifiable project member; pass X-Agent-ID when using the agent API key")
 )

--- a/services/api/internal/domain/user/system.go
+++ b/services/api/internal/domain/user/system.go
@@ -8,3 +8,14 @@ import "github.com/google/uuid"
 // reassigning a task — for pipelines (like NotificationConsumer) that require
 // a valid actor_user_id.
 var SystemActorUserID = uuid.MustParse("00000000-0000-0000-0000-000000000002")
+
+// IsUnidentifiedSystemActor reports whether (actorID, agentID) is the
+// system/agent-bot identity with no specific agent selected — i.e. a request
+// authenticated with the shared agent API key but no X-Agent-ID header. That
+// identity is a technical placeholder and, by design, is never itself a
+// project member, so callers that need to attribute an action to a specific
+// member (e.g. authoring a comment) should treat this case specially rather
+// than surfacing a generic "member not found".
+func IsUnidentifiedSystemActor(actorID uuid.UUID, agentID *uuid.UUID) bool {
+	return agentID == nil && actorID == SystemActorUserID
+}

--- a/services/api/internal/service/doc/activity_service.go
+++ b/services/api/internal/service/doc/activity_service.go
@@ -3,12 +3,14 @@ package docsvc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
 	docdom "github.com/Paca-AI/api/internal/domain/doc"
 	notificationdom "github.com/Paca-AI/api/internal/domain/notification"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/events"
 	mentionpkg "github.com/Paca-AI/api/internal/pkg/mention"
 	"github.com/Paca-AI/api/internal/platform/messaging"
@@ -88,7 +90,7 @@ func (s *ActivitySvc) AddComment(ctx context.Context, in docdom.AddCommentInput)
 	}
 	member, err := s.memberRepo.FindMemberByActor(ctx, in.ProjectID, in.ActorID, in.AgentID)
 	if err != nil {
-		return nil, err
+		return nil, wrapMemberLookupErr(err, in.ActorID, in.AgentID)
 	}
 	now := time.Now()
 	a := &docdom.Activity{
@@ -131,7 +133,7 @@ func (s *ActivitySvc) UpdateComment(ctx context.Context, id uuid.UUID, projectID
 	}
 	member, err := s.memberRepo.FindMemberByActor(ctx, projectID, actorID, agentID)
 	if err != nil {
-		return nil, err
+		return nil, wrapMemberLookupErr(err, actorID, agentID)
 	}
 	if a.ActorID == nil || *a.ActorID != member.ID {
 		return nil, docdom.ErrActivityForbidden
@@ -164,7 +166,7 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 	}
 	member, err := s.memberRepo.FindMemberByActor(ctx, projectID, actorID, agentID)
 	if err != nil {
-		return err
+		return wrapMemberLookupErr(err, actorID, agentID)
 	}
 	if a.ActorID == nil || *a.ActorID != member.ID {
 		return docdom.ErrActivityForbidden
@@ -182,6 +184,20 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 }
 
 // --- helpers ----------------------------------------------------------------
+
+// wrapMemberLookupErr replaces ErrMemberNotFound with the clearer
+// docdom.ErrCommentActorUnidentified when the actor is the system/agent-bot
+// identity (userdom.SystemActorUserID) with no agentID — i.e. the request
+// authenticated with the shared agent API key but omitted X-Agent-ID. That
+// identity is never itself a project member by design, so "member not found"
+// is misleading; the caller instead needs to know to supply X-Agent-ID. Any
+// other lookup failure (a genuine non-member) is returned unchanged.
+func wrapMemberLookupErr(err error, actorID uuid.UUID, agentID *uuid.UUID) error {
+	if agentID == nil && actorID == userdom.SystemActorUserID && errors.Is(err, projectdom.ErrMemberNotFound) {
+		return docdom.ErrCommentActorUnidentified
+	}
+	return err
+}
 
 // activityPayload builds the full stream message body for a doc activity.
 // projectID is included so the consumer can resolve the actor (user UUID) to

--- a/services/api/internal/service/doc/activity_service.go
+++ b/services/api/internal/service/doc/activity_service.go
@@ -187,13 +187,14 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 
 // wrapMemberLookupErr replaces ErrMemberNotFound with the clearer
 // docdom.ErrCommentActorUnidentified when the actor is the system/agent-bot
-// identity (userdom.SystemActorUserID) with no agentID — i.e. the request
-// authenticated with the shared agent API key but omitted X-Agent-ID. That
-// identity is never itself a project member by design, so "member not found"
-// is misleading; the caller instead needs to know to supply X-Agent-ID. Any
-// other lookup failure (a genuine non-member) is returned unchanged.
+// identity with no agentID (see userdom.IsUnidentifiedSystemActor) — i.e. the
+// request authenticated with the shared agent API key but omitted
+// X-Agent-ID. That identity is never itself a project member by design, so
+// "member not found" is misleading; the caller instead needs to know to
+// supply X-Agent-ID. Any other lookup failure (a genuine non-member) is
+// returned unchanged.
 func wrapMemberLookupErr(err error, actorID uuid.UUID, agentID *uuid.UUID) error {
-	if agentID == nil && actorID == userdom.SystemActorUserID && errors.Is(err, projectdom.ErrMemberNotFound) {
+	if errors.Is(err, projectdom.ErrMemberNotFound) && userdom.IsUnidentifiedSystemActor(actorID, agentID) {
 		return docdom.ErrCommentActorUnidentified
 	}
 	return err

--- a/services/api/internal/service/doc/activity_service_test.go
+++ b/services/api/internal/service/doc/activity_service_test.go
@@ -1,0 +1,204 @@
+// Package docsvc_test contains unit tests for the doc activity service.
+// Tests use in-memory fake repositories and do not require any infrastructure.
+package docsvc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	docdom "github.com/Paca-AI/api/internal/domain/doc"
+	projectdom "github.com/Paca-AI/api/internal/domain/project"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
+	docsvc "github.com/Paca-AI/api/internal/service/doc"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeCommentActivityRepo is a minimal in-memory docdom.ActivityRepository.
+type fakeCommentActivityRepo struct {
+	activities map[uuid.UUID]*docdom.Activity
+}
+
+func newFakeCommentActivityRepo() *fakeCommentActivityRepo {
+	return &fakeCommentActivityRepo{activities: make(map[uuid.UUID]*docdom.Activity)}
+}
+
+func (r *fakeCommentActivityRepo) ListActivities(_ context.Context, documentID uuid.UUID) ([]*docdom.Activity, error) {
+	var out []*docdom.Activity
+	for _, a := range r.activities {
+		if a.DocumentID == documentID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeCommentActivityRepo) FindActivityByID(_ context.Context, id uuid.UUID) (*docdom.Activity, error) {
+	a, ok := r.activities[id]
+	if !ok {
+		return nil, docdom.ErrActivityNotFound
+	}
+	return a, nil
+}
+
+func (r *fakeCommentActivityRepo) CreateActivity(_ context.Context, a *docdom.Activity) error {
+	r.activities[a.ID] = a
+	return nil
+}
+
+func (r *fakeCommentActivityRepo) UpdateActivity(_ context.Context, a *docdom.Activity) error {
+	r.activities[a.ID] = a
+	return nil
+}
+
+func (r *fakeCommentActivityRepo) DeleteActivity(_ context.Context, id uuid.UUID) error {
+	delete(r.activities, id)
+	return nil
+}
+
+// fakeCommentMemberRepo mirrors production FindMemberByActor semantics
+// closely enough to exercise the unidentified-actor branch: the
+// userdom.SystemActorUserID identity (with no agentID) is never itself a
+// project member, exactly like the real repository.
+type fakeCommentMemberRepo struct {
+	membersByUser map[uuid.UUID]*projectdom.ProjectMember
+}
+
+func (r *fakeCommentMemberRepo) FindMemberByActor(_ context.Context, _ uuid.UUID, actorID uuid.UUID, agentID *uuid.UUID) (*projectdom.ProjectMember, error) {
+	if agentID != nil {
+		return &projectdom.ProjectMember{ID: *agentID, MemberType: "agent"}, nil
+	}
+	if actorID == userdom.SystemActorUserID {
+		// Matches production: the system/agent-bot identity is never itself
+		// a project member.
+		return nil, projectdom.ErrMemberNotFound
+	}
+	if m, ok := r.membersByUser[actorID]; ok {
+		return m, nil
+	}
+	return nil, projectdom.ErrMemberNotFound
+}
+
+func validCommentContent() json.RawMessage {
+	return json.RawMessage(`[{"type":"paragraph","content":[{"type":"text","text":"hello"}]}]`)
+}
+
+// ---------------------------------------------------------------------------
+// AddComment
+// ---------------------------------------------------------------------------
+
+func TestActivitySvc_AddComment_UnidentifiedSystemActor_ReturnsClearError(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := docsvc.NewActivityService(repo, memberRepo, nil)
+
+	_, err := svc.AddComment(context.Background(), docdom.AddCommentInput{
+		DocumentID: uuid.New(),
+		ProjectID:  uuid.New(),
+		ActorID:    userdom.SystemActorUserID, // shared agent key, no X-Agent-ID
+		AgentID:    nil,
+		Content:    validCommentContent(),
+	})
+
+	if !errors.Is(err, docdom.ErrCommentActorUnidentified) {
+		t.Fatalf("expected ErrCommentActorUnidentified, got %v", err)
+	}
+	if errors.Is(err, projectdom.ErrMemberNotFound) {
+		t.Errorf("clear error should not also satisfy errors.Is(ErrMemberNotFound); callers must not accidentally treat this as the generic not-a-member case")
+	}
+}
+
+func TestActivitySvc_AddComment_GenuineNonMember_ReturnsMemberNotFound(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := docsvc.NewActivityService(repo, memberRepo, nil)
+
+	realUserID := uuid.New() // a real human, just not a member of this project
+
+	_, err := svc.AddComment(context.Background(), docdom.AddCommentInput{
+		DocumentID: uuid.New(),
+		ProjectID:  uuid.New(),
+		ActorID:    realUserID,
+		AgentID:    nil,
+		Content:    validCommentContent(),
+	})
+
+	if !errors.Is(err, projectdom.ErrMemberNotFound) {
+		t.Fatalf("expected ErrMemberNotFound for a genuine non-member, got %v", err)
+	}
+	if errors.Is(err, docdom.ErrCommentActorUnidentified) {
+		t.Errorf("a genuine non-member should not be rewrapped as ErrCommentActorUnidentified")
+	}
+}
+
+func TestActivitySvc_AddComment_ResolvedMember_Succeeds(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	memberID := uuid.New()
+	actorID := uuid.New()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{
+		actorID: {ID: memberID, MemberType: "human"},
+	}}
+	svc := docsvc.NewActivityService(repo, memberRepo, nil)
+
+	a, err := svc.AddComment(context.Background(), docdom.AddCommentInput{
+		DocumentID: uuid.New(),
+		ProjectID:  uuid.New(),
+		ActorID:    actorID,
+		Content:    validCommentContent(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.ActorID == nil || *a.ActorID != memberID {
+		t.Errorf("expected comment actor_id %s, got %v", memberID, a.ActorID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateComment / DeleteComment
+// ---------------------------------------------------------------------------
+
+func TestActivitySvc_UpdateComment_UnidentifiedSystemActor_ReturnsClearError(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	commentID := uuid.New()
+	existingAuthor := uuid.New()
+	repo.activities[commentID] = &docdom.Activity{
+		ID:           commentID,
+		ActivityType: docdom.ActivityTypeComment,
+		ActorID:      &existingAuthor,
+		Content:      validCommentContent(),
+	}
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := docsvc.NewActivityService(repo, memberRepo, nil)
+
+	_, err := svc.UpdateComment(context.Background(), commentID, uuid.New(), userdom.SystemActorUserID, nil, validCommentContent())
+
+	if !errors.Is(err, docdom.ErrCommentActorUnidentified) {
+		t.Fatalf("expected ErrCommentActorUnidentified, got %v", err)
+	}
+}
+
+func TestActivitySvc_DeleteComment_UnidentifiedSystemActor_ReturnsClearError(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	commentID := uuid.New()
+	existingAuthor := uuid.New()
+	repo.activities[commentID] = &docdom.Activity{
+		ID:           commentID,
+		ActivityType: docdom.ActivityTypeComment,
+		ActorID:      &existingAuthor,
+		Content:      validCommentContent(),
+	}
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := docsvc.NewActivityService(repo, memberRepo, nil)
+
+	err := svc.DeleteComment(context.Background(), commentID, uuid.New(), userdom.SystemActorUserID, nil)
+
+	if !errors.Is(err, docdom.ErrCommentActorUnidentified) {
+		t.Fatalf("expected ErrCommentActorUnidentified, got %v", err)
+	}
+}

--- a/services/api/internal/service/task/activity_service.go
+++ b/services/api/internal/service/task/activity_service.go
@@ -3,6 +3,7 @@ package tasksvc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	notificationdom "github.com/Paca-AI/api/internal/domain/notification"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/events"
 	mentionpkg "github.com/Paca-AI/api/internal/pkg/mention"
 	"github.com/Paca-AI/api/internal/platform/messaging"
@@ -100,7 +102,7 @@ func (s *ActivitySvc) AddComment(ctx context.Context, in taskdom.AddCommentInput
 	}
 	member, err := s.memberRepo.FindMemberByActor(ctx, in.ProjectID, in.ActorID, in.AgentID)
 	if err != nil {
-		return nil, err
+		return nil, wrapMemberLookupErr(err, in.ActorID, in.AgentID)
 	}
 	now := time.Now()
 	a := &taskdom.Activity{
@@ -198,7 +200,7 @@ func (s *ActivitySvc) UpdateComment(ctx context.Context, id uuid.UUID, projectID
 	}
 	member, err := s.memberRepo.FindMemberByActor(ctx, projectID, actorID, agentID)
 	if err != nil {
-		return nil, err
+		return nil, wrapMemberLookupErr(err, actorID, agentID)
 	}
 	if a.ActorID == nil || *a.ActorID != member.ID {
 		return nil, taskdom.ErrActivityForbidden
@@ -224,7 +226,7 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 	// Resolve caller's actor UUID to their member UUID for ownership comparison.
 	member, err := s.memberRepo.FindMemberByActor(ctx, projectID, actorID, agentID)
 	if err != nil {
-		return err
+		return wrapMemberLookupErr(err, actorID, agentID)
 	}
 	if a.ActorID == nil || *a.ActorID != member.ID {
 		return taskdom.ErrActivityForbidden
@@ -242,6 +244,20 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 }
 
 // --- helpers ----------------------------------------------------------------
+
+// wrapMemberLookupErr replaces ErrMemberNotFound with the clearer
+// taskdom.ErrCommentActorUnidentified when the actor is the system/agent-bot
+// identity (userdom.SystemActorUserID) with no agentID — i.e. the request
+// authenticated with the shared agent API key but omitted X-Agent-ID. That
+// identity is never itself a project member by design, so "member not found"
+// is misleading; the caller instead needs to know to supply X-Agent-ID. Any
+// other lookup failure (a genuine non-member) is returned unchanged.
+func wrapMemberLookupErr(err error, actorID uuid.UUID, agentID *uuid.UUID) error {
+	if agentID == nil && actorID == userdom.SystemActorUserID && errors.Is(err, projectdom.ErrMemberNotFound) {
+		return taskdom.ErrCommentActorUnidentified
+	}
+	return err
+}
 
 // activityPayload builds the full stream message body for an activity entry.
 // projectID is included so the consumer can resolve the actor (user UUID) to

--- a/services/api/internal/service/task/activity_service.go
+++ b/services/api/internal/service/task/activity_service.go
@@ -247,13 +247,14 @@ func (s *ActivitySvc) DeleteComment(ctx context.Context, id uuid.UUID, projectID
 
 // wrapMemberLookupErr replaces ErrMemberNotFound with the clearer
 // taskdom.ErrCommentActorUnidentified when the actor is the system/agent-bot
-// identity (userdom.SystemActorUserID) with no agentID — i.e. the request
-// authenticated with the shared agent API key but omitted X-Agent-ID. That
-// identity is never itself a project member by design, so "member not found"
-// is misleading; the caller instead needs to know to supply X-Agent-ID. Any
-// other lookup failure (a genuine non-member) is returned unchanged.
+// identity with no agentID (see userdom.IsUnidentifiedSystemActor) — i.e. the
+// request authenticated with the shared agent API key but omitted
+// X-Agent-ID. That identity is never itself a project member by design, so
+// "member not found" is misleading; the caller instead needs to know to
+// supply X-Agent-ID. Any other lookup failure (a genuine non-member) is
+// returned unchanged.
 func wrapMemberLookupErr(err error, actorID uuid.UUID, agentID *uuid.UUID) error {
-	if agentID == nil && actorID == userdom.SystemActorUserID && errors.Is(err, projectdom.ErrMemberNotFound) {
+	if errors.Is(err, projectdom.ErrMemberNotFound) && userdom.IsUnidentifiedSystemActor(actorID, agentID) {
 		return taskdom.ErrCommentActorUnidentified
 	}
 	return err

--- a/services/api/internal/service/task/activity_service_test.go
+++ b/services/api/internal/service/task/activity_service_test.go
@@ -1,0 +1,211 @@
+// Package tasksvc_test contains unit tests for the task activity service.
+// Tests use in-memory fake repositories and do not require any infrastructure.
+package tasksvc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	projectdom "github.com/Paca-AI/api/internal/domain/project"
+	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
+	tasksvc "github.com/Paca-AI/api/internal/service/task"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// fakeCommentActivityRepo is a minimal in-memory taskdom.ActivityRepository.
+type fakeCommentActivityRepo struct {
+	activities map[uuid.UUID]*taskdom.Activity
+}
+
+func newFakeCommentActivityRepo() *fakeCommentActivityRepo {
+	return &fakeCommentActivityRepo{activities: make(map[uuid.UUID]*taskdom.Activity)}
+}
+
+func (r *fakeCommentActivityRepo) ListActivities(_ context.Context, taskID uuid.UUID) ([]*taskdom.Activity, error) {
+	var out []*taskdom.Activity
+	for _, a := range r.activities {
+		if a.TaskID == taskID {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+func (r *fakeCommentActivityRepo) FindActivityByID(_ context.Context, id uuid.UUID) (*taskdom.Activity, error) {
+	a, ok := r.activities[id]
+	if !ok {
+		return nil, taskdom.ErrActivityNotFound
+	}
+	return a, nil
+}
+
+func (r *fakeCommentActivityRepo) CreateActivity(_ context.Context, a *taskdom.Activity) error {
+	r.activities[a.ID] = a
+	return nil
+}
+
+func (r *fakeCommentActivityRepo) UpdateActivity(_ context.Context, a *taskdom.Activity) error {
+	r.activities[a.ID] = a
+	return nil
+}
+
+func (r *fakeCommentActivityRepo) DeleteActivity(_ context.Context, id uuid.UUID) error {
+	delete(r.activities, id)
+	return nil
+}
+
+// fakeCommentMemberRepo mirrors production FindMemberByActor semantics
+// closely enough to exercise the unidentified-actor branch: the
+// userdom.SystemActorUserID identity (with no agentID) is never itself a
+// project member, exactly like the real repository.
+type fakeCommentMemberRepo struct {
+	// membersByUser maps a user UUID to the ProjectMember it resolves to.
+	// Any user UUID not present here (other than the system actor) simulates
+	// a genuine "not a member of this project" case.
+	membersByUser map[uuid.UUID]*projectdom.ProjectMember
+}
+
+func (r *fakeCommentMemberRepo) FindMemberByActor(_ context.Context, _ uuid.UUID, actorID uuid.UUID, agentID *uuid.UUID) (*projectdom.ProjectMember, error) {
+	if agentID != nil {
+		return &projectdom.ProjectMember{ID: *agentID, MemberType: "agent"}, nil
+	}
+	if actorID == userdom.SystemActorUserID {
+		// Matches production: the system/agent-bot identity is never itself
+		// a project member.
+		return nil, projectdom.ErrMemberNotFound
+	}
+	if m, ok := r.membersByUser[actorID]; ok {
+		return m, nil
+	}
+	return nil, projectdom.ErrMemberNotFound
+}
+
+func (r *fakeCommentMemberRepo) FindMemberByAgent(_ context.Context, _ uuid.UUID, agentID uuid.UUID) (*projectdom.ProjectMember, error) {
+	return &projectdom.ProjectMember{ID: agentID, MemberType: "agent"}, nil
+}
+
+func validCommentContent() json.RawMessage {
+	return json.RawMessage(`[{"type":"paragraph","content":[{"type":"text","text":"hello"}]}]`)
+}
+
+// ---------------------------------------------------------------------------
+// AddComment
+// ---------------------------------------------------------------------------
+
+func TestActivitySvc_AddComment_UnidentifiedSystemActor_ReturnsClearError(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil)
+
+	_, err := svc.AddComment(context.Background(), taskdom.AddCommentInput{
+		TaskID:    uuid.New(),
+		ProjectID: uuid.New(),
+		ActorID:   userdom.SystemActorUserID, // shared agent key, no X-Agent-ID
+		AgentID:   nil,
+		Content:   validCommentContent(),
+	})
+
+	if !errors.Is(err, taskdom.ErrCommentActorUnidentified) {
+		t.Fatalf("expected ErrCommentActorUnidentified, got %v", err)
+	}
+	if errors.Is(err, projectdom.ErrMemberNotFound) {
+		t.Errorf("clear error should not also satisfy errors.Is(ErrMemberNotFound); callers must not accidentally treat this as the generic not-a-member case")
+	}
+}
+
+func TestActivitySvc_AddComment_GenuineNonMember_ReturnsMemberNotFound(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil)
+
+	realUserID := uuid.New() // a real human, just not a member of this project
+
+	_, err := svc.AddComment(context.Background(), taskdom.AddCommentInput{
+		TaskID:    uuid.New(),
+		ProjectID: uuid.New(),
+		ActorID:   realUserID,
+		AgentID:   nil,
+		Content:   validCommentContent(),
+	})
+
+	if !errors.Is(err, projectdom.ErrMemberNotFound) {
+		t.Fatalf("expected ErrMemberNotFound for a genuine non-member, got %v", err)
+	}
+	if errors.Is(err, taskdom.ErrCommentActorUnidentified) {
+		t.Errorf("a genuine non-member should not be rewrapped as ErrCommentActorUnidentified")
+	}
+}
+
+func TestActivitySvc_AddComment_ResolvedMember_Succeeds(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	memberID := uuid.New()
+	actorID := uuid.New()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{
+		actorID: {ID: memberID, MemberType: "human"},
+	}}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil)
+
+	a, err := svc.AddComment(context.Background(), taskdom.AddCommentInput{
+		TaskID:    uuid.New(),
+		ProjectID: uuid.New(),
+		ActorID:   actorID,
+		Content:   validCommentContent(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.ActorID == nil || *a.ActorID != memberID {
+		t.Errorf("expected comment actor_id %s, got %v", memberID, a.ActorID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateComment / DeleteComment
+// ---------------------------------------------------------------------------
+
+func TestActivitySvc_UpdateComment_UnidentifiedSystemActor_ReturnsClearError(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	commentID := uuid.New()
+	existingAuthor := uuid.New()
+	repo.activities[commentID] = &taskdom.Activity{
+		ID:           commentID,
+		ActivityType: taskdom.ActivityTypeComment,
+		ActorID:      &existingAuthor,
+		Content:      validCommentContent(),
+	}
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil)
+
+	_, err := svc.UpdateComment(context.Background(), commentID, uuid.New(), userdom.SystemActorUserID, nil, validCommentContent())
+
+	if !errors.Is(err, taskdom.ErrCommentActorUnidentified) {
+		t.Fatalf("expected ErrCommentActorUnidentified, got %v", err)
+	}
+}
+
+func TestActivitySvc_DeleteComment_UnidentifiedSystemActor_ReturnsClearError(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	commentID := uuid.New()
+	existingAuthor := uuid.New()
+	repo.activities[commentID] = &taskdom.Activity{
+		ID:           commentID,
+		ActivityType: taskdom.ActivityTypeComment,
+		ActorID:      &existingAuthor,
+		Content:      validCommentContent(),
+	}
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil)
+
+	err := svc.DeleteComment(context.Background(), commentID, uuid.New(), userdom.SystemActorUserID, nil)
+
+	if !errors.Is(err, taskdom.ErrCommentActorUnidentified) {
+		t.Fatalf("expected ErrCommentActorUnidentified, got %v", err)
+	}
+}

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -431,7 +431,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeCustomFieldTypeInvalid,
 		apierr.CodeCustomFieldNameInvalid,
 		apierr.CodeActivityNotAComment,
-		apierr.CodeCommentContentInvalid:
+		apierr.CodeCommentContentInvalid,
+		apierr.CodeCommentActorUnidentified:
 		return http.StatusBadRequest
 	case apierr.CodeActivityNotFound:
 		return http.StatusNotFound
@@ -456,7 +457,8 @@ func httpStatusForCode(code apierr.Code) int {
 		apierr.CodeDocFolderNotInProject,
 		apierr.CodeDocFolderSelfParent,
 		apierr.CodeDocActivityNotAComment,
-		apierr.CodeDocCommentContentInvalid:
+		apierr.CodeDocCommentContentInvalid,
+		apierr.CodeDocCommentActorUnidentified:
 		return http.StatusBadRequest
 	case apierr.CodeDocActivityForbidden:
 		return http.StatusForbidden

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -215,6 +215,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeActivityNotAComment
 	case errors.Is(err, taskdom.ErrCommentContentInvalid):
 		return http.StatusBadRequest, apierr.CodeCommentContentInvalid
+	case errors.Is(err, taskdom.ErrCommentActorUnidentified):
+		return http.StatusBadRequest, apierr.CodeCommentActorUnidentified
 	case errors.Is(err, taskdom.ErrTaskLinkNotFound):
 		return http.StatusNotFound, apierr.CodeTaskLinkNotFound
 	case errors.Is(err, taskdom.ErrTaskLinkSelf):
@@ -245,6 +247,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeDocActivityNotAComment
 	case errors.Is(err, docdom.ErrCommentContentInvalid):
 		return http.StatusBadRequest, apierr.CodeDocCommentContentInvalid
+	case errors.Is(err, docdom.ErrCommentActorUnidentified):
+		return http.StatusBadRequest, apierr.CodeDocCommentActorUnidentified
 	case errors.Is(err, notificationdom.ErrNotificationNotFound):
 		return http.StatusNotFound, apierr.CodeNotificationNotFound
 	case errors.Is(err, apikeydom.ErrNotFound):

--- a/services/api/internal/worker/activity_consumer.go
+++ b/services/api/internal/worker/activity_consumer.go
@@ -11,6 +11,7 @@ import (
 
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/events"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -196,8 +197,16 @@ func (c *ActivityConsumer) handle(msg redis.XMessage) {
 				if mErr == nil {
 					a.ActorID = &member.ID
 				} else {
+					// actorID is userdom.SystemActorUserID for requests
+					// authenticated with the shared agent API key but no
+					// X-Agent-ID header — that identity is never itself a
+					// project member by design, so the lookup "failing" is
+					// expected there, not a bug; only warn when a genuine
+					// actor can't be resolved to a member.
+					if agentID != nil || actorID != userdom.SystemActorUserID {
+						c.log.Warn("activity consumer: could not resolve member for actor", "actor_id", a.ActorID, "agent_id", p.ActorAgentID, "project_id", projectID, "err", mErr)
+					}
 					// Member may have been removed; store nil rather than a stale UUID.
-					c.log.Warn("activity consumer: could not resolve member for actor", "actor_id", a.ActorID, "agent_id", p.ActorAgentID, "project_id", projectID, "err", mErr)
 					a.ActorID = nil
 				}
 			}

--- a/services/api/internal/worker/activity_consumer.go
+++ b/services/api/internal/worker/activity_consumer.go
@@ -4,6 +4,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -200,10 +201,12 @@ func (c *ActivityConsumer) handle(msg redis.XMessage) {
 					// actorID is userdom.SystemActorUserID for requests
 					// authenticated with the shared agent API key but no
 					// X-Agent-ID header — that identity is never itself a
-					// project member by design, so the lookup "failing" is
+					// project member by design, so ErrMemberNotFound is
 					// expected there, not a bug; only warn when a genuine
-					// actor can't be resolved to a member.
-					if agentID != nil || actorID != userdom.SystemActorUserID {
+					// actor can't be resolved to a member, or when the
+					// lookup failed for some other (unexpected) reason.
+					expected := userdom.IsUnidentifiedSystemActor(actorID, agentID) && errors.Is(mErr, projectdom.ErrMemberNotFound)
+					if !expected {
 						c.log.Warn("activity consumer: could not resolve member for actor", "actor_id", a.ActorID, "agent_id", p.ActorAgentID, "project_id", projectID, "err", mErr)
 					}
 					// Member may have been removed; store nil rather than a stale UUID.

--- a/services/api/internal/worker/doc_activity_consumer.go
+++ b/services/api/internal/worker/doc_activity_consumer.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -196,10 +197,12 @@ func (c *DocActivityConsumer) handle(msg redis.XMessage) {
 					// actorID is userdom.SystemActorUserID for requests
 					// authenticated with the shared agent API key but no
 					// X-Agent-ID header — that identity is never itself a
-					// project member by design, so the lookup "failing" is
+					// project member by design, so ErrMemberNotFound is
 					// expected there, not a bug; only warn when a genuine
-					// actor can't be resolved to a member.
-					if agentID != nil || actorID != userdom.SystemActorUserID {
+					// actor can't be resolved to a member, or when the
+					// lookup failed for some other (unexpected) reason.
+					expected := userdom.IsUnidentifiedSystemActor(actorID, agentID) && errors.Is(mErr, projectdom.ErrMemberNotFound)
+					if !expected {
 						c.log.Warn("doc activity consumer: could not resolve member for actor", "actor_id", a.ActorID, "agent_id", p.ActorAgentID, "project_id", projectID, "err", mErr)
 					}
 					a.ActorID = nil

--- a/services/api/internal/worker/doc_activity_consumer.go
+++ b/services/api/internal/worker/doc_activity_consumer.go
@@ -10,6 +10,7 @@ import (
 
 	docdom "github.com/Paca-AI/api/internal/domain/doc"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/events"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -192,7 +193,15 @@ func (c *DocActivityConsumer) handle(msg redis.XMessage) {
 				if mErr == nil {
 					a.ActorID = &member.ID
 				} else {
-					c.log.Warn("doc activity consumer: could not resolve member for actor", "actor_id", a.ActorID, "agent_id", p.ActorAgentID, "project_id", projectID, "err", mErr)
+					// actorID is userdom.SystemActorUserID for requests
+					// authenticated with the shared agent API key but no
+					// X-Agent-ID header — that identity is never itself a
+					// project member by design, so the lookup "failing" is
+					// expected there, not a bug; only warn when a genuine
+					// actor can't be resolved to a member.
+					if agentID != nil || actorID != userdom.SystemActorUserID {
+						c.log.Warn("doc activity consumer: could not resolve member for actor", "actor_id", a.ActorID, "agent_id", p.ActorAgentID, "project_id", projectID, "err", mErr)
+					}
 					a.ActorID = nil
 				}
 			}

--- a/services/api/test/integration/agent_apikey_test.go
+++ b/services/api/test/integration/agent_apikey_test.go
@@ -14,6 +14,7 @@ import (
 
 	apikeydom "github.com/Paca-AI/api/internal/domain/apikey"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/platform/authz"
 	jwttoken "github.com/Paca-AI/api/internal/platform/token"
 	apikeysvc "github.com/Paca-AI/api/internal/service/apikey"
@@ -37,6 +38,17 @@ const testAgentBotUserID = "00000000-0000-0000-0000-000000000001"
 
 // buildAgentKeyRouter creates a test router with agent API key authentication configured
 func buildAgentKeyRouter(taskRepo *fakeTaskRepo, apiKeyRepo *fakeAPIKeyRepo, store *projectPermStore, activityRepos ...*fakeTaskActivityRepo) http.Handler {
+	return buildAgentKeyRouterWithBotID(taskRepo, apiKeyRepo, store, uuid.MustParse(testAgentBotUserID), activityRepos...)
+}
+
+// buildAgentKeyRouterWithBotID is like buildAgentKeyRouter but lets the test
+// choose which user ID the shared agent key authenticates as when no
+// X-Agent-ID header is present. buildAgentKeyRouter always uses
+// testAgentBotUserID, a test-local placeholder distinct from the real
+// userdom.SystemActorUserID seeded in production — tests that need to
+// exercise the userdom.SystemActorUserID-specific "unidentified actor"
+// comment-error path must use this variant instead.
+func buildAgentKeyRouterWithBotID(taskRepo *fakeTaskRepo, apiKeyRepo *fakeAPIKeyRepo, store *projectPermStore, botUserID uuid.UUID, activityRepos ...*fakeTaskActivityRepo) http.Handler {
 	tm := jwttoken.New(testSecret, 15*time.Minute, 168*time.Hour)
 	refreshStore := &fakeRefreshStore{}
 	userRepo := newFakeUserRepo()
@@ -55,7 +67,7 @@ func buildAgentKeyRouter(taskRepo *fakeTaskRepo, apiKeyRepo *fakeAPIKeyRepo, sto
 	}
 	activityService := tasksvc.NewActivityService(activityRepo, &fakeActivityMemberRepo{}, nil)
 
-	apiKeyService := apikeysvc.New(apiKeyRepo).WithAgentKey(testAgentAPIKey, uuid.MustParse(testAgentBotUserID))
+	apiKeyService := apikeysvc.New(apiKeyRepo).WithAgentKey(testAgentAPIKey, botUserID)
 
 	if store == nil {
 		store = &projectPermStore{}
@@ -320,6 +332,64 @@ func TestAgentAPIKey_AddComment_Success(t *testing.T) {
 
 	if env.Data.ActivityType != "comment" {
 		t.Errorf("expected activity_type 'comment', got %q", env.Data.ActivityType)
+	}
+}
+
+// TestAgentAPIKey_AddComment_MissingAgentID_ReturnsClearError covers the
+// regression from GitHub issue #269: a request authenticated with the shared
+// agent API key but no X-Agent-ID header resolves to the system/agent-bot
+// identity (userdom.SystemActorUserID), which is never itself a project
+// member. Before the fix this surfaced a confusing 404
+// PROJECT_MEMBER_NOT_FOUND; it should now return a clear, actionable 400.
+func TestAgentAPIKey_AddComment_MissingAgentID_ReturnsClearError(t *testing.T) {
+	taskRepo := newFakeTaskRepoIT()
+	activityRepo := newFakeTaskActivityRepo()
+	apiKeyRepo := newFakeAPIKeyRepo()
+	projectID := uuid.New()
+	taskID := uuid.New()
+	botUserID := userdom.SystemActorUserID
+
+	store := &projectPermStore{
+		userPerms: map[uuid.UUID]map[uuid.UUID][]authz.Permission{
+			botUserID: {
+				projectID: {authz.PermissionTasksWrite},
+			},
+		},
+	}
+
+	taskRepo.tasks[taskID] = &taskdom.Task{
+		ID:        taskID,
+		ProjectID: projectID,
+		Title:     "Test Task",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	r := buildAgentKeyRouterWithBotID(taskRepo, apiKeyRepo, store, botUserID, activityRepo)
+	commentURL := fmt.Sprintf("/api/v1/projects/%s/tasks/%s/activities/comments", projectID, taskID)
+
+	// No agentID (uuid.Nil) means agentKeyAuthReq omits the X-Agent-ID header.
+	w := serve(r, agentKeyAuthReq(t.Context(), http.MethodPost, commentURL, uuid.Nil, map[string]any{
+		"content": []map[string]any{
+			{
+				"type":    "paragraph",
+				"content": []map[string]any{{"type": "text", "text": "orphan comment"}},
+			},
+		},
+	}))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var env struct {
+		ErrorCode string `json:"error_code"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if env.ErrorCode != "ACTIVITY_COMMENT_ACTOR_UNIDENTIFIED" {
+		t.Errorf("expected error_code=ACTIVITY_COMMENT_ACTOR_UNIDENTIFIED, got %q", env.ErrorCode)
 	}
 }
 

--- a/services/api/test/integration/document_test.go
+++ b/services/api/test/integration/document_test.go
@@ -13,6 +13,7 @@ import (
 
 	docdom "github.com/Paca-AI/api/internal/domain/doc"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/platform/authz"
 	jwttoken "github.com/Paca-AI/api/internal/platform/token"
 	authsvc "github.com/Paca-AI/api/internal/service/auth"
@@ -284,11 +285,17 @@ func (r *fakeDocRepoIT) DeleteActivity(_ context.Context, id uuid.UUID) error {
 // is the agent ID (when present) or the user UUID.
 // ---------------------------------------------------------------------------
 
+// The one deliberate exception mirrors production: userdom.SystemActorUserID
+// with no agentID (the shared agent API key used without X-Agent-ID) never
+// resolves, since that identity is never itself a project member.
 type fakeDocMemberLookup struct{}
 
 func (f *fakeDocMemberLookup) FindMemberByActor(_ context.Context, _, actorID uuid.UUID, agentID *uuid.UUID) (*projectdom.ProjectMember, error) {
 	if agentID != nil {
 		return &projectdom.ProjectMember{ID: *agentID}, nil
+	}
+	if actorID == userdom.SystemActorUserID {
+		return nil, projectdom.ErrMemberNotFound
 	}
 	return &projectdom.ProjectMember{ID: actorID}, nil
 }

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -19,6 +19,7 @@ import (
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	sprintdom "github.com/Paca-AI/api/internal/domain/sprint"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/platform/authz"
 	jwttoken "github.com/Paca-AI/api/internal/platform/token"
 	authsvc "github.com/Paca-AI/api/internal/service/auth"
@@ -686,11 +687,18 @@ func (r *fakeTaskActivityRepo) DeleteActivity(_ context.Context, id uuid.UUID) e
 // actor to a synthetic ProjectMember using the agent ID (when present) or the
 // user UUID as the member UUID. This lets comment operations in integration
 // tests pass actor-resolution without a real project_members store.
+//
+// The one deliberate exception mirrors production: userdom.SystemActorUserID
+// with no agentID (the shared agent API key used without X-Agent-ID) never
+// resolves, since that identity is never itself a project member.
 type fakeActivityMemberRepo struct{}
 
 func (r *fakeActivityMemberRepo) FindMemberByActor(_ context.Context, _, actorID uuid.UUID, agentID *uuid.UUID) (*projectdom.ProjectMember, error) {
 	if agentID != nil {
 		return &projectdom.ProjectMember{ID: *agentID}, nil
+	}
+	if actorID == userdom.SystemActorUserID {
+		return nil, projectdom.ErrMemberNotFound
 	}
 	return &projectdom.ProjectMember{ID: actorID}, nil
 }


### PR DESCRIPTION
## Summary

Fixes #269. `POST /projects/{id}/tasks/{id}/activities/comments` (and the equivalent doc-comment endpoints) returned a confusing `PROJECT_MEMBER_NOT_FOUND` for requests authenticated with the shared `AGENT_API_KEY` when no `X-Agent-ID` header was sent.

**Root cause:** the shared agent key with no `X-Agent-ID` authenticates as the seeded system/agent-bot identity (`00000000-0000-0000-0000-000000000002`), which by design is never itself a `project_members` row. Field-update activities (`PATCH`) already tolerated this — the async `ActivityConsumer` just stores a `NULL` actor and logs a `WARN` — but comment creation resolved the actor *synchronously* and had no equivalent tolerance, so it surfaced the raw, misleading `project: member not found` error straight to the caller.

**Fix:**
- `AddComment` / `UpdateComment` / `DeleteComment` (task and doc activity services) now translate that specific case into a new, actionable error — `ACTIVITY_COMMENT_ACTOR_UNIDENTIFIED` / `DOC_COMMENT_ACTOR_UNIDENTIFIED` (HTTP 400, "pass X-Agent-ID when using the agent API key") — while leaving genuine "caller isn't a project member" failures unchanged.
- `ActivityConsumer` / `DocActivityConsumer` no longer log a `WARN` for this same expected case, mirroring the existing precedent in `NotificationConsumer` that already special-cases this sentinel actor.

## Testing

- `go build ./...`, `go vet`, and the full unit test suite pass.
- Reproduced the bug end-to-end against a live Postgres/Redis-backed e2e environment: confirmed a genuine personal API key was unaffected throughout, and the shared-key-without-`X-Agent-ID` case now returns the new `400 ACTIVITY_COMMENT_ACTOR_UNIDENTIFIED` instead of `404 PROJECT_MEMBER_NOT_FOUND`.
