### PR TITLE
feat: implement sprint event handling and real-time updates

### DIFF
--- a/apps/web/src/components/app-shell/app-sidebar.tsx
+++ b/apps/web/src/components/app-shell/app-sidebar.tsx
@@ -1168,11 +1168,13 @@ function ProjectInteractionsSection({
 		updateSprintMutation.mutate({ taskId, sprintId });
 	};
 
+	// No refetchInterval: kept live via useProjectRealtime's socket-driven
+	// sprint.* invalidation (see hooks/use-project-realtime.ts) instead of
+	// polling.
 	const { data: sprints = [] } = useQuery({
 		...sprintsQueryOptions(projectId),
 		enabled: canViewSprints,
 		retry: false,
-		refetchInterval: 30_000,
 	});
 
 	// Hide entire section if user lacks the "View Sprints" permission

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -75,6 +75,7 @@ import {
 } from "@/lib/interaction-api";
 import type { PluginRegistration } from "@/lib/plugin-api";
 import { RemoteComponent } from "@/lib/plugins/loader";
+import { usePluginBaseProps } from "@/lib/plugins/plugin-props";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 import {
 	customFieldsQueryOptions,
@@ -487,6 +488,13 @@ export function InteractionLayout({
 						r.component === activeView.config?.plugin_component,
 				) ?? null)
 			: null;
+
+	// BaseExtensionProps (api/ui/meta) for the active plugin view, if any —
+	// every ViewExtensionProps component expects these alongside projectId.
+	const activePluginViewBaseProps = usePluginBaseProps(
+		activePluginView ?? undefined,
+		projectId,
+	);
 
 	useEffect(() => {
 		if (!activeViewId) return;
@@ -1656,11 +1664,13 @@ export function InteractionLayout({
 				ref={viewContentRef}
 				className="flex flex-1 flex-col overflow-hidden"
 			>
-				{activePluginView ? (
+				{activePluginView && activeView ? (
 					<RemoteComponent
 						registration={activePluginView}
 						componentProps={{
+							...activePluginViewBaseProps,
 							projectId,
+							viewId: activeView.id,
 							tasks: tasks,
 							statuses,
 							taskTypes,

--- a/apps/web/src/hooks/use-project-permissions.ts
+++ b/apps/web/src/hooks/use-project-permissions.ts
@@ -12,9 +12,10 @@ import { myProjectPermissionsQueryOptions } from "@/lib/project-api";
  * without requiring access to the full members or roles lists.
  */
 export function useProjectPermissions(projectId: string) {
-	const { data: permissionsMap = {} } = useQuery(
-		myProjectPermissionsQueryOptions(projectId),
-	);
+	const { data: permissionsMap = {} } = useQuery({
+		...myProjectPermissionsQueryOptions(projectId),
+		enabled: !!projectId,
+	});
 
 	// Convert the {perm: boolean} map to the string[] form expected by the
 	// shared hasPermission helper.

--- a/apps/web/src/hooks/use-project-realtime.ts
+++ b/apps/web/src/hooks/use-project-realtime.ts
@@ -20,6 +20,9 @@
 // doc.* events   → invalidate ["projects", projectId, "docs"]
 //                  This covers docFoldersQueryOptions, docListQueryOptions,
 //                  docQueryOptions, etc.
+// sprint.* events → invalidate ["projects", projectId, "sprints"]
+//                  This covers sprintsQueryOptions and sprintQueryOptions —
+//                  replaces the sidebar's old refetchInterval polling.
 // workflow.* events → invalidate ["projects", projectId, "workflows"] (the
 //                  automation list/graph queries) and ["projects", projectId,
 //                  "tasks"] (covers workflowsForTaskQueryOptions, which hangs
@@ -62,6 +65,13 @@ export function useProjectRealtime(projectId: string): void {
 			if (type.startsWith("doc.")) {
 				void queryClient.invalidateQueries({
 					queryKey: ["projects", projectId, "docs"],
+				});
+				return;
+			}
+
+			if (type.startsWith("sprint.")) {
+				void queryClient.invalidateQueries({
+					queryKey: ["projects", projectId, "sprints"],
 				});
 				return;
 			}

--- a/apps/web/src/lib/plugins/plugin-client.ts
+++ b/apps/web/src/lib/plugins/plugin-client.ts
@@ -31,6 +31,18 @@ function pluginUrl(pluginId: string, path: string): string {
 	return `${API_BASE_URL}/plugins/${pluginId}${p}`;
 }
 
+// Project-scoped methods (listTasks/getTask/getProject/listMembers) are only
+// meaningful when the client was built with a projectId — admin/global-scope
+// pages build one without. Fail loudly instead of hitting a malformed
+// `/projects//...` URL, which otherwise surfaces as an opaque 404.
+function requireProjectId(projectId: string, method: string): void {
+	if (!projectId) {
+		throw new Error(
+			`[PluginApiClient] ${method}() requires a project-scoped client, but no projectId was provided — this plugin page is rendered without a project context (e.g. an admin/global-scope page).`,
+		);
+	}
+}
+
 async function request<T>(
 	method: string,
 	url: string,
@@ -69,6 +81,7 @@ export function createPluginApiClient(projectId = ""): HostPluginApiClient {
 	return {
 		projectId,
 		listTasks: (filters) => {
+			requireProjectId(projectId, "listTasks");
 			const params = new URLSearchParams();
 			for (const [key, value] of Object.entries(filters ?? {})) {
 				if (value !== undefined && value !== null && value !== "") {
@@ -82,11 +95,21 @@ export function createPluginApiClient(projectId = ""): HostPluginApiClient {
 				`${API_BASE_URL}/projects/${projectId}/tasks${qs ? `?${qs}` : ""}`,
 			).then((envelope) => envelope.items);
 		},
-		getTask: (taskId) =>
-			request("GET", `${API_BASE_URL}/projects/${projectId}/tasks/${taskId}`),
-		getProject: () => request("GET", `${API_BASE_URL}/projects/${projectId}`),
-		listMembers: () =>
-			request("GET", `${API_BASE_URL}/projects/${projectId}/members`),
+		getTask: (taskId) => {
+			requireProjectId(projectId, "getTask");
+			return request(
+				"GET",
+				`${API_BASE_URL}/projects/${projectId}/tasks/${taskId}`,
+			);
+		},
+		getProject: () => {
+			requireProjectId(projectId, "getProject");
+			return request("GET", `${API_BASE_URL}/projects/${projectId}`);
+		},
+		listMembers: () => {
+			requireProjectId(projectId, "listMembers");
+			return request("GET", `${API_BASE_URL}/projects/${projectId}/members`);
+		},
 		pluginGet: (pluginId, path) => request("GET", pluginUrl(pluginId, path)),
 		pluginPost: (pluginId, path, body) =>
 			request("POST", pluginUrl(pluginId, path), body),

--- a/apps/web/src/lib/plugins/plugin-client.ts
+++ b/apps/web/src/lib/plugins/plugin-client.ts
@@ -1,0 +1,98 @@
+/**
+ * Host-side implementation of the plugin SDK's PluginApiClient contract
+ * (see @paca-ai/plugin-sdk-react's api-client.ts, which every plugin
+ * frontend bundles its own copy of via Module Federation). apps/web does
+ * not depend on that package, so this is duck-typed to match its runtime
+ * shape rather than sharing a class — plugin components call `props.api.*`
+ * and don't care which implementation answers.
+ */
+
+interface SuccessEnvelope<T> {
+	success: true;
+	data: T;
+}
+
+export interface HostPluginApiClient {
+	readonly projectId: string;
+	listTasks(filters?: Record<string, unknown>): Promise<unknown[]>;
+	getTask(taskId: string): Promise<unknown>;
+	getProject(): Promise<unknown>;
+	listMembers(): Promise<unknown[]>;
+	pluginGet<T>(pluginId: string, path: string): Promise<T>;
+	pluginPost<T>(pluginId: string, path: string, body: unknown): Promise<T>;
+	pluginPatch<T>(pluginId: string, path: string, body: unknown): Promise<T>;
+	pluginDelete(pluginId: string, path: string): Promise<void>;
+}
+
+const API_BASE_URL = `${window.location.origin}/api/v1`;
+
+function pluginUrl(pluginId: string, path: string): string {
+	const p = path.startsWith("/") ? path : `/${path}`;
+	return `${API_BASE_URL}/plugins/${pluginId}${p}`;
+}
+
+async function request<T>(
+	method: string,
+	url: string,
+	body?: unknown,
+): Promise<T> {
+	const init: RequestInit = {
+		method,
+		// Auth is via an HttpOnly session cookie (see apiClient's withCredentials
+		// use of the same cookie) rather than a bearer token, so plain fetch
+		// with credentials included is sufficient — no token to attach.
+		credentials: "include",
+		headers: { "Content-Type": "application/json" },
+	};
+	if (body !== undefined) {
+		init.body = JSON.stringify(body);
+	}
+
+	const res = await fetch(url, init);
+	if (!res.ok) {
+		const text = await res.text().catch(() => res.statusText);
+		throw new Error(
+			`[PluginApiClient] ${method} ${url} → ${res.status}: ${text}`,
+		);
+	}
+	if (res.status === 204) return undefined as T;
+	const json = (await res.json()) as SuccessEnvelope<T>;
+	return json.data;
+}
+
+/**
+ * Builds the client injected as `props.api` into every plugin extension-point
+ * component. `projectId` should be omitted for admin/global-scope pages,
+ * matching BaseExtensionProps's contract.
+ */
+export function createPluginApiClient(projectId = ""): HostPluginApiClient {
+	return {
+		projectId,
+		listTasks: (filters) => {
+			const params = new URLSearchParams();
+			for (const [key, value] of Object.entries(filters ?? {})) {
+				if (value !== undefined && value !== null && value !== "") {
+					params.set(key, String(value));
+				}
+			}
+			if (!params.has("page_size")) params.set("page_size", "200");
+			const qs = params.toString();
+			return request<{ items: unknown[] }>(
+				"GET",
+				`${API_BASE_URL}/projects/${projectId}/tasks${qs ? `?${qs}` : ""}`,
+			).then((envelope) => envelope.items);
+		},
+		getTask: (taskId) =>
+			request("GET", `${API_BASE_URL}/projects/${projectId}/tasks/${taskId}`),
+		getProject: () => request("GET", `${API_BASE_URL}/projects/${projectId}`),
+		listMembers: () =>
+			request("GET", `${API_BASE_URL}/projects/${projectId}/members`),
+		pluginGet: (pluginId, path) => request("GET", pluginUrl(pluginId, path)),
+		pluginPost: (pluginId, path, body) =>
+			request("POST", pluginUrl(pluginId, path), body),
+		pluginPatch: (pluginId, path, body) =>
+			request("PATCH", pluginUrl(pluginId, path), body),
+		pluginDelete: (pluginId, path) =>
+			request("DELETE", pluginUrl(pluginId, path), undefined),
+	};
+}

--- a/apps/web/src/lib/plugins/plugin-props.ts
+++ b/apps/web/src/lib/plugins/plugin-props.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { type PluginRegistration, pluginsQueryOptions } from "@/lib/plugin-api";
+import { createPluginApiClient } from "./plugin-client";
+
+/**
+ * Host-side implementation of BaseExtensionProps (@paca-ai/plugin-sdk-react)
+ * — every mounted plugin component destructures `{ api, ui, meta }` from its
+ * props, but RemoteComponent only forwards whatever componentProps its
+ * caller passes in, so each route that mounts a plugin page must build this
+ * itself. `toast`/`confirm` are stubs — the host has no toast or confirm
+ * dialog system yet — `navigate` is wired to the real router since that's
+ * already available.
+ *
+ * `registration` may be undefined while the caller's own data is still
+ * resolving — call this unconditionally (before any early return) like any
+ * other hook, the result just won't be used until a real registration is
+ * available.
+ */
+export function usePluginBaseProps(
+	registration: PluginRegistration | undefined,
+	projectId?: string,
+) {
+	const navigate = useNavigate();
+	const { data: plugins = [] } = useQuery(pluginsQueryOptions);
+	const pluginId = registration?.pluginId ?? "";
+	const pluginName = registration?.pluginName ?? "";
+	const version =
+		plugins.find((p) => p.manifest.id === pluginId)?.manifest.version ??
+		"0.0.0";
+
+	return useMemo(
+		() => ({
+			api: createPluginApiClient(projectId),
+			ui: {
+				toast: () => {},
+				confirm: () => Promise.resolve(false),
+				navigate: (path: string) => void navigate({ to: path as "/" }),
+			},
+			meta: { pluginId, displayName: pluginName, version },
+		}),
+		[pluginId, pluginName, projectId, version, navigate],
+	);
+}

--- a/apps/web/src/routes/_authenticated/admin/plugins/$pluginId/$slug.tsx
+++ b/apps/web/src/routes/_authenticated/admin/plugins/$pluginId/$slug.tsx
@@ -5,6 +5,7 @@ import { myPermissionsQueryOptions } from "@/lib/admin-api";
 import { hasPermission } from "@/lib/permissions";
 import { buildNavItems, pluginsQueryOptions } from "@/lib/plugin-api";
 import { RemoteComponent } from "@/lib/plugins/loader";
+import { usePluginBaseProps } from "@/lib/plugins/plugin-props";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 
 export const Route = createFileRoute(
@@ -49,13 +50,12 @@ function AdminPluginPage() {
 	const { t } = useTranslation("errors");
 	const { pluginId, slug } = Route.useParams();
 	const { getNavItems, isLoading } = usePluginRegistry();
-
-	if (isLoading) return null;
-
 	const navItem = getNavItems("admin").find(
 		(item) => item.pluginId === pluginId && item.slug === slug,
 	);
+	const baseProps = usePluginBaseProps(navItem?.registration);
 
+	if (isLoading) return null;
 	if (!navItem) {
 		throw notFound();
 	}
@@ -64,6 +64,7 @@ function AdminPluginPage() {
 		<div className="flex flex-col h-full">
 			<RemoteComponent
 				registration={navItem.registration}
+				componentProps={baseProps}
 				fallback={
 					<div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive m-6">
 						<AlertCircle className="size-3.5 shrink-0" />

--- a/apps/web/src/routes/_authenticated/projects/$projectId/plugins/$pluginId/$slug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/plugins/$pluginId/$slug.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { hasPermission } from "@/lib/permissions";
 import { buildNavItems, pluginsQueryOptions } from "@/lib/plugin-api";
 import { RemoteComponent } from "@/lib/plugins/loader";
+import { usePluginBaseProps } from "@/lib/plugins/plugin-props";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 import { myProjectPermissionsQueryOptions } from "@/lib/project-api";
 
@@ -53,13 +54,12 @@ function ProjectPluginPage() {
 	const { t } = useTranslation("errors");
 	const { projectId, pluginId, slug } = Route.useParams();
 	const { getNavItems, isLoading } = usePluginRegistry();
-
-	if (isLoading) return null;
-
 	const navItem = getNavItems("project").find(
 		(item) => item.pluginId === pluginId && item.slug === slug,
 	);
+	const baseProps = usePluginBaseProps(navItem?.registration, projectId);
 
+	if (isLoading) return null;
 	if (!navItem) {
 		throw notFound();
 	}
@@ -68,7 +68,7 @@ function ProjectPluginPage() {
 		<div className="flex flex-col h-full">
 			<RemoteComponent
 				registration={navItem.registration}
-				componentProps={{ projectId }}
+				componentProps={{ ...baseProps, projectId }}
 				fallback={
 					<div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive m-6">
 						<AlertCircle className="size-3.5 shrink-0" />

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -142,7 +142,7 @@ func New(cfg *config.Config) (*App, error) {
 	globalRoleService := globalrolesvc.NewCachedService(globalrolesvc.New(globalRoleRepo), cacheStore, cfg.Cache.ConfigTTL, log)
 	projectService := projectsvc.NewCachedService(projectsvc.New(projectRepo, taskRepo), cacheStore, cfg.Cache.ProjectTTL, cfg.Cache.ConfigTTL, log)
 	taskService := tasksvc.NewCachedService(tasksvc.New(taskRepo).WithWorkflowStatusChecker(rawWorkflowRepo), cacheStore, cfg.Cache.ConfigTTL, log)
-	sprintService := sprintsvc.NewCachedSprintService(sprintsvc.New(sprintRepo, taskRepo), cacheStore, cfg.Cache.SprintTTL, log)
+	sprintService := sprintsvc.NewCachedSprintService(sprintsvc.New(sprintRepo, taskRepo, publisher), cacheStore, cfg.Cache.SprintTTL, log)
 	viewService := sprintsvc.NewCachedViewService(sprintsvc.NewViewService(viewRepo), cacheStore, cfg.Cache.SprintTTL, log)
 	notificationService := notificationsvc.New(notificationRepo, projectRepo, publisher)
 	agentRepo := pgRepo.NewAgentRepository(db)

--- a/services/api/internal/domain/plugin/entity.go
+++ b/services/api/internal/domain/plugin/entity.go
@@ -211,6 +211,10 @@ type ExtensionPointRegistration struct {
 	Point string `json:"point"`
 	// Component is the exported React component name from the remote entry.
 	Component string `json:"component"`
+	// Label is the human-readable name shown where the host lists this
+	// registration as a user-facing choice (e.g. the "New view" picker for
+	// the "view" extension point). Falls back to Component when omitted.
+	Label string `json:"label,omitempty"`
 	// Order is the default display order within the extension point.
 	Order int `json:"order,omitempty"`
 }

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -72,6 +72,12 @@ const (
 	TopicDocCommentUpdated = "doc.comment.updated"
 	TopicDocCommentDeleted = "doc.comment.deleted"
 
+	// --- Sprint events --------------------------------------------------------
+	TopicSprintCreated   = "sprint.created"
+	TopicSprintUpdated   = "sprint.updated"
+	TopicSprintDeleted   = "sprint.deleted"
+	TopicSprintCompleted = "sprint.completed"
+
 	// --- Notification events ------------------------------------------------
 	// TopicNotificationCreated is published to ChannelRealtime when a new
 	// notification is created.  The payload includes recipient_user_id so the

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -495,6 +495,48 @@ func (r *Runtime) registerDBFunctions(b wazero.HostModuleBuilder, p plugindom.Pl
 			nil).
 		Export("db_query")
 
+	// paca.db_query2(sqlPtr, sqlLen, paramsPtr, paramsLen, resultPtrPtr, resultLenPtr, errPtrPtr, errLenPtr)
+	// Same as db_query but also reports execution errors back to the plugin.
+	// db_query's signature has no error channel, so a query that fails to
+	// execute (e.g. references a column that doesn't exist) silently looks
+	// like a zero-row success to the plugin — see the `return` with no
+	// output write in the error branch above. Exposed as a separate export
+	// rather than changing db_query in place: WASM import/export signatures
+	// are matched exactly at instantiation time, so widening db_query would
+	// break every already-compiled plugin binary that still imports the old
+	// 6-arg form. New/rebuilt plugins should call this one instead.
+	b.NewFunctionBuilder().
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			sqlStr, err := readString(m, stack[0], stack[1])
+			if err != nil {
+				r.log.Error("paca.db_query2: read sql", "plugin", p.Name, "error", err)
+				return
+			}
+			paramsJSON, err := readString(m, stack[2], stack[3])
+			if err != nil {
+				r.log.Error("paca.db_query2: read params", "plugin", p.Name, "error", err)
+				return
+			}
+
+			result, err := r.execQuery(ctx, schema, sqlStr, paramsJSON)
+			if err != nil {
+				errBytes := []byte(err.Error())
+				ptrLen, _ := writeToMemory(m, errBytes)
+				m.Memory().WriteUint32Le(uint32(stack[4]), 0)
+				m.Memory().WriteUint32Le(uint32(stack[5]), 0)
+				m.Memory().WriteUint32Le(uint32(stack[6]), uint32(ptrLen[0]))
+				m.Memory().WriteUint32Le(uint32(stack[7]), uint32(ptrLen[1]))
+				return
+			}
+			resultPtrLen := writeJSONResult(m, result)
+			m.Memory().WriteUint32Le(uint32(stack[4]), uint32(resultPtrLen[0]))
+			m.Memory().WriteUint32Le(uint32(stack[5]), uint32(resultPtrLen[1]))
+			m.Memory().WriteUint32Le(uint32(stack[6]), 0)
+			m.Memory().WriteUint32Le(uint32(stack[7]), 0)
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64},
+			nil).
+		Export("db_query2")
+
 	// paca.db_exec(sqlPtr, sqlLen, paramsPtr, paramsLen, rowsAffectedPtr, errPtrPtr, errLenPtr)
 	b.NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -520,12 +520,15 @@ func (r *Runtime) registerDBFunctions(b wazero.HostModuleBuilder, p plugindom.Pl
 
 			result, err := r.execQuery(ctx, schema, sqlStr, paramsJSON)
 			if err != nil {
-				errBytes := []byte(err.Error())
-				ptrLen, _ := writeToMemory(m, errBytes)
+				errPtrLen, writeErr := writeToMemory(m, []byte(err.Error()))
+				if writeErr != nil {
+					r.log.Error("paca.db_query2: write error", "plugin", p.Name, "error", writeErr)
+					errPtrLen = []uint64{0, 0}
+				}
 				m.Memory().WriteUint32Le(uint32(stack[4]), 0)
 				m.Memory().WriteUint32Le(uint32(stack[5]), 0)
-				m.Memory().WriteUint32Le(uint32(stack[6]), uint32(ptrLen[0]))
-				m.Memory().WriteUint32Le(uint32(stack[7]), uint32(ptrLen[1]))
+				m.Memory().WriteUint32Le(uint32(stack[6]), uint32(errPtrLen[0]))
+				m.Memory().WriteUint32Le(uint32(stack[7]), uint32(errPtrLen[1]))
 				return
 			}
 			resultPtrLen := writeJSONResult(m, result)

--- a/services/api/internal/service/sprint/sprint_service.go
+++ b/services/api/internal/service/sprint/sprint_service.go
@@ -8,18 +8,36 @@ import (
 
 	sprintdom "github.com/Paca-AI/api/internal/domain/sprint"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
+	"github.com/Paca-AI/api/internal/events"
+	"github.com/Paca-AI/api/internal/platform/messaging"
 	"github.com/google/uuid"
 )
 
 // Service is the concrete implementation of sprintdom.SprintService.
 type Service struct {
-	repo     sprintdom.SprintRepository
-	taskRepo taskdom.TaskRepository
+	repo      sprintdom.SprintRepository
+	taskRepo  taskdom.TaskRepository
+	publisher *messaging.Publisher
 }
 
-// New returns a configured sprint service.
-func New(repo sprintdom.SprintRepository, taskRepo taskdom.TaskRepository) *Service {
-	return &Service{repo: repo, taskRepo: taskRepo}
+// New returns a configured sprint service. publisher may be nil; real-time
+// events are then skipped silently.
+func New(repo sprintdom.SprintRepository, taskRepo taskdom.TaskRepository, publisher *messaging.Publisher) *Service {
+	return &Service{repo: repo, taskRepo: taskRepo, publisher: publisher}
+}
+
+// publish sends a real-time pub/sub notification for a sprint change.
+// Errors are silently swallowed so a messaging failure never blocks the
+// primary HTTP response — this is how the frontend now learns to refresh
+// its sprint list/detail instead of polling on an interval.
+func (s *Service) publish(ctx context.Context, topic string, payload map[string]any) {
+	if s.publisher == nil {
+		return
+	}
+	_ = s.publisher.Publish(ctx, events.ChannelRealtime, map[string]any{
+		"type":    topic,
+		"payload": payload,
+	})
 }
 
 // ListSprints returns all sprints for a project.
@@ -70,6 +88,10 @@ func (s *Service) CreateSprint(ctx context.Context, in sprintdom.CreateSprintInp
 	if err := s.repo.CreateSprint(ctx, sp); err != nil {
 		return nil, err
 	}
+	s.publish(ctx, events.TopicSprintCreated, map[string]any{
+		"project_id": sp.ProjectID.String(),
+		"sprint_id":  sp.ID.String(),
+	})
 	return sp, nil
 }
 
@@ -107,6 +129,10 @@ func (s *Service) UpdateSprint(ctx context.Context, projectID, id uuid.UUID, in 
 	if err := s.repo.UpdateSprint(ctx, sp); err != nil {
 		return nil, err
 	}
+	s.publish(ctx, events.TopicSprintUpdated, map[string]any{
+		"project_id": sp.ProjectID.String(),
+		"sprint_id":  sp.ID.String(),
+	})
 	return sp, nil
 }
 
@@ -119,7 +145,14 @@ func (s *Service) DeleteSprint(ctx context.Context, projectID, id uuid.UUID) err
 	if sp.ProjectID != projectID {
 		return sprintdom.ErrSprintNotFound
 	}
-	return s.repo.DeleteSprint(ctx, id)
+	if err := s.repo.DeleteSprint(ctx, id); err != nil {
+		return err
+	}
+	s.publish(ctx, events.TopicSprintDeleted, map[string]any{
+		"project_id": sp.ProjectID.String(),
+		"sprint_id":  sp.ID.String(),
+	})
+	return nil
 }
 
 // CompleteSprint bulk-moves all non-done tasks out of the sprint and marks
@@ -148,5 +181,9 @@ func (s *Service) CompleteSprint(ctx context.Context, projectID, id uuid.UUID, i
 	if err := s.repo.UpdateSprint(ctx, sp); err != nil {
 		return nil, err
 	}
+	s.publish(ctx, events.TopicSprintCompleted, map[string]any{
+		"project_id": sp.ProjectID.String(),
+		"sprint_id":  sp.ID.String(),
+	})
 	return sp, nil
 }

--- a/services/api/internal/service/sprint/sprint_service_test.go
+++ b/services/api/internal/service/sprint/sprint_service_test.go
@@ -217,7 +217,7 @@ func (r *fakeTaskRepo) BulkMoveSprintTasks(_ context.Context, projectID, sourceS
 
 func TestCreateSprint_OK(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 
 	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
@@ -245,7 +245,7 @@ func TestCreateSprint_OK(t *testing.T) {
 
 func TestCreateSprint_DefaultStatus(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	sp, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
 		ProjectID: uuid.New(),
@@ -262,7 +262,7 @@ func TestCreateSprint_DefaultStatus(t *testing.T) {
 
 func TestCreateSprint_EmptyName(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	_, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
 		ProjectID: uuid.New(),
@@ -275,7 +275,7 @@ func TestCreateSprint_EmptyName(t *testing.T) {
 
 func TestCreateSprint_InvalidStatus(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	_, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
 		ProjectID: uuid.New(),
@@ -289,7 +289,7 @@ func TestCreateSprint_InvalidStatus(t *testing.T) {
 
 func TestUpdateSprint_ActivateSprint(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 
 	sp, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
@@ -313,7 +313,7 @@ func TestUpdateSprint_ActivateSprint(t *testing.T) {
 
 func TestUpdateSprint_InvalidStatus(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	sp, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
 		ProjectID: uuid.New(),
@@ -334,7 +334,7 @@ func TestUpdateSprint_InvalidStatus(t *testing.T) {
 // when the request omits them (nil outer pointer = absent, not "clear").
 func TestUpdateSprint_OmittedFieldsUnchanged(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -378,7 +378,7 @@ func TestUpdateSprint_OmittedFieldsUnchanged(t *testing.T) {
 // pointer) clears the field rather than being ignored.
 func TestUpdateSprint_ExplicitNullClearsGoal(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 
 	goal := "Ship the thing"
@@ -405,7 +405,7 @@ func TestUpdateSprint_ExplicitNullClearsGoal(t *testing.T) {
 
 func TestDeleteSprint_OK(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	sp, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
 		ProjectID: uuid.New(),
@@ -422,7 +422,7 @@ func TestDeleteSprint_OK(t *testing.T) {
 
 func TestDeleteSprint_NotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	err := svc.DeleteSprint(ctx, uuid.New(), uuid.New())
 	if err != sprintdom.ErrSprintNotFound {
@@ -432,7 +432,7 @@ func TestDeleteSprint_NotFound(t *testing.T) {
 
 func TestGetSprint_OK(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 
 	sp, err := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
@@ -458,7 +458,7 @@ func TestGetSprint_OK(t *testing.T) {
 
 func TestGetSprint_NotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	_, err := svc.GetSprint(ctx, uuid.New(), uuid.New())
 	if err != sprintdom.ErrSprintNotFound {
@@ -468,7 +468,7 @@ func TestGetSprint_NotFound(t *testing.T) {
 
 func TestListSprints_ReturnsProjectSprints(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 	otherProjectID := uuid.New()
 
@@ -507,7 +507,7 @@ func TestListSprints_ReturnsProjectSprints(t *testing.T) {
 func TestCompleteSprint_MovesToBacklog(t *testing.T) {
 	ctx := context.Background()
 	taskRepo := newFakeTaskRepo()
-	svc := sprintsvc.New(newFakeSprintRepo(), taskRepo)
+	svc := sprintsvc.New(newFakeSprintRepo(), taskRepo, nil)
 	projectID := uuid.New()
 
 	sp, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
@@ -550,7 +550,7 @@ func TestCompleteSprint_MovesToOtherSprint(t *testing.T) {
 	ctx := context.Background()
 	taskRepo := newFakeTaskRepo()
 	repo := newFakeSprintRepo()
-	svc := sprintsvc.New(repo, taskRepo)
+	svc := sprintsvc.New(repo, taskRepo, nil)
 	projectID := uuid.New()
 
 	source, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
@@ -588,7 +588,7 @@ func TestCompleteSprint_MovesToOtherSprint(t *testing.T) {
 func TestCompleteSprint_SkipsDoneTasks(t *testing.T) {
 	ctx := context.Background()
 	taskRepo := newFakeTaskRepo()
-	svc := sprintsvc.New(newFakeSprintRepo(), taskRepo)
+	svc := sprintsvc.New(newFakeSprintRepo(), taskRepo, nil)
 	projectID := uuid.New()
 
 	sp, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
@@ -642,7 +642,7 @@ func TestCompleteSprint_SkipsDoneTasks(t *testing.T) {
 
 func TestCompleteSprint_AlreadyCompleted(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 	projectID := uuid.New()
 
 	sp, _ := svc.CreateSprint(ctx, sprintdom.CreateSprintInput{
@@ -659,7 +659,7 @@ func TestCompleteSprint_AlreadyCompleted(t *testing.T) {
 
 func TestCompleteSprint_NotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo())
+	svc := sprintsvc.New(newFakeSprintRepo(), newFakeTaskRepo(), nil)
 
 	_, err := svc.CompleteSprint(ctx, uuid.New(), uuid.New(), sprintdom.CompleteSprintInput{})
 	if err != sprintdom.ErrSprintNotFound {

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -206,7 +206,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
 	sprintRepo := pgRepo.NewSprintRepository(db)
-	sprintService := sprintsvc.New(sprintRepo, taskRepo)
+	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
 	viewRepo := pgRepo.NewViewRepository(db)
 	viewService := sprintsvc.NewViewService(viewRepo)
 	attachmentRepo := pgRepo.NewAttachmentRepository(db)

--- a/services/api/test/integration/agent_apikey_test.go
+++ b/services/api/test/integration/agent_apikey_test.go
@@ -57,7 +57,7 @@ func buildAgentKeyRouterWithBotID(taskRepo *fakeTaskRepo, apiKeyRepo *fakeAPIKey
 	projectRepo := newFakeProjectRepo()
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
-	sprintService := sprintsvc.New(newFakeSprintRepoIT(), taskRepo)
+	sprintService := sprintsvc.New(newFakeSprintRepoIT(), taskRepo, nil)
 	viewService := sprintsvc.NewViewService(newFakeViewRepoIT())
 	var activityRepo *fakeTaskActivityRepo
 	if len(activityRepos) > 0 && activityRepos[0] != nil {

--- a/services/api/test/integration/attachment_test.go
+++ b/services/api/test/integration/attachment_test.go
@@ -232,7 +232,7 @@ func buildAttachmentTestRouter(attachRepo *fakeAttachmentRepo, store *fakeStorag
 	}
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
-	sprintService := sprintsvc.New(newFakeSprintRepoIT(), taskRepo)
+	sprintService := sprintsvc.New(newFakeSprintRepoIT(), taskRepo, nil)
 	viewService := sprintsvc.NewViewService(newFakeViewRepoIT())
 	active := tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)
 	attachmentService := attachmentsvc.New(attachRepo, attachmentsvc.NewTaskOwnerChecker(taskRepo), store, "test-bucket")

--- a/services/api/test/integration/document_test.go
+++ b/services/api/test/integration/document_test.go
@@ -316,7 +316,7 @@ func buildDocTestRouter(docRepo *fakeDocRepoIT, store *projectPermStore) http.Ha
 	taskService := tasksvc.New(taskRepo)
 	sprintRepo := newFakeSprintRepoIT()
 	viewRepo := newFakeViewRepoIT()
-	sprintService := sprintsvc.New(sprintRepo, taskRepo)
+	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
 	viewService := sprintsvc.NewViewService(viewRepo)
 	activityRepo := newFakeTaskActivityRepo()
 	activityService := tasksvc.NewActivityService(activityRepo, &fakeActivityMemberRepo{}, nil)

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -724,7 +724,7 @@ func buildTaskTestRouterWithSprints(taskRepo *fakeTaskRepo, sprintRepo *fakeSpri
 	projectRepo := newFakeProjectRepo()
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
-	sprintService := sprintsvc.New(sprintRepo, taskRepo)
+	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
 	viewService := sprintsvc.NewViewService(viewRepo)
 	activityRepo := newFakeTaskActivityRepo()
 	activityService := tasksvc.NewActivityService(activityRepo, &fakeActivityMemberRepo{}, nil)

--- a/services/api/test/integration/view_test.go
+++ b/services/api/test/integration/view_test.go
@@ -191,7 +191,7 @@ func buildViewTestRouter(viewRepo *fakeViewRepoIT, sprintRepo *fakeSprintRepoIT,
 	taskRepo := newFakeTaskRepoIT()
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
-	sprintService := sprintsvc.New(sprintRepo, taskRepo)
+	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
 	viewService := sprintsvc.NewViewService(viewRepo)
 	activityService := tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))

--- a/services/realtime/src/permissions.ts
+++ b/services/realtime/src/permissions.ts
@@ -6,14 +6,15 @@
 //   project:<projectId>:tasks      — receives all task.* events
 //   project:<projectId>:docs       — receives all doc.* events
 //   project:<projectId>:workflows  — receives all workflow.* graph events
+//   project:<projectId>:sprints    — receives all sprint.* events
 //
 // Room membership is determined once when the client emits "join": the server
 // fetches the user's project permissions, then joins only the rooms the user is
 // allowed to see.  The Pub/Sub subscriber routes events directly to the correct
 // room with a plain io.to(room).emit() — no per-socket checks needed.
 
-// EventNamespace identifies the three permission-gated sub-domains.
-export type EventNamespace = "tasks" | "docs" | "workflows";
+// EventNamespace identifies the permission-gated sub-domains.
+export type EventNamespace = "tasks" | "docs" | "workflows" | "sprints";
 
 // NAMESPACE_PERMISSIONS maps each namespace to the project permission required
 // to receive events in that namespace.
@@ -21,6 +22,7 @@ export const NAMESPACE_PERMISSIONS: Record<EventNamespace, string> = {
 	tasks: "tasks.read",
 	docs: "docs.read",
 	workflows: "workflows.read",
+	sprints: "sprints.read",
 };
 
 // projectRoomName returns the Socket.IO room name for a project + namespace pair.
@@ -50,6 +52,7 @@ export function eventNamespace(type: string): EventNamespace | undefined {
 	// itself (nodes, edges, rules, transitions, lifecycle) and require
 	// workflows.read — a permission distinct from tasks.read.
 	if (type.startsWith("workflow.")) return "workflows";
+	if (type.startsWith("sprint.")) return "sprints";
 	return undefined;
 }
 

--- a/services/realtime/src/server.ts
+++ b/services/realtime/src/server.ts
@@ -18,11 +18,12 @@
 //
 // Room management
 // ---------------
-// Events are routed through three namespace-scoped rooms per project:
+// Events are routed through namespace-scoped rooms per project:
 //
 //   project:<projectId>:tasks      — all task.* events
 //   project:<projectId>:docs       — all doc.* events
 //   project:<projectId>:workflows  — all workflow.* graph events
+//   project:<projectId>:sprints    — all sprint.* events
 //
 // When a client emits "join" with { projectId }, the server fetches the user's
 // project permissions via the API, then joins only the namespace rooms the user

--- a/services/realtime/src/subscriber.ts
+++ b/services/realtime/src/subscriber.ts
@@ -13,6 +13,7 @@
 //   doc.*      events  →  project:<projectId>:docs
 //   workflow.* events  →  project:<projectId>:workflows (except
 //                          workflow.assigned, which is task-scoped)
+//   sprint.*   events  →  project:<projectId>:sprints
 //
 // Sockets are pre-placed in the correct rooms at join time based on their
 // project permissions.  No per-message permission checks are needed here —


### PR DESCRIPTION
## Summary

Moves sprints from interval polling to socket-driven real-time updates, and adds the shared plugin `api`/`ui`/`meta` props scaffolding that plugin view/nav components expect.

### Sprint real-time updates
- Added `sprint.created` / `sprint.updated` / `sprint.deleted` / `sprint.completed` topics and publish them from `sprint_service.go` on every mutation (best-effort — publish failures never block the HTTP response).
- Added a `sprints` namespace to the realtime service (`permissions.ts` / `server.ts` / `subscriber.ts`), gated on the `sprints.read` permission, mirroring the existing `tasks` / `docs` / `workflows` namespaces.
- `useProjectRealtime` now invalidates `["projects", projectId, "sprints"]` on `sprint.*` events.
- Removed the sidebar's `refetchInterval: 30_000` on the sprints query now that it updates live.

### Plugin base props (`api` / `ui` / `meta`)
- Added `usePluginBaseProps` (`plugin-props.ts`), which builds the `BaseExtensionProps` every plugin extension-point component expects: an `api` client, `ui` (toast/confirm stubs + a real `navigate`), and `meta` (plugin id/name/version).
- Added `createPluginApiClient` (`plugin-client.ts`), a duck-typed host implementation of the plugin SDK's `PluginApiClient` (fetch-based, session-cookie auth) covering `listTasks`/`getTask`/`getProject`/`listMembers` and generic `pluginGet`/`pluginPost`/`pluginPatch`/`pluginDelete`.
- Wired these props into the plugin `view` extension point in `InteractionLayout`, and into both the admin and project plugin nav routes (previously those routes passed no/partial props to mounted plugin components).
- `ExtensionPointRegistration` gained an optional `Label` field for host-facing display names (falls back to `Component`).

### Plugin runtime: `db_query2`
- Added a `db_query2` WASM export in `runtime.go` that reports query execution errors back to the plugin. The existing `db_query` has no error channel, so a failing query (e.g. bad column reference) silently looks like a zero-row success — added as a new export rather than changing `db_query` in place, since widening its signature would break already-compiled plugin binaries that still import the 6-arg form.

### Misc
- `useProjectPermissions` now guards its query with `enabled: !!projectId`.
