### PR TITLE
Add Keycloak OIDC login

### DIFF
--- a/apps/web/src/components/auth/login/LoginFormPanel.tsx
+++ b/apps/web/src/components/auth/login/LoginFormPanel.tsx
@@ -190,6 +190,24 @@ export function LoginFormPanel() {
 					</form.Subscribe>
 				</form>
 
+				<div className="my-5 flex items-center gap-3">
+					<div className="h-px flex-1 bg-(--line)" />
+					<span className="text-xs uppercase tracking-wide text-(--sea-ink-soft)">
+						{t("login.orDivider")}
+					</span>
+					<div className="h-px flex-1 bg-(--line)" />
+				</div>
+
+				<a
+					href="/api/v1/auth/keycloak"
+					className={cn(
+						buttonVariants({ variant: "outline", size: "lg" }),
+						"h-11 w-full font-semibold tracking-wide",
+					)}
+				>
+					{t("login.signInWithKeycloak")}
+				</a>
+
 				{/* Divider + admin note */}
 				<div className="mt-6 border-t border-(--line) pt-5">
 					<p className="text-xs leading-relaxed text-(--sea-ink-soft)/70">

--- a/apps/web/src/i18n/locales/en/auth.json
+++ b/apps/web/src/i18n/locales/en/auth.json
@@ -33,6 +33,8 @@
 		"rememberMe": "Keep me signed in",
 		"signIn": "Sign in",
 		"signingIn": "Signing in…",
+		"orDivider": "or",
+		"signInWithKeycloak": "Sign in with Keycloak",
 		"adminManagedNote": "Account access and password resets are managed by your administrator.",
 		"footerCopyright": "© {{year}} Paca",
 		"footerGitHub": "GitHub",

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -204,6 +204,12 @@ services:
       PLUGINS_MCP_DIR: /plugins-mcp
       # Pre-shared key matching PACA_API_KEY in the ai-agent service.
       AGENT_API_KEY: ${AGENT_API_KEY:-}
+      # Optional Keycloak/OIDC login. Leave unset to disable.
+      KEYCLOAK_HOST: ${KEYCLOAK_HOST:-}
+      KEYCLOAK_REALM: ${KEYCLOAK_REALM:-}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID:-}
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET:-}
+      KEYCLOAK_ADMIN_ROLE: ${KEYCLOAK_ADMIN_ROLE:-paca-admin}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -287,7 +287,7 @@ func New(cfg *config.Config) (*App, error) {
 		APIKeyAuth:           apiKeyService,
 		Authorizer:           authorizer,
 		Health:               handler.NewHealthHandler(),
-		Auth:                 handler.NewAuthHandler(authService, cookieCfg),
+		Auth:                 handler.NewAuthHandler(authService, cookieCfg).WithKeycloak(userService, cfg.Keycloak, cfg.Server.PublicURL),
 		User:                 handler.NewUserHandler(userService, authService),
 		GlobalRole:           handler.NewGlobalRoleHandler(globalRoleService),
 		ProjectVisibilitySvc: projectService,

--- a/services/api/internal/config/config.go
+++ b/services/api/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Admin      AdminConfig
 	Storage    StorageConfig
 	Security   SecurityConfig
+	Keycloak   KeycloakConfig
 	Plugins    PluginsConfig
 	AIAgentURL string // base URL of the ai-agent service, e.g. http://ai-agent:8080
 	Env        string // development | production
@@ -141,6 +142,24 @@ type PluginLimitsConfig struct {
 	// that may be proxied to a plugin route, and of an event payload
 	// dispatched to a plugin. 0 means "no limit".
 	MaxRequestBodyBytes int64
+}
+
+// KeycloakConfig holds settings for the optional Keycloak/OIDC login.
+// Login via Keycloak is disabled (the initiate/callback routes return
+// "not configured") unless Host, Realm, and ClientID are all non-empty.
+type KeycloakConfig struct {
+	Host         string // base URL, e.g. https://auth.example.com
+	Realm        string
+	ClientID     string
+	ClientSecret string
+	// AdminRole is the Keycloak realm role name that maps to Paca's ADMIN
+	// role; any other (or absent) role maps to Paca's default USER role.
+	AdminRole string
+}
+
+// Enabled reports whether Keycloak login has been configured.
+func (k KeycloakConfig) Enabled() bool {
+	return k.Host != "" && k.Realm != "" && k.ClientID != ""
 }
 
 // SecurityConfig holds secrets used by first-party and plugin features.

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -195,6 +195,13 @@ func Load() (*Config, error) {
 				MaxRequestBodyBytes: pluginMaxRequestBodyBytes,
 			},
 		},
+		Keycloak: KeycloakConfig{
+			Host:         env("KEYCLOAK_HOST", ""),
+			Realm:        env("KEYCLOAK_REALM", ""),
+			ClientID:     env("KEYCLOAK_CLIENT_ID", ""),
+			ClientSecret: env("KEYCLOAK_CLIENT_SECRET", ""),
+			AdminRole:    env("KEYCLOAK_ADMIN_ROLE", "paca-admin"),
+		},
 		AIAgentURL: env("AI_AGENT_URL", "http://ai-agent:8080"),
 	}, nil
 }

--- a/services/api/internal/domain/auth/service.go
+++ b/services/api/internal/domain/auth/service.go
@@ -25,4 +25,8 @@ type Service interface {
 	Refresh(ctx context.Context, refreshToken string) (*TokenPair, error)
 	// Logout revokes the entire token family identified by familyID.
 	Logout(ctx context.Context, familyID string) error
+	// LoginAsUser issues a fresh token pair for a user who has already been
+	// authenticated by an external identity provider (e.g. Keycloak/OIDC), so
+	// no password check is performed here.
+	LoginAsUser(ctx context.Context, userID, username, role string, rememberMe bool) (*TokenPair, error)
 }

--- a/services/api/internal/domain/user/service.go
+++ b/services/api/internal/domain/user/service.go
@@ -32,6 +32,8 @@ type AdminUpdateInput struct {
 // Service defines the user use-case contract.
 type Service interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*User, error)
+	// FindByUsername returns a user by username, or ErrNotFound.
+	FindByUsername(ctx context.Context, username string) (*User, error)
 	// List returns a page of users and the total count.
 	List(ctx context.Context, page, pageSize int) ([]*User, int64, error)
 	ListGlobalPermissions(ctx context.Context, id uuid.UUID) ([]string, error)

--- a/services/api/internal/service/auth/auth_service.go
+++ b/services/api/internal/service/auth/auth_service.go
@@ -67,19 +67,32 @@ func (s *Service) Login(ctx context.Context, username, password string, remember
 		return nil, domainauth.ErrInvalidCredentials
 	}
 
+	return s.issueTokenPair(u.ID.String(), u.Username, u.Role, rememberMe, u.MustChangePassword)
+}
+
+// LoginAsUser issues a fresh token pair for a user already authenticated by an
+// external identity provider (e.g. Keycloak/OIDC). No password check is
+// performed; the caller is responsible for having verified the user's
+// identity before calling this method.
+func (s *Service) LoginAsUser(ctx context.Context, userID, username, role string, rememberMe bool) (*domainauth.TokenPair, error) {
+	return s.issueTokenPair(userID, username, role, rememberMe, false)
+}
+
+// issueTokenPair signs a fresh access+refresh token pair for the given
+// (already-authenticated) identity. Shared by Login and LoginAsUser.
+func (s *Service) issueTokenPair(sub, username, role string, rememberMe, mustChangePassword bool) (*domainauth.TokenPair, error) {
 	familyID := uuid.NewString()
-	sub := u.ID.String()
 
 	refreshTTL := s.refreshTTL
 	if !rememberMe {
 		refreshTTL = s.refreshSessionTTL
 	}
 
-	access, err := s.tokens.IssueAccess(sub, u.Username, u.Role, familyID, u.MustChangePassword)
+	access, err := s.tokens.IssueAccess(sub, username, role, familyID, mustChangePassword)
 	if err != nil {
 		return nil, err
 	}
-	refresh, err := s.tokens.IssueRefreshWithTTL(sub, u.Username, u.Role, familyID, rememberMe, refreshTTL)
+	refresh, err := s.tokens.IssueRefreshWithTTL(sub, username, role, familyID, rememberMe, refreshTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/services/api/internal/service/user/user_service.go
+++ b/services/api/internal/service/user/user_service.go
@@ -56,6 +56,11 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*userdom.User, err
 	return s.repo.FindByID(ctx, id)
 }
 
+// FindByUsername returns a user by username, or ErrNotFound.
+func (s *Service) FindByUsername(ctx context.Context, username string) (*userdom.User, error) {
+	return s.repo.FindByUsername(ctx, username)
+}
+
 // List returns a page of users and the total count.
 func (s *Service) List(ctx context.Context, page, pageSize int) ([]*userdom.User, int64, error) {
 	if page < 1 {

--- a/services/api/internal/transport/http/handler/auth_handler.go
+++ b/services/api/internal/transport/http/handler/auth_handler.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/Paca-AI/api/internal/apierr"
+	"github.com/Paca-AI/api/internal/config"
 	domainauth "github.com/Paca-AI/api/internal/domain/auth"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
 	"github.com/Paca-AI/api/internal/transport/http/dto"
 	"github.com/Paca-AI/api/internal/transport/http/middleware"
 	"github.com/Paca-AI/api/internal/transport/http/presenter"
@@ -31,11 +33,32 @@ type CookieConfig struct {
 type AuthHandler struct {
 	svc    domainauth.Service
 	cookie CookieConfig
+
+	// users and keycloak are only set when WithKeycloak has been called;
+	// KeycloakInitiate/KeycloakCallback respond with apierr.CodeNotFound
+	// when keycloak.Enabled() is false.
+	users     userdom.Service
+	keycloak  config.KeycloakConfig
+	publicURL string
+	http      *http.Client
 }
 
 // NewAuthHandler returns an AuthHandler wired to the provided auth service.
 func NewAuthHandler(svc domainauth.Service, cookie CookieConfig) *AuthHandler {
 	return &AuthHandler{svc: svc, cookie: cookie}
+}
+
+// WithKeycloak enables the Keycloak/OIDC login routes. users is used to
+// find-or-create the local account for a Keycloak-authenticated identity.
+// publicURL is the externally reachable base URL of this API (used to build
+// the OAuth2 redirect_uri) — it must match a valid redirect URI configured on
+// the Keycloak client.
+func (h *AuthHandler) WithKeycloak(users userdom.Service, kc config.KeycloakConfig, publicURL string) *AuthHandler {
+	h.users = users
+	h.keycloak = kc
+	h.publicURL = publicURL
+	h.http = &http.Client{Timeout: 10 * time.Second}
+	return h
 }
 
 // Login handles POST /auth/login.

--- a/services/api/internal/transport/http/handler/auth_handler_test.go
+++ b/services/api/internal/transport/http/handler/auth_handler_test.go
@@ -53,6 +53,9 @@ func (m *mockAuthSvc) Logout(ctx context.Context, familyID string) error {
 	}
 	return errors.New("mock: logout not configured")
 }
+func (m *mockAuthSvc) LoginAsUser(ctx context.Context, userID, username, role string, rememberMe bool) (*domainauth.TokenPair, error) {
+	return nil, errors.New("mock: loginAsUser not configured")
+}
 
 // verify mock satisfies the interface at compile time
 var _ domainauth.Service = (*mockAuthSvc)(nil)

--- a/services/api/internal/transport/http/handler/keycloak_handler.go
+++ b/services/api/internal/transport/http/handler/keycloak_handler.go
@@ -1,0 +1,262 @@
+package handler
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Paca-AI/api/internal/apierr"
+	userdom "github.com/Paca-AI/api/internal/domain/user"
+	"github.com/Paca-AI/api/internal/transport/http/presenter"
+)
+
+// keycloakStateCookie carries the CSRF state value between InitiateKeycloak
+// and KeycloakCallback. It is short-lived and scoped to the callback path.
+const (
+	keycloakStateCookie = "keycloak_state"
+	keycloakStatePath    = "/api/v1/auth/keycloak"
+	keycloakStateTTL = 5 * time.Minute
+)
+
+// keycloakTokenResponse is the subset of the OIDC token endpoint response we
+// need. Fields not listed here (id_token, expires_in, ...) are ignored.
+type keycloakTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Error       string `json:"error"`
+	ErrorDesc   string `json:"error_description"`
+}
+
+// keycloakAccessClaims is the subset of access-token JWT claims we read.
+// The token is decoded without signature verification: it was received
+// directly from Keycloak over TLS via the confidential-client token
+// exchange (never from the browser/end user), so the transport itself is
+// the trust boundary.
+type keycloakAccessClaims struct {
+	Subject           string `json:"sub"`
+	PreferredUsername string `json:"preferred_username"`
+	Name              string `json:"name"`
+	RealmAccess       struct {
+		Roles []string `json:"roles"`
+	} `json:"realm_access"`
+}
+
+func (h *AuthHandler) keycloakEnabled() bool {
+	return h.keycloak.Enabled() && h.users != nil
+}
+
+func (h *AuthHandler) keycloakAuthURL() string {
+	return strings.TrimRight(h.keycloak.Host, "/") + "/realms/" + h.keycloak.Realm + "/protocol/openid-connect/auth"
+}
+
+func (h *AuthHandler) keycloakTokenURL() string {
+	return strings.TrimRight(h.keycloak.Host, "/") + "/realms/" + h.keycloak.Realm + "/protocol/openid-connect/token"
+}
+
+func (h *AuthHandler) keycloakRedirectURI() string {
+	return strings.TrimRight(h.publicURL, "/") + "/api/v1/auth/keycloak/callback"
+}
+
+// KeycloakInitiate handles GET /auth/keycloak. It redirects the browser to
+// Keycloak's authorization endpoint, starting the authorization-code flow.
+func (h *AuthHandler) KeycloakInitiate(w http.ResponseWriter, r *http.Request) {
+	if !h.keycloakEnabled() {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "keycloak login is not configured"))
+		return
+	}
+
+	state, err := randomState()
+	if err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to start keycloak login"))
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     keycloakStateCookie,
+		Value:    state,
+		Path:     keycloakStatePath,
+		HttpOnly: true,
+		Secure:   h.cookie.Secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(keycloakStateTTL.Seconds()),
+	})
+
+	q := url.Values{}
+	q.Set("client_id", h.keycloak.ClientID)
+	q.Set("redirect_uri", h.keycloakRedirectURI())
+	q.Set("response_type", "code")
+	q.Set("scope", "openid profile roles")
+	q.Set("state", state)
+
+	http.Redirect(w, r, h.keycloakAuthURL()+"?"+q.Encode(), http.StatusFound)
+}
+
+// KeycloakCallback handles GET /auth/keycloak/callback. It exchanges the
+// authorization code for tokens, finds-or-creates the local user account,
+// syncs their role from Keycloak realm roles, and issues Paca session
+// cookies exactly as Login does.
+func (h *AuthHandler) KeycloakCallback(w http.ResponseWriter, r *http.Request) {
+	if !h.keycloakEnabled() {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "keycloak login is not configured"))
+		return
+	}
+
+	stateCookie, err := r.Cookie(keycloakStateCookie)
+	if err != nil || stateCookie.Value == "" || stateCookie.Value != r.URL.Query().Get("state") {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid or expired keycloak login state"))
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     keycloakStateCookie,
+		Value:    "",
+		Path:     keycloakStatePath,
+		HttpOnly: true,
+		Secure:   h.cookie.Secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "missing authorization code"))
+		return
+	}
+
+	claims, err := h.exchangeKeycloakCode(r.Context(), code)
+	if err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeUnauthenticated, "keycloak login failed"))
+		return
+	}
+	if claims.PreferredUsername == "" {
+		presenter.Error(w, r, apierr.New(apierr.CodeUnauthenticated, "keycloak identity missing preferred_username"))
+		return
+	}
+
+	role := userdom.RoleUser
+	for _, rn := range claims.RealmAccess.Roles {
+		if rn == h.keycloak.AdminRole {
+			role = userdom.RoleAdmin
+			break
+		}
+	}
+
+	u, err := h.findOrSyncKeycloakUser(r.Context(), claims, role)
+	if err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to provision keycloak user"))
+		return
+	}
+
+	pair, err := h.svc.LoginAsUser(r.Context(), u.ID.String(), u.Username, u.Role, true)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	h.setTokenCookies(w, pair, pair.RefreshTTL)
+	http.Redirect(w, r, strings.TrimRight(h.publicURL, "/")+"/", http.StatusFound)
+}
+
+// exchangeKeycloakCode exchanges an authorization code for an access token
+// and decodes its claims (without signature verification — see
+// keycloakAccessClaims doc comment for why that is safe here).
+func (h *AuthHandler) exchangeKeycloakCode(ctx context.Context, code string) (*keycloakAccessClaims, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", h.keycloak.ClientID)
+	form.Set("client_secret", h.keycloak.ClientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", h.keycloakRedirectURI())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.keycloakTokenURL(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var tok keycloakTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		return nil, fmt.Errorf("keycloak: decode token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK || tok.AccessToken == "" {
+		return nil, fmt.Errorf("keycloak: token exchange failed: status=%d error=%s desc=%s", resp.StatusCode, tok.Error, tok.ErrorDesc)
+	}
+
+	return decodeJWTClaims(tok.AccessToken)
+}
+
+// decodeJWTClaims decodes (without verifying) the payload segment of a
+// compact JWT into keycloakAccessClaims.
+func decodeJWTClaims(token string) (*keycloakAccessClaims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("keycloak: malformed access token")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: decode token payload: %w", err)
+	}
+	var claims keycloakAccessClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("keycloak: unmarshal token claims: %w", err)
+	}
+	return &claims, nil
+}
+
+// findOrSyncKeycloakUser finds the local user matching the Keycloak
+// preferred_username, creating it on first login. On every login the role is
+// re-synced to match the caller's current Keycloak realm roles.
+func (h *AuthHandler) findOrSyncKeycloakUser(ctx context.Context, claims *keycloakAccessClaims, role string) (*userdom.User, error) {
+	u, err := h.users.FindByUsername(ctx, claims.PreferredUsername)
+	if err != nil {
+		if !errors.Is(err, userdom.ErrNotFound) {
+			return nil, err
+		}
+
+		fullName := claims.Name
+		if fullName == "" {
+			fullName = claims.PreferredUsername
+		}
+		pw, perr := randomState()
+		if perr != nil {
+			return nil, perr
+		}
+		return h.users.Create(ctx, userdom.CreateInput{
+			Username: claims.PreferredUsername,
+			// The password is never used for login (Keycloak owns the
+			// credential) — a random value just satisfies the NOT NULL
+			// password_hash column.
+			Password: pw,
+			FullName: fullName,
+			Role:     role,
+		})
+	}
+
+	if u.Role != role {
+		return h.users.AdminUpdate(ctx, u.ID, userdom.AdminUpdateInput{Role: role})
+	}
+	return u, nil
+}
+
+// randomState returns a URL-safe random string suitable for OAuth2 state
+// parameters and one-off placeholder passwords.
+func randomState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -62,6 +62,8 @@ func New(deps Deps) http.Handler {
 				r.Post("/login", deps.Auth.Login)
 				r.Post("/refresh", deps.Auth.Refresh)
 				r.With(httpmw.Authn(deps.TokenManager)).Post("/logout", deps.Auth.Logout)
+				r.Get("/keycloak", deps.Auth.KeycloakInitiate)
+				r.Get("/keycloak/callback", deps.Auth.KeycloakCallback)
 			})
 
 			// Users


### PR DESCRIPTION
## Summary
- Adds Keycloak/OIDC login as an optional, additive auth path alongside existing username/password login.
- New endpoints: `GET /api/v1/auth/keycloak` (initiate) and `GET /api/v1/auth/keycloak/callback` (exchange code, find-or-create user, sync role, issue session cookies).
- Config: `KEYCLOAK_HOST`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_ADMIN_ROLE` (default `paca-admin`). Feature is disabled unless host/realm/client_id are set.
- Frontend: "Sign in with Keycloak" button added to the login page, below the existing local-login form (kept as a fallback break-glass path).

## Test plan
- [ ] CI: lint/build/unit/e2e pass on this PR
- [ ] Manual: with a real Keycloak realm/client configured, log in via the new button, confirm a local user is auto-created with the correct role, and role updates on Keycloak re-sync on next login
- [ ] Manual: confirm local username/password login still works unaffected