### PR TITLE
feat: enhance sensitive data handling in plugin queries and updates

### DIFF
--- a/services/api/internal/domain/plugin/entity.go
+++ b/services/api/internal/domain/plugin/entity.go
@@ -131,6 +131,23 @@ type BackendManifest struct {
 	// AllowedConfigKeys is the list of host config keys the plugin may read via
 	// paca.config_get. Keys not listed here are not exposed to the plugin.
 	AllowedConfigKeys []string `json:"allowedConfigKeys,omitempty"`
+	// SensitiveFields declares which columns in this plugin's own database
+	// schema contain sensitive data, keyed by unqualified table name. When a
+	// different plugin's db_query/db_query2 call reads from this plugin's
+	// schema (via an explicit schema-qualified table reference), the host
+	// replaces these columns' values with "***" in the result. Queries this
+	// plugin runs against its own schema are never redacted.
+	SensitiveFields map[string][]string `json:"sensitiveFields,omitempty"`
+	// RequestedSensitiveFields declares which sensitive fields outside this
+	// plugin's own schema it needs read/write access to via
+	// db_query/db_query2/db_exec. Entries are "table.column" for a core
+	// (platform-owned) field, or "<owningPluginID>:table.column" for a field
+	// another plugin declared in its own SensitiveFields. A field is exempt
+	// from redaction/write-blocking for this plugin only if it's listed
+	// here — everything else stays masked/blocked. This list must be
+	// surfaced to admins in the plugin marketplace before install, the same
+	// way an OAuth scope or mobile app permission prompt would be.
+	RequestedSensitiveFields []string `json:"requestedSensitiveFields,omitempty"`
 }
 
 // FrontendManifest describes the frontend (Module Federation) side of the plugin.

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -744,16 +744,38 @@ var coreSensitiveFields = map[string][]string{
 	"agent_environment_variables": {"encrypted_value"},
 }
 
-// fromJoinTableRe extracts (schema, table) pairs referenced after FROM/JOIN
-// in a query's SQL text. Like paca-plugin-dashboard's own query guard, this
-// is a lightweight pattern match rather than a full SQL parser: adequate as
-// a defense-in-depth signal over plugin-authored SQL, not a guarantee for
-// arbitrarily obfuscated queries.
-var fromJoinTableRe = regexp.MustCompile(`(?i)\b(?:from|join)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+// sqlCommentRe matches SQL line comments (-- ...) and block comments
+// (/* ... */, including ones spanning multiple lines). PostgreSQL treats a
+// comment as equivalent to whitespace during tokenization — e.g.
+// "FROM/*x*/table" parses identically to "FROM table" — so comments must be
+// stripped (replaced with a space, to keep tokens from merging) before
+// running the table-reference regexes below. Otherwise a plugin could
+// trivially defeat both read redaction and write blocking by inserting a
+// comment between a keyword and the table name it introduces.
+var sqlCommentRe = regexp.MustCompile(`(?s)/\*.*?\*/|--[^\n]*`)
 
-// writeTargetRe extracts the (schema, table) pair a single INSERT/UPDATE/
-// DELETE statement writes to.
-var writeTargetRe = regexp.MustCompile(`(?i)^\s*(?:insert\s+into|update|delete\s+from)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+func stripSQLComments(sqlStr string) string {
+	return sqlCommentRe.ReplaceAllString(sqlStr, " ")
+}
+
+// tableRefRe extracts (schema, table) pairs referenced after FROM, JOIN,
+// INTO, or USING anywhere in a query's SQL text — covering SELECT/DELETE's
+// FROM, JOIN, INSERT's INTO, the source side of UPDATE ... FROM ..., and
+// DELETE ... USING .... It is intentionally unanchored (not tied to
+// statement start or type), so it also matches table references nested
+// inside WITH-CTE bodies and INSERT ... SELECT ... FROM subqueries.
+//
+// Like paca-plugin-dashboard's own query guard, this is a lightweight
+// pattern match rather than a full SQL parser: adequate as a
+// defense-in-depth signal over plugin-authored SQL, not a guarantee for
+// arbitrarily obfuscated queries. Callers must run stripSQLComments on
+// sqlStr first.
+var tableRefRe = regexp.MustCompile(`(?i)\b(?:from|join|into|using)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+
+// updateTargetRe extracts the (schema, table) pair immediately following
+// UPDATE — the write target of an UPDATE statement, which (unlike INSERT
+// and DELETE) isn't introduced by FROM/INTO/USING.
+var updateTargetRe = regexp.MustCompile(`(?i)\bupdate\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
 
 // tableRef is a (possibly schema-qualified) table reference extracted from
 // SQL text. Schema is empty when the reference is unqualified.
@@ -762,28 +784,34 @@ type tableRef struct {
 	table  string
 }
 
-func referencedTables(sqlStr string) []tableRef {
-	matches := fromJoinTableRe.FindAllStringSubmatch(sqlStr, -1)
-	refs := make([]tableRef, 0, len(matches))
-	for _, m := range matches {
-		if m[2] != "" {
-			refs = append(refs, tableRef{schema: strings.ToLower(m[1]), table: strings.ToLower(m[2])})
-		} else {
-			refs = append(refs, tableRef{table: strings.ToLower(m[1])})
-		}
+// newTableRef builds a tableRef from a regex match's two capture groups:
+// first is always the leading identifier, second is only non-empty when the
+// reference was schema-qualified (first.second) — in which case first is
+// the schema, not the table.
+func newTableRef(first, second string) tableRef {
+	if second != "" {
+		return tableRef{schema: strings.ToLower(first), table: strings.ToLower(second)}
 	}
-	return refs
+	return tableRef{table: strings.ToLower(first)}
 }
 
-func writeTargetTable(sqlStr string) (tableRef, bool) {
-	m := writeTargetRe.FindStringSubmatch(sqlStr)
-	if m == nil {
-		return tableRef{}, false
+// referencedTables extracts every (schema, table) reference in sqlStr —
+// every FROM/JOIN/INTO/USING target plus every UPDATE target — regardless
+// of where in the statement it appears. It deliberately over-matches rather
+// than trying to identify a single "primary" table, since a single
+// statement (UPDATE ... FROM, DELETE ... USING, INSERT ... SELECT ... FROM)
+// can touch more than one table at once; every table it touches is treated
+// the same way by both read redaction and write blocking.
+func referencedTables(sqlStr string) []tableRef {
+	stripped := stripSQLComments(sqlStr)
+	var refs []tableRef
+	for _, m := range tableRefRe.FindAllStringSubmatch(stripped, -1) {
+		refs = append(refs, newTableRef(m[1], m[2]))
 	}
-	if m[2] != "" {
-		return tableRef{schema: strings.ToLower(m[1]), table: strings.ToLower(m[2])}, true
+	for _, m := range updateTargetRe.FindAllStringSubmatch(stripped, -1) {
+		refs = append(refs, newTableRef(m[1], m[2]))
 	}
-	return tableRef{table: strings.ToLower(m[1])}, true
+	return refs
 }
 
 // sensitiveTableColumns returns the sensitive columns declared for a
@@ -865,29 +893,33 @@ func (r *Runtime) sensitiveColumnsForQuery(caller plugindom.Plugin, sqlStr strin
 }
 
 // checkWriteAllowed rejects an INSERT/UPDATE/DELETE statement outright when
-// its target table has sensitive columns declared (core, or another
-// plugin's own SensitiveFields) that caller hasn't requested access to.
+// any table it references — its write target, or a source table pulled in
+// via UPDATE ... FROM, DELETE ... USING, or INSERT ... SELECT ... FROM —
+// has a declared-sensitive column (core, or another plugin's own
+// SensitiveFields) that caller hasn't requested access to. A table's
+// sensitive columns must *all* be individually requested for that table to
+// be exempted: requesting access to one sensitive column of a table does
+// not grant access to that table's other, unrequested sensitive columns.
+//
 // Unlike reads, sensitivity can't be masked away column-by-column for a
-// write, so the whole statement is blocked before it ever reaches Postgres.
-// A table with no declared sensitive columns is unaffected (out of scope,
-// same boundary as read redaction). funcName is used only in the returned
-// error to name the host function that rejected the call.
+// write — the value could already have been copied into another column, or
+// into the caller's own schema, by the time the statement finishes — so
+// the whole statement is rejected before it ever reaches Postgres. A table
+// with no declared sensitive columns is unaffected (out of scope, same
+// boundary as read redaction). funcName is used only in the returned error
+// to name the host function that rejected the call.
 func (r *Runtime) checkWriteAllowed(caller plugindom.Plugin, sqlStr, funcName string) error {
-	ref, ok := writeTargetTable(sqlStr)
-	if !ok {
-		return nil
-	}
 	callerSchema := schemaName(caller.Name)
-	owner, cols := r.sensitiveTableColumns(callerSchema, ref)
-	if len(cols) == 0 {
-		return nil
-	}
-	for _, col := range cols {
-		if isRequestedSensitiveField(caller, owner, ref.table, col) {
-			return nil
+	for _, ref := range referencedTables(sqlStr) {
+		owner, cols := r.sensitiveTableColumns(callerSchema, ref)
+		for _, col := range cols {
+			if isRequestedSensitiveField(caller, owner, ref.table, col) {
+				continue
+			}
+			return fmt.Errorf("%s: table %q has sensitive fields this plugin has not requested access to (declare requestedSensitiveFields in plugin.json)", funcName, ref.table)
 		}
 	}
-	return fmt.Errorf("%s: table %q has sensitive fields this plugin has not requested access to (declare requestedSensitiveFields in plugin.json)", funcName, ref.table)
+	return nil
 }
 
 // redactColumns overwrites every row's value with "***" at each column index

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -763,19 +763,38 @@ func stripSQLComments(sqlStr string) string {
 // FROM, JOIN, INSERT's INTO, the source side of UPDATE ... FROM ..., and
 // DELETE ... USING .... It is intentionally unanchored (not tied to
 // statement start or type), so it also matches table references nested
-// inside WITH-CTE bodies and INSERT ... SELECT ... FROM subqueries.
+// inside WITH-CTE bodies and INSERT ... SELECT ... FROM subqueries. The
+// optional ONLY keyword (e.g. "DELETE FROM ONLY users") is skipped so it
+// isn't mistaken for the table name itself.
 //
 // Like paca-plugin-dashboard's own query guard, this is a lightweight
 // pattern match rather than a full SQL parser: adequate as a
 // defense-in-depth signal over plugin-authored SQL, not a guarantee for
 // arbitrarily obfuscated queries. Callers must run stripSQLComments on
 // sqlStr first.
-var tableRefRe = regexp.MustCompile(`(?i)\b(?:from|join|into|using)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+var tableRefRe = regexp.MustCompile(`(?i)\b(?:from|join|into|using)\s+(?:only\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
 
 // updateTargetRe extracts the (schema, table) pair immediately following
 // UPDATE — the write target of an UPDATE statement, which (unlike INSERT
 // and DELETE) isn't introduced by FROM/INTO/USING.
-var updateTargetRe = regexp.MustCompile(`(?i)\bupdate\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+var updateTargetRe = regexp.MustCompile(`(?i)\bupdate\s+(?:only\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+
+// tableShorthandRe extracts the (schema, table) pair from PostgreSQL's
+// "TABLE name" shorthand for "SELECT * FROM name", which can appear as a
+// full statement or nested in a FROM clause (e.g. "FROM (TABLE users) u").
+var tableShorthandRe = regexp.MustCompile(`(?i)\btable\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+
+// fromClauseRe captures the full comma-separated table list following a
+// FROM keyword, stopping at the next clause keyword that can legally follow
+// one (or a closing paren/semicolon/end of string). It exists to catch
+// old-style implicit joins ("FROM a, b, c"), where every table after the
+// first is introduced by a comma rather than by FROM/JOIN/INTO/USING and so
+// wouldn't otherwise be matched by tableRefRe.
+var fromClauseRe = regexp.MustCompile(`(?i)\bfrom\s+(.+?)(?:\s+(?:where|group\s+by|order\s+by|having|limit|offset|on|join|returning|union|except|intersect|window|fetch|for)\b|\)|;|$)`)
+
+// leadingTableRefRe extracts the (schema, table) pair at the start of a
+// single comma-separated FROM-list item, ignoring any trailing alias.
+var leadingTableRefRe = regexp.MustCompile(`(?i)^\s*(?:only\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
 
 // tableRef is a (possibly schema-qualified) table reference extracted from
 // SQL text. Schema is empty when the reference is unqualified.
@@ -795,13 +814,45 @@ func newTableRef(first, second string) tableRef {
 	return tableRef{table: strings.ToLower(first)}
 }
 
+// commaJoinedTables splits a FROM clause's table list on top-level commas
+// (tracking paren depth, so a comma inside a nested subquery doesn't split
+// the list) and extracts the leading table reference from each item,
+// discarding any trailing alias.
+func commaJoinedTables(list string) []tableRef {
+	var refs []tableRef
+	depth, start := 0, 0
+	var items []string
+	for i, ch := range list {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				items = append(items, list[start:i])
+				start = i + 1
+			}
+		}
+	}
+	items = append(items, list[start:])
+	for _, item := range items {
+		if m := leadingTableRefRe.FindStringSubmatch(item); m != nil {
+			refs = append(refs, newTableRef(m[1], m[2]))
+		}
+	}
+	return refs
+}
+
 // referencedTables extracts every (schema, table) reference in sqlStr —
-// every FROM/JOIN/INTO/USING target plus every UPDATE target — regardless
-// of where in the statement it appears. It deliberately over-matches rather
-// than trying to identify a single "primary" table, since a single
-// statement (UPDATE ... FROM, DELETE ... USING, INSERT ... SELECT ... FROM)
-// can touch more than one table at once; every table it touches is treated
-// the same way by both read redaction and write blocking.
+// every FROM/JOIN/INTO/USING target, every UPDATE target, every TABLE
+// shorthand reference, and every table in a comma-separated FROM list —
+// regardless of where in the statement it appears. It deliberately
+// over-matches rather than trying to identify a single "primary" table,
+// since a single statement (UPDATE ... FROM, DELETE ... USING,
+// INSERT ... SELECT ... FROM, "FROM a, b, c") can touch more than one table
+// at once; every table it touches is treated the same way by both read
+// redaction and write blocking.
 func referencedTables(sqlStr string) []tableRef {
 	stripped := stripSQLComments(sqlStr)
 	var refs []tableRef
@@ -810,6 +861,12 @@ func referencedTables(sqlStr string) []tableRef {
 	}
 	for _, m := range updateTargetRe.FindAllStringSubmatch(stripped, -1) {
 		refs = append(refs, newTableRef(m[1], m[2]))
+	}
+	for _, m := range tableShorthandRe.FindAllStringSubmatch(stripped, -1) {
+		refs = append(refs, newTableRef(m[1], m[2]))
+	}
+	for _, m := range fromClauseRe.FindAllStringSubmatch(stripped, -1) {
+		refs = append(refs, commaJoinedTables(m[1])...)
 	}
 	return refs
 }
@@ -872,13 +929,31 @@ func isRequestedSensitiveField(caller plugindom.Plugin, owner, table, col string
 	return false
 }
 
+// sensitiveColumnAliasRe finds "<col> AS <alias>" for a specific sensitive
+// column name — built per-column since the name is interpolated into the
+// pattern — so that redaction can key on the result column's alias, not
+// just its un-aliased name. redactColumns only ever sees the query's output
+// column names, so "SELECT password_hash AS ph FROM users" would otherwise
+// return "ph" unredacted even though sensitiveColumnsForQuery correctly
+// identified users.password_hash as sensitive: it never connects "ph" back
+// to "password_hash" without this. Requires the explicit AS keyword — an
+// implicit alias ("password_hash ph") isn't distinguishable by pattern
+// match alone from "password_hash FROM ..." (FROM would parse as the
+// "alias") without a real parser, so it isn't covered.
+func sensitiveColumnAliasRe(col string) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(col) + `\s+as\s+"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+}
+
 // sensitiveColumnsForQuery returns the set of lowercased column names that
 // must be redacted in the result of sqlStr run by caller: for every
 // FROM/JOIN table the query references, any sensitive column declared for
 // it (core, or another plugin's own SensitiveFields) that caller hasn't
-// explicitly requested access to via its own RequestedSensitiveFields.
+// explicitly requested access to via its own RequestedSensitiveFields —
+// plus any "AS alias" the query renames that column to, so the alias is
+// redacted in the result under its own name too (see sensitiveColumnAliasRe).
 func (r *Runtime) sensitiveColumnsForQuery(caller plugindom.Plugin, sqlStr string) map[string]struct{} {
 	callerSchema := schemaName(caller.Name)
+	stripped := stripSQLComments(sqlStr)
 	sensitive := make(map[string]struct{})
 	for _, ref := range referencedTables(sqlStr) {
 		owner, cols := r.sensitiveTableColumns(callerSchema, ref)
@@ -887,6 +962,9 @@ func (r *Runtime) sensitiveColumnsForQuery(caller plugindom.Plugin, sqlStr strin
 				continue
 			}
 			sensitive[strings.ToLower(col)] = struct{}{}
+			for _, m := range sensitiveColumnAliasRe(col).FindAllStringSubmatch(stripped, -1) {
+				sensitive[strings.ToLower(m[1])] = struct{}{}
+			}
 		}
 	}
 	return sensitive

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -483,7 +484,7 @@ func (r *Runtime) registerDBFunctions(b wazero.HostModuleBuilder, p plugindom.Pl
 				return
 			}
 
-			result, err := r.execQuery(ctx, schema, sqlStr, paramsJSON)
+			result, err := r.execQuery(ctx, p, schema, sqlStr, paramsJSON)
 			if err != nil {
 				r.log.Error("paca.db_query: exec", "plugin", p.Name, "error", err)
 				return
@@ -518,7 +519,7 @@ func (r *Runtime) registerDBFunctions(b wazero.HostModuleBuilder, p plugindom.Pl
 				return
 			}
 
-			result, err := r.execQuery(ctx, schema, sqlStr, paramsJSON)
+			result, err := r.execQuery(ctx, p, schema, sqlStr, paramsJSON)
 			if err != nil {
 				errPtrLen, writeErr := writeToMemory(m, []byte(err.Error()))
 				if writeErr != nil {
@@ -552,7 +553,7 @@ func (r *Runtime) registerDBFunctions(b wazero.HostModuleBuilder, p plugindom.Pl
 				return
 			}
 
-			rows, err := r.execStatement(ctx, schema, sqlStr, paramsJSON)
+			rows, err := r.execStatement(ctx, p, schema, sqlStr, paramsJSON)
 			if err != nil {
 				errBytes := []byte(err.Error())
 				ptrLen, _ := writeToMemory(m, errBytes)
@@ -630,13 +631,21 @@ func (r *Runtime) registerDBFunctions(b wazero.HostModuleBuilder, p plugindom.Pl
 }
 
 // execQuery runs a SELECT statement scoped to the plugin schema and returns a
-// dbQueryResult JSON-encoded result.
-func (r *Runtime) execQuery(ctx context.Context, schema, sqlStr, paramsJSON string) (*dbQueryResult, error) {
+// dbQueryResult JSON-encoded result. caller is the requesting plugin, used to
+// redact sensitive columns (core, or declared by other plugins) the query
+// reaches, and to gate DML-with-RETURNING writes to sensitive tables (see
+// sensitiveColumnsForQuery and checkWriteAllowed).
+func (r *Runtime) execQuery(ctx context.Context, caller plugindom.Plugin, schema, sqlStr, paramsJSON string) (*dbQueryResult, error) {
 	// Allow SELECT and DML statements that use RETURNING.
 	trimmed := strings.TrimSpace(strings.ToUpper(sqlStr))
 	isDML := strings.HasPrefix(trimmed, "INSERT") || strings.HasPrefix(trimmed, "UPDATE") || strings.HasPrefix(trimmed, "DELETE")
 	if !strings.HasPrefix(trimmed, "SELECT") && (!isDML || !strings.Contains(trimmed, "RETURNING")) {
 		return nil, fmt.Errorf("paca.db_query: only SELECT and DML with RETURNING statements are allowed")
+	}
+	if isDML {
+		if err := r.checkWriteAllowed(caller, sqlStr, "paca.db_query"); err != nil {
+			return nil, err
+		}
 	}
 
 	var queryParams []any
@@ -702,16 +711,208 @@ func (r *Runtime) execQuery(ctx context.Context, schema, sqlStr, paramsJSON stri
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("paca.db_query: commit: %w", err)
 	}
+
+	if sensitive := r.sensitiveColumnsForQuery(caller, sqlStr); len(sensitive) > 0 {
+		redactColumns(result.Columns, result.Rows, sensitive)
+	}
+
 	return result, nil
 }
 
+// coreSensitiveFields lists platform database columns that
+// db_query/db_query2/db_exec must always treat as sensitive, regardless of
+// which schema a plugin's search_path resolves them through. Nobody "owns"
+// this data the way a plugin owns its own schema (declared via
+// BackendManifest.SensitiveFields) — a plugin may only read or write it if
+// it explicitly lists the field in its own manifest's
+// RequestedSensitiveFields, which must be surfaced to admins in the plugin
+// marketplace before install so the request is visible, not silently
+// granted.
+//
+// github_integrations/github_repositories used to live here too (they
+// predate the per-plugin schema model and lived in core `public`), but
+// migrations/000007_remove_github_tables.sql dropped them from public and
+// paca-plugin-github/backend/migrations/0001_create_github_tables.sql
+// recreates them under its own plugin_data_com_paca_github schema — so
+// they're now an ordinary plugin-owned-schema case, protected via that
+// plugin's own BackendManifest.SensitiveFields instead of this registry.
+var coreSensitiveFields = map[string][]string{
+	"users":                       {"password_hash"},
+	"api_keys":                    {"key_hash"},
+	"agents":                      {"llm_api_key_secret", "acp_bridge_token_hash"},
+	"agent_mcp_servers":           {"env"},
+	"agent_environment_variables": {"encrypted_value"},
+}
+
+// fromJoinTableRe extracts (schema, table) pairs referenced after FROM/JOIN
+// in a query's SQL text. Like paca-plugin-dashboard's own query guard, this
+// is a lightweight pattern match rather than a full SQL parser: adequate as
+// a defense-in-depth signal over plugin-authored SQL, not a guarantee for
+// arbitrarily obfuscated queries.
+var fromJoinTableRe = regexp.MustCompile(`(?i)\b(?:from|join)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+
+// writeTargetRe extracts the (schema, table) pair a single INSERT/UPDATE/
+// DELETE statement writes to.
+var writeTargetRe = regexp.MustCompile(`(?i)^\s*(?:insert\s+into|update|delete\s+from)\s+"?([A-Za-z_][A-Za-z0-9_]*)"?(?:\s*\.\s*"?([A-Za-z_][A-Za-z0-9_]*)"?)?`)
+
+// tableRef is a (possibly schema-qualified) table reference extracted from
+// SQL text. Schema is empty when the reference is unqualified.
+type tableRef struct {
+	schema string
+	table  string
+}
+
+func referencedTables(sqlStr string) []tableRef {
+	matches := fromJoinTableRe.FindAllStringSubmatch(sqlStr, -1)
+	refs := make([]tableRef, 0, len(matches))
+	for _, m := range matches {
+		if m[2] != "" {
+			refs = append(refs, tableRef{schema: strings.ToLower(m[1]), table: strings.ToLower(m[2])})
+		} else {
+			refs = append(refs, tableRef{table: strings.ToLower(m[1])})
+		}
+	}
+	return refs
+}
+
+func writeTargetTable(sqlStr string) (tableRef, bool) {
+	m := writeTargetRe.FindStringSubmatch(sqlStr)
+	if m == nil {
+		return tableRef{}, false
+	}
+	if m[2] != "" {
+		return tableRef{schema: strings.ToLower(m[1]), table: strings.ToLower(m[2])}, true
+	}
+	return tableRef{table: strings.ToLower(m[1])}, true
+}
+
+// sensitiveTableColumns returns the sensitive columns declared for a
+// resolved (schema, table) reference and, when the table belongs to another
+// plugin's own schema rather than being a core table, that plugin's name
+// (owner is "" for core fields, since nobody owns those). callerSchema is
+// the calling plugin's own schema: a reference into it is never sensitive,
+// since a plugin always has full access to its own data.
+//
+// An unqualified table name (schema == "") can only ever resolve to the
+// caller's own schema or the core `public` schema (search_path never
+// reaches another plugin's schema without explicit qualification), so it's
+// checked against the core registry directly. This means a plugin that
+// happens to name one of its own tables identically to a core table (e.g.
+// "users") would have that column over-redacted/write-blocked too — a
+// fail-safe false positive, not a false negative.
+func (r *Runtime) sensitiveTableColumns(callerSchema string, ref tableRef) (owner string, cols []string) {
+	if ref.schema != "" && strings.EqualFold(ref.schema, callerSchema) {
+		return "", nil
+	}
+	if ref.schema == "" || strings.EqualFold(ref.schema, "public") {
+		return "", coreSensitiveFields[ref.table]
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for name, inst := range r.plugins {
+		if !strings.EqualFold(schemaName(name), ref.schema) {
+			continue
+		}
+		if inst.plugin.Manifest.Backend == nil {
+			return name, nil
+		}
+		return name, inst.plugin.Manifest.Backend.SensitiveFields[ref.table]
+	}
+	return "", nil
+}
+
+// isRequestedSensitiveField reports whether caller's own manifest declares
+// wanting access to table.column, where owner is "" for a core field or the
+// owning plugin's ID for a field declared sensitive in that plugin's own
+// SensitiveFields.
+func isRequestedSensitiveField(caller plugindom.Plugin, owner, table, col string) bool {
+	if caller.Manifest.Backend == nil {
+		return false
+	}
+	var key string
+	if owner == "" {
+		key = table + "." + col
+	} else {
+		key = owner + ":" + table + "." + col
+	}
+	for _, f := range caller.Manifest.Backend.RequestedSensitiveFields {
+		if strings.EqualFold(f, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// sensitiveColumnsForQuery returns the set of lowercased column names that
+// must be redacted in the result of sqlStr run by caller: for every
+// FROM/JOIN table the query references, any sensitive column declared for
+// it (core, or another plugin's own SensitiveFields) that caller hasn't
+// explicitly requested access to via its own RequestedSensitiveFields.
+func (r *Runtime) sensitiveColumnsForQuery(caller plugindom.Plugin, sqlStr string) map[string]struct{} {
+	callerSchema := schemaName(caller.Name)
+	sensitive := make(map[string]struct{})
+	for _, ref := range referencedTables(sqlStr) {
+		owner, cols := r.sensitiveTableColumns(callerSchema, ref)
+		for _, col := range cols {
+			if isRequestedSensitiveField(caller, owner, ref.table, col) {
+				continue
+			}
+			sensitive[strings.ToLower(col)] = struct{}{}
+		}
+	}
+	return sensitive
+}
+
+// checkWriteAllowed rejects an INSERT/UPDATE/DELETE statement outright when
+// its target table has sensitive columns declared (core, or another
+// plugin's own SensitiveFields) that caller hasn't requested access to.
+// Unlike reads, sensitivity can't be masked away column-by-column for a
+// write, so the whole statement is blocked before it ever reaches Postgres.
+// A table with no declared sensitive columns is unaffected (out of scope,
+// same boundary as read redaction). funcName is used only in the returned
+// error to name the host function that rejected the call.
+func (r *Runtime) checkWriteAllowed(caller plugindom.Plugin, sqlStr, funcName string) error {
+	ref, ok := writeTargetTable(sqlStr)
+	if !ok {
+		return nil
+	}
+	callerSchema := schemaName(caller.Name)
+	owner, cols := r.sensitiveTableColumns(callerSchema, ref)
+	if len(cols) == 0 {
+		return nil
+	}
+	for _, col := range cols {
+		if isRequestedSensitiveField(caller, owner, ref.table, col) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s: table %q has sensitive fields this plugin has not requested access to (declare requestedSensitiveFields in plugin.json)", funcName, ref.table)
+}
+
+// redactColumns overwrites every row's value with "***" at each column index
+// whose lowercased name is in sensitive.
+func redactColumns(cols []string, rows [][]any, sensitive map[string]struct{}) {
+	for i, col := range cols {
+		if _, ok := sensitive[strings.ToLower(col)]; !ok {
+			continue
+		}
+		for _, row := range rows {
+			row[i] = "***"
+		}
+	}
+}
+
 // execStatement runs a non-SELECT DML statement scoped to the plugin schema.
-func (r *Runtime) execStatement(ctx context.Context, schema, sqlStr, paramsJSON string) (int64, error) {
+func (r *Runtime) execStatement(ctx context.Context, caller plugindom.Plugin, schema, sqlStr, paramsJSON string) (int64, error) {
 	trimmed := strings.TrimSpace(strings.ToUpper(sqlStr))
 	for _, banned := range []string{"DROP", "TRUNCATE", "ALTER", "CREATE", "GRANT", "REVOKE"} {
 		if strings.HasPrefix(trimmed, banned) {
 			return 0, fmt.Errorf("paca.db_exec: DDL/DCL statements are not allowed")
 		}
+	}
+	if err := r.checkWriteAllowed(caller, sqlStr, "paca.db_exec"); err != nil {
+		return 0, err
 	}
 
 	var queryParams []any

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -340,6 +340,32 @@ func TestSensitiveColumnsForQuery_CoreTable(t *testing.T) {
 	})
 }
 
+// TestSensitiveColumnsForQuery_CommentBypass pins comment-stripping: since
+// PostgreSQL treats a comment as equivalent to whitespace during
+// tokenization, "FROM/*x*/table" parses identically to "FROM table" and
+// must not be able to slip past the FROM/JOIN detection regex just because
+// there's no literal whitespace character between the keyword and the
+// table name.
+func TestSensitiveColumnsForQuery_CommentBypass(t *testing.T) {
+	rt := &Runtime{plugins: map[string]*pluginInstance{}}
+
+	t.Run("block comment between FROM and table name is still detected", func(t *testing.T) {
+		sql := "SELECT * FROM/*x*/users"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["password_hash"]; !ok {
+			t.Fatalf("expected users.password_hash redacted despite comment obfuscation, got %v", got)
+		}
+	})
+
+	t.Run("line comment before FROM is still detected", func(t *testing.T) {
+		sql := "SELECT * -- x\nFROM users"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["password_hash"]; !ok {
+			t.Fatalf("expected users.password_hash redacted despite comment obfuscation, got %v", got)
+		}
+	})
+}
+
 // TestCheckWriteAllowed pins write-side protection: INSERT/UPDATE/DELETE
 // against a sensitive table (core or another plugin's) is rejected outright
 // unless caller has requested access to it, while writes to the caller's
@@ -374,6 +400,17 @@ func TestCheckWriteAllowed(t *testing.T) {
 		{"owner writing its own schema is unaffected", callerPlugin("com.paca.b"), "UPDATE plugin_data_com_paca_b.customers SET email = $1 WHERE id = $2", false},
 		{"write to own schema table is unaffected", callerPlugin("com.paca.a"), "INSERT INTO my_table (col) VALUES ($1)", false},
 		{"write to non-sensitive core table is unaffected", callerPlugin("com.paca.a"), "UPDATE tasks SET title = $1 WHERE id = $2", false},
+
+		// Regression cases: a pattern-based guard is only as strong as what
+		// it recognizes as a write. These previously bypassed detection
+		// entirely (checkWriteAllowed silently allowed them).
+		{"leading line comment before INSERT no longer bypasses detection", callerPlugin("com.paca.a"), "-- x\nINSERT INTO users (username, password_hash) VALUES ($1, $2)", true},
+		{"block comment between INTO and table no longer bypasses detection", callerPlugin("com.paca.a"), "INSERT INTO/*x*/users (username, password_hash) VALUES ($1, $2)", true},
+		{"INSERT...SELECT exfiltrating from a sensitive table is blocked", callerPlugin("com.paca.a"), "INSERT INTO my_table (stolen) SELECT password_hash FROM users", true},
+		{"UPDATE...FROM exfiltrating from a sensitive table is blocked", callerPlugin("com.paca.a"), "UPDATE my_table SET note = u.password_hash FROM users u WHERE u.id = my_table.uid", true},
+		{"DELETE...USING referencing a sensitive table is blocked", callerPlugin("com.paca.a"), "DELETE FROM my_table USING users WHERE my_table.uid = users.id", true},
+		{"requesting one sensitive column does not exempt a table's other sensitive columns", callerPlugin("com.paca.a", "agents.llm_api_key_secret"), "UPDATE agents SET acp_bridge_token_hash = $1 WHERE id = $2", true},
+		{"requesting every sensitive column of a table does exempt it", callerPlugin("com.paca.a", "agents.llm_api_key_secret", "agents.acp_bridge_token_hash"), "UPDATE agents SET acp_bridge_token_hash = $1 WHERE id = $2", false},
 	}
 
 	for _, tc := range cases {

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -366,6 +366,57 @@ func TestSensitiveColumnsForQuery_CommentBypass(t *testing.T) {
 	})
 }
 
+// TestSensitiveColumnsForQuery_SyntaxVariants pins detection of standard
+// Postgres syntax that the original pattern set missed: old-style
+// comma-joins, the "TABLE name" shorthand, and result-column aliasing that
+// would otherwise let the aliased name slip past redaction untouched.
+func TestSensitiveColumnsForQuery_SyntaxVariants(t *testing.T) {
+	rt := &Runtime{plugins: map[string]*pluginInstance{}}
+
+	t.Run("comma-joined table beyond the first is detected", func(t *testing.T) {
+		sql := "SELECT password_hash FROM tasks, users WHERE tasks.user_id = users.id"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["password_hash"]; !ok {
+			t.Fatalf("expected users.password_hash redacted for a comma-joined table, got %v", got)
+		}
+	})
+
+	t.Run("TABLE shorthand nested in a FROM clause is detected", func(t *testing.T) {
+		sql := "SELECT password_hash FROM (TABLE users) u"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["password_hash"]; !ok {
+			t.Fatalf("expected users.password_hash redacted via TABLE shorthand, got %v", got)
+		}
+	})
+
+	t.Run("result column alias is redacted under its own name", func(t *testing.T) {
+		sql := "SELECT password_hash AS ph FROM users"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["ph"]; !ok {
+			t.Fatalf("expected alias %q to be redacted, got %v", "ph", got)
+		}
+	})
+
+	t.Run("table-qualified column alias is redacted under its own name", func(t *testing.T) {
+		sql := "SELECT u.password_hash AS ph FROM users u"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["ph"]; !ok {
+			t.Fatalf("expected alias %q to be redacted, got %v", "ph", got)
+		}
+	})
+
+	t.Run("unrelated columns do not spuriously gain aliases", func(t *testing.T) {
+		sql := "SELECT id, username FROM users"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["id"]; ok {
+			t.Fatalf("did not expect id redacted, got %v", got)
+		}
+		if _, ok := got["username"]; ok {
+			t.Fatalf("did not expect username redacted, got %v", got)
+		}
+	})
+}
+
 // TestCheckWriteAllowed pins write-side protection: INSERT/UPDATE/DELETE
 // against a sensitive table (core or another plugin's) is rejected outright
 // unless caller has requested access to it, while writes to the caller's
@@ -411,6 +462,9 @@ func TestCheckWriteAllowed(t *testing.T) {
 		{"DELETE...USING referencing a sensitive table is blocked", callerPlugin("com.paca.a"), "DELETE FROM my_table USING users WHERE my_table.uid = users.id", true},
 		{"requesting one sensitive column does not exempt a table's other sensitive columns", callerPlugin("com.paca.a", "agents.llm_api_key_secret"), "UPDATE agents SET acp_bridge_token_hash = $1 WHERE id = $2", true},
 		{"requesting every sensitive column of a table does exempt it", callerPlugin("com.paca.a", "agents.llm_api_key_secret", "agents.acp_bridge_token_hash"), "UPDATE agents SET acp_bridge_token_hash = $1 WHERE id = $2", false},
+		{"DELETE FROM ONLY a sensitive table is blocked", callerPlugin("com.paca.a"), "DELETE FROM ONLY users WHERE id = $1", true},
+		{"UPDATE ONLY a sensitive table is blocked", callerPlugin("com.paca.a"), "UPDATE ONLY users SET password_hash = $1 WHERE id = $2", true},
+		{"comma-joined sensitive table beyond the first is blocked", callerPlugin("com.paca.a"), "INSERT INTO my_table (stolen) SELECT password_hash FROM tasks, users", true},
 	}
 
 	for _, tc := range cases {

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -195,6 +195,236 @@ func TestDispatchEvent_OversizedPayload_RejectedWithoutTouchingPlugin(t *testing
 	}
 }
 
+// callerPlugin builds a plugindom.Plugin for use as execQuery/execStatement's
+// caller argument, with an optional RequestedSensitiveFields declaration.
+func callerPlugin(name string, requested ...string) plugindom.Plugin {
+	return plugindom.Plugin{
+		Name: name,
+		Manifest: plugindom.PluginManifest{
+			Backend: &plugindom.BackendManifest{
+				RequestedSensitiveFields: requested,
+			},
+		},
+	}
+}
+
+// TestSensitiveColumnsForQuery_ForeignPluginSchema pins the detection logic
+// for cross-plugin schema access: a caller's SQL text referencing another
+// loaded plugin's schema (by its distinctive plugin_data_<name> name) should
+// pull in that plugin's declared sensitive columns for the specific table
+// referenced, while SQL that only touches the caller's own schema, an
+// unrelated table in that schema, or no foreign schema at all should not.
+func TestSensitiveColumnsForQuery_ForeignPluginSchema(t *testing.T) {
+	rt := &Runtime{
+		plugins: map[string]*pluginInstance{
+			"com.paca.a": {plugin: plugindom.Plugin{
+				Name: "com.paca.a",
+				Manifest: plugindom.PluginManifest{
+					Backend: &plugindom.BackendManifest{},
+				},
+			}},
+			"com.paca.b": {plugin: plugindom.Plugin{
+				Name: "com.paca.b",
+				Manifest: plugindom.PluginManifest{
+					Backend: &plugindom.BackendManifest{
+						SensitiveFields: map[string][]string{
+							"customers": {"Email", "phone"},
+							"orders":    {"internal_notes"},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	t.Run("references foreign schema unquoted", func(t *testing.T) {
+		sql := "SELECT * FROM plugin_data_com_paca_b.customers"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.a"), sql)
+		want := map[string]struct{}{"email": {}, "phone": {}}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for k := range want {
+			if _, ok := got[k]; !ok {
+				t.Fatalf("missing column %q in %v", k, got)
+			}
+		}
+	})
+
+	t.Run("references foreign schema quoted", func(t *testing.T) {
+		sql := `SELECT * FROM "plugin_data_com_paca_b".customers`
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.a"), sql)
+		if _, ok := got["email"]; !ok {
+			t.Fatalf("expected quoted schema reference to be detected, got %v", got)
+		}
+	})
+
+	t.Run("only pulls columns for the table actually referenced", func(t *testing.T) {
+		sql := "SELECT * FROM plugin_data_com_paca_b.orders"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.a"), sql)
+		if _, ok := got["internal_notes"]; !ok {
+			t.Fatalf("expected orders.internal_notes redacted, got %v", got)
+		}
+		if _, ok := got["email"]; ok {
+			t.Fatalf("customers.email should not be pulled in when only orders is referenced, got %v", got)
+		}
+	})
+
+	t.Run("caller's own schema is never redacted", func(t *testing.T) {
+		sql := "SELECT * FROM plugin_data_com_paca_b.customers"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.b"), sql)
+		if len(got) != 0 {
+			t.Fatalf("expected no redaction when the owning plugin queries its own schema, got %v", got)
+		}
+	})
+
+	t.Run("query touching only own schema or public", func(t *testing.T) {
+		sql := "SELECT * FROM my_table JOIN public.tasks ON true"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.a"), sql)
+		if len(got) != 0 {
+			t.Fatalf("expected no redaction for a query with no foreign schema reference, got %v", got)
+		}
+	})
+
+	t.Run("requested access exempts specific columns only", func(t *testing.T) {
+		sql := "SELECT * FROM plugin_data_com_paca_b.customers"
+		caller := callerPlugin("com.paca.a", "com.paca.b:customers.email")
+		got := rt.sensitiveColumnsForQuery(caller, sql)
+		if _, ok := got["email"]; ok {
+			t.Fatalf("expected email exempted by RequestedSensitiveFields, got %v", got)
+		}
+		if _, ok := got["phone"]; !ok {
+			t.Fatalf("expected phone to remain redacted (not requested), got %v", got)
+		}
+	})
+}
+
+// TestSensitiveColumnsForQuery_CoreTable pins core-table protection: an
+// unqualified reference to a core sensitive table (reachable via every
+// plugin's search_path through `public`) is redacted for every plugin
+// unless it explicitly requests that field.
+func TestSensitiveColumnsForQuery_CoreTable(t *testing.T) {
+	rt := &Runtime{plugins: map[string]*pluginInstance{}}
+
+	t.Run("unqualified core table is redacted by default", func(t *testing.T) {
+		sql := "SELECT id, password_hash FROM users WHERE id = $1"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if _, ok := got["password_hash"]; !ok {
+			t.Fatalf("expected users.password_hash redacted, got %v", got)
+		}
+	})
+
+	t.Run("explicit public-qualified core table is redacted", func(t *testing.T) {
+		sql := "SELECT encrypted_value FROM public.agent_environment_variables WHERE agent_id = $1"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.other"), sql)
+		if _, ok := got["encrypted_value"]; !ok {
+			t.Fatalf("expected agent_environment_variables.encrypted_value redacted by default, got %v", got)
+		}
+	})
+
+	t.Run("requested access exempts a core field for the requesting plugin", func(t *testing.T) {
+		sql := "SELECT encrypted_value FROM agent_environment_variables WHERE agent_id = $1"
+		caller := callerPlugin("com.paca.admin-tools", "agent_environment_variables.encrypted_value")
+		got := rt.sensitiveColumnsForQuery(caller, sql)
+		if len(got) != 0 {
+			t.Fatalf("expected no redaction once requested, got %v", got)
+		}
+	})
+
+	t.Run("non-sensitive core table is untouched", func(t *testing.T) {
+		sql := "SELECT id, title FROM tasks WHERE project_id = $1"
+		got := rt.sensitiveColumnsForQuery(callerPlugin("com.paca.dashboard"), sql)
+		if len(got) != 0 {
+			t.Fatalf("expected no redaction for a table with no declared sensitive columns, got %v", got)
+		}
+	})
+}
+
+// TestCheckWriteAllowed pins write-side protection: INSERT/UPDATE/DELETE
+// against a sensitive table (core or another plugin's) is rejected outright
+// unless caller has requested access to it, while writes to the caller's
+// own schema or to tables with no declared sensitive columns are untouched.
+func TestCheckWriteAllowed(t *testing.T) {
+	rt := &Runtime{
+		plugins: map[string]*pluginInstance{
+			"com.paca.b": {plugin: plugindom.Plugin{
+				Name: "com.paca.b",
+				Manifest: plugindom.PluginManifest{
+					Backend: &plugindom.BackendManifest{
+						SensitiveFields: map[string][]string{
+							"customers": {"email"},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		caller    plugindom.Plugin
+		sql       string
+		wantError bool
+	}{
+		{"insert into core users table blocked", callerPlugin("com.paca.a"), "INSERT INTO users (username, password_hash) VALUES ($1, $2)", true},
+		{"update core users table blocked", callerPlugin("com.paca.a"), "UPDATE users SET password_hash = $1 WHERE id = $2", true},
+		{"delete from core users table blocked", callerPlugin("com.paca.a"), "DELETE FROM users WHERE id = $1", true},
+		{"requested access allows the write", callerPlugin("com.paca.admin-tools", "agent_environment_variables.encrypted_value"), "INSERT INTO agent_environment_variables (agent_id, key, encrypted_value) VALUES ($1, $2, $3)", false},
+		{"write to foreign plugin's sensitive table blocked", callerPlugin("com.paca.a"), "UPDATE plugin_data_com_paca_b.customers SET email = $1 WHERE id = $2", true},
+		{"owner writing its own schema is unaffected", callerPlugin("com.paca.b"), "UPDATE plugin_data_com_paca_b.customers SET email = $1 WHERE id = $2", false},
+		{"write to own schema table is unaffected", callerPlugin("com.paca.a"), "INSERT INTO my_table (col) VALUES ($1)", false},
+		{"write to non-sensitive core table is unaffected", callerPlugin("com.paca.a"), "UPDATE tasks SET title = $1 WHERE id = $2", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rt.checkWriteAllowed(tc.caller, tc.sql, "paca.db_exec")
+			if tc.wantError && err == nil {
+				t.Fatalf("expected write to be blocked, got no error")
+			}
+			if !tc.wantError && err != nil {
+				t.Fatalf("expected write to be allowed, got error: %v", err)
+			}
+		})
+	}
+}
+
+// TestRedactColumns replaces the declared sensitive columns' values with
+// "***" across every row, matching column names case-insensitively, and
+// leaves everything else untouched.
+func TestRedactColumns(t *testing.T) {
+	cols := []string{"id", "Email", "title"}
+	rows := [][]any{
+		{1, "a@example.com", "first"},
+		{2, "b@example.com", "second"},
+	}
+	sensitive := map[string]struct{}{"email": {}}
+
+	redactColumns(cols, rows, sensitive)
+
+	for i, row := range rows {
+		if row[1] != "***" {
+			t.Fatalf("row %d: expected email column redacted, got %v", i, row[1])
+		}
+	}
+	if rows[0][0] != 1 || rows[0][2] != "first" {
+		t.Fatalf("expected non-sensitive columns untouched, got %v", rows[0])
+	}
+	if rows[1][0] != 2 || rows[1][2] != "second" {
+		t.Fatalf("expected non-sensitive columns untouched, got %v", rows[1])
+	}
+}
+
+// TestRedactColumns_NoMatch is a no-op when no column name matches.
+func TestRedactColumns_NoMatch(t *testing.T) {
+	cols := []string{"id", "title"}
+	rows := [][]any{{1, "first"}}
+	redactColumns(cols, rows, map[string]struct{}{"email": {}})
+	if rows[0][0] != 1 || rows[0][1] != "first" {
+		t.Fatalf("expected rows untouched when no column matches, got %v", rows[0])
+	}
+}
+
 // TestHandleRequest_Concurrent_DoesNotCorruptSharedInstance pins the
 // lock-ordering fix: writeToMemory (which calls the plugin's malloc export)
 // must happen while holding the per-instance lock, not before acquiring it,


### PR DESCRIPTION
## Summary

Plugins run raw SQL via `paca.db_query`/`db_query2`/`db_exec`, scoped to their own Postgres schema with `search_path = <own_schema>,public`. Since every plugin shares the same DB role, a plugin could always reach sensitive data it shouldn't:

- **Other plugins' schemas** — by writing an explicit schema-qualified table reference (`plugin_data_other.table`); `search_path` only affects unqualified name resolution.
- **Core platform tables** — implicitly, since `public` is always in `search_path` (e.g. an unqualified `SELECT password_hash FROM users` just works today).

This PR adds host-enforced protection for both, without requiring every plugin to build its own ad-hoc guard (`paca-plugin-dashboard`'s `query_guard.go` had already hand-rolled a table allowlist for exactly this reason).

## What changed

- **`BackendManifest.SensitiveFields`** (`entity.go`) — a plugin declares which columns in its *own* schema are sensitive, keyed by table name.
- **`BackendManifest.RequestedSensitiveFields`** (`entity.go`) — the request-and-disclose counterpart: a plugin declares which sensitive fields *outside* its own schema it needs (`"table.column"` for a core field, `"<owningPluginID>:table.column"` for another plugin's declared field). Only requested fields are exempted; everything else stays masked/blocked. This is meant to be surfaced to admins in the plugin marketplace before install (like an OAuth scope prompt) — that UI isn't built yet, tracked separately.
- **`coreSensitiveFields`** (`runtime.go`) — a host-curated (not plugin-configurable) registry of true platform secrets: `users.password_hash`, `api_keys.key_hash`, `agents.llm_api_key_secret`/`acp_bridge_token_hash`, `agent_mcp_servers.env`, `agent_environment_variables.encrypted_value`. No plugin may self-assert ownership of these.
- **Read redaction** (`sensitiveColumnsForQuery`) — table-aware: extracts FROM/JOIN table references from the query text (pattern-based, same style as `paca-plugin-dashboard`'s own guard, not a full SQL parser), resolves each to core/foreign-plugin/own-schema, and redacts declared-sensitive columns to `"***"` in the result — except for the owning plugin or a plugin that explicitly requested that field.
- **Write blocking** (`checkWriteAllowed`) — INSERT/UPDATE/DELETE against a table with declared-sensitive columns is rejected outright (before reaching Postgres) unless the caller requested access to it. Applies to `execStatement` (`db_exec`) and the DML-with-RETURNING branch of `execQuery`.

## Scope / non-goals

- Only the `db_query`/`db_query2`/`db_exec` host functions are covered. The event bus (`paca.event_emit`/`dispatchEvent`) and the core `paca.tasks_list`/`task_get`/`project_get`/`members_list` functions are untouched — neither has an "owning plugin" concept the exemption model relies on.
- Detection is regex/pattern-based, not a full SQL parser (documented as an accepted limitation in the code) — it fails safe (over-redacts/over-blocks) rather than fails open.
- Companion manifest updates for plugins with real sensitive columns (`paca-plugin-github`'s `access_token_enc`/`webhook_secret_enc`, `paca-plugin-webhook`'s `secret_enc`) and the removal of `paca-plugin-dashboard`'s now-redundant table whitelist are separate PRs in those repos.

## Test plan

- [x] `go build ./...` and `go vet ./...`
- [x] `go test ./internal/platform/plugin/...` — new coverage: cross-plugin schema redaction (table-precision, quoted/unquoted schema refs, own-schema exemption), core-table redaction (default-redacted, explicit `public.` qualification, exemption via `RequestedSensitiveFields`), and write-blocking for INSERT/UPDATE/DELETE against core and foreign-plugin sensitive tables (blocked, exempted-by-request, and unaffected-table cases)
- [x] `go test ./...` for the full `services/api` module — no regressions