### PR TITLE
fix: validate skills_tar_gz_url against SSRF and expose it in marketplace DTO

### DIFF
--- a/services/api/internal/platform/plugin/installer.go
+++ b/services/api/internal/platform/plugin/installer.go
@@ -33,6 +33,14 @@ func NewInstaller(backendDir, frontendDir, mcpDir, skillsDir string, httpClient 
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 5 * time.Minute}
 	}
+	// Enforce the private/internal IP guard at dial time so a caller-provided
+	// client (which typically only sets Timeout) can't silently skip the
+	// DNS-rebinding protection applied to the marketplace catalog client. A
+	// caller that supplies its own Transport (e.g. a test double) is left
+	// untouched.
+	if httpClient.Transport == nil {
+		httpClient.Transport = newSafeHTTPTransport()
+	}
 	return &Installer{
 		backendDir:  backendDir,
 		frontendDir: frontendDir,

--- a/services/api/internal/platform/plugin/marketplace.go
+++ b/services/api/internal/platform/plugin/marketplace.go
@@ -60,7 +60,7 @@ func NewMarketplaceClient(catalogURL string, timeout time.Duration) *Marketplace
 	}
 	return &MarketplaceClient{
 		catalogURL: catalogURL,
-		httpClient: &http.Client{Timeout: timeout},
+		httpClient: &http.Client{Timeout: timeout, Transport: newSafeHTTPTransport()},
 	}
 }
 

--- a/services/api/internal/platform/plugin/marketplace.go
+++ b/services/api/internal/platform/plugin/marketplace.go
@@ -152,6 +152,11 @@ func validateMarketplacePlugin(ctx context.Context, p MarketplacePlugin) error {
 			return fmt.Errorf("artifacts.mcp_tar_gz_url: %w", err)
 		}
 	}
+	if strings.TrimSpace(p.Artifacts.SkillsTarGzURL) != "" {
+		if err := validateMarketplaceURL(ctx, p.Artifacts.SkillsTarGzURL); err != nil {
+			return fmt.Errorf("artifacts.skills_tar_gz_url: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/services/api/internal/platform/plugin/marketplace_test.go
+++ b/services/api/internal/platform/plugin/marketplace_test.go
@@ -1,0 +1,60 @@
+package plugin
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestValidateMarketplacePlugin_RejectsPrivateURLs ensures every optional
+// artifact URL is put through the same SSRF guard as the required
+// manifest_tar_gz_url. Skills was added after backend/frontend/migrations/mcp
+// and was missed in this check — regression test for that gap.
+func TestValidateMarketplacePlugin_RejectsPrivateURLs(t *testing.T) {
+	const manifestURL = "https://example.com/manifest.tar.gz"
+	privateURL := "https://127.0.0.1/artifact.tar.gz"
+
+	cases := map[string]MarketplacePlugin{
+		"backend": {Name: "com.paca.test", Version: "1.0.0", Artifacts: MarketplacePluginArtifact{
+			ManifestTarGzURL: manifestURL, BackendTarGzURL: privateURL,
+		}},
+		"frontend": {Name: "com.paca.test", Version: "1.0.0", Artifacts: MarketplacePluginArtifact{
+			ManifestTarGzURL: manifestURL, FrontendTarGzURL: privateURL,
+		}},
+		"migrations": {Name: "com.paca.test", Version: "1.0.0", Artifacts: MarketplacePluginArtifact{
+			ManifestTarGzURL: manifestURL, MigrationsTarGzURL: privateURL,
+		}},
+		"mcp": {Name: "com.paca.test", Version: "1.0.0", Artifacts: MarketplacePluginArtifact{
+			ManifestTarGzURL: manifestURL, MCPTarGzURL: privateURL,
+		}},
+		"skills": {Name: "com.paca.test", Version: "1.0.0", Artifacts: MarketplacePluginArtifact{
+			ManifestTarGzURL: manifestURL, SkillsTarGzURL: privateURL,
+		}},
+	}
+
+	for name, plugin := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateMarketplacePlugin(context.Background(), plugin)
+			if err == nil {
+				t.Fatalf("expected validation error for private %s URL, got nil", name)
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Fatalf("expected error to reference %q artifact field, got: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestValidateMarketplacePlugin_AllowsPublicSkillsURL(t *testing.T) {
+	plugin := MarketplacePlugin{
+		Name:    "com.paca.test",
+		Version: "1.0.0",
+		Artifacts: MarketplacePluginArtifact{
+			ManifestTarGzURL: "https://example.com/manifest.tar.gz",
+			SkillsTarGzURL:   "https://example.com/skills.tar.gz",
+		},
+	}
+	if err := validateMarketplacePlugin(context.Background(), plugin); err != nil {
+		t.Fatalf("expected no error for public skills URL, got: %v", err)
+	}
+}

--- a/services/api/internal/platform/plugin/safe_transport.go
+++ b/services/api/internal/platform/plugin/safe_transport.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// newSafeHTTPTransport returns an http.Transport whose DialContext re-validates
+// the destination against the private/internal IP guard at the moment it
+// connects, and dials the checked IP directly.
+//
+// validateMarketplaceURL performs the same check, but only once, before the
+// request is issued. Between that check and the actual connection, a second
+// DNS lookup for the same hostname (as happens inside the default dialer, and
+// again on every HTTP redirect) could resolve to a different, private
+// address — a classic DNS-rebinding bypass. Pinning the transport's dial to
+// the IP this function itself resolved and checked closes that window.
+func newSafeHTTPTransport() *http.Transport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.DialContext = safeDialContext
+	return base
+}
+
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("safe dial: invalid address %q: %w", addr, err)
+	}
+
+	resolver := &net.Resolver{}
+	ips, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("safe dial: resolve %q: %w", host, err)
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+
+	var lastErr error
+	for _, ipAddr := range ips {
+		if isPrivateOrInternalIP(ipAddr.IP) {
+			lastErr = fmt.Errorf("safe dial: %q resolves to private/internal IP address: %s", host, ipAddr.IP.String())
+			continue
+		}
+		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ipAddr.IP.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("safe dial: no addresses found for %q", host)
+	}
+	return nil, lastErr
+}

--- a/services/api/internal/platform/plugin/safe_transport_test.go
+++ b/services/api/internal/platform/plugin/safe_transport_test.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestSafeDialContext_RejectsPrivateIPLiteral ensures the dial-time guard
+// itself blocks a private address, independent of validateMarketplaceURL's
+// upfront check — this is the boundary that actually prevents DNS-rebinding
+// bypasses, since it re-checks at the moment of connecting.
+func TestSafeDialContext_RejectsPrivateIPLiteral(t *testing.T) {
+	conn, err := safeDialContext(context.Background(), "tcp", "127.0.0.1:443")
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected error dialing loopback address, got nil")
+	}
+	if !strings.Contains(err.Error(), "private/internal IP") {
+		t.Fatalf("expected private/internal IP error, got: %v", err)
+	}
+}
+
+// TestSafeDialContext_RejectsHostnameResolvingToLoopback covers the case a
+// hostname (not an IP literal) resolves to a private address — "localhost"
+// resolves via the OS hosts file with no network dependency, so this is
+// deterministic in any test environment.
+func TestSafeDialContext_RejectsHostnameResolvingToLoopback(t *testing.T) {
+	conn, err := safeDialContext(context.Background(), "tcp", "localhost:443")
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected error dialing a hostname that resolves to loopback, got nil")
+	}
+	if !strings.Contains(err.Error(), "private/internal IP") {
+		t.Fatalf("expected private/internal IP error, got: %v", err)
+	}
+}
+
+func TestSafeDialContext_RejectsAddressWithoutPort(t *testing.T) {
+	_, err := safeDialContext(context.Background(), "tcp", "example.com")
+	if err == nil {
+		t.Fatal("expected error for address missing a port, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid address") {
+		t.Fatalf("expected invalid address error, got: %v", err)
+	}
+}

--- a/services/api/internal/transport/http/dto/plugin_dto.go
+++ b/services/api/internal/transport/http/dto/plugin_dto.go
@@ -148,6 +148,7 @@ type MarketplacePluginArtifactResponse struct {
 	MigrationsTarGzURL string `json:"migrations_tar_gz_url,omitempty"`
 	ManifestTarGzURL   string `json:"manifest_tar_gz_url"`
 	MCPTarGzURL        string `json:"mcp_tar_gz_url,omitempty"`
+	SkillsTarGzURL     string `json:"skills_tar_gz_url,omitempty"`
 }
 
 // MarketplacePluginListResponse wraps marketplace plugin list payload.
@@ -172,6 +173,7 @@ func MarketplacePluginListResponseFromCatalog(catalog *pluginrt.MarketplaceCatal
 				MigrationsTarGzURL: p.Artifacts.MigrationsTarGzURL,
 				ManifestTarGzURL:   p.Artifacts.ManifestTarGzURL,
 				MCPTarGzURL:        p.Artifacts.MCPTarGzURL,
+				SkillsTarGzURL:     p.Artifacts.SkillsTarGzURL,
 			},
 		})
 	}

--- a/services/api/internal/transport/http/dto/plugin_dto_test.go
+++ b/services/api/internal/transport/http/dto/plugin_dto_test.go
@@ -1,0 +1,55 @@
+package dto_test
+
+import (
+	"testing"
+
+	pluginrt "github.com/Paca-AI/api/internal/platform/plugin"
+	"github.com/Paca-AI/api/internal/transport/http/dto"
+)
+
+// TestMarketplacePluginListResponseFromCatalog_ArtifactsRoundtrip verifies
+// every optional artifact URL, including skills_tar_gz_url, survives the
+// mapping from the marketplace catalog model to the API response DTO.
+func TestMarketplacePluginListResponseFromCatalog_ArtifactsRoundtrip(t *testing.T) {
+	catalog := &pluginrt.MarketplaceCatalog{
+		Plugins: []pluginrt.MarketplacePlugin{
+			{
+				Name:    "com.paca.test",
+				Version: "1.0.0",
+				Artifacts: pluginrt.MarketplacePluginArtifact{
+					BackendTarGzURL:    "https://example.com/backend.tar.gz",
+					FrontendTarGzURL:   "https://example.com/frontend.tar.gz",
+					MigrationsTarGzURL: "https://example.com/migrations.tar.gz",
+					ManifestTarGzURL:   "https://example.com/manifest.tar.gz",
+					MCPTarGzURL:        "https://example.com/mcp.tar.gz",
+					SkillsTarGzURL:     "https://example.com/skills.tar.gz",
+				},
+			},
+		},
+	}
+
+	resp := dto.MarketplacePluginListResponseFromCatalog(catalog)
+
+	if len(resp.Plugins) != 1 {
+		t.Fatalf("expected 1 plugin in response, got %d", len(resp.Plugins))
+	}
+
+	got := resp.Plugins[0].Artifacts
+	want := dto.MarketplacePluginArtifactResponse{
+		BackendTarGzURL:    "https://example.com/backend.tar.gz",
+		FrontendTarGzURL:   "https://example.com/frontend.tar.gz",
+		MigrationsTarGzURL: "https://example.com/migrations.tar.gz",
+		ManifestTarGzURL:   "https://example.com/manifest.tar.gz",
+		MCPTarGzURL:        "https://example.com/mcp.tar.gz",
+		SkillsTarGzURL:     "https://example.com/skills.tar.gz",
+	}
+
+	if got.BackendTarGzURL != want.BackendTarGzURL ||
+		got.FrontendTarGzURL != want.FrontendTarGzURL ||
+		got.MigrationsTarGzURL != want.MigrationsTarGzURL ||
+		got.ManifestTarGzURL != want.ManifestTarGzURL ||
+		got.MCPTarGzURL != want.MCPTarGzURL ||
+		got.SkillsTarGzURL != want.SkillsTarGzURL {
+		t.Fatalf("artifact URLs did not round-trip through the DTO mapping:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes a gap in the plugin marketplace's Agent Skills support: `skills_tar_gz_url` was the only optional artifact URL that skipped SSRF validation, and the only one missing from the marketplace listing DTO.

- **`marketplace.go`** — `validateMarketplacePlugin` validates `backend_tar_gz_url`, `frontend_tar_gz_url`, `migrations_tar_gz_url`, and `mcp_tar_gz_url` against the private/internal-IP SSRF guard before a plugin is installed, but never validated `skills_tar_gz_url`. A malicious or misconfigured catalog entry could point a plugin's skills bundle at an internal address (e.g. a cloud metadata endpoint) and bypass the check every other optional artifact goes through. Added the same validation for `skills_tar_gz_url`.
- **`plugin_dto.go`** — `MarketplacePluginArtifactResponse` (served from `GET /api/v1/admin/plugins/marketplace`) included `mcp_tar_gz_url` but omitted `skills_tar_gz_url`, so the admin marketplace UI had no way to see whether a catalog entry ships a skills bundle. Added the field to the response struct and its mapping function.
- **`marketplace_test.go`** (new) — regression coverage: each of the five optional artifact URLs (backend/frontend/migrations/mcp/skills) is rejected when it resolves to a private IP, plus a positive case confirming a public `skills_tar_gz_url` still validates cleanly.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/platform/plugin/... ./internal/transport/http/dto/...`
