### PR TITLE
feat: add support for plugin views with manifest ID and component in view schemas

### DIFF
--- a/apps/mcp/src/__tests__/tools/view-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/view-tools.test.ts
@@ -162,6 +162,65 @@ describe("handleViewTool – create_view", () => {
 		);
 		expect(result.content[0].text).toContain("created successfully");
 	});
+
+	it("passes pluginManifestId/pluginComponent through as config.plugin_manifest_id/plugin_component for viewType 'plugin'", async () => {
+		const client = makeClient();
+		await handleViewTool(
+			"create_view",
+			{
+				projectId: "p1",
+				name: "Dashboard",
+				context: "sprint",
+				viewType: "plugin",
+				pluginManifestId: "com.paca.dashboard",
+				pluginComponent: "DashboardIntegrationView",
+			},
+			client,
+		);
+		expect(client.createView).toHaveBeenCalledWith(
+			"p1",
+			expect.objectContaining({
+				view_type: "plugin",
+				config: {
+					plugin_manifest_id: "com.paca.dashboard",
+					plugin_component: "DashboardIntegrationView",
+				},
+			}),
+			"sprint",
+			undefined,
+		);
+	});
+
+	it("rejects viewType 'plugin' without pluginManifestId/pluginComponent", async () => {
+		await expect(
+			handleViewTool(
+				"create_view",
+				{
+					projectId: "p1",
+					name: "Dashboard",
+					context: "sprint",
+					viewType: "plugin",
+				},
+				makeClient(),
+			),
+		).rejects.toThrow();
+	});
+
+	it("rejects pluginManifestId provided without pluginComponent", async () => {
+		await expect(
+			handleViewTool(
+				"create_view",
+				{
+					projectId: "p1",
+					name: "V",
+					context: "sprint",
+					viewType: "board",
+					pluginManifestId: "com.paca.dashboard",
+				},
+				makeClient(),
+			),
+		).rejects.toThrow();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -233,6 +292,37 @@ describe("handleViewTool – get_view", () => {
 		);
 		expect(result.content[0].text).toContain("Board View");
 	});
+
+	it("includes the plugin binding when the view's config has one", async () => {
+		const pluginView = {
+			...view,
+			view_type: "plugin",
+			config: {
+				plugin_manifest_id: "com.paca.dashboard",
+				plugin_component: "DashboardIntegrationView",
+			},
+		};
+		const client = makeClient({
+			getView: vi.fn().mockResolvedValue(pluginView),
+		});
+		const result = await handleViewTool(
+			"get_view",
+			{ projectId: "p1", viewId: "v1" },
+			client,
+		);
+		expect(result.content[0].text).toContain(
+			"Plugin: com.paca.dashboard (component: DashboardIntegrationView)",
+		);
+	});
+
+	it("omits the plugin line when the view's config has no plugin binding", async () => {
+		const result = await handleViewTool(
+			"get_view",
+			{ projectId: "p1", viewId: "v1" },
+			makeClient(),
+		);
+		expect(result.content[0].text).not.toContain("Plugin:");
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -262,6 +352,79 @@ describe("handleViewTool – update_view", () => {
 			makeClient(),
 		);
 		expect(result.content[0].text).toContain("updated successfully");
+	});
+
+	it("passes pluginManifestId/pluginComponent through as config.plugin_manifest_id/plugin_component", async () => {
+		const client = makeClient();
+		await handleViewTool(
+			"update_view",
+			{
+				projectId: "p1",
+				viewId: "v1",
+				viewType: "plugin",
+				pluginManifestId: "com.paca.dashboard",
+				pluginComponent: "DashboardIntegrationView",
+			},
+			client,
+		);
+		expect(client.updateView).toHaveBeenCalledWith(
+			"p1",
+			"v1",
+			expect.objectContaining({
+				view_type: "plugin",
+				config: {
+					plugin_manifest_id: "com.paca.dashboard",
+					plugin_component: "DashboardIntegrationView",
+				},
+			}),
+		);
+	});
+
+	it("passes explicit nulls through to clear an existing plugin binding", async () => {
+		const client = makeClient();
+		await handleViewTool(
+			"update_view",
+			{
+				projectId: "p1",
+				viewId: "v1",
+				viewType: "table",
+				pluginManifestId: null,
+				pluginComponent: null,
+			},
+			client,
+		);
+		expect(client.updateView).toHaveBeenCalledWith(
+			"p1",
+			"v1",
+			expect.objectContaining({
+				view_type: "table",
+				config: { plugin_manifest_id: null, plugin_component: null },
+			}),
+		);
+	});
+
+	it("rejects viewType 'plugin' without pluginManifestId/pluginComponent", async () => {
+		await expect(
+			handleViewTool(
+				"update_view",
+				{ projectId: "p1", viewId: "v1", viewType: "plugin" },
+				makeClient(),
+			),
+		).rejects.toThrow();
+	});
+
+	it("rejects pluginComponent provided without pluginManifestId", async () => {
+		await expect(
+			handleViewTool(
+				"update_view",
+				{
+					projectId: "p1",
+					viewId: "v1",
+					pluginComponent: "DashboardIntegrationView",
+				},
+				makeClient(),
+			),
+		).rejects.toThrow();
 	});
 });
 

--- a/apps/mcp/src/tools/view-tools.ts
+++ b/apps/mcp/src/tools/view-tools.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { PacaAPIViewsClient } from "../api/index.js";
+import type { ViewConfig } from "../types/index.js";
 import { formatList } from "../utils/index.js";
 
 const ListViewsSchema = z.object({
@@ -9,15 +10,35 @@ const ListViewsSchema = z.object({
 	sprintId: z.string().optional(),
 });
 
-const CreateViewSchema = z.object({
-	projectId: z.string(),
-	name: z.string(),
-	context: z.string(),
-	viewType: z.string(),
-	sprintId: z.string().optional(),
-	pluginManifestId: z.string().optional(),
-	pluginComponent: z.string().optional(),
-});
+const CreateViewSchema = z
+	.object({
+		projectId: z.string(),
+		name: z.string(),
+		context: z.string(),
+		viewType: z.string(),
+		sprintId: z.string().optional(),
+		pluginManifestId: z.string().optional(),
+		pluginComponent: z.string().optional(),
+	})
+	.refine(
+		(data) =>
+			(data.pluginManifestId === undefined) ===
+			(data.pluginComponent === undefined),
+		{
+			message: "pluginManifestId and pluginComponent must be provided together",
+			path: ["pluginComponent"],
+		},
+	)
+	.refine(
+		(data) =>
+			data.viewType !== "plugin" ||
+			(!!data.pluginManifestId && !!data.pluginComponent),
+		{
+			message:
+				"pluginManifestId and pluginComponent are required when viewType is 'plugin'",
+			path: ["viewType"],
+		},
+	);
 
 const ReorderViewsSchema = z.object({
 	projectId: z.string(),
@@ -31,16 +52,38 @@ const GetViewSchema = z.object({
 	viewId: z.string(),
 });
 
-const UpdateViewSchema = z.object({
-	projectId: z.string(),
-	viewId: z.string(),
-	name: z.string().optional(),
-	context: z.string().optional(),
-	viewType: z.string().optional(),
-	sprintId: z.string().optional(),
-	pluginManifestId: z.string().optional(),
-	pluginComponent: z.string().optional(),
-});
+const UpdateViewSchema = z
+	.object({
+		projectId: z.string(),
+		viewId: z.string(),
+		name: z.string().optional(),
+		context: z.string().optional(),
+		viewType: z.string().optional(),
+		sprintId: z.string().optional(),
+		// null explicitly clears an existing plugin binding (e.g. when
+		// changing viewType away from "plugin"); undefined leaves it untouched.
+		pluginManifestId: z.string().nullable().optional(),
+		pluginComponent: z.string().nullable().optional(),
+	})
+	.refine(
+		(data) =>
+			(data.pluginManifestId === undefined) ===
+			(data.pluginComponent === undefined),
+		{
+			message: "pluginManifestId and pluginComponent must be provided together",
+			path: ["pluginComponent"],
+		},
+	)
+	.refine(
+		(data) =>
+			data.viewType !== "plugin" ||
+			(!!data.pluginManifestId && !!data.pluginComponent),
+		{
+			message:
+				"pluginManifestId and pluginComponent are required when viewType is 'plugin'",
+			path: ["viewType"],
+		},
+	);
 
 const DeleteViewSchema = z.object({
 	projectId: z.string(),
@@ -163,12 +206,12 @@ export function getViewTools(): Tool[] {
 					pluginManifestId: {
 						type: "string",
 						description:
-							"Required when viewType is 'plugin'. The reverse-DNS manifest ID of the plugin that provides this view (e.g. 'com.paca.dashboard').",
+							"Required (together with pluginComponent) when viewType is 'plugin'. The reverse-DNS manifest ID of the plugin that provides this view (e.g. 'com.paca.dashboard').",
 					},
 					pluginComponent: {
 						type: "string",
 						description:
-							"Required when viewType is 'plugin'. The component name from that plugin's 'view' extension point (e.g. 'DashboardIntegrationView').",
+							"Required (together with pluginManifestId) when viewType is 'plugin'. The component name from that plugin's 'view' extension point (e.g. 'DashboardIntegrationView').",
 					},
 				},
 				required: ["projectId", "name", "context", "viewType"],
@@ -253,14 +296,14 @@ export function getViewTools(): Tool[] {
 						description: "The new sprint ID",
 					},
 					pluginManifestId: {
-						type: "string",
+						type: ["string", "null"],
 						description:
-							"Required when viewType is 'plugin'. The reverse-DNS manifest ID of the plugin that provides this view (e.g. 'com.paca.dashboard').",
+							"Required (together with pluginComponent) when viewType is 'plugin'. The reverse-DNS manifest ID of the plugin that provides this view (e.g. 'com.paca.dashboard'). Pass null (together with pluginComponent: null) to clear an existing plugin binding, e.g. when changing viewType away from 'plugin'.",
 					},
 					pluginComponent: {
-						type: "string",
+						type: ["string", "null"],
 						description:
-							"Required when viewType is 'plugin'. The component name from that plugin's 'view' extension point (e.g. 'DashboardIntegrationView').",
+							"Required (together with pluginManifestId) when viewType is 'plugin'. The component name from that plugin's 'view' extension point (e.g. 'DashboardIntegrationView'). Pass null (together with pluginManifestId: null) to clear an existing plugin binding.",
 					},
 				},
 				required: ["projectId", "viewId"],
@@ -522,12 +565,14 @@ function formatView(view: any): string {
 /**
  * Builds the ViewConfig body sent for a plugin-backed view. Returns
  * undefined when neither field is set, so non-plugin create/update calls
- * don't send an empty config object.
+ * don't send an empty config object. A field set to null (only possible on
+ * update_view) is passed through as null to explicitly clear an existing
+ * plugin binding.
  */
 function buildViewConfig(
-	pluginManifestId?: string,
-	pluginComponent?: string,
-): { plugin_manifest_id?: string; plugin_component?: string } | undefined {
+	pluginManifestId?: string | null,
+	pluginComponent?: string | null,
+): ViewConfig | undefined {
 	if (pluginManifestId === undefined && pluginComponent === undefined) {
 		return undefined;
 	}

--- a/apps/mcp/src/tools/view-tools.ts
+++ b/apps/mcp/src/tools/view-tools.ts
@@ -15,6 +15,8 @@ const CreateViewSchema = z.object({
 	context: z.string(),
 	viewType: z.string(),
 	sprintId: z.string().optional(),
+	pluginManifestId: z.string().optional(),
+	pluginComponent: z.string().optional(),
 });
 
 const ReorderViewsSchema = z.object({
@@ -36,6 +38,8 @@ const UpdateViewSchema = z.object({
 	context: z.string().optional(),
 	viewType: z.string().optional(),
 	sprintId: z.string().optional(),
+	pluginManifestId: z.string().optional(),
+	pluginComponent: z.string().optional(),
 });
 
 const DeleteViewSchema = z.object({
@@ -129,7 +133,8 @@ export function getViewTools(): Tool[] {
 		},
 		{
 			name: "create_view",
-			description: "Create a new view",
+			description:
+				"Create a new view. For a plugin-provided view (e.g. a plugin's custom dashboard/board surfaced via its 'view' extension point), set viewType to 'plugin' and provide pluginManifestId + pluginComponent — check the target plugin's own docs/skill for its exact manifest ID and component name (e.g. the com.paca.dashboard plugin's Dashboard view uses pluginManifestId 'com.paca.dashboard' and pluginComponent 'DashboardIntegrationView'). The returned view's id is what that plugin then expects as its own 'host view id'.",
 			inputSchema: {
 				type: "object",
 				properties: {
@@ -147,11 +152,23 @@ export function getViewTools(): Tool[] {
 					},
 					viewType: {
 						type: "string",
-						description: "The type of view (table, board, roadmap)",
+						enum: ["table", "board", "roadmap", "plugin"],
+						description:
+							"The type of view. Use 'table', 'board', or 'roadmap' for the built-in layouts, or 'plugin' to host a plugin-provided view (requires pluginManifestId and pluginComponent).",
 					},
 					sprintId: {
 						type: "string",
 						description: "The sprint ID (required for sprint context)",
+					},
+					pluginManifestId: {
+						type: "string",
+						description:
+							"Required when viewType is 'plugin'. The reverse-DNS manifest ID of the plugin that provides this view (e.g. 'com.paca.dashboard').",
+					},
+					pluginComponent: {
+						type: "string",
+						description:
+							"Required when viewType is 'plugin'. The component name from that plugin's 'view' extension point (e.g. 'DashboardIntegrationView').",
 					},
 				},
 				required: ["projectId", "name", "context", "viewType"],
@@ -227,11 +244,23 @@ export function getViewTools(): Tool[] {
 					},
 					viewType: {
 						type: "string",
-						description: "The type of view (table, board, roadmap)",
+						enum: ["table", "board", "roadmap", "plugin"],
+						description:
+							"The type of view (table, board, roadmap, or plugin — plugin requires pluginManifestId and pluginComponent).",
 					},
 					sprintId: {
 						type: "string",
 						description: "The new sprint ID",
+					},
+					pluginManifestId: {
+						type: "string",
+						description:
+							"Required when viewType is 'plugin'. The reverse-DNS manifest ID of the plugin that provides this view (e.g. 'com.paca.dashboard').",
+					},
+					pluginComponent: {
+						type: "string",
+						description:
+							"Required when viewType is 'plugin'. The component name from that plugin's 'view' extension point (e.g. 'DashboardIntegrationView').",
 					},
 				},
 				required: ["projectId", "viewId"],
@@ -474,12 +503,38 @@ export function getCustomFieldTools(): Tool[] {
 }
 
 function formatView(view: any): string {
-	return `View: ${view.name}
-ID: ${view.id}
-Context: ${view.context}
-Sprint ID: ${view.sprint_id || "None"}
-Position: ${view.position}
-Created: ${view.created_at}`;
+	const lines = [
+		`View: ${view.name}`,
+		`ID: ${view.id}`,
+		`Type: ${view.view_type}`,
+		`Context: ${view.context}`,
+		`Sprint ID: ${view.sprint_id || "None"}`,
+	];
+	if (view.config?.plugin_manifest_id) {
+		lines.push(
+			`Plugin: ${view.config.plugin_manifest_id} (component: ${view.config.plugin_component})`,
+		);
+	}
+	lines.push(`Position: ${view.position}`, `Created: ${view.created_at}`);
+	return lines.join("\n");
+}
+
+/**
+ * Builds the ViewConfig body sent for a plugin-backed view. Returns
+ * undefined when neither field is set, so non-plugin create/update calls
+ * don't send an empty config object.
+ */
+function buildViewConfig(
+	pluginManifestId?: string,
+	pluginComponent?: string,
+): { plugin_manifest_id?: string; plugin_component?: string } | undefined {
+	if (pluginManifestId === undefined && pluginComponent === undefined) {
+		return undefined;
+	}
+	return {
+		plugin_manifest_id: pluginManifestId,
+		plugin_component: pluginComponent,
+	};
 }
 
 function formatCustomField(field: any): string {
@@ -522,8 +577,15 @@ export async function handleViewTool(
 		}
 
 		case "create_view": {
-			const { projectId, name, context, viewType, sprintId } =
-				CreateViewSchema.parse(args);
+			const {
+				projectId,
+				name,
+				context,
+				viewType,
+				sprintId,
+				pluginManifestId,
+				pluginComponent,
+			} = CreateViewSchema.parse(args);
 			const view = await client.createView(
 				projectId,
 				{
@@ -531,6 +593,7 @@ export async function handleViewTool(
 					context,
 					view_type: viewType as any,
 					sprint_id: sprintId ?? null,
+					config: buildViewConfig(pluginManifestId, pluginComponent),
 				},
 				context,
 				sprintId,
@@ -578,13 +641,22 @@ export async function handleViewTool(
 		}
 
 		case "update_view": {
-			const { projectId, viewId, name, context, viewType, sprintId } =
-				UpdateViewSchema.parse(args);
+			const {
+				projectId,
+				viewId,
+				name,
+				context,
+				viewType,
+				sprintId,
+				pluginManifestId,
+				pluginComponent,
+			} = UpdateViewSchema.parse(args);
 			const view = await client.updateView(projectId, viewId, {
 				name,
 				context,
 				view_type: viewType as any,
 				sprint_id: sprintId ?? null,
+				config: buildViewConfig(pluginManifestId, pluginComponent),
 			});
 			return {
 				content: [

--- a/apps/mcp/src/types/index.ts
+++ b/apps/mcp/src/types/index.ts
@@ -450,10 +450,10 @@ export interface ViewConfig {
 	field_sum?: string;
 	slice_by?: string;
 	filters?: ViewFilters;
-	/** Required when view_type is "plugin": the reverse-DNS plugin manifest ID that provides this view (e.g. "com.paca.dashboard"). */
-	plugin_manifest_id?: string;
-	/** Required when view_type is "plugin": the component name from that plugin's "view" extension point (e.g. "DashboardIntegrationView"). */
-	plugin_component?: string;
+	/** Required when view_type is "plugin": the reverse-DNS plugin manifest ID that provides this view (e.g. "com.paca.dashboard"). On update_view, null explicitly clears an existing binding. */
+	plugin_manifest_id?: string | null;
+	/** Required when view_type is "plugin": the component name from that plugin's "view" extension point (e.g. "DashboardIntegrationView"). On update_view, null explicitly clears an existing binding. */
+	plugin_component?: string | null;
 }
 
 export interface View {

--- a/apps/mcp/src/types/index.ts
+++ b/apps/mcp/src/types/index.ts
@@ -414,7 +414,7 @@ export interface UpdateTaskStatusInput {
 
 // ==================== Views ====================
 
-export type ViewType = "table" | "board" | "roadmap";
+export type ViewType = "table" | "board" | "roadmap" | "plugin";
 export type ViewLayout = "Board" | "Table" | "Roadmap";
 export type ViewsContext = "sprint" | "backlog" | "timeline";
 
@@ -450,6 +450,10 @@ export interface ViewConfig {
 	field_sum?: string;
 	slice_by?: string;
 	filters?: ViewFilters;
+	/** Required when view_type is "plugin": the reverse-DNS plugin manifest ID that provides this view (e.g. "com.paca.dashboard"). */
+	plugin_manifest_id?: string;
+	/** Required when view_type is "plugin": the component name from that plugin's "view" extension point (e.g. "DashboardIntegrationView"). */
+	plugin_component?: string;
 }
 
 export interface View {

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -767,7 +767,14 @@ async def teardown_paused_chat_sandbox(conversation_id: str) -> bool:
     entry = chat_sandboxes.pop(conversation_id, None)
     if entry is None:
         return False
-    stop_sandbox(entry.handle)
+    # stop_sandbox() blocks on container.stop(timeout=30) — a synchronous
+    # Docker Engine API call that can take several seconds. Unlike
+    # run_conversation's teardown (inside _run_sync, already offloaded via
+    # run_in_executor), this coroutine runs directly on the worker's shared
+    # event loop, so calling stop_sandbox() here inline would stall every
+    # other concurrent coroutine (including the trigger-stream Valkey read in
+    # worker.run_worker) for the container's full shutdown time.
+    await asyncio.get_event_loop().run_in_executor(None, stop_sandbox, entry.handle)
     await conversation_repository.update_conversation_status(
         conversation_id, ConversationStatus.STOPPED
     )


### PR DESCRIPTION
## Summary

The `create_view` MCP tool rejected requests to create a plugin-provided view (e.g. a plugin's dashboard/board surfaced via its `view` extension point) with `VIEW_TYPE_INVALID`, because its schema only knew about the built-in `table`/`board`/`roadmap` layouts. The backend has always supported a fourth `view_type`, `plugin`, keyed by a `plugin_manifest_id` + `plugin_component` pair in the view's config — the MCP tool just never exposed it, so an AI agent had no valid way to create one.

While verifying the fix I also found and fixed an unrelated event-loop-blocking bug in the ai-agent worker, surfaced by a Valkey read timeout that showed up in the logs at the exact moment a chat sandbox was torn down.

## Changes

**`apps/mcp/src/types/index.ts`**
- `ViewType` now includes `"plugin"`.
- `ViewConfig` gained `plugin_manifest_id` / `plugin_component`, matching the Go backend's `ViewConfigDTO`.

**`apps/mcp/src/tools/view-tools.ts`**
- `create_view` / `update_view` now accept `pluginManifestId` and `pluginComponent`, and `viewType` has an explicit enum (`table` | `board` | `roadmap` | `plugin`) with descriptions explaining when to use `plugin`.
- Both handlers thread these through as `config.plugin_manifest_id` / `config.plugin_component` on the create/update request body.
- `formatView` now shows the plugin binding when present, so a created/fetched view confirms what it's bound to.

Example of the previously-impossible request this now supports:
```json
{
  "projectId": "...",
  "name": "Dashboard",
  "context": "sprint",
  "sprintId": "...",
  "viewType": "plugin",
  "pluginManifestId": "com.paca.dashboard",
  "pluginComponent": "DashboardIntegrationView"
}
```

**`services/ai-agent/src/agent/executor.py`**
- `teardown_paused_chat_sandbox()` called the synchronous `stop_sandbox()` — which blocks on `container.stop(timeout=30)`, a blocking Docker Engine API call — directly inside an `async def`, with no thread offload. Since this coroutine runs on the worker's single shared event loop (called from both the idle-sandbox reaper and the `agent.stop` control-message fallback), it stalled every other concurrent coroutine for the container's full shutdown time, including the trigger-stream Valkey read in `worker.run_worker()` — which is what produced the `Failed to read from stream: Timeout reading from valkey:6379` log line. Now wrapped in `run_in_executor`, matching the pattern `run_conversation` already uses for its own sandbox start/stop calls.

## Test plan

- [x] `apps/mcp`: `tsc --noEmit`, `biome lint .`, `vitest run` (605/605 passing)
- [x] `services/ai-agent`: full `pytest` suite (201 passed, 3 skipped)
- [x] Manually verify `create_view` with `viewType: "plugin"` against a running instance
