### PR TITLE
Feature/enhance acp agent workflow

### DIFF
--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -11,6 +11,22 @@ means the CLI's own native tools (bash, git, gh, etc.) run with the user's own
 real credentials, so it can clone/push/open PRs exactly as if the user were
 driving it themselves — something a Paca-hosted sandbox can never do, since
 ACPAgent doesn't accept custom tools.
+
+Conversations are driven via `conversation.arun()` (the SDK's async run
+loop), scheduled as a plain `asyncio.Task` on this daemon's own event loop,
+rather than `conversation.run()` on a dedicated thread. `run()`/`pause()`
+only take effect *between* whole agent steps and can't cancel one already in
+flight — for `ACPAgent` a single step is the whole ACP turn (every tool call
+the coding CLI makes before replying), so pressing "stop" mid-turn wouldn't
+actually stop anything until that turn finished on its own. `arun()` tracks
+the run as a cancellable `asyncio.Task`, so `conversation.interrupt()` can
+cancel it immediately (mid-tool-call) and the SDK sends the coding CLI a
+real ACP `session/cancel` in response — see `LocalConversation.interrupt()`
+and `ACPAgent.astep()`'s `CancelledError` handling. It also sidesteps a
+cross-thread state-lock deadlock the SDK documents for the sync `run()` path
+(OpenHands SDK issues #3348/#3350): here, `interrupt()` never blocks waiting
+on the conversation's state lock, so it's safe to call directly from this
+event loop's own thread.
 """
 
 from __future__ import annotations
@@ -18,7 +34,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import threading
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -34,7 +49,7 @@ SendFn = Callable[[dict[str, Any]], Awaitable[None]]
 @dataclasses.dataclass
 class _ConversationHandle:
     conversation: Conversation
-    thread: threading.Thread
+    task: asyncio.Task[None]
 
 
 def resolve_acp_command(acp_provider: str | None, acp_command: list[str]) -> list[str]:
@@ -70,7 +85,8 @@ class ConversationRunner:
         # Captured lazily in start_turn() (always awaited from inside the
         # running loop) rather than here — __init__ runs before
         # asyncio.run() starts the loop that will actually be running when
-        # background threads need to schedule coroutines back onto it.
+        # ACPAgent's own background ("portal") thread needs to schedule
+        # coroutines back onto it (e.g. mid-turn streaming events).
         self._loop: asyncio.AbstractEventLoop | None = None
         self._conversations: dict[str, _ConversationHandle] = {}
 
@@ -82,14 +98,14 @@ class ConversationRunner:
 
         existing = self._conversations.get(conversation_id)
         if existing is not None:
-            if existing.thread.is_alive():
-                # A previous turn's thread is still driving this same
-                # Conversation object via .send_message()/.run() — starting
-                # a second thread on top of it would call into the SDK
-                # concurrently from two threads, which Conversation isn't
-                # built to handle. Reject explicitly rather than risking
-                # corrupted state, so the caller gets an immediate failure
-                # instead of waiting out acp_dispatch.py's watchdog timeout.
+            if not existing.task.done():
+                # A previous turn's task is still driving this same
+                # Conversation object via .send_message()/.arun() — starting
+                # a second one on top of it would call into the SDK
+                # concurrently, which Conversation isn't built to handle.
+                # Reject explicitly rather than risking corrupted state, so
+                # the caller gets an immediate failure instead of waiting
+                # out acp_dispatch.py's watchdog timeout.
                 logger.warning(
                     "Ignoring start_turn for conversation %s: a previous turn is still running",
                     conversation_id,
@@ -102,19 +118,10 @@ class ConversationRunner:
                 )
                 return
             # Resume — reply on the conversation object already running from
-            # an earlier turn in this same chat session. `.run()` is a
-            # blocking, synchronous SDK call for a local (non-remote)
-            # Conversation, so it must happen on its own thread here too —
-            # calling it directly from this coroutine would freeze the
-            # daemon's whole event loop (heartbeats, other conversations'
-            # events) until the turn finishes.
-            thread = threading.Thread(
-                target=self._run_conversation,
-                args=(existing.conversation, conversation_id, project_id, message),
-                daemon=True,
+            # an earlier turn in this same chat session.
+            existing.task = asyncio.create_task(
+                self._run_conversation(existing.conversation, conversation_id, project_id, message)
             )
-            existing.thread = thread
-            thread.start()
             return
 
         try:
@@ -130,62 +137,44 @@ class ConversationRunner:
             workspace=self.workspace,
             callbacks=[self._make_event_callback(conversation_id, project_id)],
         )
-        thread = threading.Thread(
-            target=self._run_conversation,
-            args=(conversation, conversation_id, project_id, message),
-            daemon=True,
+        task = asyncio.create_task(
+            self._run_conversation(conversation, conversation_id, project_id, message)
         )
         self._conversations[conversation_id] = _ConversationHandle(
-            conversation=conversation, thread=thread
+            conversation=conversation, task=task
         )
-        thread.start()
 
     def interrupt(self, conversation_id: str | None) -> None:
         """Handle a stop_turn/pause_turn message — both just interrupt the
         in-flight turn; there's no sandbox lifecycle to additionally tear
         down (unlike the cloud path's full stop vs. pause distinction).
 
-        Dispatched onto its own thread rather than calling
-        `conversation.interrupt()` directly here on the event-loop thread:
-        this bridge only ever uses the synchronous `conversation.run()`, so
-        the SDK's `interrupt()` always falls back to `pause()`, which
-        acquires the conversation's state lock and can synchronously invoke
-        our event callback — which itself calls back into this same event
-        loop via `run_coroutine_threadsafe(...).result()`. Running that
-        chain directly on the loop's thread means the loop wants to wait on
-        itself (or contend the lock with the conversation's own background
-        thread, which is doing the same call-back-into-the-loop dance),
-        freezing every other conversation and the heartbeat for the full
-        10s timeout. The SDK documents `interrupt()` as safe to call from
-        any thread, so a dedicated one sidesteps the reentrancy entirely.
+        Safe to call directly here, synchronously, on the event-loop thread:
+        `conversation.interrupt()` cancels the tracked `arun()` task via a
+        non-blocking `call_soon_threadsafe` — it never waits on the
+        conversation's state lock, so it can't stall this loop the way the
+        sync `run()` path's `pause()` fallback could (see module docstring).
         """
         if not conversation_id:
             return
         handle = self._conversations.get(conversation_id)
         if handle is None:
             return
-        threading.Thread(
-            target=self._interrupt_conversation,
-            args=(handle.conversation, conversation_id),
-            daemon=True,
-        ).start()
-
-    def _interrupt_conversation(self, conversation: Conversation, conversation_id: str) -> None:
         try:
-            conversation.interrupt()
+            handle.conversation.interrupt()
         except Exception:
             logger.exception("Failed to interrupt conversation %s", conversation_id)
 
-    def _run_conversation(
+    async def _run_conversation(
         self, conversation: Conversation, conversation_id: str, project_id: str, message: str
     ) -> None:
         try:
             conversation.send_message(message)
-            conversation.run()
-            self._report_status_threadsafe(conversation_id, project_id, "finished")
+            await conversation.arun()
+            await self._report_status(conversation_id, project_id, "finished")
         except Exception as exc:
             logger.exception("Conversation %s failed", conversation_id)
-            self._report_status_threadsafe(conversation_id, project_id, "failed", str(exc))
+            await self._report_status(conversation_id, project_id, "failed", str(exc))
 
     def _make_event_callback(self, conversation_id: str, project_id: str) -> Callable[[Any], None]:
         def callback(event: Any) -> None:
@@ -199,6 +188,10 @@ class ConversationRunner:
                     "event_source": str(getattr(event, "source", "agent")),
                     "payload": payload,
                 }
+                # ACPAgent streams mid-turn events from its own background
+                # ("portal") thread, not necessarily this callback's caller,
+                # so this still has to hop back onto the event loop
+                # threadsafe rather than assuming it's already there.
                 future = asyncio.run_coroutine_threadsafe(self._send(message), self._loop)
                 future.result(timeout=10)
             except Exception:
@@ -210,19 +203,6 @@ class ConversationRunner:
                 )
 
         return callback
-
-    def _report_status_threadsafe(
-        self, conversation_id: str, project_id: str, status: str, error_message: str | None = None
-    ) -> None:
-        future = asyncio.run_coroutine_threadsafe(
-            self._report_status(conversation_id, project_id, status, error_message), self._loop
-        )
-        try:
-            future.result(timeout=10)
-        except Exception:
-            logger.warning(
-                "Failed to report status for conversation %s", conversation_id, exc_info=True
-            )
 
     async def _report_status(
         self, conversation_id: str, project_id: str, status: str, error_message: str | None = None

--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -178,26 +178,42 @@ class ConversationRunner:
 
     def _make_event_callback(self, conversation_id: str, project_id: str) -> Callable[[Any], None]:
         def callback(event: Any) -> None:
+            event_type = type(event).__name__
             try:
                 payload = event.model_dump_json() if hasattr(event, "model_dump_json") else "{}"
                 message = {
                     "type": "event",
                     "conversation_id": conversation_id,
                     "project_id": project_id,
-                    "event_type": type(event).__name__,
+                    "event_type": event_type,
                     "event_source": str(getattr(event, "source", "agent")),
                     "payload": payload,
                 }
-                # ACPAgent streams mid-turn events from its own background
-                # ("portal") thread, not necessarily this callback's caller,
-                # so this still has to hop back onto the event loop
-                # threadsafe rather than assuming it's already there.
-                future = asyncio.run_coroutine_threadsafe(self._send(message), self._loop)
-                future.result(timeout=10)
+                try:
+                    called_from_our_loop = asyncio.get_running_loop() is self._loop
+                except RuntimeError:
+                    called_from_our_loop = False
+                if called_from_our_loop:
+                    # Most on_event calls now happen this way: arun() runs as
+                    # a task directly on this daemon's own loop, and things
+                    # like finalizing a turn or emitting InterruptEvent on
+                    # cancellation call back into this callback synchronously
+                    # from that same task. Blocking here with
+                    # run_coroutine_threadsafe(...).result() would deadlock —
+                    # the loop can't run the coroutine it just scheduled
+                    # while its own thread is stuck waiting on it (always
+                    # timing out after the full 10s). Just schedule it.
+                    asyncio.get_running_loop().create_task(self._send(message))
+                else:
+                    # Mid-turn ACP streaming updates fire from ACPAgent's own
+                    # background ("portal") thread, so this hop really is
+                    # cross-thread there, and safe to wait on.
+                    future = asyncio.run_coroutine_threadsafe(self._send(message), self._loop)
+                    future.result(timeout=10)
             except Exception:
                 logger.warning(
                     "Failed to report event %s for conversation %s",
-                    type(event).__name__,
+                    event_type,
                     conversation_id,
                     exc_info=True,
                 )

--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -150,10 +150,15 @@ class ConversationRunner:
         down (unlike the cloud path's full stop vs. pause distinction).
 
         Safe to call directly here, synchronously, on the event-loop thread:
-        `conversation.interrupt()` cancels the tracked `arun()` task via a
-        non-blocking `call_soon_threadsafe` — it never waits on the
-        conversation's state lock, so it can't stall this loop the way the
-        sync `run()` path's `pause()` fallback could (see module docstring).
+        while a turn is actually in flight, `conversation.interrupt()`
+        cancels the tracked `arun()` task via a non-blocking
+        `call_soon_threadsafe`, so it can't stall this loop the way the sync
+        `run()` path's `pause()` fallback could (see module docstring). If
+        the tracked task has already finished by the time this runs (a race
+        with the turn wrapping up on its own), `interrupt()` falls back to a
+        synchronous `pause()` that does briefly acquire the state lock — a
+        much smaller window than the sync-`run()` deadlock this replaces,
+        since nothing here holds that lock for the duration of a whole turn.
         """
         if not conversation_id:
             return
@@ -171,10 +176,26 @@ class ConversationRunner:
         try:
             conversation.send_message(message)
             await conversation.arun()
-            await self._report_status(conversation_id, project_id, "finished")
         except Exception as exc:
             logger.exception("Conversation %s failed", conversation_id)
-            await self._report_status(conversation_id, project_id, "failed", str(exc))
+            await self._report_status_safely(conversation_id, project_id, "failed", str(exc))
+            return
+        await self._report_status_safely(conversation_id, project_id, "finished")
+
+    async def _report_status_safely(
+        self, conversation_id: str, project_id: str, status: str, error_message: str | None = None
+    ) -> None:
+        # A failure to *report* status (e.g. the bridge's outbox raising
+        # during shutdown) must not be conflated with the conversation
+        # itself failing — isolated here so it can only ever produce a log
+        # line, never a misleading "failed" status for a turn that actually
+        # ran fine (or a second, unhandled exception out of the task).
+        try:
+            await self._report_status(conversation_id, project_id, status, error_message)
+        except Exception:
+            logger.warning(
+                "Failed to report status for conversation %s", conversation_id, exc_info=True
+            )
 
     def _make_event_callback(self, conversation_id: str, project_id: str) -> Callable[[Any], None]:
         def callback(event: Any) -> None:
@@ -202,8 +223,29 @@ class ConversationRunner:
                     # run_coroutine_threadsafe(...).result() would deadlock —
                     # the loop can't run the coroutine it just scheduled
                     # while its own thread is stuck waiting on it (always
-                    # timing out after the full 10s). Just schedule it.
-                    asyncio.get_running_loop().create_task(self._send(message))
+                    # timing out after the full 10s). Just schedule it — but
+                    # still log if _send ends up failing, same as the
+                    # cross-thread branch below, rather than letting it
+                    # become a silent unretrieved-exception warning.
+                    def _log_send_failure(
+                        task: asyncio.Task[None],
+                        _event_type: str = event_type,
+                        _conversation_id: str = conversation_id,
+                    ) -> None:
+                        if task.cancelled():
+                            return
+                        exc = task.exception()
+                        if exc is not None:
+                            logger.warning(
+                                "Failed to report event %s for conversation %s",
+                                _event_type,
+                                _conversation_id,
+                                exc_info=exc,
+                            )
+
+                    asyncio.get_running_loop().create_task(self._send(message)).add_done_callback(
+                        _log_send_failure
+                    )
                 else:
                     # Mid-turn ACP streaming updates fire from ACPAgent's own
                     # background ("portal") thread, so this hop really is

--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -143,14 +143,36 @@ class ConversationRunner:
     def interrupt(self, conversation_id: str | None) -> None:
         """Handle a stop_turn/pause_turn message — both just interrupt the
         in-flight turn; there's no sandbox lifecycle to additionally tear
-        down (unlike the cloud path's full stop vs. pause distinction)."""
+        down (unlike the cloud path's full stop vs. pause distinction).
+
+        Dispatched onto its own thread rather than calling
+        `conversation.interrupt()` directly here on the event-loop thread:
+        this bridge only ever uses the synchronous `conversation.run()`, so
+        the SDK's `interrupt()` always falls back to `pause()`, which
+        acquires the conversation's state lock and can synchronously invoke
+        our event callback — which itself calls back into this same event
+        loop via `run_coroutine_threadsafe(...).result()`. Running that
+        chain directly on the loop's thread means the loop wants to wait on
+        itself (or contend the lock with the conversation's own background
+        thread, which is doing the same call-back-into-the-loop dance),
+        freezing every other conversation and the heartbeat for the full
+        10s timeout. The SDK documents `interrupt()` as safe to call from
+        any thread, so a dedicated one sidesteps the reentrancy entirely.
+        """
         if not conversation_id:
             return
         handle = self._conversations.get(conversation_id)
         if handle is None:
             return
+        threading.Thread(
+            target=self._interrupt_conversation,
+            args=(handle.conversation, conversation_id),
+            daemon=True,
+        ).start()
+
+    def _interrupt_conversation(self, conversation: Conversation, conversation_id: str) -> None:
         try:
-            handle.conversation.interrupt()
+            conversation.interrupt()
         except Exception:
             logger.exception("Failed to interrupt conversation %s", conversation_id)
 

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -6,6 +6,7 @@ than a real `openhands.sdk.Conversation`.
 """
 
 import asyncio
+import logging
 import threading
 
 import pytest
@@ -242,3 +243,54 @@ async def test_event_callback_uses_threadsafe_dispatch_when_called_off_loop():
     assert not thread.is_alive()
     assert len(sent) == 1
     assert sent[0]["conversation_id"] == "conv-1"
+
+
+async def test_run_conversation_survives_status_report_failure_after_success():
+    """A failure in the outbound _send/report path (e.g. the bridge's outbox
+    raising during shutdown) must not be conflated with the conversation
+    itself failing — see _report_status_safely in runner.py. Locks in that
+    a successful arun() only ever attempts one status report, even if that
+    report itself blows up."""
+    calls = []
+
+    async def send(message):
+        calls.append(message)
+        raise RuntimeError("outbox closed")
+
+    runner = ConversationRunner(workspace="/tmp", send=send)
+
+    class _FakeConversation:
+        def send_message(self, message):
+            pass
+
+        async def arun(self):
+            pass
+
+    # Must not raise, even though `send` always raises.
+    await runner._run_conversation(_FakeConversation(), "conv-1", "proj-1", "hi")
+
+    assert len(calls) == 1
+    assert calls[0]["status"] == "finished"
+
+
+async def test_event_callback_logs_when_send_fails_on_loop(caplog):
+    """The same-loop dispatch branch schedules _send as a fire-and-forget
+    task; a failure there must still surface as a logged warning instead of
+    silently becoming an unretrieved-task-exception."""
+
+    async def send(message):
+        raise RuntimeError("boom")
+
+    runner = ConversationRunner(workspace="/tmp", send=send)
+    runner._loop = asyncio.get_running_loop()
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    with caplog.at_level(logging.WARNING, logger="paca_acp_bridge.runner"):
+        callback(_FakeEvent())
+        # Two yields: one for the scheduled _send task to run and raise, a
+        # second for its add_done_callback (scheduled once the task becomes
+        # done) to actually fire.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert any("Failed to report event" in record.getMessage() for record in caplog.records)

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -5,7 +5,7 @@ Exercises the daemon's own logic without spawning a real ACP CLI subprocess —
 than a real `openhands.sdk.Conversation`.
 """
 
-import threading
+import asyncio
 
 import pytest
 
@@ -43,25 +43,24 @@ async def test_interrupt_calls_conversation_interrupt_for_known_conversation():
 
     class _FakeConversation:
         def __init__(self):
-            self.interrupted = threading.Event()
+            self.interrupted = False
 
         def interrupt(self):
-            self.interrupted.set()
+            self.interrupted = True
 
     fake_conv = _FakeConversation()
     from paca_acp_bridge.runner import _ConversationHandle
 
+    completed_task = asyncio.get_running_loop().create_future()
+    completed_task.set_result(None)
     runner._conversations["conv-1"] = _ConversationHandle(
         conversation=fake_conv,
-        thread=None,  # type: ignore[arg-type]
+        task=completed_task,  # type: ignore[arg-type]
     )
 
-    # interrupt() dispatches onto its own thread rather than calling
-    # conversation.interrupt() inline (see runner.py's docstring for why),
-    # so wait for that thread's effect instead of asserting immediately.
     runner.interrupt("conv-1")
 
-    assert fake_conv.interrupted.wait(timeout=2) is True
+    assert fake_conv.interrupted is True
 
 
 async def test_interrupt_is_a_no_op_for_unknown_conversation():
@@ -110,16 +109,16 @@ async def test_start_turn_rejects_resume_while_previous_turn_still_running():
     class _FakeConversation:
         pass
 
-    class _FakeAliveThread:
-        def is_alive(self):
-            return True
+    class _FakeRunningTask:
+        def done(self):
+            return False
 
     from paca_acp_bridge.runner import _ConversationHandle
 
     fake_conv = _FakeConversation()
     runner._conversations["conv-1"] = _ConversationHandle(
         conversation=fake_conv,
-        thread=_FakeAliveThread(),  # type: ignore[arg-type]
+        task=_FakeRunningTask(),  # type: ignore[arg-type]
     )
 
     await runner.start_turn(
@@ -134,5 +133,55 @@ async def test_start_turn_rejects_resume_while_previous_turn_still_running():
     assert sent[0]["type"] == "turn_status"
     assert sent[0]["status"] == "failed"
     # The still-running conversation's handle must be left untouched — no
-    # second thread should have been started against it.
+    # second task should have been started against it.
     assert runner._conversations["conv-1"].conversation is fake_conv
+
+
+async def test_start_turn_resume_drives_conversation_via_arun_and_reports_finished():
+    """Locks in the arun()-based (not run()-on-a-thread) execution path:
+    conversation.interrupt() can only cancel a turn immediately if the turn
+    is actually tracked as an asyncio Task via arun() — see runner.py's
+    module docstring for why the old thread+run() model couldn't do this."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner = ConversationRunner(workspace="/tmp", send=send)
+
+    class _FakeConversation:
+        def __init__(self):
+            self.sent_messages: list[str] = []
+            self.ran = False
+
+        def send_message(self, message):
+            self.sent_messages.append(message)
+
+        async def arun(self):
+            self.ran = True
+
+    fake_conv = _FakeConversation()
+    from paca_acp_bridge.runner import _ConversationHandle
+
+    done_task = asyncio.get_running_loop().create_future()
+    done_task.set_result(None)
+    runner._conversations["conv-1"] = _ConversationHandle(
+        conversation=fake_conv,
+        task=done_task,  # type: ignore[arg-type]
+    )
+
+    await runner.start_turn(
+        {"conversation_id": "conv-1", "project_id": "proj-1", "message": "a follow-up message"}
+    )
+    await runner._conversations["conv-1"].task
+
+    assert fake_conv.sent_messages == ["a follow-up message"]
+    assert fake_conv.ran is True
+    assert sent == [
+        {
+            "type": "turn_status",
+            "conversation_id": "conv-1",
+            "project_id": "proj-1",
+            "status": "finished",
+        }
+    ]

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -6,6 +6,7 @@ than a real `openhands.sdk.Conversation`.
 """
 
 import asyncio
+import threading
 
 import pytest
 
@@ -185,3 +186,59 @@ async def test_start_turn_resume_drives_conversation_via_arun_and_reports_finish
             "status": "finished",
         }
     ]
+
+
+class _FakeEvent:
+    def model_dump_json(self):
+        return "{}"
+
+
+async def test_event_callback_schedules_without_blocking_when_called_on_loop():
+    """arun()'s own on_event calls (finalizing a turn, emitting InterruptEvent
+    on cancellation) happen synchronously on this daemon's own event-loop
+    thread. Blocking there with run_coroutine_threadsafe(...).result() would
+    make the loop wait on a coroutine it can only run once this call
+    returns — a guaranteed 10s self-deadlock. Calling the callback directly
+    (as arun() does) must return immediately instead."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner = ConversationRunner(workspace="/tmp", send=send)
+    runner._loop = asyncio.get_running_loop()
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    callback(_FakeEvent())  # must not block waiting for _send to run
+
+    await asyncio.sleep(0)  # let the scheduled task actually run
+
+    assert len(sent) == 1
+    assert sent[0]["conversation_id"] == "conv-1"
+    assert sent[0]["event_type"] == "_FakeEvent"
+
+
+async def test_event_callback_uses_threadsafe_dispatch_when_called_off_loop():
+    """ACPAgent streams some mid-turn updates from its own background
+    ("portal") thread — a genuinely different thread than this daemon's
+    loop — where the blocking run_coroutine_threadsafe(...).result() dispatch
+    is still correct and necessary."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner = ConversationRunner(workspace="/tmp", send=send)
+    runner._loop = asyncio.get_running_loop()
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    thread = threading.Thread(target=callback, args=(_FakeEvent(),))
+    thread.start()
+    for _ in range(200):
+        if not thread.is_alive():
+            break
+        await asyncio.sleep(0.01)
+
+    assert not thread.is_alive()
+    assert len(sent) == 1
+    assert sent[0]["conversation_id"] == "conv-1"

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -5,6 +5,8 @@ Exercises the daemon's own logic without spawning a real ACP CLI subprocess —
 than a real `openhands.sdk.Conversation`.
 """
 
+import threading
+
 import pytest
 
 from paca_acp_bridge.runner import ConversationRunner, resolve_acp_command
@@ -41,10 +43,10 @@ async def test_interrupt_calls_conversation_interrupt_for_known_conversation():
 
     class _FakeConversation:
         def __init__(self):
-            self.interrupted = False
+            self.interrupted = threading.Event()
 
         def interrupt(self):
-            self.interrupted = True
+            self.interrupted.set()
 
     fake_conv = _FakeConversation()
     from paca_acp_bridge.runner import _ConversationHandle
@@ -54,9 +56,12 @@ async def test_interrupt_calls_conversation_interrupt_for_known_conversation():
         thread=None,  # type: ignore[arg-type]
     )
 
+    # interrupt() dispatches onto its own thread rather than calling
+    # conversation.interrupt() inline (see runner.py's docstring for why),
+    # so wait for that thread's effect instead of asserting immediately.
     runner.interrupt("conv-1")
 
-    assert fake_conv.interrupted is True
+    assert fake_conv.interrupted.wait(timeout=2) is True
 
 
 async def test_interrupt_is_a_no_op_for_unknown_conversation():

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -30,7 +30,7 @@ from ..repositories import conversation_repository
 from . import trigger_skills
 from .builder import build_llm, build_mcp_config, build_skills, load_default_skills
 from .docker_workspace import start_sandbox, stop_sandbox
-from .prompt import build_initial_prompt, build_trigger_suffix
+from .prompt import build_initial_prompt, build_project_context_suffix, build_trigger_suffix
 from .repo_tools import make_repository_tool_specs
 
 # The trigger_type Go publishes for direct-chat messages (agent_service.go's
@@ -461,16 +461,6 @@ def _make_reconciler(
     return reconcile
 
 
-def _build_project_context_suffix(project_id: str) -> str:
-    return (
-        f"\n\n## Current Project Context\n"
-        f"You are working inside project `{project_id}`.\n"
-        "**Always pass this value as `projectId` in every MCP tool call** "
-        "that requires it — never ask the user for the project ID and "
-        "never call `list_projects` to find it.\n"
-    )
-
-
 # ─── Main entry point ─────────────────────────────────────────────────────────
 
 
@@ -525,7 +515,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
 
         # Inject current project context so the AI never needs to ask for the
         # project ID or call list_projects to discover it.
-        system_suffix += _build_project_context_suffix(trigger.project_id)
+        system_suffix += build_project_context_suffix(trigger.project_id)
 
         # Documentation lives in Paca — never create local files, and always
         # read it before acting (it holds architecture/conventions/prior

--- a/services/ai-agent/src/agent/prompt.py
+++ b/services/ai-agent/src/agent/prompt.py
@@ -45,6 +45,16 @@ def build_initial_prompt(trigger: TriggerMessage) -> str:
     return trigger.message
 
 
+def build_project_context_suffix(project_id: str) -> str:
+    return (
+        f"\n\n## Current Project Context\n"
+        f"You are working inside project `{project_id}`.\n"
+        "**Always pass this value as `projectId` in every MCP tool call** "
+        "that requires it — never ask the user for the project ID and "
+        "never call `list_projects` to find it.\n"
+    )
+
+
 # ACP agents don't get Paca-managed skills injected via system context the
 # way the LLM/sandbox path does (see skills/paca/SKILL.md) — the only way to
 # route a local ACP CLI (Claude Code, Codex, ...) through the Paca skill is
@@ -53,8 +63,21 @@ _ACP_SKILL_TRIGGER = "/paca"
 
 
 def build_acp_message(trigger: TriggerMessage) -> str:
-    """Prefix the initial prompt with the `/paca` skill trigger for ACP agents."""
-    return f"{_ACP_SKILL_TRIGGER} {build_initial_prompt(trigger)}"
+    """Build the message sent to trigger an ACP agent.
+
+    The LLM/sandbox path (executor.py) carries project and trigger context in
+    AgentContext.system_message_suffix, a channel ACP agents don't have —
+    apps/acp-bridge's ConversationRunner only ever calls
+    conversation.send_message(message) on the plain local Conversation, with
+    no separate system-suffix argument. So instead of a suffix, that same
+    context (minus the repo section, which points at sandbox-only tools like
+    clone_repository — ACP agents already have local repo access) is folded
+    directly into this message, prefixed with the `/paca` skill trigger.
+    """
+    message = f"{_ACP_SKILL_TRIGGER} {build_initial_prompt(trigger)}"
+    message += build_project_context_suffix(trigger.project_id)
+    message += build_trigger_suffix(trigger)
+    return message
 
 
 def build_trigger_suffix(trigger: TriggerMessage, all_repos: list[dict] | None = None) -> str:

--- a/services/ai-agent/tests/test_acp_dispatch.py
+++ b/services/ai-agent/tests/test_acp_dispatch.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import src.agent.acp_dispatch as acp_dispatch
+from src.agent.prompt import build_acp_message
 from src.core.streams import TriggerMessage
 from src.models.agent import AgentConfig
 from src.models.conversation_status import ConversationStatus
@@ -83,7 +84,7 @@ async def test_online_bridge_dispatches_start_turn(monkeypatch):
             "type": "start_turn",
             "conversation_id": "conv-1",
             "project_id": "proj-1",
-            "message": "/paca hello",
+            "message": build_acp_message(trigger),
             "trigger_type": "chat_message",
             "acp_provider": "claude-code",
             "acp_command": [],

--- a/services/ai-agent/tests/test_executor.py
+++ b/services/ai-agent/tests/test_executor.py
@@ -10,7 +10,6 @@ import pytest
 from src.agent import executor
 from src.agent.executor import (
     _AtomicCounter,
-    _build_project_context_suffix,
     _find_idle_chat_sandboxes,
     _keep_sandbox_alive,
     _make_event_callback,
@@ -24,26 +23,6 @@ from src.core import streams as stream_store
 from src.core.registry import ChatSandboxState, chat_sandboxes, stop_events
 from src.core.streams import TriggerMessage
 from src.repositories import conversation_repository
-
-
-def test_project_id_appears_in_suffix():
-    result = _build_project_context_suffix("proj-123")
-    assert "proj-123" in result
-
-
-def test_suffix_instructs_agent_to_pass_project_id():
-    result = _build_project_context_suffix("proj-abc")
-    assert "projectId" in result
-
-
-def test_suffix_discourages_list_projects_call():
-    result = _build_project_context_suffix("proj-abc")
-    assert "list_projects" in result
-
-
-def test_different_project_ids_produce_different_suffixes():
-    assert _build_project_context_suffix("proj-1") != _build_project_context_suffix("proj-2")
-
 
 # ─── _AtomicCounter ─────────────────────────────────────────────────────────
 

--- a/services/ai-agent/tests/test_prompt.py
+++ b/services/ai-agent/tests/test_prompt.py
@@ -1,6 +1,11 @@
 """Tests for the prompt and system-suffix builders."""
 
-from src.agent.prompt import build_acp_message, build_initial_prompt, build_trigger_suffix
+from src.agent.prompt import (
+    build_acp_message,
+    build_initial_prompt,
+    build_project_context_suffix,
+    build_trigger_suffix,
+)
 from src.core.streams import TriggerMessage
 
 
@@ -45,18 +50,61 @@ def test_initial_prompt_empty_stays_empty_for_other_triggers():
     assert result == ""
 
 
+# ── build_project_context_suffix ──────────────────────────────────────────────
+
+
+def test_project_id_appears_in_suffix():
+    result = build_project_context_suffix("proj-123")
+    assert "proj-123" in result
+
+
+def test_suffix_instructs_agent_to_pass_project_id():
+    result = build_project_context_suffix("proj-abc")
+    assert "projectId" in result
+
+
+def test_suffix_discourages_list_projects_call():
+    result = build_project_context_suffix("proj-abc")
+    assert "list_projects" in result
+
+
+def test_different_project_ids_produce_different_suffixes():
+    assert build_project_context_suffix("proj-1") != build_project_context_suffix("proj-2")
+
+
 # ── build_acp_message ─────────────────────────────────────────────────────────
 
 
 def test_acp_message_prefixes_paca_skill():
     result = build_acp_message(_trigger(message="Do something"))
-    assert result == "/paca Do something"
+    assert result.startswith("/paca Do something")
 
 
 def test_acp_message_uses_task_assigned_fallback():
     result = build_acp_message(_trigger(trigger_type="task_assigned", message=""))
     assert result.startswith("/paca ")
     assert "assigned" in result.lower()
+
+
+def test_acp_message_includes_project_context():
+    result = build_acp_message(_trigger(project_id="proj-789"))
+    assert "proj-789" in result
+    assert "projectId" in result
+
+
+def test_acp_message_includes_trigger_context():
+    result = build_acp_message(_trigger(trigger_type="task_assigned", task_id="task-42"))
+    assert "Action type: Task assignment" in result
+    assert "task-42" in result
+
+
+def test_acp_message_omits_repo_instructions():
+    """ACP agents already have local repo access — clone_repository is a
+    sandbox-only tool, so the repo section of build_trigger_suffix must not
+    be folded into the ACP message even when the trigger has linked repos."""
+    result = build_acp_message(_trigger(repo_plugin_ids=["plugin-1"]))
+    assert "clone_repository" not in result
+    assert "Repository" not in result
 
 
 def test_action_type_task_assigned():


### PR DESCRIPTION
## Summary

Fixes two problems with ACP agent conversations (Claude Code / Codex running locally against a user's own credentials, via `apps/acp-bridge`):

- **Stop/interrupt didn't actually stop anything mid-turn.** `ConversationRunner` drove each turn with `conversation.run()` on a dedicated `threading.Thread`. `run()`/`pause()` only take effect *between* whole agent steps, and for `ACPAgent` a single step is the entire ACP turn (every tool call the coding CLI makes before replying) — so pressing "stop" wouldn't cancel anything until the turn finished on its own. Switched to `conversation.arun()` scheduled as a plain `asyncio.Task` on the daemon's own event loop, so `conversation.interrupt()` can cancel the task immediately (mid-tool-call) and the SDK sends the coding CLI a real ACP `session/cancel`. This also sidesteps a cross-thread state-lock deadlock the OpenHands SDK documents for the sync `run()` path (SDK issues #3348/#3350), since `interrupt()` no longer needs to block waiting on the conversation's state lock.
- **ACP agents never learned which project they were working in.** The LLM/sandbox path (`executor.py`) injects project + trigger context via `AgentContext.system_message_suffix`, but ACP agents have no equivalent system-suffix channel — `ConversationRunner` only ever calls `conversation.send_message(message)`. `build_acp_message()` now folds that same context (project ID + trigger suffix, minus the repo section, which points at sandbox-only tools like `clone_repository` that ACP agents don't need since they already have local repo access) directly into the message text.

## Changes

- `apps/acp-bridge/src/paca_acp_bridge/runner.py`
  - `_ConversationHandle.thread: threading.Thread` → `task: asyncio.Task[None]`; `_run_conversation` is now a coroutine driving `conversation.arun()` instead of a thread target calling `conversation.run()`.
  - `interrupt()` can now be called synchronously and safely from the event-loop thread — documented why in the module docstring and the method docstring.
  - `_make_event_callback`'s dispatch now branches on whether it's invoked from the daemon's own loop (most calls now, since `arun()` runs as a task on that same loop) vs. a genuinely different thread (`ACPAgent`'s background "portal" thread, which still streams some mid-turn updates cross-thread). Calling the blocking `run_coroutine_threadsafe(...).result()` path from the daemon's own loop would self-deadlock — the loop can't run a coroutine it just scheduled while its own thread is stuck waiting on it — so same-loop calls now just `create_task` instead.
  - Dropped `_report_status_threadsafe`, folded into the coroutine directly.
- `services/ai-agent/src/agent/prompt.py`
  - Moved `_build_project_context_suffix` here from `executor.py` as a public `build_project_context_suffix`.
  - `build_acp_message()` now appends `build_project_context_suffix(trigger.project_id)` and `build_trigger_suffix(trigger)` to the `/paca`-prefixed prompt.
- `services/ai-agent/src/agent/executor.py`: uses the relocated `build_project_context_suffix` instead of the local private helper.
- Tests: new/updated coverage in `apps/acp-bridge/tests/test_runner.py` (arun()-based resume path, both event-callback dispatch branches — same-loop vs. cross-thread) and `services/ai-agent/tests/{test_prompt,test_acp_dispatch,test_executor}.py` (suffix-builder tests moved to `test_prompt.py`, `build_acp_message` now checked for project/trigger context and repo-section omission).

## Testing

- `apps/acp-bridge/tests/test_runner.py` and `services/ai-agent/tests/test_prompt.py`, `test_acp_dispatch.py`, `test_executor.py` cover the new behavior (see test list above).
