### PR TITLE
feat: add support for skills in plugins, including listing and localization

### DIFF
--- a/apps/web/src/components/plugins/PluginMarketplacePanel.tsx
+++ b/apps/web/src/components/plugins/PluginMarketplacePanel.tsx
@@ -8,6 +8,7 @@ import {
 	Search,
 	Server,
 	Trash2,
+	Wand2,
 	Zap,
 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -129,6 +130,7 @@ function PluginCard({
 	const hasFrontend = !!artifacts.frontend_tar_gz_url;
 	const hasMigrations = !!artifacts.migrations_tar_gz_url;
 	const hasMCP = !!artifacts.mcp_tar_gz_url;
+	const hasSkills = !!artifacts.skills_tar_gz_url;
 
 	let upgradeAvailable = false;
 	if (isInstalled && installedVersion) {
@@ -206,6 +208,12 @@ function PluginCard({
 						<FeatureBadge
 							icon={<Zap className="size-3" />}
 							label={t("marketplace.card.features.mcp")}
+						/>
+					)}
+					{hasSkills && (
+						<FeatureBadge
+							icon={<Wand2 className="size-3" />}
+							label={t("marketplace.card.features.skills")}
 						/>
 					)}
 				</div>

--- a/apps/web/src/i18n/locales/en/plugins.json
+++ b/apps/web/src/i18n/locales/en/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "Backend",
 				"frontend": "Frontend",
 				"migrations": "Migrations",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "Skills"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/es/plugins.json
+++ b/apps/web/src/i18n/locales/es/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "Backend",
 				"frontend": "Frontend",
 				"migrations": "Migraciones",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "Habilidades"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/fr/plugins.json
+++ b/apps/web/src/i18n/locales/fr/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "Backend",
 				"frontend": "Frontend",
 				"migrations": "Migrations",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "Compétences"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/ja/plugins.json
+++ b/apps/web/src/i18n/locales/ja/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "バックエンド",
 				"frontend": "フロントエンド",
 				"migrations": "マイグレーション",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "スキル"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/ko/plugins.json
+++ b/apps/web/src/i18n/locales/ko/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "백엔드",
 				"frontend": "프론트엔드",
 				"migrations": "마이그레이션",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "스킬"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/pt-BR/plugins.json
+++ b/apps/web/src/i18n/locales/pt-BR/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "Backend",
 				"frontend": "Frontend",
 				"migrations": "Migrações",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "Habilidades"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/ru/plugins.json
+++ b/apps/web/src/i18n/locales/ru/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "Backend",
 				"frontend": "Frontend",
 				"migrations": "Миграции",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "Навыки"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/vi/plugins.json
+++ b/apps/web/src/i18n/locales/vi/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "Backend",
 				"frontend": "Frontend",
 				"migrations": "Migrations",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "Kỹ năng"
 			}
 		}
 	},

--- a/apps/web/src/i18n/locales/zh-CN/plugins.json
+++ b/apps/web/src/i18n/locales/zh-CN/plugins.json
@@ -17,7 +17,8 @@
 				"backend": "后端",
 				"frontend": "前端",
 				"migrations": "数据库迁移",
-				"mcp": "MCP"
+				"mcp": "MCP",
+				"skills": "技能"
 			}
 		}
 	},

--- a/apps/web/src/lib/plugin-api.ts
+++ b/apps/web/src/lib/plugin-api.ts
@@ -109,6 +109,7 @@ export interface MarketplacePluginArtifacts {
 	migrations_tar_gz_url?: string;
 	manifest_tar_gz_url: string;
 	mcp_tar_gz_url?: string;
+	skills_tar_gz_url?: string;
 }
 
 export interface MarketplacePlugin {

--- a/scripts/install-paca-skills.sh
+++ b/scripts/install-paca-skills.sh
@@ -599,7 +599,17 @@ fi
 echo ""
 echo "  Installed skills:"
 echo "  ──────────────────────────────────────────────────────────────────────"
-cat "${SUMMARY_TMP}"
+# GET /api/v1/skills (the "bundled" fetch above) now also returns plugin-
+# contributed skills alongside Paca's own, so a plugin skill gets installed
+# twice: once here labeled "bundled" (technically installed, but mislabeled
+# — it came from a plugin), then again below labeled "plugin:<name>" (the
+# correct label, from resolving it via GET /api/v1/plugins). Both writes are
+# identical content to the same file, so nothing is functionally wrong, but
+# printing both lines would be confusing. Keep the last (correctly labeled)
+# occurrence per skill name while preserving overall order — the classic
+# reverse/dedupe-first/reverse idiom, since `awk '!seen[$1]++'` alone would
+# keep the first (mislabeled) occurrence instead.
+tac "${SUMMARY_TMP}" | awk '!seen[$1]++' | tac
 echo ""
 echo "  Where they went:"
 $INSTALL_CLAUDE && echo "    Claude Code   → ${CLAUDE_DIR}/"

--- a/scripts/install-paca-skills.sh
+++ b/scripts/install-paca-skills.sh
@@ -321,11 +321,20 @@ if $INSTALL_CURSOR || $INSTALL_AGENTS; then
 fi
 
 AGENTS_TMP=""
+# Names already appended to AGENTS_TMP, one per line — guards against the
+# same skill being installed twice (once mislabeled "bundled" via
+# GET /api/v1/skills, which now also returns plugin skills, then again
+# correctly labeled "plugin:<name>" via GET /api/v1/plugins) from producing
+# a duplicate "## /{name}" section in the regenerated AGENTS.md. A plain
+# temp file, not a bash associative array, so this still works under
+# macOS's default bash 3.2.
+AGENTS_SEEN_TMP=""
 SUMMARY_TMP="$(mktemp)"
 if [[ -n "${PROJECT_ROOT}" ]] && $INSTALL_AGENTS; then
   AGENTS_TMP="$(mktemp)"
+  AGENTS_SEEN_TMP="$(mktemp)"
 fi
-cleanup() { rm -f "${AGENTS_TMP:-}" "${SUMMARY_TMP}"; }
+cleanup() { rm -f "${AGENTS_TMP:-}" "${AGENTS_SEEN_TMP:-}" "${SUMMARY_TMP}"; }
 trap cleanup EXIT
 
 # ─── PACA_API_URL / PACA_API_KEY (if not already set) ──────────────────────
@@ -421,8 +430,10 @@ install_one_skill() {
     printf '%s\n' "${body}" > "${PROJECT_ROOT}/.cursor/commands/${name}.md"
   fi
 
-  # AGENTS.md — project-scoped only.
-  if $INSTALL_AGENTS && [[ -n "${AGENTS_TMP}" ]]; then
+  # AGENTS.md — project-scoped only. Skip a name already appended (see
+  # AGENTS_SEEN_TMP above) instead of duplicating its section.
+  if $INSTALL_AGENTS && [[ -n "${AGENTS_TMP}" ]] && ! grep -qxF "${name}" "${AGENTS_SEEN_TMP}"; then
+    printf '%s\n' "${name}" >> "${AGENTS_SEEN_TMP}"
     {
       printf '## /%s\n\n' "${name}"
       [[ -n "${description}" ]] && printf '_%s_\n\n' "${description}"

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -311,7 +311,7 @@ func New(cfg *config.Config) (*App, error) {
 		DocFile:            handler.NewDocFileHandler(attachmentService),
 		Notification:       handler.NewNotificationHandler(notificationService),
 		APIKey:             handler.NewAPIKeyHandler(apiKeyService),
-		Skills:             handler.NewSkillsHandler(),
+		Skills:             handler.NewSkillsHandler(pluginService, cfg.Plugins.SkillsDir),
 		Plugin:             pluginHandler,
 		Agent:              agentHandler,
 		Conversation:       convHandler,

--- a/services/api/internal/domain/plugin/entity.go
+++ b/services/api/internal/domain/plugin/entity.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
+	"github.com/Paca-AI/api/internal/platform/bundledskills"
 )
 
 // Plugin represents one installed plugin in the registry.
@@ -148,7 +149,11 @@ type SkillsManifest struct {
 // validate checks that the skills manifest is well-formed: a base URL and at
 // least one uniquely-named skill, each name following the AgentSkills naming
 // convention and none colliding with a reserved trigger-skill name (see
-// agentdom.ReservedSkillNames).
+// agentdom.ReservedSkillNames) or one of Paca's own bundled skill names (see
+// bundledskills.IsBuiltinName) — the latter would otherwise let a plugin
+// silently shadow a bundled skill users already trust, since neither the
+// GET /api/v1/skills merge nor scripts/install-paca-skills.sh's by-name file
+// writes dedupe against that list.
 func (m SkillsManifest) validate() error {
 	if strings.TrimSpace(m.BaseURL) == "" {
 		return fmt.Errorf("skills: baseUrl is required")
@@ -170,6 +175,9 @@ func (m SkillsManifest) validate() error {
 		}
 		if agentdom.IsReservedSkillName(name) {
 			return fmt.Errorf("skills: name %q is reserved", name)
+		}
+		if bundledskills.IsBuiltinName(name) {
+			return fmt.Errorf("skills: name %q collides with a bundled Paca skill", name)
 		}
 		if seen[name] {
 			return fmt.Errorf("skills: duplicate name %q", name)

--- a/services/api/internal/domain/plugin/entity_test.go
+++ b/services/api/internal/domain/plugin/entity_test.go
@@ -1,6 +1,10 @@
 package plugindom
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Paca-AI/api/internal/platform/bundledskills"
+)
 
 func TestPluginManifestValidate_Skills(t *testing.T) {
 	base := func(skills *SkillsManifest) PluginManifest {
@@ -69,6 +73,17 @@ func TestPluginManifestValidate_Skills(t *testing.T) {
 			skills: &SkillsManifest{
 				BaseURL: "/plugins-skills/com.paca.example",
 				Names:   []string{"paca-trigger-chat"},
+			},
+			wantErr: true,
+		},
+		{
+			// A plugin declaring one of Paca's own bundled skill names (e.g.
+			// "paca-setup") would otherwise silently shadow it — see
+			// bundledskills.IsBuiltinName.
+			name: "collides with a bundled skill name",
+			skills: &SkillsManifest{
+				BaseURL: "/plugins-skills/com.paca.example",
+				Names:   []string{bundledskills.List(bundledskills.TargetCLI)[0].Name},
 			},
 			wantErr: true,
 		},

--- a/services/api/internal/platform/bundledskills/bundledskills.go
+++ b/services/api/internal/platform/bundledskills/bundledskills.go
@@ -128,6 +128,23 @@ func List(target string) []Skill {
 	return result
 }
 
+// IsBuiltinName reports whether name matches one of Paca's own bundled
+// skills. A plugin declaring a skill with one of these names would collide
+// with — and silently shadow, since neither the API's merge nor
+// scripts/install-paca-skills.sh's by-name file writes dedupe against this
+// list — a skill users and conversations already trust as Paca's own.
+// plugindom.SkillsManifest.validate() calls this to reject such a name at
+// install/update time, and pluginrt.ListSkills calls it again at serving
+// time as a second line of defense.
+func IsBuiltinName(name string) bool {
+	for _, e := range skillEntries {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 var skillEntries = []skillEntry{
 	{
 		Name: "paca",

--- a/services/api/internal/platform/plugin/skills.go
+++ b/services/api/internal/platform/plugin/skills.go
@@ -1,0 +1,60 @@
+package plugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+	"github.com/Paca-AI/api/internal/platform/bundledskills"
+)
+
+// PluginLister is the subset of plugindom.Service that ListSkills needs —
+// narrowed from the full service interface so callers (and tests) don't
+// need to satisfy install/update/delete/extension-setting methods just to
+// list skills.
+type PluginLister interface {
+	ListPlugins(ctx context.Context) ([]*plugindom.Plugin, error)
+}
+
+// ListSkills returns every skill contributed by an enabled plugin that
+// declares a `skills` section in its manifest (see plugindom.SkillsManifest),
+// read directly from the local skills store the Installer already extracted
+// each bundle to — skillsDir/{pluginName}/{skillName}/SKILL.md — rather than
+// over HTTP. This is the same process that populated that directory (see
+// Installer.Install), so there's no network round trip and the result always
+// reflects the plugin's currently installed/enabled state.
+//
+// A plugin with no skills section, a disabled plugin, or one declared skill
+// whose SKILL.md can't be read is silently skipped rather than failing the
+// whole list — the same per-skill isolation
+// docs/plugins/skills-plugin-system.md documents for services/ai-agent's
+// analogous (HTTP-based) load_plugin_skills.
+func ListSkills(ctx context.Context, svc PluginLister, skillsDir string) ([]bundledskills.Skill, error) {
+	if skillsDir == "" || svc == nil {
+		return nil, nil
+	}
+	plugins, err := svc.ListPlugins(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var result []bundledskills.Skill
+	for _, p := range plugins {
+		if !p.Enabled || p.Manifest.Skills == nil {
+			continue
+		}
+		for _, name := range p.Manifest.Skills.Names {
+			skillPath := filepath.Join(skillsDir, p.Name, name, "SKILL.md")
+			content, err := os.ReadFile(skillPath)
+			if err != nil {
+				continue
+			}
+			result = append(result, bundledskills.Skill{
+				Name:    name,
+				Path:    p.Name + "/" + name + "/SKILL.md",
+				Content: string(content),
+			})
+		}
+	}
+	return result, nil
+}

--- a/services/api/internal/platform/plugin/skills.go
+++ b/services/api/internal/platform/plugin/skills.go
@@ -10,11 +10,11 @@ import (
 	"github.com/Paca-AI/api/internal/platform/bundledskills"
 )
 
-// PluginLister is the subset of plugindom.Service that ListSkills needs —
-// narrowed from the full service interface so callers (and tests) don't
-// need to satisfy install/update/delete/extension-setting methods just to
-// list skills.
-type PluginLister interface {
+// Lister is the subset of plugindom.Service that ListSkills needs — narrowed
+// from the full service interface so callers (and tests) don't need to
+// satisfy install/update/delete/extension-setting methods just to list
+// skills.
+type Lister interface {
 	ListPlugins(ctx context.Context) ([]*plugindom.Plugin, error)
 }
 
@@ -41,7 +41,7 @@ type PluginLister interface {
 // caller (skills_handler.go) merges this result into, so letting a
 // collision through would silently shadow a bundled skill both in the API
 // response and in whatever scripts/install-paca-skills.sh writes to disk.
-func ListSkills(ctx context.Context, svc PluginLister, skillsDir string) ([]bundledskills.Skill, error) {
+func ListSkills(ctx context.Context, svc Lister, skillsDir string) ([]bundledskills.Skill, error) {
 	if skillsDir == "" || svc == nil {
 		return nil, nil
 	}

--- a/services/api/internal/platform/plugin/skills.go
+++ b/services/api/internal/platform/plugin/skills.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -30,6 +31,16 @@ type PluginLister interface {
 // whole list — the same per-skill isolation
 // docs/plugins/skills-plugin-system.md documents for services/ai-agent's
 // analogous (HTTP-based) load_plugin_skills.
+//
+// A declared name that collides with one of Paca's own bundled skills (see
+// bundledskills.IsBuiltinName) is skipped and logged rather than returned.
+// plugindom.SkillsManifest.validate() already rejects such a name at
+// install/update time, but this is a second line of defense against a
+// plugin installed before that check existed, or any other path that
+// bypassed it — nothing here dedupes by name against the bundled list the
+// caller (skills_handler.go) merges this result into, so letting a
+// collision through would silently shadow a bundled skill both in the API
+// response and in whatever scripts/install-paca-skills.sh writes to disk.
 func ListSkills(ctx context.Context, svc PluginLister, skillsDir string) ([]bundledskills.Skill, error) {
 	if skillsDir == "" || svc == nil {
 		return nil, nil
@@ -44,6 +55,11 @@ func ListSkills(ctx context.Context, svc PluginLister, skillsDir string) ([]bund
 			continue
 		}
 		for _, name := range p.Manifest.Skills.Names {
+			if bundledskills.IsBuiltinName(name) {
+				slog.Warn("skills: plugin skill name collides with a bundled skill, skipping",
+					"plugin", p.Name, "skill", name)
+				continue
+			}
 			skillPath := filepath.Join(skillsDir, p.Name, name, "SKILL.md")
 			content, err := os.ReadFile(skillPath)
 			if err != nil {

--- a/services/api/internal/platform/plugin/skills_test.go
+++ b/services/api/internal/platform/plugin/skills_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+	"github.com/Paca-AI/api/internal/platform/bundledskills"
 )
 
 type fakePluginLister struct {
@@ -130,6 +131,38 @@ func TestListSkills_SkipsUnreadableSkillFileRatherThanFailing(t *testing.T) {
 	}
 	if len(skills) != 1 || skills[0].Name != "paca-a" {
 		t.Fatalf("expected only paca-a to be returned, got %+v", skills)
+	}
+}
+
+func TestListSkills_SkipsNameCollidingWithBundledSkill(t *testing.T) {
+	dir := t.TempDir()
+	// Manifest validation should already reject this at install time (see
+	// entity_test.go's "collides with a bundled skill name" case), but this
+	// exercises ListSkills' own defense-in-depth for a plugin that was
+	// installed before that check existed.
+	builtinName := bundledskills.List(bundledskills.TargetCLI)[0].Name
+	writeSkillFile(t, dir, "com.paca.example", builtinName, "shadow content")
+	writeSkillFile(t, dir, "com.paca.example", "paca-example", "content")
+
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{
+			Name:    "com.paca.example",
+			Enabled: true,
+			Manifest: plugindom.PluginManifest{
+				Skills: &plugindom.SkillsManifest{
+					BaseURL: "/plugins-skills/com.paca.example",
+					Names:   []string{builtinName, "paca-example"},
+				},
+			},
+		},
+	}}
+
+	skills, err := ListSkills(context.Background(), svc, dir)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Name != "paca-example" {
+		t.Fatalf("expected only the non-colliding skill to be returned, got %+v", skills)
 	}
 }
 

--- a/services/api/internal/platform/plugin/skills_test.go
+++ b/services/api/internal/platform/plugin/skills_test.go
@@ -16,7 +16,7 @@ type fakePluginLister struct {
 	err     error
 }
 
-func (f *fakePluginLister) ListPlugins(ctx context.Context) ([]*plugindom.Plugin, error) {
+func (f *fakePluginLister) ListPlugins(_ context.Context) ([]*plugindom.Plugin, error) {
 	return f.plugins, f.err
 }
 

--- a/services/api/internal/platform/plugin/skills_test.go
+++ b/services/api/internal/platform/plugin/skills_test.go
@@ -1,0 +1,152 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+)
+
+type fakePluginLister struct {
+	plugins []*plugindom.Plugin
+	err     error
+}
+
+func (f *fakePluginLister) ListPlugins(ctx context.Context) ([]*plugindom.Plugin, error) {
+	return f.plugins, f.err
+}
+
+func writeSkillFile(t *testing.T, dir, pluginName, skillName, content string) {
+	t.Helper()
+	path := filepath.Join(dir, pluginName, skillName, "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestListSkills_ReturnsEnabledPluginSkills(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "com.paca.dashboard", "paca-dashboard-builder", "---\nname: paca-dashboard-builder\n---\nbody")
+
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{
+			Name:    "com.paca.dashboard",
+			Enabled: true,
+			Manifest: plugindom.PluginManifest{
+				Skills: &plugindom.SkillsManifest{
+					BaseURL: "/plugins-skills/com.paca.dashboard",
+					Names:   []string{"paca-dashboard-builder"},
+				},
+			},
+		},
+	}}
+
+	skills, err := ListSkills(context.Background(), svc, dir)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d: %+v", len(skills), skills)
+	}
+	if skills[0].Name != "paca-dashboard-builder" {
+		t.Errorf("expected paca-dashboard-builder, got %q", skills[0].Name)
+	}
+	if skills[0].Path != "com.paca.dashboard/paca-dashboard-builder/SKILL.md" {
+		t.Errorf("unexpected path: %q", skills[0].Path)
+	}
+	if skills[0].Content == "" {
+		t.Error("expected non-empty content")
+	}
+}
+
+func TestListSkills_SkipsDisabledPlugins(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "com.paca.dashboard", "paca-dashboard-builder", "content")
+
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{
+			Name:    "com.paca.dashboard",
+			Enabled: false,
+			Manifest: plugindom.PluginManifest{
+				Skills: &plugindom.SkillsManifest{
+					BaseURL: "/plugins-skills/com.paca.dashboard",
+					Names:   []string{"paca-dashboard-builder"},
+				},
+			},
+		},
+	}}
+
+	skills, err := ListSkills(context.Background(), svc, dir)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Fatalf("expected disabled plugin's skills to be excluded, got %+v", skills)
+	}
+}
+
+func TestListSkills_SkipsPluginsWithoutSkillsManifest(t *testing.T) {
+	dir := t.TempDir()
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{Name: "com.paca.webhook", Enabled: true, Manifest: plugindom.PluginManifest{}},
+	}}
+
+	skills, err := ListSkills(context.Background(), svc, dir)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Fatalf("expected no skills for a plugin with no skills manifest, got %+v", skills)
+	}
+}
+
+func TestListSkills_SkipsUnreadableSkillFileRatherThanFailing(t *testing.T) {
+	dir := t.TempDir()
+	// paca-a exists on disk, paca-b was declared but never extracted.
+	writeSkillFile(t, dir, "com.paca.example", "paca-a", "content-a")
+
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{
+			Name:    "com.paca.example",
+			Enabled: true,
+			Manifest: plugindom.PluginManifest{
+				Skills: &plugindom.SkillsManifest{
+					BaseURL: "/plugins-skills/com.paca.example",
+					Names:   []string{"paca-a", "paca-b"},
+				},
+			},
+		},
+	}}
+
+	skills, err := ListSkills(context.Background(), svc, dir)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Name != "paca-a" {
+		t.Fatalf("expected only paca-a to be returned, got %+v", skills)
+	}
+}
+
+func TestListSkills_PropagatesListPluginsError(t *testing.T) {
+	svc := &fakePluginLister{err: errors.New("db unavailable")}
+
+	_, err := ListSkills(context.Background(), svc, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
+
+func TestListSkills_NoSkillsDirOrService(t *testing.T) {
+	if skills, err := ListSkills(context.Background(), nil, "/some/dir"); err != nil || skills != nil {
+		t.Fatalf("expected (nil, nil) for nil service, got (%+v, %v)", skills, err)
+	}
+	if skills, err := ListSkills(context.Background(), &fakePluginLister{}, ""); err != nil || skills != nil {
+		t.Fatalf("expected (nil, nil) for empty skillsDir, got (%+v, %v)", skills, err)
+	}
+}

--- a/services/api/internal/transport/http/handler/skills_handler.go
+++ b/services/api/internal/transport/http/handler/skills_handler.go
@@ -15,14 +15,14 @@ import (
 // bundledskills package for why those are compiled into the binary) plus,
 // for the "cli" flavor only, skills contributed by enabled plugins.
 type SkillsHandler struct {
-	pluginSvc pluginrt.PluginLister
+	pluginSvc pluginrt.Lister
 	skillsDir string
 }
 
 // NewSkillsHandler returns a SkillsHandler. pluginSvc and skillsDir may be
 // left zero-valued (nil / ""), in which case ListSkills falls back to
 // bundled skills only.
-func NewSkillsHandler(pluginSvc pluginrt.PluginLister, skillsDir string) *SkillsHandler {
+func NewSkillsHandler(pluginSvc pluginrt.Lister, skillsDir string) *SkillsHandler {
 	return &SkillsHandler{pluginSvc: pluginSvc, skillsDir: skillsDir}
 }
 

--- a/services/api/internal/transport/http/handler/skills_handler.go
+++ b/services/api/internal/transport/http/handler/skills_handler.go
@@ -1,33 +1,65 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
+	"sort"
 
 	"github.com/Paca-AI/api/internal/platform/bundledskills"
+	pluginrt "github.com/Paca-AI/api/internal/platform/plugin"
 	"github.com/Paca-AI/api/internal/transport/http/dto"
 	"github.com/Paca-AI/api/internal/transport/http/presenter"
 )
 
-// SkillsHandler serves Paca's bundled Agent Skills — see the bundledskills
-// package for why these are compiled into the binary rather than read from
-// a database or the filesystem at request time.
-type SkillsHandler struct{}
+// SkillsHandler serves Paca's Agent Skills: its own bundled skills (see the
+// bundledskills package for why those are compiled into the binary) plus,
+// for the "cli" flavor only, skills contributed by enabled plugins.
+type SkillsHandler struct {
+	pluginSvc pluginrt.PluginLister
+	skillsDir string
+}
 
-// NewSkillsHandler returns a SkillsHandler.
-func NewSkillsHandler() *SkillsHandler { return &SkillsHandler{} }
+// NewSkillsHandler returns a SkillsHandler. pluginSvc and skillsDir may be
+// left zero-valued (nil / ""), in which case ListSkills falls back to
+// bundled skills only.
+func NewSkillsHandler(pluginSvc pluginrt.PluginLister, skillsDir string) *SkillsHandler {
+	return &SkillsHandler{pluginSvc: pluginSvc, skillsDir: skillsDir}
+}
 
-// ListSkills responds with every bundled skill's name, path, and raw file
-// content for the requested flavor.
+// ListSkills responds with every skill's name, path, and raw file content
+// for the requested flavor.
 //
-//   - GET /api/v1/skills            → "cli" flavor (default): consumed by
+//   - GET /api/v1/skills              → "cli" flavor (default): every
+//     bundled skill plus every skill contributed by an enabled plugin (read
+//     from the local skills store — see pluginrt.ListSkills). Consumed by
 //     scripts/install-paca-skills.sh in place of fetching from GitHub, so
 //     installed content always matches the exact version this instance is
 //     running.
-//   - GET /api/v1/skills?target=agent → "agent" flavor: consumed by
-//     services/ai-agent's builder.load_default_skills() for every
-//     "llm"-type agent conversation, in place of reading its own bundled
-//     src/skills/ directory.
+//   - GET /api/v1/skills?target=agent → "agent" flavor: Paca's bundled
+//     skills only, deliberately excluding plugin skills. Consumed by
+//     services/ai-agent's builder.load_default_skills(), which caches the
+//     response for the life of the worker process — mixing plugin skills
+//     into that cache would leave a disabled/uninstalled plugin's skill
+//     stuck there until the process restarts, breaking the "install/enable/
+//     disable takes effect on the next conversation" guarantee documented
+//     in docs/plugins/skills-plugin-system.md. Every conversation already
+//     gets live, uncached plugin skills through a separate path
+//     (agent_repository.list_enabled_plugin_skills +
+//     builder.load_plugin_skills), so nothing is missing for the "agent"
+//     flavor by leaving plugin skills out of it here.
 func (h *SkillsHandler) ListSkills(w http.ResponseWriter, r *http.Request) {
 	target := r.URL.Query().Get("target")
-	presenter.OK(w, r, dto.SkillListResponseFromEntities(bundledskills.List(target)))
+	skills := bundledskills.List(target)
+
+	if target != bundledskills.TargetAgent {
+		pluginSkills, err := pluginrt.ListSkills(r.Context(), h.pluginSvc, h.skillsDir)
+		if err != nil {
+			slog.Error("skills: failed to list plugin-contributed skills", "error", err)
+		} else if len(pluginSkills) > 0 {
+			skills = append(skills, pluginSkills...)
+			sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+		}
+	}
+
+	presenter.OK(w, r, dto.SkillListResponseFromEntities(skills))
 }

--- a/services/api/internal/transport/http/handler/skills_handler_test.go
+++ b/services/api/internal/transport/http/handler/skills_handler_test.go
@@ -75,7 +75,7 @@ func TestSkillsHandler_ListSkills_MergesPluginSkillsIntoCLIFlavor(t *testing.T) 
 	h := handler.NewSkillsHandler(svc, dir)
 
 	w := httptest.NewRecorder()
-	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil))
+	h.ListSkills(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/skills", nil))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -109,7 +109,7 @@ func TestSkillsHandler_ListSkills_AgentFlavorExcludesPluginSkills(t *testing.T) 
 	h := handler.NewSkillsHandler(svc, dir)
 
 	w := httptest.NewRecorder()
-	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills?target=agent", nil))
+	h.ListSkills(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/skills?target=agent", nil))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -129,7 +129,7 @@ func TestSkillsHandler_ListSkills_FallsBackToBundledOnPluginListError(t *testing
 	h := handler.NewSkillsHandler(svc, t.TempDir())
 
 	w := httptest.NewRecorder()
-	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil))
+	h.ListSkills(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/skills", nil))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 even when the plugin lister errors, got %d: %s", w.Code, w.Body.String())
@@ -145,7 +145,7 @@ func TestSkillsHandler_ListSkills_NoPluginServiceConfigured(t *testing.T) {
 	h := handler.NewSkillsHandler(nil, "")
 
 	w := httptest.NewRecorder()
-	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil))
+	h.ListSkills(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/skills", nil))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())

--- a/services/api/internal/transport/http/handler/skills_handler_test.go
+++ b/services/api/internal/transport/http/handler/skills_handler_test.go
@@ -1,0 +1,158 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
+	"github.com/Paca-AI/api/internal/platform/bundledskills"
+	"github.com/Paca-AI/api/internal/transport/http/dto"
+	"github.com/Paca-AI/api/internal/transport/http/handler"
+)
+
+type fakePluginLister struct {
+	plugins []*plugindom.Plugin
+	err     error
+}
+
+func (f *fakePluginLister) ListPlugins(_ context.Context) ([]*plugindom.Plugin, error) {
+	return f.plugins, f.err
+}
+
+func writeSkillFile(t *testing.T, dir, pluginName, skillName, content string) {
+	t.Helper()
+	path := filepath.Join(dir, pluginName, skillName, "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func decodeSkills(t *testing.T, w *httptest.ResponseRecorder) []dto.SkillResponse {
+	t.Helper()
+	var envelope struct {
+		Data dto.SkillListResponse `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return envelope.Data.Skills
+}
+
+func hasSkillNamed(skills []dto.SkillResponse, name string) bool {
+	for _, s := range skills {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSkillsHandler_ListSkills_MergesPluginSkillsIntoCLIFlavor(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "com.paca.dashboard", "paca-dashboard-builder", "content")
+
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{
+			Name:    "com.paca.dashboard",
+			Enabled: true,
+			Manifest: plugindom.PluginManifest{
+				Skills: &plugindom.SkillsManifest{
+					BaseURL: "/plugins-skills/com.paca.dashboard",
+					Names:   []string{"paca-dashboard-builder"},
+				},
+			},
+		},
+	}}
+	h := handler.NewSkillsHandler(svc, dir)
+
+	w := httptest.NewRecorder()
+	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	skills := decodeSkills(t, w)
+	bundledCount := len(bundledskills.List(bundledskills.TargetCLI))
+	if len(skills) != bundledCount+1 {
+		t.Fatalf("expected %d skills (bundled + 1 plugin), got %d", bundledCount+1, len(skills))
+	}
+	if !hasSkillNamed(skills, "paca-dashboard-builder") {
+		t.Errorf("expected plugin skill paca-dashboard-builder in response, got %+v", skills)
+	}
+}
+
+func TestSkillsHandler_ListSkills_AgentFlavorExcludesPluginSkills(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "com.paca.dashboard", "paca-dashboard-builder", "content")
+
+	svc := &fakePluginLister{plugins: []*plugindom.Plugin{
+		{
+			Name:    "com.paca.dashboard",
+			Enabled: true,
+			Manifest: plugindom.PluginManifest{
+				Skills: &plugindom.SkillsManifest{
+					BaseURL: "/plugins-skills/com.paca.dashboard",
+					Names:   []string{"paca-dashboard-builder"},
+				},
+			},
+		},
+	}}
+	h := handler.NewSkillsHandler(svc, dir)
+
+	w := httptest.NewRecorder()
+	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills?target=agent", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	skills := decodeSkills(t, w)
+	bundledCount := len(bundledskills.List(bundledskills.TargetAgent))
+	if len(skills) != bundledCount {
+		t.Fatalf("expected agent flavor to stay bundled-only (%d skills), got %d", bundledCount, len(skills))
+	}
+	if hasSkillNamed(skills, "paca-dashboard-builder") {
+		t.Error("expected agent flavor to exclude plugin-contributed skills, but found paca-dashboard-builder")
+	}
+}
+
+func TestSkillsHandler_ListSkills_FallsBackToBundledOnPluginListError(t *testing.T) {
+	svc := &fakePluginLister{err: errors.New("db unavailable")}
+	h := handler.NewSkillsHandler(svc, t.TempDir())
+
+	w := httptest.NewRecorder()
+	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even when the plugin lister errors, got %d: %s", w.Code, w.Body.String())
+	}
+	skills := decodeSkills(t, w)
+	bundledCount := len(bundledskills.List(bundledskills.TargetCLI))
+	if len(skills) != bundledCount {
+		t.Fatalf("expected bundled-only fallback (%d skills), got %d", bundledCount, len(skills))
+	}
+}
+
+func TestSkillsHandler_ListSkills_NoPluginServiceConfigured(t *testing.T) {
+	h := handler.NewSkillsHandler(nil, "")
+
+	w := httptest.NewRecorder()
+	h.ListSkills(w, httptest.NewRequest(http.MethodGet, "/api/v1/skills", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	skills := decodeSkills(t, w)
+	bundledCount := len(bundledskills.List(bundledskills.TargetCLI))
+	if len(skills) != bundledCount {
+		t.Fatalf("expected bundled-only (%d skills) with no plugin service configured, got %d", bundledCount, len(skills))
+	}
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/skills` only ever returned Paca's own bundled skills, so a plugin's contributed skill (e.g. the Dashboard plugin's `paca-dashboard-builder`) never showed up there even after the plugin was installed and enabled — even though the rest of the pipeline (agent conversations, `scripts/install-paca-skills.sh`) already picked it up correctly through separate paths. The marketplace UI also never surfaced whether a plugin ships a skills bundle at all.

This PR closes both gaps.

## Changes

**API — plugin skills in the default skill list**
- `services/api/internal/platform/plugin/skills.go` (new): reads every enabled plugin's declared `SKILL.md` files directly from the local skills store the installer already extracted them to (no network round trip).
- `services/api/internal/transport/http/handler/skills_handler.go`: merges those into the **default/"cli" flavor** of `GET /api/v1/skills` only. The `target=agent` flavor (cached for the life of the `ai-agent` worker process) is deliberately left bundled-only — mixing plugin skills into that permanent cache would leave a disabled/uninstalled plugin's skill stuck there until a restart, breaking the documented "install/enable/disable takes effect on the next conversation" guarantee. Conversations already get live, uncached plugin skills through their own separate path.
- `services/api/internal/bootstrap/app.go`: wires the plugin service and skills directory into the handler.
- `services/api/internal/platform/plugin/skills_test.go`: coverage for enabled/disabled plugins, plugins with no skills manifest, missing/unreadable `SKILL.md` files, and error propagation.

**CLI installer — cleaner summary output**
- `scripts/install-paca-skills.sh`: since `GET /api/v1/skills` now includes plugin skills, the script's own bundled-fetch loop and its separate plugin-fetch loop would both install the same skill and print it twice (once mislabeled `[bundled]`, once correctly `[plugin:...]`). Dedupe the final summary table, keeping the correctly labeled entry.

**Web — surface the skills artifact in the marketplace UI**
- `apps/web/src/lib/plugin-api.ts`: the `MarketplacePluginArtifacts` TS type was missing `skills_tar_gz_url` even though the backend already served it.
- `apps/web/src/components/plugins/PluginMarketplacePanel.tsx`: add a "Skills" feature badge to the plugin card, matching the existing Backend/Frontend/Migrations/MCP badges.
- `apps/web/src/i18n/locales/*/plugins.json` (all 9 locales): add the corresponding `marketplace.card.features.skills` translation key.

## Testing
- `go build ./...` and `go test ./...` — all packages pass.
- `tsc --noEmit` — clean.
- Verified live against a running dev stack: `GET /api/v1/skills` now includes `paca-dashboard-builder`/`paca-bdd-scenarios` alongside bundled skills; `target=agent` unaffected; re-ran `scripts/install-paca-skills.sh` end-to-end and confirmed each skill appears once with the correct label.
