### PR TITLE
feat: implement conversations page

### DIFF
--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
 	GanttChart,
 	Home,
 	KanbanSquare,
+	MessageSquare,
 	Monitor,
 	Moon,
 	MoreHorizontal,
@@ -865,6 +866,11 @@ function NavItem({
 // ── Project Nav ───────────────────────────────────────────────────────────────
 const PROJECT_NAV_ITEMS = [
 	{ segment: "agents", icon: Bot, labelKey: "nav.agents" },
+	{
+		segment: "conversations",
+		icon: MessageSquare,
+		labelKey: "nav.conversations",
+	},
 	{ segment: "automation", icon: Workflow, labelKey: "nav.automation" },
 	{ segment: "team", icon: Users, labelKey: "nav.team" },
 	{ segment: "settings", icon: Settings, labelKey: "nav.settings" },
@@ -894,6 +900,7 @@ function ProjectNav() {
 
 const ANON_HIDDEN_SEGMENTS = new Set([
 	"agents",
+	"conversations",
 	"automation",
 	"team",
 	"settings",

--- a/apps/web/src/i18n/locales/en/appShell.json
+++ b/apps/web/src/i18n/locales/en/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "All Projects",
 		"project": "Project",
 		"agents": "Agents",
+		"conversations": "Conversations",
 		"automation": "Automation",
 		"team": "Team",
 		"settings": "Settings"

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -121,8 +121,7 @@
 				"overview": "Overview",
 				"mcpServers": "MCP Servers",
 				"skills": "Skills",
-				"envVars": "Environment",
-				"conversations": "Conversations"
+				"envVars": "Environment"
 			},
 			"overview": {
 				"nameLabel": "Name",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "Cancel",
 					"addSkill": "Add skill"
-				}
-			},
-			"conversations": {
-				"triggerChat": "Chat",
-				"triggerWriteDescription": "Write description",
-				"triggerTask": "Task",
-				"iterations_one": "{{count}} iteration",
-				"iterations_other": "{{count}} iterations",
-				"prOpened": "PR opened",
-				"empty": {
-					"title": "No conversations yet",
-					"description": "Conversations start when a task is assigned to this agent or someone messages it."
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "Product Backlog",
 			"description": "All work items not assigned to a sprint."
+		}
+	},
+	"conversationsPage": {
+		"title": "Conversations",
+		"triggerChat": "Chat",
+		"triggerWriteDescription": "Write description",
+		"triggerTask": "Task",
+		"iterations_one": "{{count}} iteration",
+		"iterations_other": "{{count}} iterations",
+		"prOpened": "PR opened",
+		"list": {
+			"empty": {
+				"title": "No conversations yet",
+				"description": "Conversations start when a task is assigned to an agent or someone messages one."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "No conversation selected",
+				"description": "Select a conversation from the list to view it."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/es/appShell.json
+++ b/apps/web/src/i18n/locales/es/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "Todos los proyectos",
 		"project": "Proyecto",
 		"agents": "Agentes",
+		"conversations": "Conversaciones",
 		"automation": "Automatización",
 		"team": "Equipo",
 		"settings": "Configuración"

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -121,8 +121,7 @@
 				"overview": "Resumen",
 				"mcpServers": "Servidores MCP",
 				"skills": "Skills",
-				"envVars": "Entorno",
-				"conversations": "Conversaciones"
+				"envVars": "Entorno"
 			},
 			"overview": {
 				"nameLabel": "Nombre",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "Cancelar",
 					"addSkill": "Añadir skill"
-				}
-			},
-			"conversations": {
-				"triggerChat": "Chat",
-				"triggerWriteDescription": "Redactar descripción",
-				"triggerTask": "Tarea",
-				"iterations_one": "{{count}} iteración",
-				"iterations_other": "{{count}} iteraciones",
-				"prOpened": "PR abierto",
-				"empty": {
-					"title": "Aún no hay conversaciones",
-					"description": "Las conversaciones comienzan cuando se asigna una tarea a este agente o alguien le envía un mensaje."
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "Backlog del producto",
 			"description": "Todos los elementos de trabajo no asignados a un sprint."
+		}
+	},
+	"conversationsPage": {
+		"title": "Conversaciones",
+		"triggerChat": "Chat",
+		"triggerWriteDescription": "Redactar descripción",
+		"triggerTask": "Tarea",
+		"iterations_one": "{{count}} iteración",
+		"iterations_other": "{{count}} iteraciones",
+		"prOpened": "PR abierto",
+		"list": {
+			"empty": {
+				"title": "Aún no hay conversaciones",
+				"description": "Las conversaciones comienzan cuando se asigna una tarea a un agente o alguien le envía un mensaje."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "Ninguna conversación seleccionada",
+				"description": "Selecciona una conversación de la lista para verla."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/fr/appShell.json
+++ b/apps/web/src/i18n/locales/fr/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "Tous les projets",
 		"project": "Projet",
 		"agents": "Agents",
+		"conversations": "Conversations",
 		"automation": "Automatisation",
 		"team": "Équipe",
 		"settings": "Paramètres"

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -121,8 +121,7 @@
 				"overview": "Aperçu",
 				"mcpServers": "Serveurs MCP",
 				"skills": "Compétences",
-				"envVars": "Environnement",
-				"conversations": "Conversations"
+				"envVars": "Environnement"
 			},
 			"overview": {
 				"nameLabel": "Nom",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "Annuler",
 					"addSkill": "Ajouter la compétence"
-				}
-			},
-			"conversations": {
-				"triggerChat": "Discussion",
-				"triggerWriteDescription": "Rédaction de description",
-				"triggerTask": "Tâche",
-				"iterations_one": "{{count}} itération",
-				"iterations_other": "{{count}} itérations",
-				"prOpened": "PR ouverte",
-				"empty": {
-					"title": "Aucune conversation pour le moment",
-					"description": "Les conversations démarrent lorsqu'une tâche est attribuée à cet agent ou que quelqu'un lui envoie un message."
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "Backlog produit",
 			"description": "Tous les éléments de travail non assignés à un sprint."
+		}
+	},
+	"conversationsPage": {
+		"title": "Conversations",
+		"triggerChat": "Discussion",
+		"triggerWriteDescription": "Rédaction de description",
+		"triggerTask": "Tâche",
+		"iterations_one": "{{count}} itération",
+		"iterations_other": "{{count}} itérations",
+		"prOpened": "PR ouverte",
+		"list": {
+			"empty": {
+				"title": "Aucune conversation pour le moment",
+				"description": "Les conversations démarrent lorsqu'une tâche est attribuée à un agent ou que quelqu'un lui envoie un message."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "Aucune conversation sélectionnée",
+				"description": "Sélectionnez une conversation dans la liste pour l'afficher."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/ja/appShell.json
+++ b/apps/web/src/i18n/locales/ja/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "すべてのプロジェクト",
 		"project": "プロジェクト",
 		"agents": "エージェント",
+		"conversations": "会話",
 		"automation": "自動化",
 		"team": "チーム",
 		"settings": "設定"

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -121,8 +121,7 @@
 				"overview": "概要",
 				"mcpServers": "MCPサーバー",
 				"skills": "スキル",
-				"envVars": "環境変数",
-				"conversations": "会話"
+				"envVars": "環境変数"
 			},
 			"overview": {
 				"nameLabel": "名前",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "キャンセル",
 					"addSkill": "スキルを追加"
-				}
-			},
-			"conversations": {
-				"triggerChat": "チャット",
-				"triggerWriteDescription": "説明の作成",
-				"triggerTask": "タスク",
-				"iterations_one": "{{count}}回の反復",
-				"iterations_other": "{{count}}回の反復",
-				"prOpened": "PRを作成しました",
-				"empty": {
-					"title": "会話はまだありません",
-					"description": "タスクがこのエージェントに割り当てられるか、誰かがメッセージを送ると会話が始まります。"
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "プロダクトバックログ",
 			"description": "スプリントに割り当てられていないすべての作業項目です。"
+		}
+	},
+	"conversationsPage": {
+		"title": "会話",
+		"triggerChat": "チャット",
+		"triggerWriteDescription": "説明の作成",
+		"triggerTask": "タスク",
+		"iterations_one": "{{count}}回の反復",
+		"iterations_other": "{{count}}回の反復",
+		"prOpened": "PRを作成しました",
+		"list": {
+			"empty": {
+				"title": "会話はまだありません",
+				"description": "タスクがエージェントに割り当てられるか、誰かがメッセージを送ると会話が始まります。"
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "会話が選択されていません",
+				"description": "リストから会話を選択すると表示されます。"
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/ko/appShell.json
+++ b/apps/web/src/i18n/locales/ko/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "모든 프로젝트",
 		"project": "프로젝트",
 		"agents": "에이전트",
+		"conversations": "대화",
 		"automation": "자동화",
 		"team": "팀",
 		"settings": "설정"

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -121,8 +121,7 @@
 				"overview": "개요",
 				"mcpServers": "MCP 서버",
 				"skills": "스킬",
-				"envVars": "환경 변수",
-				"conversations": "대화"
+				"envVars": "환경 변수"
 			},
 			"overview": {
 				"nameLabel": "이름",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "취소",
 					"addSkill": "스킬 추가"
-				}
-			},
-			"conversations": {
-				"triggerChat": "채팅",
-				"triggerWriteDescription": "설명 작성",
-				"triggerTask": "작업",
-				"iterations_one": "{{count}}회 반복",
-				"iterations_other": "{{count}}회 반복",
-				"prOpened": "PR 열림",
-				"empty": {
-					"title": "아직 대화가 없습니다",
-					"description": "이 에이전트에게 작업이 배정되거나 누군가 메시지를 보내면 대화가 시작됩니다."
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "제품 백로그",
 			"description": "스프린트에 배정되지 않은 모든 작업 항목입니다."
+		}
+	},
+	"conversationsPage": {
+		"title": "대화",
+		"triggerChat": "채팅",
+		"triggerWriteDescription": "설명 작성",
+		"triggerTask": "작업",
+		"iterations_one": "{{count}}회 반복",
+		"iterations_other": "{{count}}회 반복",
+		"prOpened": "PR 열림",
+		"list": {
+			"empty": {
+				"title": "아직 대화가 없습니다",
+				"description": "에이전트에게 작업이 배정되거나 누군가 메시지를 보내면 대화가 시작됩니다."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "선택된 대화가 없습니다",
+				"description": "목록에서 대화를 선택하면 여기에 표시됩니다."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/pt-BR/appShell.json
+++ b/apps/web/src/i18n/locales/pt-BR/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "Todos os Projetos",
 		"project": "Projeto",
 		"agents": "Agentes",
+		"conversations": "Conversas",
 		"automation": "Automação",
 		"team": "Equipe",
 		"settings": "Configurações"

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -121,8 +121,7 @@
 				"overview": "Visão geral",
 				"mcpServers": "Servidores MCP",
 				"skills": "Skills",
-				"envVars": "Ambiente",
-				"conversations": "Conversas"
+				"envVars": "Ambiente"
 			},
 			"overview": {
 				"nameLabel": "Nome",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "Cancelar",
 					"addSkill": "Adicionar skill"
-				}
-			},
-			"conversations": {
-				"triggerChat": "Chat",
-				"triggerWriteDescription": "Escrever descrição",
-				"triggerTask": "Tarefa",
-				"iterations_one": "{{count}} iteração",
-				"iterations_other": "{{count}} iterações",
-				"prOpened": "PR aberto",
-				"empty": {
-					"title": "Nenhuma conversa ainda",
-					"description": "As conversas começam quando uma tarefa é atribuída a este agente ou quando alguém envia uma mensagem a ele."
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "Backlog do produto",
 			"description": "Todos os itens de trabalho não atribuídos a um sprint."
+		}
+	},
+	"conversationsPage": {
+		"title": "Conversas",
+		"triggerChat": "Chat",
+		"triggerWriteDescription": "Escrever descrição",
+		"triggerTask": "Tarefa",
+		"iterations_one": "{{count}} iteração",
+		"iterations_other": "{{count}} iterações",
+		"prOpened": "PR aberto",
+		"list": {
+			"empty": {
+				"title": "Nenhuma conversa ainda",
+				"description": "As conversas começam quando uma tarefa é atribuída a um agente ou quando alguém envia uma mensagem a ele."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "Nenhuma conversa selecionada",
+				"description": "Selecione uma conversa na lista para visualizá-la."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/ru/appShell.json
+++ b/apps/web/src/i18n/locales/ru/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "Все проекты",
 		"project": "Проект",
 		"agents": "Агенты",
+		"conversations": "Диалоги",
 		"automation": "Автоматизация",
 		"team": "Команда",
 		"settings": "Настройки"

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -121,8 +121,7 @@
 				"overview": "Обзор",
 				"mcpServers": "MCP-серверы",
 				"skills": "Навыки",
-				"envVars": "Окружение",
-				"conversations": "Диалоги"
+				"envVars": "Окружение"
 			},
 			"overview": {
 				"nameLabel": "Имя",
@@ -217,20 +216,6 @@
 					"urlLabel": "URL",
 					"cancel": "Отмена",
 					"addSkill": "Добавить навык"
-				}
-			},
-			"conversations": {
-				"triggerChat": "Чат",
-				"triggerWriteDescription": "Написать описание",
-				"triggerTask": "Задача",
-				"iterations_one": "{{count}} итерация",
-				"iterations_few": "{{count}} итерации",
-				"iterations_many": "{{count}} итераций",
-				"iterations_other": "{{count}} итерации",
-				"prOpened": "PR открыт",
-				"empty": {
-					"title": "Диалогов пока нет",
-					"description": "Диалоги начинаются, когда задача назначена этому агенту или кто-то пишет ему сообщение."
 				}
 			}
 		},
@@ -1001,6 +986,29 @@
 		"backlog": {
 			"title": "Бэклог продукта",
 			"description": "Все элементы работы, не назначенные в спринт."
+		}
+	},
+	"conversationsPage": {
+		"title": "Диалоги",
+		"triggerChat": "Чат",
+		"triggerWriteDescription": "Написать описание",
+		"triggerTask": "Задача",
+		"iterations_one": "{{count}} итерация",
+		"iterations_few": "{{count}} итерации",
+		"iterations_many": "{{count}} итераций",
+		"iterations_other": "{{count}} итерации",
+		"prOpened": "PR открыт",
+		"list": {
+			"empty": {
+				"title": "Диалогов пока нет",
+				"description": "Диалоги начинаются, когда задача назначена агенту или кто-то пишет ему сообщение."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "Диалог не выбран",
+				"description": "Выберите диалог из списка, чтобы просмотреть его."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/vi/appShell.json
+++ b/apps/web/src/i18n/locales/vi/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "Tất cả dự án",
 		"project": "Dự án",
 		"agents": "Agent",
+		"conversations": "Hội thoại",
 		"automation": "Tự động hóa",
 		"team": "Đội nhóm",
 		"settings": "Cài đặt"

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -121,8 +121,7 @@
 				"overview": "Tổng quan",
 				"mcpServers": "Máy chủ MCP",
 				"skills": "Skill",
-				"envVars": "Môi trường",
-				"conversations": "Hội thoại"
+				"envVars": "Môi trường"
 			},
 			"overview": {
 				"nameLabel": "Tên",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "Hủy",
 					"addSkill": "Thêm skill"
-				}
-			},
-			"conversations": {
-				"triggerChat": "Trò chuyện",
-				"triggerWriteDescription": "Viết mô tả",
-				"triggerTask": "Nhiệm vụ",
-				"iterations_one": "{{count}} lượt lặp",
-				"iterations_other": "{{count}} lượt lặp",
-				"prOpened": "PR đã mở",
-				"empty": {
-					"title": "Chưa có hội thoại nào",
-					"description": "Hội thoại bắt đầu khi một nhiệm vụ được giao cho agent này hoặc khi có ai đó nhắn tin cho nó."
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "Product Backlog",
 			"description": "Tất cả công việc chưa được gán vào sprint nào."
+		}
+	},
+	"conversationsPage": {
+		"title": "Hội thoại",
+		"triggerChat": "Trò chuyện",
+		"triggerWriteDescription": "Viết mô tả",
+		"triggerTask": "Nhiệm vụ",
+		"iterations_one": "{{count}} lượt lặp",
+		"iterations_other": "{{count}} lượt lặp",
+		"prOpened": "PR đã mở",
+		"list": {
+			"empty": {
+				"title": "Chưa có hội thoại nào",
+				"description": "Hội thoại bắt đầu khi một nhiệm vụ được giao cho agent hoặc khi có ai đó nhắn tin cho agent đó."
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "Chưa chọn hội thoại nào",
+				"description": "Chọn một hội thoại từ danh sách để xem."
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/i18n/locales/zh-CN/appShell.json
+++ b/apps/web/src/i18n/locales/zh-CN/appShell.json
@@ -24,6 +24,7 @@
 		"allProjects": "所有项目",
 		"project": "项目",
 		"agents": "智能体",
+		"conversations": "对话",
 		"automation": "自动化",
 		"team": "团队",
 		"settings": "设置"

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -121,8 +121,7 @@
 				"overview": "概览",
 				"mcpServers": "MCP 服务器",
 				"skills": "技能",
-				"envVars": "环境变量",
-				"conversations": "对话"
+				"envVars": "环境变量"
 			},
 			"overview": {
 				"nameLabel": "名称",
@@ -211,18 +210,6 @@
 					"urlLabel": "URL",
 					"cancel": "取消",
 					"addSkill": "添加技能"
-				}
-			},
-			"conversations": {
-				"triggerChat": "聊天",
-				"triggerWriteDescription": "编写描述",
-				"triggerTask": "任务",
-				"iterations_one": "{{count}} 次迭代",
-				"iterations_other": "{{count}} 次迭代",
-				"prOpened": "PR 已创建",
-				"empty": {
-					"title": "暂无对话",
-					"description": "当任务分配给该智能体或有人向其发送消息时，对话将开始。"
 				}
 			}
 		},
@@ -983,6 +970,27 @@
 		"backlog": {
 			"title": "产品待办列表",
 			"description": "所有未分配到冲刺的工作项。"
+		}
+	},
+	"conversationsPage": {
+		"title": "对话",
+		"triggerChat": "聊天",
+		"triggerWriteDescription": "编写描述",
+		"triggerTask": "任务",
+		"iterations_one": "{{count}} 次迭代",
+		"iterations_other": "{{count}} 次迭代",
+		"prOpened": "PR 已创建",
+		"list": {
+			"empty": {
+				"title": "暂无对话",
+				"description": "当任务分配给某个智能体或有人向其发送消息时，对话将开始。"
+			}
+		},
+		"detail": {
+			"empty": {
+				"title": "未选择对话",
+				"description": "从列表中选择一个对话即可查看。"
+			}
 		}
 	},
 	"layout": {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -20,9 +20,11 @@ import { Route as AuthenticatedProjectsProjectIdIndexRouteImport } from './route
 import { Route as AuthenticatedAdminUsersIndexRouteImport } from './routes/_authenticated/admin/users/index'
 import { Route as AuthenticatedAdminPluginsIndexRouteImport } from './routes/_authenticated/admin/plugins/index'
 import { Route as AuthenticatedAdminGlobalRolesIndexRouteImport } from './routes/_authenticated/admin/global-roles/index'
+import { Route as AuthenticatedProjectsProjectIdConversationsRouteImport } from './routes/_authenticated/projects/$projectId/conversations'
 import { Route as AuthenticatedProjectsProjectIdTeamIndexRouteImport } from './routes/_authenticated/projects/$projectId/team/index'
 import { Route as AuthenticatedProjectsProjectIdSettingsIndexRouteImport } from './routes/_authenticated/projects/$projectId/settings/index'
 import { Route as AuthenticatedProjectsProjectIdDocsIndexRouteImport } from './routes/_authenticated/projects/$projectId/docs/index'
+import { Route as AuthenticatedProjectsProjectIdConversationsIndexRouteImport } from './routes/_authenticated/projects/$projectId/conversations/index'
 import { Route as AuthenticatedProjectsProjectIdAutomationIndexRouteImport } from './routes/_authenticated/projects/$projectId/automation/index'
 import { Route as AuthenticatedProjectsProjectIdAgentsIndexRouteImport } from './routes/_authenticated/projects/$projectId/agents/index'
 import { Route as AuthenticatedProjectsProjectIdTasksTaskIdRouteImport } from './routes/_authenticated/projects/$projectId/tasks/$taskId'
@@ -97,6 +99,12 @@ const AuthenticatedAdminGlobalRolesIndexRoute =
     path: '/admin/global-roles/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedProjectsProjectIdConversationsRoute =
+  AuthenticatedProjectsProjectIdConversationsRouteImport.update({
+    id: '/conversations',
+    path: '/conversations',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
 const AuthenticatedProjectsProjectIdTeamIndexRoute =
   AuthenticatedProjectsProjectIdTeamIndexRouteImport.update({
     id: '/team/',
@@ -114,6 +122,12 @@ const AuthenticatedProjectsProjectIdDocsIndexRoute =
     id: '/docs/',
     path: '/docs/',
     getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
+const AuthenticatedProjectsProjectIdConversationsIndexRoute =
+  AuthenticatedProjectsProjectIdConversationsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedProjectsProjectIdConversationsRoute,
   } as any)
 const AuthenticatedProjectsProjectIdAutomationIndexRoute =
   AuthenticatedProjectsProjectIdAutomationIndexRouteImport.update({
@@ -153,9 +167,9 @@ const AuthenticatedProjectsProjectIdDocsDocIdRoute =
   } as any)
 const AuthenticatedProjectsProjectIdConversationsConversationIdRoute =
   AuthenticatedProjectsProjectIdConversationsConversationIdRouteImport.update({
-    id: '/conversations/$conversationId',
-    path: '/conversations/$conversationId',
-    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+    id: '/$conversationId',
+    path: '/$conversationId',
+    getParentRoute: () => AuthenticatedProjectsProjectIdConversationsRoute,
   } as any)
 const AuthenticatedProjectsProjectIdAutomationWorkflowIdRoute =
   AuthenticatedProjectsProjectIdAutomationWorkflowIdRouteImport.update({
@@ -195,6 +209,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId': typeof AuthenticatedProjectsProjectIdRouteWithChildren
   '/home/': typeof AuthenticatedHomeIndexRoute
   '/profile/': typeof AuthenticatedProfileIndexRoute
+  '/projects/$projectId/conversations': typeof AuthenticatedProjectsProjectIdConversationsRouteWithChildren
   '/admin/global-roles/': typeof AuthenticatedAdminGlobalRolesIndexRoute
   '/admin/plugins/': typeof AuthenticatedAdminPluginsIndexRoute
   '/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
@@ -208,6 +223,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/tasks/$taskId': typeof AuthenticatedProjectsProjectIdTasksTaskIdRoute
   '/projects/$projectId/agents/': typeof AuthenticatedProjectsProjectIdAgentsIndexRoute
   '/projects/$projectId/automation/': typeof AuthenticatedProjectsProjectIdAutomationIndexRoute
+  '/projects/$projectId/conversations/': typeof AuthenticatedProjectsProjectIdConversationsIndexRoute
   '/projects/$projectId/docs/': typeof AuthenticatedProjectsProjectIdDocsIndexRoute
   '/projects/$projectId/settings/': typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/team/': typeof AuthenticatedProjectsProjectIdTeamIndexRoute
@@ -234,6 +250,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId/tasks/$taskId': typeof AuthenticatedProjectsProjectIdTasksTaskIdRoute
   '/projects/$projectId/agents': typeof AuthenticatedProjectsProjectIdAgentsIndexRoute
   '/projects/$projectId/automation': typeof AuthenticatedProjectsProjectIdAutomationIndexRoute
+  '/projects/$projectId/conversations': typeof AuthenticatedProjectsProjectIdConversationsIndexRoute
   '/projects/$projectId/docs': typeof AuthenticatedProjectsProjectIdDocsIndexRoute
   '/projects/$projectId/settings': typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/team': typeof AuthenticatedProjectsProjectIdTeamIndexRoute
@@ -250,6 +267,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectId': typeof AuthenticatedProjectsProjectIdRouteWithChildren
   '/_authenticated/home/': typeof AuthenticatedHomeIndexRoute
   '/_authenticated/profile/': typeof AuthenticatedProfileIndexRoute
+  '/_authenticated/projects/$projectId/conversations': typeof AuthenticatedProjectsProjectIdConversationsRouteWithChildren
   '/_authenticated/admin/global-roles/': typeof AuthenticatedAdminGlobalRolesIndexRoute
   '/_authenticated/admin/plugins/': typeof AuthenticatedAdminPluginsIndexRoute
   '/_authenticated/admin/users/': typeof AuthenticatedAdminUsersIndexRoute
@@ -263,6 +281,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectId/tasks/$taskId': typeof AuthenticatedProjectsProjectIdTasksTaskIdRoute
   '/_authenticated/projects/$projectId/agents/': typeof AuthenticatedProjectsProjectIdAgentsIndexRoute
   '/_authenticated/projects/$projectId/automation/': typeof AuthenticatedProjectsProjectIdAutomationIndexRoute
+  '/_authenticated/projects/$projectId/conversations/': typeof AuthenticatedProjectsProjectIdConversationsIndexRoute
   '/_authenticated/projects/$projectId/docs/': typeof AuthenticatedProjectsProjectIdDocsIndexRoute
   '/_authenticated/projects/$projectId/settings/': typeof AuthenticatedProjectsProjectIdSettingsIndexRoute
   '/_authenticated/projects/$projectId/team/': typeof AuthenticatedProjectsProjectIdTeamIndexRoute
@@ -279,6 +298,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/home/'
     | '/profile/'
+    | '/projects/$projectId/conversations'
     | '/admin/global-roles/'
     | '/admin/plugins/'
     | '/admin/users/'
@@ -292,6 +312,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/tasks/$taskId'
     | '/projects/$projectId/agents/'
     | '/projects/$projectId/automation/'
+    | '/projects/$projectId/conversations/'
     | '/projects/$projectId/docs/'
     | '/projects/$projectId/settings/'
     | '/projects/$projectId/team/'
@@ -318,6 +339,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/tasks/$taskId'
     | '/projects/$projectId/agents'
     | '/projects/$projectId/automation'
+    | '/projects/$projectId/conversations'
     | '/projects/$projectId/docs'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/team'
@@ -333,6 +355,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectId'
     | '/_authenticated/home/'
     | '/_authenticated/profile/'
+    | '/_authenticated/projects/$projectId/conversations'
     | '/_authenticated/admin/global-roles/'
     | '/_authenticated/admin/plugins/'
     | '/_authenticated/admin/users/'
@@ -346,6 +369,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectId/tasks/$taskId'
     | '/_authenticated/projects/$projectId/agents/'
     | '/_authenticated/projects/$projectId/automation/'
+    | '/_authenticated/projects/$projectId/conversations/'
     | '/_authenticated/projects/$projectId/docs/'
     | '/_authenticated/projects/$projectId/settings/'
     | '/_authenticated/projects/$projectId/team/'
@@ -439,6 +463,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminGlobalRolesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/projects/$projectId/conversations': {
+      id: '/_authenticated/projects/$projectId/conversations'
+      path: '/conversations'
+      fullPath: '/projects/$projectId/conversations'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdConversationsRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
     '/_authenticated/projects/$projectId/team/': {
       id: '/_authenticated/projects/$projectId/team/'
       path: '/team'
@@ -459,6 +490,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/projects/$projectId/docs/'
       preLoaderRoute: typeof AuthenticatedProjectsProjectIdDocsIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
+    '/_authenticated/projects/$projectId/conversations/': {
+      id: '/_authenticated/projects/$projectId/conversations/'
+      path: '/'
+      fullPath: '/projects/$projectId/conversations/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdConversationsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdConversationsRoute
     }
     '/_authenticated/projects/$projectId/automation/': {
       id: '/_authenticated/projects/$projectId/automation/'
@@ -504,10 +542,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/projects/$projectId/conversations/$conversationId': {
       id: '/_authenticated/projects/$projectId/conversations/$conversationId'
-      path: '/conversations/$conversationId'
+      path: '/$conversationId'
       fullPath: '/projects/$projectId/conversations/$conversationId'
       preLoaderRoute: typeof AuthenticatedProjectsProjectIdConversationsConversationIdRouteImport
-      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+      parentRoute: typeof AuthenticatedProjectsProjectIdConversationsRoute
     }
     '/_authenticated/projects/$projectId/automation/$workflowId': {
       id: '/_authenticated/projects/$projectId/automation/$workflowId'
@@ -547,10 +585,28 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AuthenticatedProjectsProjectIdConversationsRouteChildren {
+  AuthenticatedProjectsProjectIdConversationsConversationIdRoute: typeof AuthenticatedProjectsProjectIdConversationsConversationIdRoute
+  AuthenticatedProjectsProjectIdConversationsIndexRoute: typeof AuthenticatedProjectsProjectIdConversationsIndexRoute
+}
+
+const AuthenticatedProjectsProjectIdConversationsRouteChildren: AuthenticatedProjectsProjectIdConversationsRouteChildren =
+  {
+    AuthenticatedProjectsProjectIdConversationsConversationIdRoute:
+      AuthenticatedProjectsProjectIdConversationsConversationIdRoute,
+    AuthenticatedProjectsProjectIdConversationsIndexRoute:
+      AuthenticatedProjectsProjectIdConversationsIndexRoute,
+  }
+
+const AuthenticatedProjectsProjectIdConversationsRouteWithChildren =
+  AuthenticatedProjectsProjectIdConversationsRoute._addFileChildren(
+    AuthenticatedProjectsProjectIdConversationsRouteChildren,
+  )
+
 interface AuthenticatedProjectsProjectIdRouteChildren {
+  AuthenticatedProjectsProjectIdConversationsRoute: typeof AuthenticatedProjectsProjectIdConversationsRouteWithChildren
   AuthenticatedProjectsProjectIdIndexRoute: typeof AuthenticatedProjectsProjectIdIndexRoute
   AuthenticatedProjectsProjectIdAutomationWorkflowIdRoute: typeof AuthenticatedProjectsProjectIdAutomationWorkflowIdRoute
-  AuthenticatedProjectsProjectIdConversationsConversationIdRoute: typeof AuthenticatedProjectsProjectIdConversationsConversationIdRoute
   AuthenticatedProjectsProjectIdDocsDocIdRoute: typeof AuthenticatedProjectsProjectIdDocsDocIdRoute
   AuthenticatedProjectsProjectIdInteractionsBacklogRoute: typeof AuthenticatedProjectsProjectIdInteractionsBacklogRoute
   AuthenticatedProjectsProjectIdInteractionsTimelineRoute: typeof AuthenticatedProjectsProjectIdInteractionsTimelineRoute
@@ -567,12 +623,12 @@ interface AuthenticatedProjectsProjectIdRouteChildren {
 
 const AuthenticatedProjectsProjectIdRouteChildren: AuthenticatedProjectsProjectIdRouteChildren =
   {
+    AuthenticatedProjectsProjectIdConversationsRoute:
+      AuthenticatedProjectsProjectIdConversationsRouteWithChildren,
     AuthenticatedProjectsProjectIdIndexRoute:
       AuthenticatedProjectsProjectIdIndexRoute,
     AuthenticatedProjectsProjectIdAutomationWorkflowIdRoute:
       AuthenticatedProjectsProjectIdAutomationWorkflowIdRoute,
-    AuthenticatedProjectsProjectIdConversationsConversationIdRoute:
-      AuthenticatedProjectsProjectIdConversationsConversationIdRoute,
     AuthenticatedProjectsProjectIdDocsDocIdRoute:
       AuthenticatedProjectsProjectIdDocsDocIdRoute,
     AuthenticatedProjectsProjectIdInteractionsBacklogRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
@@ -1,21 +1,16 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import {
 	Bot,
 	Check,
-	Clock,
 	Code2,
-	GitBranch,
-	GitPullRequest,
 	KeyRound,
 	Loader2,
-	MessageSquare,
 	Plus,
 	Save,
 	Server,
 	Trash2,
 	Wand2,
-	Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -49,7 +44,6 @@ import { useProjectPermissions } from "@/hooks/use-project-permissions";
 import {
 	type ACPProvider,
 	type Agent,
-	type AgentConversation,
 	type AgentMCPServer,
 	type AgentSkill,
 	addEnvVar,
@@ -59,9 +53,6 @@ import {
 	agentMCPServersQueryOptions,
 	agentQueryOptions,
 	agentSkillsQueryOptions,
-	CONVERSATION_STATUS_COLORS,
-	CONVERSATION_STATUS_LABELS,
-	conversationsQueryOptions,
 	deleteEnvVar,
 	deleteMCPServer,
 	deleteSkill,
@@ -86,16 +77,13 @@ export const Route = createFileRoute(
 			),
 			queryClient.ensureQueryData(agentSkillsQueryOptions(projectId, agentId)),
 			queryClient.ensureQueryData(agentEnvVarsQueryOptions(projectId, agentId)),
-			queryClient.ensureQueryData(
-				conversationsQueryOptions(projectId, agentId),
-			),
 			queryClient.ensureQueryData(llmModelsQueryOptions),
 		]);
 	},
 	component: AgentDetailPage,
 });
 
-type Tab = "overview" | "mcp-servers" | "skills" | "env-vars" | "conversations";
+type Tab = "overview" | "mcp-servers" | "skills" | "env-vars";
 
 const CUSTOM = "__custom__";
 
@@ -1232,115 +1220,6 @@ function EnvVarsTab({
 	);
 }
 
-// ── Conversations Tab ─────────────────────────────────────────────────────────
-
-function ConversationRow({
-	conv,
-	projectId,
-}: {
-	conv: AgentConversation;
-	projectId: string;
-}) {
-	const { t } = useTranslation("projects");
-	const statusColor = CONVERSATION_STATUS_COLORS[conv.status];
-	const statusLabel = CONVERSATION_STATUS_LABELS[conv.status];
-
-	return (
-		<Link
-			to="/projects/$projectId/conversations/$conversationId"
-			params={{ projectId, conversationId: conv.id }}
-			className="flex w-full flex-col gap-0.5 rounded-lg border border-border/60 bg-card px-4 py-3 text-left transition-colors hover:border-border hover:bg-accent/30"
-		>
-			<div className="flex items-center gap-2">
-				<span className="text-sm font-medium truncate">
-					{conv.trigger_type === "chat_message"
-						? t("agents.detail.conversations.triggerChat")
-						: conv.trigger_type === "description_write"
-							? t("agents.detail.conversations.triggerWriteDescription")
-							: t("agents.detail.conversations.triggerTask")}{" "}
-					· {conv.id.slice(0, 8)}
-				</span>
-				<Badge
-					variant="outline"
-					className={`text-xs font-semibold shrink-0 ${statusColor}`}
-				>
-					{statusLabel}
-				</Badge>
-			</div>
-			<div className="flex items-center gap-3 text-xs text-muted-foreground">
-				<span className="flex items-center gap-1">
-					<Zap className="size-3" />
-					{t("agents.detail.conversations.iterations", {
-						count: conv.iteration_count,
-					})}
-				</span>
-				{conv.branch_name && (
-					<span className="flex items-center gap-1 truncate">
-						<GitBranch className="size-3" />
-						{conv.branch_name}
-					</span>
-				)}
-				{conv.pr_url && (
-					<span className="flex items-center gap-1">
-						<GitPullRequest className="size-3" />
-						{t("agents.detail.conversations.prOpened")}
-					</span>
-				)}
-				<span className="flex items-center gap-1 ml-auto">
-					<Clock className="size-3" />
-					{new Date(conv.created_at).toLocaleDateString()}
-				</span>
-			</div>
-		</Link>
-	);
-}
-
-function ConversationsTab({
-	projectId,
-	agentId,
-}: {
-	projectId: string;
-	agentId: string;
-}) {
-	const { t } = useTranslation("projects");
-	const { data: conversations = [], isLoading } = useQuery(
-		conversationsQueryOptions(projectId, agentId),
-	);
-
-	if (isLoading) {
-		return (
-			<div className="space-y-2">
-				{Array.from({ length: 3 }).map((_, i) => (
-					// biome-ignore lint/suspicious/noArrayIndexKey: skeleton
-					<Skeleton key={i} className="h-16 rounded-lg" />
-				))}
-			</div>
-		);
-	}
-
-	if (conversations.length === 0) {
-		return (
-			<div className="flex flex-col items-center justify-center gap-3 py-14 rounded-xl border border-dashed border-border">
-				<MessageSquare className="size-8 text-muted-foreground/40" />
-				<p className="text-sm text-muted-foreground">
-					{t("agents.detail.conversations.empty.title")}
-				</p>
-				<p className="text-xs text-muted-foreground max-w-xs text-center">
-					{t("agents.detail.conversations.empty.description")}
-				</p>
-			</div>
-		);
-	}
-
-	return (
-		<div className="space-y-2">
-			{conversations.map((conv) => (
-				<ConversationRow key={conv.id} conv={conv} projectId={projectId} />
-			))}
-		</div>
-	);
-}
-
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 const TABS = [
@@ -1355,11 +1234,6 @@ const TABS = [
 		id: "env-vars",
 		labelKey: "agents.detail.tabs.envVars",
 		icon: KeyRound,
-	},
-	{
-		id: "conversations",
-		labelKey: "agents.detail.tabs.conversations",
-		icon: MessageSquare,
 	},
 ] as const satisfies {
 	id: Tab;
@@ -1507,9 +1381,6 @@ function AgentDetailPage() {
 						agentId={agentId}
 						canWrite={canWrite}
 					/>
-				)}
-				{activeTab === "conversations" && (
-					<ConversationsTab projectId={projectId} agentId={agentId} />
 				)}
 			</div>
 		</div>

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
@@ -1,0 +1,173 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	createFileRoute,
+	Link,
+	Outlet,
+	useParams,
+} from "@tanstack/react-router";
+import { Clock, MessageSquare, Zap } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useProjectRealtime } from "@/hooks/use-project-realtime";
+import {
+	type Agent,
+	type AgentConversation,
+	agentsQueryOptions,
+	CONVERSATION_STATUS_COLORS,
+	CONVERSATION_STATUS_LABELS,
+	conversationsQueryOptions,
+} from "@/lib/agent-api";
+import { cn } from "@/lib/utils";
+
+export const Route = createFileRoute(
+	"/_authenticated/projects/$projectId/conversations",
+)({
+	loader: async ({ context: { queryClient }, params: { projectId } }) => {
+		await Promise.all([
+			queryClient.ensureQueryData(conversationsQueryOptions(projectId)),
+			queryClient.ensureQueryData(agentsQueryOptions(projectId)),
+		]);
+	},
+	component: ConversationsLayout,
+});
+
+// ── List item ─────────────────────────────────────────────────────────────────
+
+function ConversationListItem({
+	conv,
+	agent,
+	projectId,
+	isActive,
+}: {
+	conv: AgentConversation;
+	agent: Agent | undefined;
+	projectId: string;
+	isActive: boolean;
+}) {
+	const { t } = useTranslation("projects");
+	const statusColor = CONVERSATION_STATUS_COLORS[conv.status];
+	const statusLabel = CONVERSATION_STATUS_LABELS[conv.status];
+	const triggerLabel =
+		conv.trigger_type === "chat_message"
+			? t("conversationsPage.triggerChat")
+			: conv.trigger_type === "description_write"
+				? t("conversationsPage.triggerWriteDescription")
+				: t("conversationsPage.triggerTask");
+	const initials = (agent?.name ?? "?")
+		.split(" ")
+		.map((w) => w[0])
+		.join("")
+		.toUpperCase()
+		.slice(0, 2);
+
+	return (
+		<Link
+			to="/projects/$projectId/conversations/$conversationId"
+			params={{ projectId, conversationId: conv.id }}
+			className={cn(
+				"flex w-full flex-col gap-1.5 rounded-lg border px-3 py-2.5 text-left transition-colors",
+				isActive
+					? "border-primary/40 bg-primary/5"
+					: "border-transparent hover:border-border hover:bg-accent/30",
+			)}
+		>
+			<div className="flex items-center gap-2 min-w-0">
+				<Avatar className="size-6 rounded-md bg-primary/10 shrink-0">
+					<AvatarFallback className="rounded-md bg-primary/10 text-primary text-[10px] font-semibold">
+						{initials}
+					</AvatarFallback>
+				</Avatar>
+				<span className="text-sm font-medium truncate flex-1">
+					{agent?.name ?? conv.agent_id.slice(0, 8)}
+				</span>
+				<Badge
+					variant="outline"
+					className={cn("text-[10px] font-semibold shrink-0", statusColor)}
+				>
+					{statusLabel}
+				</Badge>
+			</div>
+			<div className="flex items-center gap-1.5 text-xs text-muted-foreground pl-8">
+				<span className="flex items-center gap-1 shrink-0">
+					<Zap className="size-3" />
+					{t("conversationsPage.iterations", { count: conv.iteration_count })}
+				</span>
+				<span className="text-muted-foreground/40">·</span>
+				<span className="truncate">{triggerLabel}</span>
+				<span className="ml-auto shrink-0 flex items-center gap-1">
+					<Clock className="size-3" />
+					{new Date(conv.created_at).toLocaleDateString()}
+				</span>
+			</div>
+		</Link>
+	);
+}
+
+// ── Layout ────────────────────────────────────────────────────────────────────
+
+function ConversationsLayout() {
+	const { t } = useTranslation("projects");
+	const { projectId } = Route.useParams();
+	const { conversationId: activeConversationId } = useParams({
+		strict: false,
+	});
+
+	useProjectRealtime(projectId);
+
+	const { data: conversations = [], isLoading } = useQuery(
+		conversationsQueryOptions(projectId),
+	);
+	const { data: agents = [] } = useQuery(agentsQueryOptions(projectId));
+	const agentsById = new Map(agents.map((a) => [a.id, a]));
+
+	const sortedConversations = [...conversations].sort(
+		(a, b) =>
+			new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+	);
+
+	return (
+		<div className="flex flex-1 min-h-0">
+			<div className="w-80 shrink-0 border-r border-border/50 flex flex-col min-h-0">
+				<div className="shrink-0 border-b border-border/50 px-4 py-3">
+					<h2 className="text-sm font-semibold">
+						{t("conversationsPage.title")}
+					</h2>
+				</div>
+				<div className="flex-1 overflow-y-auto p-2 space-y-1.5">
+					{isLoading ? (
+						Array.from({ length: 4 }).map((_, i) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: skeleton
+							<Skeleton key={i} className="h-16 rounded-lg" />
+						))
+					) : sortedConversations.length === 0 ? (
+						<div className="flex flex-col items-center justify-center gap-3 py-14 px-3 text-center">
+							<MessageSquare className="size-8 text-muted-foreground/40" />
+							<p className="text-sm text-muted-foreground">
+								{t("conversationsPage.list.empty.title")}
+							</p>
+							<p className="text-xs text-muted-foreground max-w-xs">
+								{t("conversationsPage.list.empty.description")}
+							</p>
+						</div>
+					) : (
+						sortedConversations.map((conv) => (
+							<ConversationListItem
+								key={conv.id}
+								conv={conv}
+								agent={agentsById.get(conv.agent_id)}
+								projectId={projectId}
+								isActive={conv.id === activeConversationId}
+							/>
+						))
+					)}
+				</div>
+			</div>
+
+			<div className="flex-1 min-h-0">
+				<Outlet />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/$conversationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/$conversationId.tsx
@@ -1,10 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
-import { useTranslation } from "react-i18next";
+import { createFileRoute } from "@tanstack/react-router";
 import { ConversationView } from "@/components/projects/agents/conversation-view";
 import { RouteErrorComponent } from "@/components/route-error-boundary";
-import { useProjectRealtime } from "@/hooks/use-project-realtime";
 import {
 	conversationEventsQueryOptions,
 	conversationQueryOptions,
@@ -33,36 +29,9 @@ export const Route = createFileRoute(
 });
 
 function ConversationPage() {
-	const { t } = useTranslation("projects");
 	const { projectId, conversationId } = Route.useParams();
-	const { data: conversation } = useQuery(
-		conversationQueryOptions(projectId, conversationId),
-	);
-
-	useProjectRealtime(projectId);
 
 	return (
-		<div className="flex flex-col h-full overflow-hidden bg-background">
-			{/* Back navigation */}
-			<div className="shrink-0 border-b border-border/40 px-5 py-2.5 flex items-center gap-3">
-				<Link
-					to="/projects/$projectId/agents/$agentId"
-					params={{ projectId, agentId: conversation?.agent_id ?? "" }}
-					hash="conversations"
-					className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-				>
-					<ArrowLeft className="size-3.5" />
-					{t("common.back", "Back")}
-				</Link>
-			</div>
-
-			{/* Conversation view */}
-			<div className="flex-1 overflow-hidden">
-				<ConversationView
-					projectId={projectId}
-					conversationId={conversationId}
-				/>
-			</div>
-		</div>
+		<ConversationView projectId={projectId} conversationId={conversationId} />
 	);
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
@@ -1,0 +1,50 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { MessageSquare } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+	type AgentConversation,
+	conversationsQueryOptions,
+} from "@/lib/agent-api";
+
+export const Route = createFileRoute(
+	"/_authenticated/projects/$projectId/conversations/",
+)({
+	// The parent `conversations` layout route's loader already populated the
+	// conversations list in the query cache, so this can read it synchronously
+	// instead of refetching — landing directly on the most recently created
+	// conversation instead of showing a bare "pick one" screen.
+	loader: ({ context: { queryClient }, params: { projectId } }) => {
+		const conversations =
+			queryClient.getQueryData<AgentConversation[]>(
+				conversationsQueryOptions(projectId).queryKey,
+			) ?? [];
+		if (conversations.length === 0) return;
+
+		const latest = conversations.reduce((a, b) =>
+			new Date(a.created_at) > new Date(b.created_at) ? a : b,
+		);
+		throw redirect({
+			to: "/projects/$projectId/conversations/$conversationId",
+			params: { projectId, conversationId: latest.id },
+			replace: true,
+		});
+	},
+	component: EmptyConversationState,
+});
+
+function EmptyConversationState() {
+	const { t } = useTranslation("projects");
+	return (
+		<div className="flex flex-col h-full items-center justify-center gap-3 text-center px-6">
+			<MessageSquare className="size-10 text-muted-foreground/40" />
+			<div>
+				<p className="text-sm font-medium">
+					{t("conversationsPage.detail.empty.title")}
+				</p>
+				<p className="text-xs text-muted-foreground mt-1 max-w-xs">
+					{t("conversationsPage.detail.empty.description")}
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
@@ -13,7 +13,15 @@ export const Route = createFileRoute(
 	// conversations list in the query cache, so this can read it synchronously
 	// instead of refetching — landing directly on the most recently created
 	// conversation instead of showing a bare "pick one" screen.
-	loader: ({ context: { queryClient }, params: { projectId } }) => {
+	//
+	// `preload` is true when this loader runs speculatively (e.g. the sidebar
+	// nav Link's hover-intent preload, since the router defaults to
+	// `defaultPreload: "intent"`) rather than for a real navigation — must not
+	// redirect in that case, or merely hovering the nav item silently
+	// navigates the page away from wherever the user actually is.
+	loader: ({ context: { queryClient }, params: { projectId }, preload }) => {
+		if (preload) return;
+
 		const conversations =
 			queryClient.getQueryData<AgentConversation[]>(
 				conversationsQueryOptions(projectId).queryKey,


### PR DESCRIPTION
## Summary

Moves conversations out of the agent detail page and into their own project-level section, so a user can browse every conversation across all agents in one place instead of digging into each agent's tab.

- Added a top-level **Conversations** item to the project sidebar nav (between Agents and Automation).
- New `/projects/$projectId/conversations` layout route: a two-pane view with a list of all conversations for the project (sorted newest first, showing agent, status, iteration count, trigger, and created date) on the left and the selected conversation on the right via `<Outlet />`.
- New `/conversations/` index route: redirects to the most recently created conversation, or shows an empty state if the project has none.
- Simplified `/conversations/$conversationId`: now renders `ConversationView` directly — the old back-button header and standalone realtime/query wiring moved up into the shared layout route.
- Removed the "Conversations" tab from the agent detail page (`agents/$agentId/index.tsx`), since conversations now live under the dedicated route instead of being scoped per-agent.
- Added `nav.conversations` and the `conversationsPage.*` translation keys to all 9 supported locales (en, es, fr, ja, ko, pt-BR, ru, vi, zh-CN).
- Regenerated `routeTree.gen.ts` for the new/changed routes.

## Test plan
- [ ] `pnpm lint` / typecheck
- [ ] Manually verify: project sidebar shows Conversations nav item, list loads and links to a conversation, empty state shows when a project has no conversations, agent detail page no longer shows a Conversations tab
