### PR TITLE
fix: implement rejoinProject function and update related tests for so…

### DIFF
--- a/apps/web/src/hooks/use-project-realtime.test.tsx
+++ b/apps/web/src/hooks/use-project-realtime.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
 		connectSocket: vi.fn(() => socket),
 		joinProject: vi.fn(),
 		leaveProject: vi.fn(),
+		rejoinProject: vi.fn(),
 		invalidateQueries: vi.fn(),
 	};
 });
@@ -22,6 +23,7 @@ vi.mock("@/lib/socket-client", () => ({
 	connectSocket: mocks.connectSocket,
 	joinProject: mocks.joinProject,
 	leaveProject: mocks.leaveProject,
+	rejoinProject: mocks.rejoinProject,
 }));
 
 vi.mock("@tanstack/react-query", async () => {
@@ -213,7 +215,7 @@ describe("useProjectRealtime", () => {
 		);
 	});
 
-	it("re-joins the project room when the socket reconnects", () => {
+	it("re-joins the project room when the socket reconnects, without re-registering as a subscriber", () => {
 		renderHook(() => useProjectRealtime("proj-abc"));
 
 		mocks.joinProject.mockClear();
@@ -223,7 +225,11 @@ describe("useProjectRealtime", () => {
 		) as [string, () => void];
 		onConnect();
 
-		expect(mocks.joinProject).toHaveBeenCalledWith("proj-abc");
+		expect(mocks.rejoinProject).toHaveBeenCalledWith("proj-abc");
+		// Must not call joinProject again — that would bump the reference
+		// count that leaveProject decrements on unmount, since a reconnect
+		// isn't a new subscriber.
+		expect(mocks.joinProject).not.toHaveBeenCalled();
 	});
 
 	it("removes the connect listener on unmount", () => {

--- a/apps/web/src/hooks/use-project-realtime.ts
+++ b/apps/web/src/hooks/use-project-realtime.ts
@@ -5,6 +5,12 @@
 //
 //   useProjectRealtime(projectId);
 //
+// It's safe to mount this hook more than once for the same projectId at the
+// same time (e.g. once in the persistent project layout and again in a
+// nested conversations layout) — `joinProject`/`leaveProject` in
+// socket-client.ts are reference-counted, so one instance unmounting won't
+// evict room membership that another mounted instance still needs.
+//
 // The hook:
 //   1. Joins the project rooms on mount (server grants tasks/docs room
 //      access based on the caller's permissions).
@@ -41,6 +47,7 @@ import {
 	joinProject,
 	leaveProject,
 	type RealtimeEvent,
+	rejoinProject,
 } from "@/lib/socket-client";
 
 export function useProjectRealtime(projectId: string): void {
@@ -161,9 +168,11 @@ export function useProjectRealtime(projectId: string): void {
 		// just the initial connection. A reconnect starts a new server-side
 		// session with no room membership until we "join" again — without
 		// this, a network blip silently stops delivering invalidations while
-		// the socket still reports connected.
+		// the socket still reports connected. Uses `rejoinProject` (not
+		// `joinProject`) since this isn't a new subscriber — it must not bump
+		// the reference count that `leaveProject` decrements on unmount.
 		function handleConnect() {
-			joinProject(projectId);
+			rejoinProject(projectId);
 		}
 		socket.on("connect", handleConnect);
 

--- a/apps/web/src/lib/socket-client.test.ts
+++ b/apps/web/src/lib/socket-client.test.ts
@@ -31,6 +31,7 @@ import {
 	getSocket,
 	joinProject,
 	leaveProject,
+	rejoinProject,
 } from "./socket-client";
 
 describe("socket-client", () => {
@@ -134,6 +135,71 @@ describe("socket-client", () => {
 
 		it("is a no-op when no socket is connected", () => {
 			leaveProject("proj-123");
+			expect(mockSocket.emit).not.toHaveBeenCalled();
+		});
+
+		it("does not emit leave while another subscriber is still joined (reference counting)", () => {
+			connectSocket();
+			// Two independent callers join the same project (e.g. the project
+			// layout and a nested conversations layout).
+			joinProject("proj-123");
+			joinProject("proj-123");
+			mockSocket.emit.mockClear();
+
+			// First caller unmounts and leaves — the second is still joined,
+			// so the socket must stay in the project's rooms.
+			leaveProject("proj-123");
+			expect(mockSocket.emit).not.toHaveBeenCalledWith(
+				"leave",
+				expect.anything(),
+			);
+
+			// Second caller leaves too — now it should actually emit leave.
+			leaveProject("proj-123");
+			expect(mockSocket.emit).toHaveBeenCalledWith("leave", {
+				projectId: "proj-123",
+			});
+		});
+
+		it("tracks subscriber counts independently per projectId", () => {
+			connectSocket();
+			joinProject("proj-a");
+			joinProject("proj-b");
+			mockSocket.emit.mockClear();
+
+			leaveProject("proj-a");
+			expect(mockSocket.emit).toHaveBeenCalledWith("leave", {
+				projectId: "proj-a",
+			});
+			expect(mockSocket.emit).not.toHaveBeenCalledWith("leave", {
+				projectId: "proj-b",
+			});
+		});
+	});
+
+	describe("rejoinProject", () => {
+		it("emits a join event without affecting the subscriber count", () => {
+			connectSocket();
+			joinProject("proj-123");
+			mockSocket.emit.mockClear();
+
+			// Simulate a socket reconnect re-joining an already-subscribed
+			// project — this must not require a second leaveProject call to
+			// actually release the room.
+			rejoinProject("proj-123");
+			expect(mockSocket.emit).toHaveBeenCalledWith("join", {
+				projectId: "proj-123",
+			});
+
+			mockSocket.emit.mockClear();
+			leaveProject("proj-123");
+			expect(mockSocket.emit).toHaveBeenCalledWith("leave", {
+				projectId: "proj-123",
+			});
+		});
+
+		it("is a no-op when no socket is connected", () => {
+			rejoinProject("proj-123");
 			expect(mockSocket.emit).not.toHaveBeenCalled();
 		});
 	});

--- a/apps/web/src/lib/socket-client.ts
+++ b/apps/web/src/lib/socket-client.ts
@@ -3,7 +3,9 @@
 // A single socket connection is shared across the whole app.  Consumers call
 // `connectSocket()` once (authenticated layout) and `disconnectSocket()` on
 // logout.  Project pages call `joinProject` / `leaveProject` to subscribe to
-// namespace-scoped rooms.
+// namespace-scoped rooms — these are reference-counted per projectId, since
+// more than one mounted component can subscribe to the same project
+// concurrently (see the comment above `projectSubscriberCounts` below).
 //
 // The realtime service uses two rooms per project:
 //   project:<projectId>:tasks  — task.* events
@@ -62,6 +64,7 @@ export function disconnectSocket(): void {
 		socket.disconnect();
 		socket = null;
 	}
+	projectSubscriberCounts.clear();
 }
 
 /** Returns the current socket instance, or null if not connected. */
@@ -69,14 +72,53 @@ export function getSocket(): Socket | null {
 	return socket;
 }
 
-/** Ask the server to place this socket into the project's namespace rooms. */
+// Reference counts of active `joinProject` callers per projectId. Multiple
+// independent components can be subscribed to the same project at once
+// (e.g. the persistent project layout that owns the floating AI chat, and a
+// nested conversations layout) — without this, one of them unmounting and
+// calling `leaveProject` would evict the shared socket from every namespace
+// room for that project, silently starving the others of live events until
+// something happened to re-join (see `leaveProject` below).
+const projectSubscriberCounts = new Map<string, number>();
+
+/**
+ * Ask the server to place this socket into the project's namespace rooms.
+ * Reference-counted per projectId: call once per mounted subscriber,
+ * paired with a matching `leaveProject` on cleanup.
+ */
 export function joinProject(projectId: string): void {
+	const count = projectSubscriberCounts.get(projectId) ?? 0;
+	projectSubscriberCounts.set(projectId, count + 1);
 	socket?.emit("join", { projectId });
 }
 
-/** Remove this socket from the project's namespace rooms. */
+/**
+ * Remove this socket from the project's namespace rooms — but only once
+ * every subscriber registered via `joinProject` has also left. This
+ * prevents one subscriber's unmount from evicting room membership that a
+ * sibling subscriber (e.g. the floating AI chat widget's parent layout)
+ * still relies on.
+ */
 export function leaveProject(projectId: string): void {
-	socket?.emit("leave", { projectId });
+	const count = projectSubscriberCounts.get(projectId) ?? 0;
+	if (count <= 1) {
+		projectSubscriberCounts.delete(projectId);
+		socket?.emit("leave", { projectId });
+		return;
+	}
+	projectSubscriberCounts.set(projectId, count - 1);
+}
+
+/**
+ * Re-emit "join" for a project after the socket reconnects, without
+ * affecting the subscriber count used by `joinProject`/`leaveProject`. A
+ * reconnect starts a new server-side session with no room membership, so
+ * every project the socket cares about needs to be re-joined — but this
+ * isn't a new subscriber, so it must not be counted as one (or a later
+ * `leaveProject` would never bring the count back down to zero).
+ */
+export function rejoinProject(projectId: string): void {
+	socket?.emit("join", { projectId });
 }
 
 // ── Typed event payloads ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a bug where the floating AI chatbox sometimes stops receiving new conversation messages in real time until the user navigates to the conversation page.

**Root cause:** `useProjectRealtime(projectId)` is intentionally mounted in two places at once — the persistent project layout (which owns the floating chatbox) and the nested conversations layout. `leaveProject()` in `socket-client.ts` was unconditional: it told the server to leave *every* namespace room for that project. So when a user visited the Conversations section and then navigated elsewhere in the project, the conversations layout's cleanup evicted the shared socket from all rooms — even though the project layout's subscription (and the chatbox) was still mounted and expecting events. The socket stayed connected but silently received nothing until something re-emitted `join`, which happens to be exactly what re-entering the conversation page does (plus its route loader forces a fresh REST fetch), explaining why that "fixed" it.

**Fix:** made `joinProject` / `leaveProject` reference-counted per `projectId` in `socket-client.ts`, so a project's rooms are only actually released once every subscriber has unmounted. Added a separate `rejoinProject()` for the reconnect path so re-joining after a network blip isn't counted as a new subscriber (which would otherwise leak the count and prevent `leaveProject` from ever reaching zero).

## Changes

- `apps/web/src/lib/socket-client.ts` — reference-counted `joinProject`/`leaveProject`, new `rejoinProject`
- `apps/web/src/hooks/use-project-realtime.ts` — reconnect handler now calls `rejoinProject` instead of `joinProject`
- Test coverage added/updated in `socket-client.test.ts` and `use-project-realtime.test.tsx`

## Test plan

- [x] `npx vitest run` — all 310 tests pass
- [x] `npx tsc -b` — clean
- [x] `npx biome check` on changed files — clean
- [ ] Manual verification: open a project, visit Conversations, navigate to another section (e.g. Tasks), trigger an agent reply via the floating chatbox, confirm it arrives live without needing to revisit the conversation page
