### PR TITLE
refactor: simplify scrollbar styles across components

### DIFF
--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -120,7 +120,7 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
 			<ThreadPrimitive.Viewport
 				turnAnchor="top"
 				data-slot="aui_thread-viewport"
-				className="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/60 [&::-webkit-scrollbar-thumb]:hover:bg-border"
+				className="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth [scrollbar-gutter:stable]"
 			>
 				<div
 					className={cn(

--- a/apps/web/src/components/projects/automation/add-workflow-node-modal.tsx
+++ b/apps/web/src/components/projects/automation/add-workflow-node-modal.tsx
@@ -113,7 +113,7 @@ export function AddWorkflowNodeModal({
 					</div>
 				</div>
 
-				<div className="mx-5 mb-5 rounded-xl border border-border/20 overflow-hidden max-h-64 overflow-y-auto [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/40">
+				<div className="mx-5 mb-5 rounded-xl border border-border/20 overflow-hidden max-h-64 overflow-y-auto [scrollbar-gutter:stable]">
 					{loading && (
 						<div className="flex items-center justify-center py-8 text-muted-foreground/50 text-sm">
 							{t("automation.addNodeModal.loadingTasks")}

--- a/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/add-task-link-modal.tsx
@@ -208,7 +208,7 @@ export function AddTaskLinkModal({
 				</div>
 
 				{/* Task list */}
-				<div className="mx-5 mb-5 rounded-xl border border-border/20 overflow-hidden max-h-64 overflow-y-auto [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/40">
+				<div className="mx-5 mb-5 rounded-xl border border-border/20 overflow-hidden max-h-64 overflow-y-auto [scrollbar-gutter:stable]">
 					{loading && (
 						<div className="flex items-center justify-center py-8 text-muted-foreground/50 text-sm">
 							{t("taskDetail.addTaskLinkModal.loadingTasks")}

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -271,7 +271,7 @@ export function TaskDetailModal({
 			{/* ── Body: stacks on mobile, side-by-side on lg+ ── */}
 			<div className="flex flex-col lg:flex-row flex-1 min-w-0 min-h-0 overflow-y-auto lg:overflow-hidden">
 				{/* Main content area: no own scroll on mobile (body scrolls), scrollable on lg+ */}
-				<div className="lg:flex-1 lg:overflow-y-auto [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/60 [&::-webkit-scrollbar-thumb]:hover:bg-border">
+				<div className="lg:flex-1 lg:overflow-y-auto [scrollbar-gutter:stable]">
 					<div className="px-4 lg:px-8 py-5 lg:py-7 space-y-6 lg:space-y-8 max-w-3xl mx-auto">
 						{/* Type badge + Status chip + Title */}
 						<div className="space-y-4">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -137,6 +137,46 @@
 	--sidebar-ring: #9ed957;
 }
 
+/*
+ * Custom scrollbars — applied globally via the universal selector so every
+ * scrollable element (tables, dropdowns, panels, chat panes, ...) gets the
+ * themed thin scrollbar without needing per-component classes. A component
+ * can still override width/colors with a more specific selector, or opt out
+ * entirely with `.no-scrollbar`.
+ */
+* {
+	scrollbar-width: thin;
+	scrollbar-color: color-mix(in oklab, var(--border) 60%, transparent)
+		transparent;
+}
+
+*::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+	background: color-mix(in oklab, var(--border) 60%, transparent);
+	border-radius: 9999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+	background: var(--border);
+}
+
+.no-scrollbar {
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+	display: none;
+}
+
 @theme inline {
 	--font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
 	--font-display: "Syne", ui-sans-serif, sans-serif;

--- a/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
@@ -175,7 +175,7 @@ function DocEditorPage() {
 			{/* ── Body: editor + optional right panel ──────────────────────── */}
 			<div className="flex flex-1 min-h-0 overflow-hidden">
 				{/* Editor area */}
-				<div className="flex-1 overflow-y-auto [scrollbar-gutter:stable] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/60 [&::-webkit-scrollbar-thumb]:hover:bg-border">
+				<div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
 					<div className="max-w-7xl mx-auto px-8 py-7">
 						{doc && (
 							<DocEditor


### PR DESCRIPTION
## Summary
- Add a global, theme-aware custom scrollbar (thin, transparent track, rounded thumb, darkens on hover) in `index.css`, applied via the universal selector so every scrollable element in the app — tables, dropdowns, kanban board, modals, chat panes, sidebar — gets it automatically instead of relying on the browser default.
- Define the `.no-scrollbar` utility, which was referenced by the sidebar nav rail but never actually defined, so it was silently falling back to the plain scrollbar.
- Remove the duplicated per-component WebKit-only scrollbar classes that a few components had hand-rolled (chat thread, docs editor, task detail modal, add-task-link modal, add-workflow-node modal), now that the global rule covers them. `scrollbar-gutter:stable` is kept where it was preventing layout shift.

## Test plan
- [x] `bun run lint`
- [x] `tsc -b`
- [ ] Visual check in browser across a table, a dropdown, and the chat thread (light + dark mode)