### PR TITLE
fix: plugin MCP tools failing to load behind HTTPS gateway (TLS alert); fix marketplace per-plugin loading state

### DIFF
--- a/apps/web/src/components/plugins/PluginMarketplacePanel.tsx
+++ b/apps/web/src/components/plugins/PluginMarketplacePanel.tsx
@@ -297,8 +297,26 @@ export function PluginMarketplacePanel() {
 		return marketplace.filter((plugin) => matchesQuery(plugin, query));
 	}, [marketplace, query]);
 
+	const [installingNames, setInstallingNames] = useState<Set<string>>(
+		new Set(),
+	);
+	const [uninstallingIds, setUninstallingIds] = useState<Set<string>>(
+		new Set(),
+	);
+	const [upgradingIds, setUpgradingIds] = useState<Set<string>>(new Set());
+
 	const installMutation = useMutation({
 		mutationFn: installMarketplacePlugin,
+		onMutate: (variables) => {
+			setInstallingNames((prev) => new Set(prev).add(variables.name));
+		},
+		onSettled: (_data, _error, variables) => {
+			setInstallingNames((prev) => {
+				const next = new Set(prev);
+				next.delete(variables.name);
+				return next;
+			});
+		},
 		onSuccess: async () => {
 			await Promise.all([
 				qc.invalidateQueries({ queryKey: ["plugins"] }),
@@ -309,6 +327,16 @@ export function PluginMarketplacePanel() {
 
 	const uninstallMutation = useMutation({
 		mutationFn: uninstallPlugin,
+		onMutate: (pluginId) => {
+			setUninstallingIds((prev) => new Set(prev).add(pluginId));
+		},
+		onSettled: (_data, _error, pluginId) => {
+			setUninstallingIds((prev) => {
+				const next = new Set(prev);
+				next.delete(pluginId);
+				return next;
+			});
+		},
 		onSuccess: async () => {
 			await Promise.all([
 				qc.invalidateQueries({ queryKey: ["plugins"] }),
@@ -319,6 +347,16 @@ export function PluginMarketplacePanel() {
 
 	const upgradeMutation = useMutation({
 		mutationFn: upgradePlugin,
+		onMutate: (pluginId) => {
+			setUpgradingIds((prev) => new Set(prev).add(pluginId));
+		},
+		onSettled: (_data, _error, pluginId) => {
+			setUpgradingIds((prev) => {
+				const next = new Set(prev);
+				next.delete(pluginId);
+				return next;
+			});
+		},
 		onSuccess: async () => {
 			await qc.invalidateQueries({ queryKey: ["plugins"] });
 		},
@@ -356,20 +394,15 @@ export function PluginMarketplacePanel() {
 							plugin={plugin}
 							isInstalled={installedByName.has(plugin.name)}
 							installedVersion={installedByName.get(plugin.name)?.version}
-							isInstalling={
-								installMutation.isPending &&
-								installMutation.variables?.name === plugin.name
-							}
-							isUninstalling={
-								uninstallMutation.isPending &&
-								uninstallMutation.variables ===
-									installedByName.get(plugin.name)?.id
-							}
-							isUpgrading={
-								upgradeMutation.isPending &&
-								upgradeMutation.variables ===
-									installedByName.get(plugin.name)?.id
-							}
+							isInstalling={installingNames.has(plugin.name)}
+							isUninstalling={(() => {
+								const pluginId = installedByName.get(plugin.name)?.id;
+								return !!pluginId && uninstallingIds.has(pluginId);
+							})()}
+							isUpgrading={(() => {
+								const pluginId = installedByName.get(plugin.name)?.id;
+								return !!pluginId && upgradingIds.has(pluginId);
+							})()}
 							onInstall={(name) =>
 								installMutation.mutate({ name, enabled: true })
 							}

--- a/apps/web/src/components/plugins/PluginMarketplacePanel.tsx
+++ b/apps/web/src/components/plugins/PluginMarketplacePanel.tsx
@@ -388,36 +388,31 @@ export function PluginMarketplacePanel() {
 				</div>
 			) : (
 				<div className="grid grid-cols-1 gap-3">
-					{filtered.map((plugin) => (
-						<PluginCard
-							key={plugin.name}
-							plugin={plugin}
-							isInstalled={installedByName.has(plugin.name)}
-							installedVersion={installedByName.get(plugin.name)?.version}
-							isInstalling={installingNames.has(plugin.name)}
-							isUninstalling={(() => {
-								const pluginId = installedByName.get(plugin.name)?.id;
-								return !!pluginId && uninstallingIds.has(pluginId);
-							})()}
-							isUpgrading={(() => {
-								const pluginId = installedByName.get(plugin.name)?.id;
-								return !!pluginId && upgradingIds.has(pluginId);
-							})()}
-							onInstall={(name) =>
-								installMutation.mutate({ name, enabled: true })
-							}
-							onUninstall={(name) => {
-								const pluginId = installedByName.get(name)?.id;
-								if (!pluginId) return;
-								uninstallMutation.mutate(pluginId);
-							}}
-							onUpgrade={(name) => {
-								const pluginId = installedByName.get(name)?.id;
-								if (!pluginId) return;
-								upgradeMutation.mutate(pluginId);
-							}}
-						/>
-					))}
+					{filtered.map((plugin) => {
+						const pluginId = installedByName.get(plugin.name)?.id;
+						return (
+							<PluginCard
+								key={plugin.name}
+								plugin={plugin}
+								isInstalled={installedByName.has(plugin.name)}
+								installedVersion={installedByName.get(plugin.name)?.version}
+								isInstalling={installingNames.has(plugin.name)}
+								isUninstalling={!!pluginId && uninstallingIds.has(pluginId)}
+								isUpgrading={!!pluginId && upgradingIds.has(pluginId)}
+								onInstall={(name) =>
+									installMutation.mutate({ name, enabled: true })
+								}
+								onUninstall={() => {
+									if (!pluginId) return;
+									uninstallMutation.mutate(pluginId);
+								}}
+								onUpgrade={() => {
+									if (!pluginId) return;
+									upgradeMutation.mutate(pluginId);
+								}}
+							/>
+						);
+					})}
 				</div>
 			)}
 		</div>

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -180,9 +180,12 @@
 # -- Internal MCP/Skills bundle port ------------------------------------------
 #
 # The MCP server and ai-agent fetch plugin MCP/skills bundles via
-# GATEWAY_BASE_URL over plain http:// on the docker-internal network (see
-# apps/mcp/src/plugin-loader.ts and the skills-plugin-system docs). When
-# SITE_ADDRESS above is a real domain, Caddy enables automatic HTTPS for it,
+# GATEWAY_BASE_URL over plain http:// on the docker-internal network.
+# services/ai-agent/src/config.py reads GATEWAY_BASE_URL and forwards it to
+# the spawned MCP subprocess as PACA_GATEWAY_URL (see
+# services/ai-agent/src/agent/builder.py), which apps/mcp/src/plugin-loader.ts
+# then uses to resolve plugin bundle URLs. When SITE_ADDRESS above is a real
+# domain, Caddy enables automatic HTTPS for it,
 # which installs a catch-all HTTP→HTTPS redirect on port 80 for *any* Host
 # header — including these internal requests. Caddy has no certificate for
 # the "gateway" hostname, so the followed redirect's TLS handshake fails.

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -36,6 +36,38 @@
 #   install.sh enables HTTPS by default and prompts for this address.
 # =============================================================================
 
+(mcp_skills_routes) {
+	# -- MCP plugin bundles -------------------------------------------------------
+	#
+	# Self-contained ESM bundles loaded at runtime by the MCP server. Kept on a
+	# separate path from frontend assets so WASM/CSS concerns from the
+	# /plugins/* block don't bleed into MCP serving.
+	#
+	# Set remoteEntryUrl in each plugin's plugin.json mcp section to an
+	# absolute URL, for example:
+	#   ${PUBLIC_URL}/plugins-mcp/<plugin-id>/mcp.js
+	handle_path /plugins-mcp/* {
+		root * /var/www/plugins-mcp
+		header Cache-Control "public, max-age=900, immutable"
+		file_server
+	}
+
+	# -- Plugin Agent Skills bundles ----------------------------------------------
+	#
+	# SKILL.md directories loaded at conversation start by the ai-agent service.
+	# Kept on a separate path from frontend/MCP assets for the same reason as
+	# the MCP block above.
+	#
+	# Set baseUrl in each plugin's plugin.json skills section to an absolute
+	# URL, for example:
+	#   ${PUBLIC_URL}/plugins-skills/<plugin-id>
+	handle_path /plugins-skills/* {
+		root * /var/www/plugins-skills
+		header Cache-Control "public, max-age=900, immutable"
+		file_server
+	}
+}
+
 {$SITE_ADDRESS::80} {
 	encode gzip
 
@@ -105,35 +137,12 @@
 		file_server
 	}
 
-	# -- MCP plugin bundles -------------------------------------------------------
+	# -- MCP plugin bundles + Plugin Agent Skills bundles -------------------------
 	#
-	# Self-contained ESM bundles loaded at runtime by the MCP server. Kept on a
-	# separate path from frontend assets so WASM/CSS concerns from the block
-	# above don't bleed into MCP serving.
-	#
-	# Set remoteEntryUrl in each plugin's plugin.json mcp section to an
-	# absolute URL, for example:
-	#   ${PUBLIC_URL}/plugins-mcp/<plugin-id>/mcp.js
-	handle_path /plugins-mcp/* {
-		root * /var/www/plugins-mcp
-		header Cache-Control "public, max-age=900, immutable"
-		file_server
-	}
-
-	# -- Plugin Agent Skills bundles ----------------------------------------------
-	#
-	# SKILL.md directories loaded at conversation start by the ai-agent service.
-	# Kept on a separate path from frontend/MCP assets for the same reason as
-	# the MCP block above.
-	#
-	# Set baseUrl in each plugin's plugin.json skills section to an absolute
-	# URL, for example:
-	#   ${PUBLIC_URL}/plugins-skills/<plugin-id>
-	handle_path /plugins-skills/* {
-		root * /var/www/plugins-skills
-		header Cache-Control "public, max-age=900, immutable"
-		file_server
-	}
+	# See the `mcp_skills_routes` snippet above. Also served on the internal
+	# :8080 block below, which the MCP server / ai-agent use instead of this
+	# public port for their own fetches — see that block for why.
+	import mcp_skills_routes
 
 	# -- API routes ---------------------------------------------------------------
 	#
@@ -166,4 +175,23 @@
 	handle {
 		reverse_proxy web:3000
 	}
+}
+
+# -- Internal MCP/Skills bundle port ------------------------------------------
+#
+# The MCP server and ai-agent fetch plugin MCP/skills bundles via
+# GATEWAY_BASE_URL over plain http:// on the docker-internal network (see
+# apps/mcp/src/plugin-loader.ts and the skills-plugin-system docs). When
+# SITE_ADDRESS above is a real domain, Caddy enables automatic HTTPS for it,
+# which installs a catch-all HTTP→HTTPS redirect on port 80 for *any* Host
+# header — including these internal requests. Caddy has no certificate for
+# the "gateway" hostname, so the followed redirect's TLS handshake fails.
+#
+# A bare port never gets automatic HTTPS (see the SITE_ADDRESS comment at the
+# top of this file), so this dedicated internal port sidesteps the redirect
+# entirely. It is not published to the host in docker-compose — only reachable
+# from other containers on the compose network. GATEWAY_BASE_URL must point
+# here (http://gateway:8080), not at the public port.
+:8080 {
+	import mcp_skills_routes
 }

--- a/deploy/caddy/Caddyfile.dev
+++ b/deploy/caddy/Caddyfile.dev
@@ -25,6 +25,20 @@
 #                       Vite HMR WebSocket proxied automatically)
 # =============================================================================
 
+(mcp_skills_routes) {
+	handle_path /plugins-mcp/* {
+		root * /var/www/plugins-mcp
+		header Cache-Control "public, max-age=900, immutable"
+		file_server
+	}
+
+	handle_path /plugins-skills/* {
+		root * /var/www/plugins-skills
+		header Cache-Control "public, max-age=900, immutable"
+		file_server
+	}
+}
+
 :80 {
 	encode gzip
 
@@ -66,17 +80,7 @@
 		file_server
 	}
 
-	handle_path /plugins-mcp/* {
-		root * /var/www/plugins-mcp
-		header Cache-Control "public, max-age=900, immutable"
-		file_server
-	}
-
-	handle_path /plugins-skills/* {
-		root * /var/www/plugins-skills
-		header Cache-Control "public, max-age=900, immutable"
-		file_server
-	}
+	import mcp_skills_routes
 
 	handle /api/* {
 		reverse_proxy api:8080
@@ -91,4 +95,13 @@
 	handle {
 		reverse_proxy web:3000
 	}
+}
+
+# Internal-only port for GATEWAY_BASE_URL — see the matching block at the
+# bottom of ../caddy/Caddyfile for why this exists. Plain :80 here never gets
+# automatic HTTPS anyway, so this isn't strictly needed in dev, but is kept in
+# sync so GATEWAY_BASE_URL can point at the same http://gateway:8080 address
+# in every environment.
+:8080 {
+	import mcp_skills_routes
 }

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -288,7 +288,7 @@ services:
       # Gateway base URL — the MCP server uses this to resolve plugin MCP bundle
       # URLs (e.g. /plugins-mcp/<id>/mcp.js).  The gateway (Caddy) serves these
       # files, not the API service.
-      GATEWAY_BASE_URL: http://gateway
+      GATEWAY_BASE_URL: http://gateway:8080
       # API key for the built-in Paca MCP server.  Must match AGENT_API_KEY in
       # the api service so the AI agent can authenticate via the MCP.
       PACA_API_KEY: dev-agent-api-key-change-in-production

--- a/deploy/docker-compose.e2e.yml
+++ b/deploy/docker-compose.e2e.yml
@@ -200,7 +200,7 @@ services:
       # Gateway base URL — the MCP server uses this to resolve plugin MCP bundle
       # URLs (e.g. /plugins-mcp/<id>/mcp.js).  The gateway (Caddy) serves these
       # files, not the API service.
-      GATEWAY_BASE_URL: http://gateway
+      GATEWAY_BASE_URL: http://gateway:8080
       # Must match AGENT_API_KEY in the api service.
       PACA_API_KEY: e2e-agent-api-key
       DOCKER_SOCKET: /var/run/docker.sock

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -298,7 +298,7 @@ services:
       # An empty key disables authentication on the agent service endpoint.
       INTERNAL_API_KEY: ${INTERNAL_API_KEY:-}
       API_BASE_URL: http://api:8080
-      GATEWAY_BASE_URL: http://gateway
+      GATEWAY_BASE_URL: http://gateway:8080
       # Must match AGENT_API_KEY in the api service.
       PACA_API_KEY: ${AGENT_API_KEY:-}
       DOCKER_SOCKET: /var/run/docker.sock

--- a/services/ai-agent/src/config.py
+++ b/services/ai-agent/src/config.py
@@ -20,8 +20,11 @@ class Settings(BaseSettings):
     api_base_url: str = "http://api:8080"
     # Gateway base URL — used by the MCP server to resolve plugin MCP bundle URLs.
     # The gateway (Caddy) serves /plugins-mcp/, not the API service, so this must
-    # point to the gateway's internal address.
-    gateway_base_url: str = "http://gateway"
+    # point to the gateway's internal address. Must use the internal :8080 port,
+    # not the public port — see the "Internal MCP/Skills bundle port" block in
+    # deploy/caddy/Caddyfile for why (auto-HTTPS redirect breaks internal fetches
+    # on the public port when SITE_ADDRESS is a real domain).
+    gateway_base_url: str = "http://gateway:8080"
 
     # Built-in Paca MCP — the API key used by the AI agent's hardcoded paca MCP
     # server.  Set this to the same value as AGENT_API_KEY on the api service.


### PR DESCRIPTION
## Summary
- Fixes plugin MCP tools failing to load with `ERR_SSL_TLSV1_ALERT_INTERNAL_ERROR` whenever the gateway has automatic HTTPS enabled (`SITE_ADDRESS` set to a real domain). Caddy's global HTTP→HTTPS redirect on port 80 was intercepting the internal `GATEWAY_BASE_URL` fetch used by the MCP plugin loader, and the followed redirect's TLS handshake failed because Caddy has no certificate for the internal Docker hostname (`gateway`).
- Fixes the plugin marketplace UI deriving per-row install/uninstall/upgrade loading state from the single shared `useMutation().isPending`/`variables`, which can't represent more than one concurrent operation — rows could show the wrong spinner or fail to clear it when multiple plugins were installed/uninstalled/upgraded around the same time.

## Changes
- `deploy/caddy/Caddyfile`, `deploy/caddy/Caddyfile.dev`: extracted `/plugins-mcp/*` and `/plugins-skills/*` into a shared `(mcp_skills_routes)` snippet, and added a new internal-only `:8080` server block serving those routes. Bare ports never get Caddy's automatic HTTPS, so this sidesteps the redirect entirely; the public site block is unaffected.
- `deploy/docker-compose.{dev,e2e,prod}.yml`: `GATEWAY_BASE_URL` now points at `http://gateway:8080` instead of the public port.
- `apps/web/src/components/plugins/PluginMarketplacePanel.tsx`: track `installingNames` / `uninstallingIds` / `upgradingIds` as local state sets, set/cleared in each mutation's `onMutate`/`onSettled`.

## Testing
- Reproduced the original bug against a real Let's Encrypt domain: internal `http://gateway:80/...` → `SSL: TLSV1_ALERT_INTERNAL_ERROR`; confirmed `http://gateway:8080/...` returns cleanly with no redirect.
- Validated the new Caddyfile with `caddy validate`/`caddy adapt`.
- Applied to a live production instance (reload gateway + recreate ai-agent) and confirmed no regression to public HTTP→HTTPS redirect behavior.
