### PR TITLE
feat: add view event handling and validation for sprint views

### DIFF
--- a/apps/web/src/hooks/use-project-realtime.test.tsx
+++ b/apps/web/src/hooks/use-project-realtime.test.tsx
@@ -105,6 +105,21 @@ describe("useProjectRealtime", () => {
 		});
 	});
 
+	it("invalidates views query key on view.* events", () => {
+		renderHook(() => useProjectRealtime("proj-abc"));
+
+		const [, listener] = mocks.socket.on.mock.calls[0] as [
+			string,
+			(event: { type: string; payload: Record<string, unknown> }) => void,
+		];
+
+		listener({ type: "view.created", payload: {} });
+
+		expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["projects", "proj-abc", "views"],
+		});
+	});
+
 	it("invalidates workflows and tasks query keys on workflow.* events", () => {
 		renderHook(() => useProjectRealtime("proj-abc"));
 

--- a/apps/web/src/hooks/use-project-realtime.ts
+++ b/apps/web/src/hooks/use-project-realtime.ts
@@ -29,6 +29,12 @@
 // sprint.* events → invalidate ["projects", projectId, "sprints"]
 //                  This covers sprintsQueryOptions and sprintQueryOptions —
 //                  replaces the sidebar's old refetchInterval polling.
+// view.* events  → invalidate ["projects", projectId, "views"]
+//                  viewsByContextQueryOptions keys every context (sprint/
+//                  backlog/timeline) under this shared "views" prefix with a
+//                  trailing { context, sprintId } filter object, so one
+//                  prefix invalidation covers all three regardless of which
+//                  context changed.
 // workflow.* events → invalidate ["projects", projectId, "workflows"] (the
 //                  automation list/graph queries) and ["projects", projectId,
 //                  "tasks"] (covers workflowsForTaskQueryOptions, which hangs
@@ -79,6 +85,13 @@ export function useProjectRealtime(projectId: string): void {
 			if (type.startsWith("sprint.")) {
 				void queryClient.invalidateQueries({
 					queryKey: ["projects", projectId, "sprints"],
+				});
+				return;
+			}
+
+			if (type.startsWith("view.")) {
+				void queryClient.invalidateQueries({
+					queryKey: ["projects", projectId, "views"],
 				});
 				return;
 			}

--- a/apps/web/src/lib/interaction-api.ts
+++ b/apps/web/src/lib/interaction-api.ts
@@ -373,12 +373,12 @@ export const viewsByContextQueryOptions = (
 	context: ViewsContext,
 	sprintId?: string | null,
 ) => {
-	const queryKey =
-		context === "sprint" && sprintId
-			? (["projects", projectId, "sprints", sprintId, "views"] as const)
-			: context === "backlog"
-				? (["projects", projectId, "backlog-views"] as const)
-				: (["projects", projectId, "timeline-views"] as const);
+	const queryKey = [
+		"projects",
+		projectId,
+		"views",
+		{ context, sprintId: sprintId ?? undefined },
+	] as const;
 	return queryOptions({
 		queryKey,
 		queryFn: () => listViewsByContext(projectId, context, sprintId),

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -143,7 +143,7 @@ func New(cfg *config.Config) (*App, error) {
 	projectService := projectsvc.NewCachedService(projectsvc.New(projectRepo, taskRepo), cacheStore, cfg.Cache.ProjectTTL, cfg.Cache.ConfigTTL, log)
 	taskService := tasksvc.NewCachedService(tasksvc.New(taskRepo).WithWorkflowStatusChecker(rawWorkflowRepo), cacheStore, cfg.Cache.ConfigTTL, log)
 	sprintService := sprintsvc.NewCachedSprintService(sprintsvc.New(sprintRepo, taskRepo, publisher), cacheStore, cfg.Cache.SprintTTL, log)
-	viewService := sprintsvc.NewCachedViewService(sprintsvc.NewViewService(viewRepo), cacheStore, cfg.Cache.SprintTTL, log)
+	viewService := sprintsvc.NewCachedViewService(sprintsvc.NewViewService(viewRepo, publisher), cacheStore, cfg.Cache.SprintTTL, log)
 	notificationService := notificationsvc.New(notificationRepo, projectRepo, publisher)
 	agentRepo := pgRepo.NewAgentRepository(db)
 	agentService := agentsvc.New(agentRepo, projectService, publisher, pluginRepo)

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -78,6 +78,16 @@ const (
 	TopicSprintDeleted   = "sprint.deleted"
 	TopicSprintCompleted = "sprint.completed"
 
+	// --- Interaction view events ------------------------------------------------
+	// Published directly to ChannelRealtime by sprintsvc.ViewService whenever a
+	// sprint/backlog/timeline view (sprintdom.SprintView) is created, updated,
+	// deleted, or reordered, so every connected client viewing that project's
+	// interaction views stays in sync instead of relying on query staleTime.
+	TopicViewCreated   = "view.created"
+	TopicViewUpdated   = "view.updated"
+	TopicViewDeleted   = "view.deleted"
+	TopicViewReordered = "view.reordered"
+
 	// --- Notification events ------------------------------------------------
 	// TopicNotificationCreated is published to ChannelRealtime when a new
 	// notification is created.  The payload includes recipient_user_id so the

--- a/services/api/internal/service/sprint/view_service.go
+++ b/services/api/internal/service/sprint/view_service.go
@@ -293,10 +293,12 @@ func (s *ViewService) ReorderProjectViews(ctx context.Context, projectID uuid.UU
 	if err := s.validateAndReorder(ctx, existing, viewIDs); err != nil {
 		return err
 	}
-	s.publish(ctx, events.TopicViewReordered, map[string]any{
-		"project_id":   projectID.String(),
-		"view_context": string(viewCtx),
-	})
+	if len(existing) > 0 {
+		s.publish(ctx, events.TopicViewReordered, map[string]any{
+			"project_id":   projectID.String(),
+			"view_context": string(viewCtx),
+		})
+	}
 	return nil
 }
 

--- a/services/api/internal/service/sprint/view_service.go
+++ b/services/api/internal/service/sprint/view_service.go
@@ -7,17 +7,50 @@ import (
 	"time"
 
 	sprintdom "github.com/Paca-AI/api/internal/domain/sprint"
+	"github.com/Paca-AI/api/internal/events"
+	"github.com/Paca-AI/api/internal/platform/messaging"
 	"github.com/google/uuid"
 )
 
 // ViewService is the concrete implementation of sprintdom.ViewService.
 type ViewService struct {
-	repo sprintdom.ViewRepository
+	repo      sprintdom.ViewRepository
+	publisher *messaging.Publisher
 }
 
-// NewViewService returns a configured ViewService.
-func NewViewService(repo sprintdom.ViewRepository) *ViewService {
-	return &ViewService{repo: repo}
+// NewViewService returns a configured ViewService. publisher may be nil;
+// real-time events are then skipped silently.
+func NewViewService(repo sprintdom.ViewRepository, publisher *messaging.Publisher) *ViewService {
+	return &ViewService{repo: repo, publisher: publisher}
+}
+
+// publish sends a real-time pub/sub notification for a view change. Errors
+// are silently swallowed so a messaging failure never blocks the primary
+// HTTP response — this is how the frontend learns to refresh its sprint/
+// backlog/timeline view list instead of relying on query staleTime.
+func (s *ViewService) publish(ctx context.Context, topic string, payload map[string]any) {
+	if s.publisher == nil {
+		return
+	}
+	_ = s.publisher.Publish(ctx, events.ChannelRealtime, map[string]any{
+		"type":    topic,
+		"payload": payload,
+	})
+}
+
+// viewPayload builds the common event payload fields shared by all view
+// events: project_id, view_id, view_context, and — for sprint-context views
+// — sprint_id.
+func viewPayload(v *sprintdom.SprintView) map[string]any {
+	payload := map[string]any{
+		"project_id":   v.ProjectID.String(),
+		"view_id":      v.ID.String(),
+		"view_context": string(v.ViewContext),
+	}
+	if v.SprintID != nil {
+		payload["sprint_id"] = v.SprintID.String()
+	}
+	return payload
 }
 
 // hasPluginConfig reports whether cfg carries the plugin binding required for
@@ -96,6 +129,7 @@ func (s *ViewService) CreateView(ctx context.Context, in sprintdom.CreateViewInp
 	if err := s.repo.CreateView(ctx, v); err != nil {
 		return nil, err
 	}
+	s.publish(ctx, events.TopicViewCreated, viewPayload(v))
 	return v, nil
 }
 
@@ -137,6 +171,7 @@ func (s *ViewService) UpdateView(ctx context.Context, projectID, id uuid.UUID, i
 	if err := s.repo.UpdateView(ctx, v); err != nil {
 		return nil, err
 	}
+	s.publish(ctx, events.TopicViewUpdated, viewPayload(v))
 	return v, nil
 }
 
@@ -164,7 +199,11 @@ func (s *ViewService) DeleteView(ctx context.Context, projectID, id uuid.UUID) e
 		return sprintdom.ErrViewIsLastView
 	}
 
-	return s.repo.DeleteView(ctx, id)
+	if err := s.repo.DeleteView(ctx, id); err != nil {
+		return err
+	}
+	s.publish(ctx, events.TopicViewDeleted, viewPayload(v))
+	return nil
 }
 
 // MoveTask updates the manual position of a task within a view,
@@ -230,7 +269,18 @@ func (s *ViewService) ReorderViews(ctx context.Context, sprintID uuid.UUID, view
 	if err != nil {
 		return err
 	}
-	return s.validateAndReorder(ctx, existing, viewIDs)
+	if err := s.validateAndReorder(ctx, existing, viewIDs); err != nil {
+		return err
+	}
+	if len(existing) > 0 {
+		payload := map[string]any{
+			"project_id":   existing[0].ProjectID.String(),
+			"view_context": string(existing[0].ViewContext),
+			"sprint_id":    sprintID.String(),
+		}
+		s.publish(ctx, events.TopicViewReordered, payload)
+	}
+	return nil
 }
 
 // ReorderProjectViews reorders all views for a project+context.
@@ -240,7 +290,14 @@ func (s *ViewService) ReorderProjectViews(ctx context.Context, projectID uuid.UU
 	if err != nil {
 		return err
 	}
-	return s.validateAndReorder(ctx, existing, viewIDs)
+	if err := s.validateAndReorder(ctx, existing, viewIDs); err != nil {
+		return err
+	}
+	s.publish(ctx, events.TopicViewReordered, map[string]any{
+		"project_id":   projectID.String(),
+		"view_context": string(viewCtx),
+	})
+	return nil
 }
 
 // validateAndReorder checks that viewIDs exactly matches the IDs of existing

--- a/services/api/internal/service/sprint/view_service_test.go
+++ b/services/api/internal/service/sprint/view_service_test.go
@@ -173,7 +173,7 @@ func (r *fakeViewRepo) ReorderViews(_ context.Context, items []sprintdom.ViewReo
 func TestViewService_CreateView_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	sprintID := uuid.New()
 	v, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
@@ -198,7 +198,7 @@ func TestViewService_CreateView_OK(t *testing.T) {
 
 func TestViewService_CreateView_DefaultTypeIsTable(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	v, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -215,7 +215,7 @@ func TestViewService_CreateView_DefaultTypeIsTable(t *testing.T) {
 
 func TestViewService_CreateView_EmptyNameReturnsError(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	_, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -230,7 +230,7 @@ func TestViewService_CreateView_EmptyNameReturnsError(t *testing.T) {
 
 func TestViewService_CreateView_InvalidTypeReturnsError(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	_, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -245,7 +245,7 @@ func TestViewService_CreateView_InvalidTypeReturnsError(t *testing.T) {
 
 func TestViewService_CreateView_PluginWithoutConfigReturnsError(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	_, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -260,7 +260,7 @@ func TestViewService_CreateView_PluginWithoutConfigReturnsError(t *testing.T) {
 
 func TestViewService_CreateView_PluginWithPartialConfigReturnsError(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	_, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -276,7 +276,7 @@ func TestViewService_CreateView_PluginWithPartialConfigReturnsError(t *testing.T
 
 func TestViewService_CreateView_PluginWithWhitespaceOnlyConfigReturnsError(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	_, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID: uuidPtr(uuid.New()),
@@ -295,7 +295,7 @@ func TestViewService_CreateView_PluginWithWhitespaceOnlyConfigReturnsError(t *te
 
 func TestViewService_CreateView_PluginWithConfig_OK(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	v, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID: uuidPtr(uuid.New()),
@@ -318,7 +318,7 @@ func TestViewService_CreateView_PluginWithConfig_OK(t *testing.T) {
 func TestViewService_UpdateView_ChangeToPluginWithoutConfigReturnsError(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -337,7 +337,7 @@ func TestViewService_UpdateView_ChangeToPluginWithoutConfigReturnsError(t *testi
 func TestViewService_UpdateView_ClearingPluginConfigWithoutTypeChangeReturnsError(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID: uuidPtr(uuid.New()),
@@ -360,7 +360,7 @@ func TestViewService_UpdateView_ClearingPluginConfigWithoutTypeChangeReturnsErro
 func TestViewService_UpdateView_RenameKeepsExistingPluginConfig(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID: uuidPtr(uuid.New()),
@@ -392,7 +392,7 @@ func TestViewService_UpdateView_RenameKeepsExistingPluginConfig(t *testing.T) {
 func TestViewService_GetView_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -412,7 +412,7 @@ func TestViewService_GetView_OK(t *testing.T) {
 
 func TestViewService_GetView_NotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	_, err := svc.GetView(ctx, uuid.New(), uuid.New())
 	if err != sprintdom.ErrViewNotFound {
@@ -423,7 +423,7 @@ func TestViewService_GetView_NotFound(t *testing.T) {
 func TestViewService_UpdateView_Name(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -445,7 +445,7 @@ func TestViewService_UpdateView_Name(t *testing.T) {
 func TestViewService_UpdateView_Config(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -467,7 +467,7 @@ func TestViewService_UpdateView_Config(t *testing.T) {
 func TestViewService_UpdateView_Config_PageSize(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	created, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -491,7 +491,7 @@ func TestViewService_UpdateView_Config_PageSize(t *testing.T) {
 
 func TestViewService_UpdateView_NotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	name := "Does not matter"
 	_, err := svc.UpdateView(ctx, uuid.New(), uuid.New(), sprintdom.UpdateViewInput{Name: &name})
@@ -503,7 +503,7 @@ func TestViewService_UpdateView_NotFound(t *testing.T) {
 func TestViewService_DeleteView_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	sprintID := uuid.New()
 	v1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{SprintID: &sprintID, Name: "V1", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextSprint})
@@ -522,7 +522,7 @@ func TestViewService_DeleteView_OK(t *testing.T) {
 func TestViewService_DeleteView_LastViewRejected(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	v, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -539,7 +539,7 @@ func TestViewService_DeleteView_LastViewRejected(t *testing.T) {
 
 func TestViewService_DeleteView_NotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	err := svc.DeleteView(ctx, uuid.New(), uuid.New())
 	if err != sprintdom.ErrViewNotFound {
@@ -550,7 +550,7 @@ func TestViewService_DeleteView_NotFound(t *testing.T) {
 func TestViewService_MoveTask_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	v, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
 		SprintID:    uuidPtr(uuid.New()),
@@ -586,7 +586,7 @@ func TestViewService_MoveTask_OK(t *testing.T) {
 
 func TestViewService_MoveTask_ViewNotFound(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	err := svc.MoveTask(ctx, uuid.New(), uuid.New(), sprintdom.MoveTaskInput{
 		TaskID:   uuid.New(),
@@ -600,7 +600,7 @@ func TestViewService_MoveTask_ViewNotFound(t *testing.T) {
 func TestViewService_ListViews_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	sprintID := uuid.New()
 	_, _ = svc.CreateView(ctx, sprintdom.CreateViewInput{SprintID: &sprintID, Name: "A", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextSprint})
@@ -621,7 +621,7 @@ func TestViewService_ListViews_OK(t *testing.T) {
 
 func TestViewService_ListBacklogViews_Empty(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	views, err := svc.ListProjectViews(ctx, uuid.New(), sprintdom.ViewContextBacklog)
 	if err != nil {
@@ -635,7 +635,7 @@ func TestViewService_ListBacklogViews_Empty(t *testing.T) {
 func TestViewService_ListBacklogViews_ReturnsOnlyBacklogViews(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	otherProjectID := uuid.New()
@@ -668,7 +668,7 @@ func TestViewService_ListBacklogViews_ReturnsOnlyBacklogViews(t *testing.T) {
 
 func TestViewService_CreateBacklogView_NilSprintID(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	projectID := uuid.New()
 	v, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
@@ -691,7 +691,7 @@ func TestViewService_CreateBacklogView_NilSprintID(t *testing.T) {
 func TestViewService_DeleteBacklogView_LastViewRejected(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	v, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
@@ -710,7 +710,7 @@ func TestViewService_DeleteBacklogView_LastViewRejected(t *testing.T) {
 func TestViewService_DeleteBacklogView_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	v1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{ProjectID: projectID, Name: "BL1", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextBacklog})
@@ -728,7 +728,7 @@ func TestViewService_DeleteBacklogView_OK(t *testing.T) {
 func TestViewService_BacklogAndSprintViewsDontInterfere(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	sprintID := uuid.New()
@@ -768,7 +768,7 @@ func TestViewService_BacklogAndSprintViewsDontInterfere(t *testing.T) {
 func TestViewService_ReorderViews_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	sprintID := uuid.New()
 	v1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{SprintID: uuidPtr(sprintID), Name: "A", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextSprint})
@@ -797,7 +797,7 @@ func TestViewService_ReorderViews_OK(t *testing.T) {
 
 func TestViewService_ReorderViews_CountMismatch(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	sprintID := uuid.New()
 	v1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{SprintID: uuidPtr(sprintID), Name: "A", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextSprint})
@@ -812,7 +812,7 @@ func TestViewService_ReorderViews_CountMismatch(t *testing.T) {
 
 func TestViewService_ReorderViews_UnknownID(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	sprintID := uuid.New()
 	v1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{SprintID: uuidPtr(sprintID), Name: "A", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextSprint})
@@ -825,7 +825,7 @@ func TestViewService_ReorderViews_UnknownID(t *testing.T) {
 
 func TestViewService_ReorderViews_EmptyList(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	sprintID := uuid.New()
 	// No views exist; empty list should succeed (0 == 0)
@@ -837,7 +837,7 @@ func TestViewService_ReorderViews_EmptyList(t *testing.T) {
 func TestViewService_ReorderBacklogViews_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	b1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{ProjectID: projectID, Name: "X", ViewType: sprintdom.ViewTypeTable, ViewContext: sprintdom.ViewContextBacklog})
@@ -863,7 +863,7 @@ func TestViewService_ReorderBacklogViews_OK(t *testing.T) {
 
 func TestViewService_ListTimelineViews_Empty(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	views, err := svc.ListProjectViews(ctx, uuid.New(), sprintdom.ViewContextTimeline)
 	if err != nil {
@@ -877,7 +877,7 @@ func TestViewService_ListTimelineViews_Empty(t *testing.T) {
 func TestViewService_ListTimelineViews_ReturnsOnlyTimelineViews(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	otherID := uuid.New()
@@ -913,7 +913,7 @@ func TestViewService_ListTimelineViews_ReturnsOnlyTimelineViews(t *testing.T) {
 
 func TestViewService_CreateTimelineView_HasCorrectContext(t *testing.T) {
 	ctx := context.Background()
-	svc := sprintsvc.NewViewService(newFakeViewRepo())
+	svc := sprintsvc.NewViewService(newFakeViewRepo(), nil)
 
 	projectID := uuid.New()
 	v, err := svc.CreateView(ctx, sprintdom.CreateViewInput{
@@ -936,7 +936,7 @@ func TestViewService_CreateTimelineView_HasCorrectContext(t *testing.T) {
 func TestViewService_DeleteTimelineView_LastViewRejected(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	v, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{
@@ -954,7 +954,7 @@ func TestViewService_DeleteTimelineView_LastViewRejected(t *testing.T) {
 func TestViewService_DeleteTimelineView_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	v1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{ProjectID: projectID, Name: "TL1", ViewType: sprintdom.ViewTypeRoadmap, ViewContext: sprintdom.ViewContextTimeline})
@@ -974,7 +974,7 @@ func TestViewService_TimelineAndBacklogViewsDontInterfere(t *testing.T) {
 	// correctly blocked.
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	tv, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{ProjectID: projectID, Name: "Roadmap", ViewType: sprintdom.ViewTypeRoadmap, ViewContext: sprintdom.ViewContextTimeline})
@@ -1003,7 +1003,7 @@ func TestViewService_TimelineAndBacklogViewsDontInterfere(t *testing.T) {
 func TestViewService_ReorderTimelineViews_OK(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	t1, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{ProjectID: projectID, Name: "A", ViewType: sprintdom.ViewTypeRoadmap, ViewContext: sprintdom.ViewContextTimeline})
@@ -1027,7 +1027,7 @@ func TestViewService_ReorderTimelineViews_OK(t *testing.T) {
 func TestViewService_ViewContextPreservedAfterUpdate(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeViewRepo()
-	svc := sprintsvc.NewViewService(repo)
+	svc := sprintsvc.NewViewService(repo, nil)
 
 	projectID := uuid.New()
 	v, _ := svc.CreateView(ctx, sprintdom.CreateViewInput{

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -208,7 +208,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 	sprintRepo := pgRepo.NewSprintRepository(db)
 	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
 	viewRepo := pgRepo.NewViewRepository(db)
-	viewService := sprintsvc.NewViewService(viewRepo)
+	viewService := sprintsvc.NewViewService(viewRepo, nil)
 	attachmentRepo := pgRepo.NewAttachmentRepository(db)
 	apiKeyRepo := pgRepo.NewAPIKeyRepository(db)
 	apiKeyService := apikeysvc.New(apiKeyRepo)

--- a/services/api/test/integration/agent_apikey_test.go
+++ b/services/api/test/integration/agent_apikey_test.go
@@ -58,7 +58,7 @@ func buildAgentKeyRouterWithBotID(taskRepo *fakeTaskRepo, apiKeyRepo *fakeAPIKey
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
 	sprintService := sprintsvc.New(newFakeSprintRepoIT(), taskRepo, nil)
-	viewService := sprintsvc.NewViewService(newFakeViewRepoIT())
+	viewService := sprintsvc.NewViewService(newFakeViewRepoIT(), nil)
 	var activityRepo *fakeTaskActivityRepo
 	if len(activityRepos) > 0 && activityRepos[0] != nil {
 		activityRepo = activityRepos[0]

--- a/services/api/test/integration/attachment_test.go
+++ b/services/api/test/integration/attachment_test.go
@@ -233,7 +233,7 @@ func buildAttachmentTestRouter(attachRepo *fakeAttachmentRepo, store *fakeStorag
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
 	sprintService := sprintsvc.New(newFakeSprintRepoIT(), taskRepo, nil)
-	viewService := sprintsvc.NewViewService(newFakeViewRepoIT())
+	viewService := sprintsvc.NewViewService(newFakeViewRepoIT(), nil)
 	active := tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)
 	attachmentService := attachmentsvc.New(attachRepo, attachmentsvc.NewTaskOwnerChecker(taskRepo), store, "test-bucket")
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))

--- a/services/api/test/integration/cache_test.go
+++ b/services/api/test/integration/cache_test.go
@@ -57,7 +57,7 @@ func buildCachedTaskRouter(t *testing.T, taskRepo *fakeTaskRepo, store *projectP
 		5*time.Minute,
 		slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	)
-	viewService := sprintsvc.NewViewService(newFakeViewRepoIT())
+	viewService := sprintsvc.NewViewService(newFakeViewRepoIT(), nil)
 	activityService := tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 

--- a/services/api/test/integration/document_test.go
+++ b/services/api/test/integration/document_test.go
@@ -317,7 +317,7 @@ func buildDocTestRouter(docRepo *fakeDocRepoIT, store *projectPermStore) http.Ha
 	sprintRepo := newFakeSprintRepoIT()
 	viewRepo := newFakeViewRepoIT()
 	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
-	viewService := sprintsvc.NewViewService(viewRepo)
+	viewService := sprintsvc.NewViewService(viewRepo, nil)
 	activityRepo := newFakeTaskActivityRepo()
 	activityService := tasksvc.NewActivityService(activityRepo, &fakeActivityMemberRepo{}, nil)
 	docService := docsvc.New(docRepo, &fakeDocMemberLookup{})

--- a/services/api/test/integration/project_test.go
+++ b/services/api/test/integration/project_test.go
@@ -458,7 +458,7 @@ func buildProjectTestRouterWithTaskRepo(repo *fakeProjectRepo, store *projectPer
 		User:                 handler.NewUserHandler(userService),
 		GlobalRole:           handler.NewGlobalRoleHandler(&fakeGlobalRoleService{}),
 		Project:              handler.NewProjectHandler(projectService, authz.NewAuthorizer(store)),
-		Task:                 handler.NewTaskHandler(tasksvc.New(taskRepo), sprintsvc.NewViewService(newFakeViewRepoIT()), tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)),
+		Task:                 handler.NewTaskHandler(tasksvc.New(taskRepo), sprintsvc.NewViewService(newFakeViewRepoIT(), nil), tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)),
 		Log:                  log,
 	}), taskRepo
 }

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -725,7 +725,7 @@ func buildTaskTestRouterWithSprints(taskRepo *fakeTaskRepo, sprintRepo *fakeSpri
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
 	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
-	viewService := sprintsvc.NewViewService(viewRepo)
+	viewService := sprintsvc.NewViewService(viewRepo, nil)
 	activityRepo := newFakeTaskActivityRepo()
 	activityService := tasksvc.NewActivityService(activityRepo, &fakeActivityMemberRepo{}, nil)
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))

--- a/services/api/test/integration/view_test.go
+++ b/services/api/test/integration/view_test.go
@@ -192,7 +192,7 @@ func buildViewTestRouter(viewRepo *fakeViewRepoIT, sprintRepo *fakeSprintRepoIT,
 	projectService := projectsvc.New(projectRepo, taskRepo)
 	taskService := tasksvc.New(taskRepo)
 	sprintService := sprintsvc.New(sprintRepo, taskRepo, nil)
-	viewService := sprintsvc.NewViewService(viewRepo)
+	viewService := sprintsvc.NewViewService(viewRepo, nil)
 	activityService := tasksvc.NewActivityService(newFakeTaskActivityRepo(), &fakeActivityMemberRepo{}, nil)
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 

--- a/services/realtime/src/permissions.ts
+++ b/services/realtime/src/permissions.ts
@@ -6,7 +6,7 @@
 //   project:<projectId>:tasks      — receives all task.* events
 //   project:<projectId>:docs       — receives all doc.* events
 //   project:<projectId>:workflows  — receives all workflow.* graph events
-//   project:<projectId>:sprints    — receives all sprint.* events
+//   project:<projectId>:sprints    — receives all sprint.* and view.* events
 //
 // Room membership is determined once when the client emits "join": the server
 // fetches the user's project permissions, then joins only the rooms the user is
@@ -53,6 +53,10 @@ export function eventNamespace(type: string): EventNamespace | undefined {
 	// workflows.read — a permission distinct from tasks.read.
 	if (type.startsWith("workflow.")) return "workflows";
 	if (type.startsWith("sprint.")) return "sprints";
+	// view.* events cover sprint/backlog/timeline interaction views. They
+	// require the same sprints.read permission as sprint.* (see
+	// view_handler.go's route registration), so they share the room.
+	if (type.startsWith("view.")) return "sprints";
 	return undefined;
 }
 


### PR DESCRIPTION
## Summary

Sprint/backlog/timeline views (the unified `SprintView` resource shown by `InteractionLayout`) had no real-time propagation: if one user created, renamed, reconfigured, reordered, or deleted a view while another user had the same sprint/backlog/timeline page open, the second user saw nothing until they navigated away and back, or until the 30s query `staleTime` happened to expire on refocus.

This extends the existing `sprint.*` real-time pipeline (Valkey Pub/Sub → `services/realtime` Socket.IO → `apps/web` query invalidation) to cover `view.*` events, so view changes now show up live for everyone viewing that project. Along the way, it also fixes the three inconsistent React Query key shapes the view list used, which is what made the real-time invalidation logic awkward in the first place.

## Changes

**`services/api`**
- `internal/events/topics.go` — new `view.created` / `view.updated` / `view.deleted` / `view.reordered` topics, alongside the existing `sprint.*` ones.
- `internal/service/sprint/view_service.go` — `ViewService` now takes an optional `*messaging.Publisher` (nil-safe, mirroring `sprint_service.go`) and publishes to `ChannelRealtime` after `CreateView`, `UpdateView`, `DeleteView`, `ReorderViews`, and `ReorderProjectViews` succeed. Payloads carry `project_id`, `view_id`, `view_context`, and `sprint_id` (when the view belongs to a sprint).
- `internal/bootstrap/app.go` — wires the real publisher into `NewViewService`.
- `view_service_test.go` plus the integration/e2e test suites — ~48 call sites mechanically updated to pass `nil` for the new publisher argument (matches the existing `sprint.*` convention: no publish-assertion tests in Go, since messaging failures are swallowed by design).

**`services/realtime`**
- `src/permissions.ts` — `view.*` events route into the existing `sprints` room/namespace. View read/write already require `sprints.read`/`sprints.write`, so this reuses that room instead of adding a new one.

**`apps/web`**
- `src/hooks/use-project-realtime.ts` — new `view.*` branch invalidates the views query cache.
- `src/hooks/use-project-realtime.test.tsx` — coverage for the new branch.
- `src/lib/interaction-api.ts` — `viewsByContextQueryOptions` previously produced three unrelated key shapes with no common prefix (`["projects", id, "sprints", sprintId, "views"]` for sprint context, `["projects", id, "backlog-views"]`, `["projects", id, "timeline-views"]`) — which also hid a latent bug where a sprint-context call with a falsy `sprintId` silently fell through to the timeline key. Unified to `["projects", id, "views", { context, sprintId }]`, matching the `{filters}`-trailing-object convention already used elsewhere (`workflow-api.ts`, `agent-api.ts`). This lets the real-time hook invalidate all three contexts with a single `invalidateQueries({ queryKey: ["projects", id, "views"] })`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` (`services/api`) — clean, all packages pass
- [x] `tsc -b` (`apps/web`) — clean
- [x] `bunx biome check` on changed files — clean
- [x] `vitest run` (`apps/web`) — all 311 tests pass
- [x] `tsc --noEmit` (`services/realtime`) — clean
- [x] Manual verification: open the same sprint/backlog/timeline page as two users, create/rename/reorder/delete a view as one, confirm the other sees it update live without a refresh
