### PR TITLE
Fix deploy env-template gaps and stale ai-agent docs from discussion #305

### DIFF
--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -1,7 +1,9 @@
 # Container images. Override these when pulling from a registry in CI/CD.
-PACA_API_IMAGE=paca-api:latest
-PACA_WEB_IMAGE=paca-web:latest
-PACA_REALTIME_IMAGE=paca-realtime:latest
+PACA_API_IMAGE=pacaai/paca-api:latest
+PACA_WEB_IMAGE=pacaai/paca-web:latest
+PACA_REALTIME_IMAGE=pacaai/paca-realtime:latest
+# Only used when the ai-agent service is enabled (default; skip with --scale ai-agent=0).
+PACA_AI_AGENT_IMAGE=pacaai/paca-ai-agent:latest
 
 # Runtime settings.
 ENVIRONMENT=production
@@ -14,6 +16,21 @@ ENVIRONMENT=production
 # This should be the full URL where your Paca instance will be accessible,
 # e.g., https://paca.example.com or http://localhost:8080
 PUBLIC_URL=http://localhost
+
+# Domain/IP the gateway (Caddy) serves and issues a TLS certificate for.
+# - A real domain name with DNS already pointed here gets a trusted Let's
+#   Encrypt certificate, renewed automatically. Ports 80 and 443 must both be
+#   reachable from the internet for the ACME challenge to succeed.
+# - An IP address, "localhost", "*.localhost", or anything else that isn't a
+#   publicly resolvable domain gets a certificate from Caddy's own local CA
+#   instead — traffic is still encrypted, but browsers will show a trust
+#   warning since that CA isn't publicly trusted.
+# - Left unset (or set to a bare port like ":80"), the gateway serves plain
+#   HTTP — the right choice when another proxy/load balancer in front of this
+#   server already terminates TLS.
+# When set to a real domain, also update PUBLIC_URL to the https:// form above
+# and set COOKIE_SECURE=true below.
+SITE_ADDRESS=
 
 # Stateful service credentials.
 # These are optional when using AWS S3 (--scale minio=0).
@@ -91,10 +108,27 @@ STORAGE_USE_SSL=false
 # STORAGE_SECRET_ACCESS_KEY=your-aws-secret-access-key
 # STORAGE_USE_SSL=true
 
-# Encryption key for sensitive values (plugin tokens/secrets).
+# Encryption key for sensitive values (LLM-type agent API keys, plugin
+# tokens/secrets). Optional if you only ever use ACP-type agents and no
+# plugins that store secrets — but if you're not sure, set it: leaving it
+# empty doesn't fail startup, it just stores those values in plaintext.
 # Must be a 64-char lowercase hex string (32 bytes).
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=
+
+# AI agent service credentials. Generate both with: openssl rand -hex 32
+#
+# Required — the api service itself refuses to start without this set, even
+# if you're skipping the AI agent entirely (--scale ai-agent=0). It
+# authenticates the api service calling into ai-agent's internal-only routes
+# (ACP bridge status/token disconnect), and ai-agent independently requires
+# it to be non-empty to start at all whenever it does run.
+INTERNAL_API_KEY=
+# Optional — leave blank to skip. Pre-shared key the ai-agent service uses to
+# call back into the api service as its own built-in bot user (posting task
+# comments, calling the built-in paca MCP tool). Only relevant if you're
+# running the AI agent.
+AGENT_API_KEY=
 
 # Plugin subsystem settings.
 # Controls where WASM binaries are loaded from.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -42,7 +42,23 @@ The installer supports:
 | Self-hosted MinIO | Starts a MinIO container for S3-compatible file storage (default) |
 | AWS S3 | Supply AWS credentials; MinIO container is suppressed |
 | HTTPS | Enabled by default — Let's Encrypt for a real domain, Caddy's local CA otherwise; can be disabled for plain HTTP |
-| AI Agent | Enabled by default; can be skipped to reduce resource usage |
+| AI Agent | Enabled by default; can be skipped to reduce resource usage. See [docs/ai-agent/api-design.md](../docs/ai-agent/api-design.md) for the agent REST API once it's running. |
+
+**Non-interactive / CI install** — set `PACA_YES=1` to skip every prompt and use
+defaults plus freshly auto-generated secrets for all of the above (including
+`JWT_SECRET`, `ADMIN_PASSWORD`, `AGENT_API_KEY`, `INTERNAL_API_KEY`, and
+`ENCRYPTION_KEY`):
+
+```bash
+PACA_YES=1 bash install.sh
+# or, without a local copy of the script at all:
+PACA_YES=1 bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh)
+```
+
+`PACA_DIR` (default `./paca`) and `PACA_VERSION` (default `latest`) are also
+read from the environment, so a fully unattended install needs no interactive
+input at all. See the comment header at the top of
+[`scripts/install.sh`](../scripts/install.sh) for the full list of variables.
 
 ### Manual setup
 
@@ -69,10 +85,20 @@ Create a `.env` with the required variables:
 JWT_SECRET=<strong-random-secret>
 ADMIN_PASSWORD=<strong-password>
 POSTGRES_PASSWORD=<strong-random-password>
-# Required when using AI agent: generate with 'openssl rand -hex 32'
-AGENT_API_KEY=<strong-random-secret>
+# Required even if you don't plan to use the AI agent (--scale ai-agent=0) —
+# the api service itself refuses to start without this set, since it's also
+# used to authenticate the api → ai-agent internal status/control calls.
+# Generate with: openssl rand -hex 32
 INTERNAL_API_KEY=<strong-random-secret>
-# Required for plugin secrets at rest: generate with 'openssl rand -hex 32'
+# Optional — only used by the AI agent to call back into the api service as
+# its own bot user. Leave unset if you're skipping the AI agent.
+# Generate with: openssl rand -hex 32
+AGENT_API_KEY=<strong-random-secret>
+# Required to encrypt LLM-type agents' API keys and plugin secrets at rest.
+# Not enforced at startup, but leaving it empty stores those values in
+# plaintext instead of failing — set it unless you're certain you don't need
+# it (e.g. ACP-only agents, no plugins with stored secrets).
+# Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=<64-char-hex>
 PUBLIC_URL=http://your-domain-or-ip
 ```
@@ -130,6 +156,11 @@ docker compose --env-file .env up -d --scale minio=0
 ```bash
 docker compose --env-file .env up -d --scale ai-agent=0
 ```
+
+`INTERNAL_API_KEY` must still be set in `.env` even with the AI agent scaled
+to 0 — the api service requires it unconditionally at startup regardless of
+whether ai-agent is actually running (see above). `AGENT_API_KEY` can be left
+unset in this case.
 
 Flags can be combined:
 

--- a/docs/ai-agent/api-design.md
+++ b/docs/ai-agent/api-design.md
@@ -4,6 +4,11 @@ This document describes the public REST endpoints added to `services/api` for AI
 
 All endpoints follow the existing Paca API conventions: JWT authentication, project-scoped authorization, and standard error envelope `{"error": "..."}`.
 
+Every agent has an `agent_type` of either `llm` or `acp` (default `llm` when omitted). The two types are mutually exclusive in both configuration and execution:
+
+- **`llm`** — Paca runs the conversation itself, in an isolated Docker container, using the `llm_provider`/`llm_model`/`llm_api_key`/`llm_base_url` fields. See [overview.md](overview.md) for the sandboxed execution model.
+- **`acp`** — the conversation runs on the user's own machine via the [`paca-acp-bridge`](../../apps/acp-bridge/README.md) daemon, connecting to a coding CLI (Claude Code, Codex, Gemini CLI, or a custom [ACP](https://docs.openhands.dev/sdk/guides/agent-acp) server) the user already has installed and authenticated there. Paca never sees, stores, or requests an LLM credential for `acp` agents — `llm_api_key` is neither required nor read for this type. The only credential Paca manages is the bridge connection token described below, which authenticates the WebSocket link, not the LLM.
+
 ---
 
 ## Agent Management
@@ -14,25 +19,28 @@ List all agents in a project.
 
 **Response:**
 ```json
-[
-  {
-    "id": "uuid",
-    "name": "Dev Bot",
-    "handle": "dev-bot",
-    "avatar_url": null,
-    "agent_type": {
+{
+  "items": [
+    {
       "id": "uuid",
-      "name": "Developer",
-      "slug": "developer"
-    },
-    "llm_provider": "anthropic",
-    "llm_model": "claude-sonnet-4-6",
-    "max_iterations": 50,
-    "timeout_minutes": 30,
-    "member_id": "uuid",
-    "created_at": "2026-05-19T00:00:00Z"
-  }
-]
+      "project_id": "uuid",
+      "member_id": "uuid",
+      "name": "Dev Bot",
+      "handle": "dev-bot",
+      "avatar_url": null,
+      "agent_type": "llm",
+      "llm_provider": "anthropic",
+      "llm_model": "claude-sonnet-4-6",
+      "llm_base_url": "",
+      "acp_provider": null,
+      "acp_command": [],
+      "has_acp_bridge_token": false,
+      "max_iterations": 50,
+      "timeout_minutes": 30,
+      "created_at": "2026-05-19T00:00:00Z"
+    }
+  ]
+}
 ```
 
 ---
@@ -41,12 +49,12 @@ List all agents in a project.
 
 Create a new agent. This also creates the corresponding `project_members` row with `member_type = 'agent'`.
 
-**Request body:**
+**Request body (`agent_type: "llm"`, the default):**
 ```json
 {
   "name": "Dev Bot",
   "handle": "dev-bot",
-  "agent_type_id": "uuid",
+  "agent_type": "llm",
   "llm_provider": "anthropic",
   "llm_model": "claude-sonnet-4-6",
   "llm_api_key": "sk-ant-...",
@@ -58,7 +66,21 @@ Create a new agent. This also creates the corresponding `project_members` row wi
 }
 ```
 
-The `llm_api_key` is stored in the secrets store (e.g., encrypted column or external vault); only a reference is kept in the `agents` table.
+`llm_provider`, `llm_model`, and `llm_api_key` are required when `agent_type` is `llm`. `llm_api_key` is stored in the secrets store; only a reference (`llm_api_key_secret`) is kept on the `agents` row.
+
+**Request body (`agent_type: "acp"`):**
+```json
+{
+  "name": "Local Claude Code",
+  "handle": "local-claude",
+  "agent_type": "acp",
+  "acp_provider": "claude-code",
+  "system_prompt": "You are a senior software engineer...",
+  "project_role_id": "uuid"
+}
+```
+
+`acp_provider` (one of `claude-code`, `codex`, `gemini-cli`, `custom`) is required when `agent_type` is `acp`. `acp_command` is required only when `acp_provider` is `custom` — built-in providers resolve a default launch command via the OpenHands SDK's own provider registry. None of the `llm_*` fields apply to `acp` agents.
 
 **Response:** `201 Created` with the created agent object.
 
@@ -74,6 +96,7 @@ Get a single agent, including its MCP servers and skills.
   "id": "uuid",
   "name": "Dev Bot",
   "handle": "dev-bot",
+  "agent_type": "llm",
   "system_prompt": "...",
   "mcp_servers": [
     {
@@ -101,7 +124,7 @@ Get a single agent, including its MCP servers and skills.
 
 ### `PATCH /api/v1/projects/:projectId/agents/:agentId`
 
-Update agent configuration (name, handle, LLM, system prompt, limits).
+Update agent configuration. `agent_type` itself is immutable after creation — only the fields belonging to the agent's existing type (`llm_*` or `acp_*`) can be updated.
 
 ---
 
@@ -111,7 +134,42 @@ Soft-delete the agent and its corresponding project member. Stops any running co
 
 ---
 
+## ACP Local Bridge
+
+Endpoints for `acp`-type agents only; return an error for `llm`-type agents.
+
+### `POST /api/v1/projects/:projectId/agents/:agentId/acp-bridge-token`
+
+Issue a new local-bridge connection token, invalidating any previous one. The plaintext token is returned once — only its hash is persisted, so it cannot be retrieved again after this response.
+
+**Response:**
+```json
+{
+  "token": "<plaintext-token>",
+  "run_command": "uvx paca-acp-bridge run --agent-id <agent-id> --token <plaintext-token> --server https://your-paca-instance.example.com"
+}
+```
+
+---
+
+### `GET /api/v1/projects/:projectId/agents/:agentId/acp-bridge-status`
+
+Live connected/disconnected status for the agent's local bridge, proxied from `services/ai-agent`'s presence check.
+
+**Response:**
+```json
+{ "connected": true }
+```
+
+---
+
 ## Agent MCP Servers
+
+### `GET /api/v1/projects/:projectId/agents/:agentId/mcp-servers`
+
+List MCP servers configured on an agent. **Response:** `{"items": [...]}`, each item shaped like the `mcp_servers` entries above.
+
+---
 
 ### `POST /api/v1/projects/:projectId/agents/:agentId/mcp-servers`
 
@@ -144,6 +202,12 @@ Remove an MCP server from an agent.
 
 ## Agent Skills
 
+### `GET /api/v1/projects/:projectId/agents/:agentId/skills`
+
+List skills attached to an agent. **Response:** `{"items": [...]}`, each item shaped like the `skills` entries above.
+
+---
+
 ### `POST /api/v1/projects/:projectId/agents/:agentId/skills`
 
 Add a skill to an agent.
@@ -168,6 +232,8 @@ Add a skill to an agent.
 }
 ```
 
+`skill_source` is one of `inline`, `marketplace`, or `github_url`.
+
 ---
 
 ### `PATCH /api/v1/projects/:projectId/agents/:agentId/skills/:skillId`
@@ -182,39 +248,89 @@ Remove a skill.
 
 ---
 
-## Agent Types
+## Agent Environment Variables
 
-### `GET /api/v1/agent-types`
+`llm`-type agents only — secret environment variables injected into the agent's sandbox container at conversation start (e.g., a repo-specific token an MCP server needs). Unsupported for `acp` agents, which run entirely in the user's own local environment instead.
 
-List built-in and project-scoped agent types.
+### `GET /api/v1/projects/:projectId/agents/:agentId/env-vars`
 
-**Query params:** `?project_id=<uuid>` — include project-scoped types.
+List env vars for an agent. **Response:** `{"items": [...]}`. Values are always redacted (`"***"`) — the plaintext is never returned once set.
 
 ---
 
-### `POST /api/v1/projects/:projectId/agent-types`
+### `POST /api/v1/projects/:projectId/agents/:agentId/env-vars`
 
-Create a custom agent type for a project.
+Add an env var.
+
+**Request body:**
+```json
+{ "key": "GITHUB_TOKEN", "value": "ghp_..." }
+```
+
+---
+
+### `PATCH /api/v1/projects/:projectId/agents/:agentId/env-vars/:envVarId`
+
+Replace an env var's value.
+
+---
+
+### `DELETE /api/v1/projects/:projectId/agents/:agentId/env-vars/:envVarId`
+
+Remove an env var.
+
+---
+
+## LLM Models & Skill Templates
+
+Two read-only, project-agnostic reference endpoints under `/api/v1/agents`, used by the agent creation/edit UI:
+
+### `GET /api/v1/agents/llm-models`
+
+Proxies to `services/ai-agent`'s `/llm/models`, returning the verified LLM models available, grouped by provider.
+
+---
+
+### `GET /api/v1/agents/skill-templates`
+
+Lists the built-in skill templates (`developer`, `ba`, `manual-tester`, `po-assistant`) that a new agent's skills can be seeded from — see [overview.md](overview.md#skill-templates).
+
+**Response:**
+```json
+[
+  {
+    "slug": "developer",
+    "name": "Developer",
+    "description": "...",
+    "content": "---\nname: developer\n...",
+    "triggers": ["implement", "fix", "refactor"]
+  }
+]
+```
 
 ---
 
 ## Conversations
 
-### `GET /api/v1/projects/:projectId/agents/:agentId/conversations`
+Conversations are project-scoped, not nested under a specific agent — a project's conversation history spans all of its agents.
 
-List all conversations for an agent. Sorted by `created_at DESC`.
+### `GET /api/v1/projects/:projectId/conversations`
 
-**Query params:** `?status=running&task_id=<uuid>&limit=20&offset=0`
+List conversations for the project, cursor-paginated (not offset-based).
+
+**Query params:** `?status=running&agent_id=<uuid>&cursor=<opaque>&page_size=20`
 
 **Response:**
 ```json
 {
-  "conversations": [
+  "items": [
     {
       "id": "uuid",
+      "agent_id": "uuid",
+      "agent_name": "Dev Bot",
+      "agent_handle": "dev-bot",
       "trigger_type": "task_assigned",
       "task_id": "uuid",
-      "task_title": "Implement OAuth login",
       "status": "running",
       "iteration_count": 12,
       "branch_name": "agent/implement-oauth-login",
@@ -223,7 +339,8 @@ List all conversations for an agent. Sorted by `created_at DESC`.
       "finished_at": null
     }
   ],
-  "total": 1
+  "page_size": 20,
+  "next_cursor": "<opaque-or-null>"
 }
 ```
 
@@ -231,20 +348,20 @@ List all conversations for an agent. Sorted by `created_at DESC`.
 
 ### `GET /api/v1/projects/:projectId/conversations/:conversationId`
 
-Get full conversation detail including events.
-
-**Query params:** `?include_events=true&event_limit=100&event_offset=0`
+Get full conversation detail.
 
 ---
 
 ### `GET /api/v1/projects/:projectId/conversations/:conversationId/events`
 
-Paginated list of conversation events.
+Offset-paginated list of conversation events.
+
+**Query params:** `?offset=0&limit=50` (`limit` capped at 200, defaults to 50)
 
 **Response:**
 ```json
 {
-  "events": [
+  "items": [
     {
       "id": "uuid",
       "event_index": 0,
@@ -262,8 +379,7 @@ Paginated list of conversation events.
       "created_at": "2026-05-19T10:00:03Z"
     }
   ],
-  "total": 45,
-  "has_more": true
+  "total": 45
 }
 ```
 
@@ -271,31 +387,31 @@ Paginated list of conversation events.
 
 ### `POST /api/v1/projects/:projectId/conversations/:conversationId/pause`
 
-Pause a running conversation.
+Interrupt the in-flight turn without tearing anything down — for `llm` agents the container keeps running; for `acp` agents a `pause_turn` message is forwarded to the bridge. A no-op if nothing is currently running. There is no `resume` endpoint.
 
-**Response:** `200 OK` `{"status": "paused"}`
-
----
-
-### `POST /api/v1/projects/:projectId/conversations/:conversationId/resume`
-
-Resume a paused conversation.
-
-**Response:** `200 OK` `{"status": "running"}`
+**Response:** `200 OK` `{"message": "conversation pause requested"}`
 
 ---
 
 ### `POST /api/v1/projects/:projectId/conversations/:conversationId/stop`
 
-Permanently stop a conversation and destroy its container.
+Permanently stop a conversation. For `llm` agents this also destroys the container; for `acp` agents a `stop_turn` message is forwarded to the bridge instead.
 
-**Response:** `200 OK` `{"status": "stopped"}`
+**Response:** `200 OK` `{"message": "conversation stopped"}`
 
 ---
 
-### `POST /api/v1/projects/:projectId/conversations/:conversationId/message`
+### `POST /api/v1/projects/:projectId/conversations/:conversationId/heartbeat`
 
-Send an additional message to an active conversation (running or paused).
+Keepalive ping (~30s interval) from a client actively viewing a conversation, refreshing its idle timer.
+
+**Response:** `200 OK` `{"status": "ok"}`
+
+---
+
+### `POST /api/v1/projects/:projectId/conversations/:conversationId/messages`
+
+Send an additional message to a conversation. Requires the conversation to already be in `running` status — sending to a `paused` conversation returns an error rather than resuming it.
 
 **Request body:**
 ```json
@@ -308,9 +424,11 @@ Send an additional message to an active conversation (running or paused).
 
 ## Agent Chat Sessions
 
+Chat sessions are nested under their agent, not the project — a session is always between one member and one agent.
+
 ### `GET /api/v1/projects/:projectId/agents/:agentId/chat-sessions`
 
-List chat sessions for a member+agent pair.
+List chat sessions for the calling member with this agent. **Response:** `{"items": [...]}`.
 
 ---
 
@@ -325,30 +443,10 @@ Start a new chat session with an agent.
 }
 ```
 
-**Response:** `201 Created` with the new session and the queued conversation.
+**Response:** `201 Created` `{"session": {...}, "conversation": {...}}`.
 
 ---
 
-### `POST /api/v1/projects/:projectId/chat-sessions/:sessionId/messages`
+### `POST /api/v1/projects/:projectId/agents/:agentId/chat-sessions/:sessionId/messages`
 
-Send a follow-up message in an existing chat session.
-
----
-
-### `GET /api/v1/projects/:projectId/chat-sessions/:sessionId/messages`
-
-List all messages in a chat session (human turns + agent replies).
-
----
-
-## Real-time Events (Socket.IO)
-
-The `services/realtime` service emits the following events to project rooms when conversation state changes:
-
-| Event | Payload | When |
-|---|---|---|
-| `agent:conversation:started` | `{ conversation_id, agent_id, trigger_type }` | Conversation begins |
-| `agent:conversation:event` | `{ conversation_id, event_type, event_source, event_index, payload }` | Each SDK event |
-| `agent:conversation:status` | `{ conversation_id, status }` | Status change (paused, resumed, finished, stopped, failed) |
-| `agent:conversation:pr_created` | `{ conversation_id, task_id, pr_url, branch_name }` | Agent created a PR |
-| `agent:chat:reply` | `{ session_id, message, conversation_id }` | Agent replied in chat |
+Send a follow-up message in an existing chat session. **Response:** `201 Created` `{"conversation": {...}}` — the (possibly new) conversation this message triggered. There is no separate "list messages" endpoint — a session's `conversation_id` links to its conversation, whose message history is read via the conversation events endpoint above.

--- a/docs/ai-agent/overview.md
+++ b/docs/ai-agent/overview.md
@@ -1,15 +1,16 @@
 # AI Agent Feature — Overview
 
-Paca AI Agents are first-class project members powered by the [OpenHands Software Agent SDK](https://docs.openhands.dev/sdk). Each agent runs in an isolated Docker container and can be triggered by task assignment, comment @mentions, or direct chat. Agents participate in the project exactly like human members — they appear in member lists, can be assigned tasks, and exchange messages in comments and chats.
+Paca AI Agents are first-class project members, triggered by task assignment, comment @mentions, or direct chat. Agents participate in the project exactly like human members — they appear in member lists, can be assigned tasks, and exchange messages in comments and chats. Depending on `agent_type`, an agent's conversations either run in an isolated Docker container managed by Paca (`llm`, powered by the [OpenHands Software Agent SDK](https://docs.openhands.dev/sdk)) or on a coding CLI the user runs locally themselves (`acp`) — see [Execution Models](#execution-models).
 
 ## Table of Contents
 
 - [Concepts](#concepts)
 - [Architecture](#architecture)
+- [Execution Models](#execution-models)
 - [Trigger Model](#trigger-model)
 - [Conversation Lifecycle](#conversation-lifecycle)
 - [Repository Access & PR Creation](#repository-access--pr-creation)
-- [Default Agent Types](#default-agent-types)
+- [Skill Templates](#skill-templates)
 - [Customization](#customization)
 - [Related Documents](#related-documents)
 
@@ -19,12 +20,13 @@ Paca AI Agents are first-class project members powered by the [OpenHands Softwar
 
 | Term | Meaning |
 |---|---|
-| **Agent** | A project-scoped AI entity with a role, LLM config, skills, MCP servers, and a system prompt. |
+| **Agent** | A project-scoped AI entity with a role, execution config, skills, MCP servers, and a system prompt. |
 | **Agent Member** | A `project_members` row with `member_type = 'agent'` and a reference to the `agents` table. Agents are treated identically to human members in all product surfaces. |
-| **Agent Type** | A template that pre-fills LLM, skills, and system prompt. Built-in types: PO Assistant, Business Analyst, Developer, Manual Tester. Users can create custom types. |
-| **Agent Conversation** | A single OpenHands SDK `Conversation` session, spawned in a dedicated Docker container for each trigger event. |
+| **Agent Type** | `llm` (default) or `acp` — determines *where and how* an agent's conversations execute. See [Execution Models](#execution-models) below. Not to be confused with the pre-refactor "Agent Type" template concept (PO Assistant, Business Analyst, etc.); those are now [Skill Templates](#skill-templates). |
+| **Skill Template** | A built-in, reusable skill (`developer`, `ba`, `manual-tester`, `po-assistant`) that any agent — `llm` or `acp` — can attach, instead of a full agent preset. See [Skill Templates](#skill-templates). |
+| **Agent Conversation** | A single execution session for one trigger event. For `llm` agents, an OpenHands SDK `Conversation` spawned in a dedicated Docker container; for `acp` agents, a turn dispatched to the user's own locally-run bridge. |
 | **Conversation Event** | An atomic action/observation within a conversation (LLM message, bash command, file edit, etc.). Persisted to the database for history and real-time monitoring. |
-| **Trigger** | An event that creates an agent conversation: task assignment, comment @mention, or direct chat message. |
+| **Trigger** | An event that creates an agent conversation: task assignment, comment @mention, or direct chat message. Applies identically to both agent types — only how the resulting conversation executes differs. |
 
 ---
 
@@ -77,6 +79,22 @@ Paca AI Agents are first-class project members powered by the [OpenHands Softwar
 | `services/ai-agent` | Executes agent conversations via OpenHands SDK, manages Docker container lifecycle, streams events back. |
 | `services/realtime` | Delivers real-time conversation events to the web client via Socket.IO (same existing Valkey→Socket.IO fan-out). |
 | Docker host | Provides container isolation. Agent containers cannot reach other Paca service containers on the internal network by default. |
+
+---
+
+## Execution Models
+
+Every agent has an `agent_type` of `llm` (default) or `acp`, fixed at creation. The trigger model, comment/chat surfaces, and conversation history all work identically for both — only *where the conversation actually runs* differs:
+
+| | `llm` | `acp` |
+|---|---|---|
+| Runs in | A Paca-managed Docker container (the architecture diagram above) | A coding CLI running as a real local process on the user's own machine |
+| LLM credential | `llm_api_key`, stored encrypted, managed by Paca | The user's own local CLI auth (e.g. `claude setup-token`, `OPENAI_API_KEY`) — Paca never sees, stores, or requests this |
+| MCP servers / skills / env vars | Configured on the agent in Paca, injected into the container at conversation start | Entirely the user's own local CLI configuration — Paca injects nothing |
+| Git / VCS access | Short-lived scoped token from a repository plugin (see [Repository Access & PR Creation](#repository-access--pr-creation)) | Whatever `git`/`gh` credentials are already configured on the user's machine |
+| Connection to Paca | N/A — the container is spawned and controlled by `services/ai-agent` directly | An authenticated WebSocket from the [`paca-acp-bridge`](../../apps/acp-bridge/README.md) daemon to `services/ai-agent`, using a per-agent bridge token generated in the Agents UI (`POST .../agents/:agentId/acp-bridge-token`) |
+
+`acp` exists for users who already have a coding CLI configured the way they want (auth, MCP servers, skills, git access) and would rather point Paca at that setup than duplicate it in a sandboxed container. See [api-design.md](api-design.md) for the full field-level split between the two types, and the bridge's own README for its local setup and auth model.
 
 ---
 
@@ -137,6 +155,8 @@ A dedicated chat API allows users to send messages to an agent member. Internall
 
 ## Conversation Lifecycle
 
+This describes the `llm` execution path (see [Execution Models](#execution-models)). `acp` conversations skip container spawning entirely — the trigger is dispatched as a `start_turn` message to the user's already-running bridge, which runs the turn locally and streams events back over the bridge's WebSocket instead.
+
 ```
 Trigger event published
         │
@@ -184,6 +204,8 @@ Container destroyed, conversation state archived
 
 ## Repository Access & PR Creation
 
+This describes the `llm` execution path. `acp` agents don't go through a repository plugin at all — they use whatever `git`/`gh` credentials are already configured on the user's own machine, exactly as if the user were driving the CLI themselves; see the [Execution Models](#execution-models) table.
+
 Agents must be able to read and write code without ever seeing VCS credentials directly.
 
 ### Clone Flow
@@ -208,29 +230,31 @@ This design means:
 
 ---
 
-## Default Agent Types
+## Skill Templates
 
-| Type | Role | Default LLM | Pre-loaded Skills |
-|---|---|---|---|
-| **PO Assistant** | Product Owner — backlog grooming, acceptance criteria, prioritization | `anthropic/claude-sonnet-4-6` | `po-assistant` skill with Agile PO guidelines |
-| **Business Analyst** | Requirements analysis, user story writing, gap analysis | `anthropic/claude-sonnet-4-6` | `ba-assistant` skill |
-| **Developer** | Coding, code review, PR creation, bug fixing | `anthropic/claude-sonnet-4-6` | `developer` skill + `github`/`gitlab` skills |
-| **Manual Tester** | Test case design, exploratory testing docs, defect analysis | `anthropic/claude-sonnet-4-6` | `manual-tester` skill |
+There is no longer a preset "agent type" that bundles an LLM, skills, and a system prompt together — every agent is configured individually (`llm` or `acp`, any LLM provider, any skills, any MCP servers). What used to be built-in agent types are now built-in **skill templates**: reusable skill content a user attaches to whichever agent they're configuring, listed via `GET /api/v1/agents/skill-templates` ([api-design.md](api-design.md#llm-models--skill-templates)).
 
-Users can create custom agent types with any combination of LLM provider, skills, MCP servers, and system prompt.
+| Slug | Name | Description |
+|---|---|---|
+| `developer` | Developer | Implements features, fixes bugs, writes tests, and creates pull requests. |
+| `ba` | Business Analyst | Requirements analysis, gap analysis, process modelling, functional specifications. |
+| `manual-tester` | Manual Tester | Test case design, test plans, defect report analysis, testing documentation. |
+| `po-assistant` | Product Owner Assistant | Backlog grooming, acceptance criteria, prioritization, roadmap questions. |
+
+Each template also carries a set of trigger keywords (e.g. `developer` triggers on "implement", "fix", "bug", "pr", ...) used to route `@mention`-less task assignments to the right skill context. Users can also write their own inline or GitHub-URL-sourced skills — templates are just a shortcut, not the only option.
 
 ---
 
 ## Customization
 
-Every agent exposes four customization axes:
+`llm` agents expose four customization axes; `acp` agents only the latter two, since MCP servers/skills for `acp` live in the user's own local CLI config rather than Paca (see [Execution Models](#execution-models)):
 
-| Axis | Description |
-|---|---|
-| **LLM Provider** | Any LiteLLM-supported provider: Anthropic, OpenAI, Azure, AWS Bedrock, Gemini, Groq, OpenRouter, local LLMs, etc. |
-| **System Prompt** | Free-form Jinja2 template or plain text, pre-filled from the agent type. |
-| **Skills** | AgentSkills-standard `SKILL.md` directories or inline text skills. Stored in the DB, mounted into the container at runtime. |
-| **MCP Servers** | JSON MCP config following the standard `mcpServers` format. Evaluated inside the container at conversation start. |
+| Axis | Applies to | Description |
+|---|---|---|
+| **LLM Provider** | `llm` only | Any LiteLLM-supported provider: Anthropic, OpenAI, Azure, AWS Bedrock, Gemini, Groq, OpenRouter, local LLMs, etc. |
+| **System Prompt** | both | Free-form Jinja2 template or plain text, optionally pre-filled from a skill template. |
+| **Skills** | `llm` only | AgentSkills-standard `SKILL.md` directories or inline text skills. Stored in the DB, mounted into the container at runtime. |
+| **MCP Servers** | `llm` only | JSON MCP config following the standard `mcpServers` format. Evaluated inside the container at conversation start. |
 
 ---
 

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -157,6 +157,14 @@ func New(cfg *config.Config) (*App, error) {
 			agentService = agentService.WithEncryptor(enc)
 			log.Info("agent LLM API key at-rest encryption enabled")
 		}
+	} else {
+		// Not fatal — deployments using only ACP-type agents and no plugins
+		// with stored secrets have nothing to encrypt. But when this is
+		// unintentional, the effect is silent: encryptKey() falls back to
+		// storing the plaintext unchanged when no encryptor is configured, so
+		// LLM API keys and plugin secrets end up in the database in plaintext
+		// with no error or signal anywhere. Surface it once at startup.
+		log.Warn("ENCRYPTION_KEY not set: agent LLM API keys and plugin secrets will be stored in plaintext, not encrypted")
 	}
 	activityService := tasksvc.NewActivityService(activityRepo, projectRepo, publisher).
 		WithNotificationService(notificationService).

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -24,10 +24,11 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockAgentSvc struct {
-	getAgent          func(ctx context.Context, projectID, agentID uuid.UUID) (*agentdom.Agent, error)
-	createAgent       func(ctx context.Context, projectID uuid.UUID, in agentdom.CreateAgentInput) (*agentdom.Agent, error)
-	startChatSession  func(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error)
-	listConversations func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
+	getAgent               func(ctx context.Context, projectID, agentID uuid.UUID) (*agentdom.Agent, error)
+	createAgent            func(ctx context.Context, projectID uuid.UUID, in agentdom.CreateAgentInput) (*agentdom.Agent, error)
+	startChatSession       func(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error)
+	listConversations      func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
+	listConversationEvents func(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error)
 }
 
 func (m *mockAgentSvc) ListAgents(_ context.Context, _ uuid.UUID) ([]*agentdom.Agent, error) {
@@ -96,7 +97,10 @@ func (m *mockAgentSvc) ListConversations(ctx context.Context, filter agentdom.Li
 func (m *mockAgentSvc) GetConversation(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 	return nil, errors.New("not found")
 }
-func (m *mockAgentSvc) ListConversationEvents(_ context.Context, _ uuid.UUID, _, _ int) ([]*agentdom.AgentConversationEvent, int64, error) {
+func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+	if m.listConversationEvents != nil {
+		return m.listConversationEvents(ctx, conversationID, offset, limit)
+	}
 	return nil, 0, nil
 }
 func (m *mockAgentSvc) StopConversation(_ context.Context, _, _ uuid.UUID) error  { return nil }

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -101,7 +101,11 @@ func (h *ConversationHandler) ListConversationEvents(w http.ResponseWriter, r *h
 		return
 	}
 
-	offset, limit := parseOffsetLimit(r)
+	offset, limit, err := parseOffsetLimit(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
 	events, total, err := h.svc.ListConversationEvents(r.Context(), convID, offset, limit)
 	if err != nil {
 		presenter.Error(w, r, err)

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/google/uuid"
 
@@ -31,9 +30,10 @@ func (h *ConversationHandler) ListConversations(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	pageSize, _ := strconv.Atoi(defaultQuery(r, "page_size", "20"))
-	if pageSize < 1 || pageSize > 200 {
-		pageSize = 20
+	pageSize, err := parsePageSize(r, 20, 200)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
 	}
 
 	filter := agentdom.ListConversationsFilter{

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -82,19 +82,16 @@ func TestListConversations_DefaultPageSize(t *testing.T) {
 	}
 }
 
-func TestListConversations_PageSizeClamping(t *testing.T) {
+func TestListConversations_PageSizeValid(t *testing.T) {
 	cases := []struct {
 		name      string
 		query     string
 		wantLimit int
 	}{
-		{"zero_clamped_to_default", "page_size=0", 20},
-		{"negative_clamped_to_default", "page_size=-5", 20},
-		{"over_max_clamped_to_default", "page_size=201", 20},
+		{"absent_defaults", "", 20},
 		{"valid_custom_size_kept", "page_size=50", 50},
 		{"max_boundary_kept", "page_size=200", 200},
 		{"min_boundary_kept", "page_size=1", 1},
-		{"non_numeric_clamped_to_default", "page_size=abc", 20},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -105,12 +102,43 @@ func TestListConversations_PageSizeClamping(t *testing.T) {
 					return nil, false, nil
 				},
 			}
-			_, resp := doListConversations(t, svc, uuid.New().String(), tc.query)
+			rec, resp := doListConversations(t, svc, uuid.New().String(), tc.query)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
 			if gotLimit != tc.wantLimit {
 				t.Errorf("expected service called with limit=%d, got %d", tc.wantLimit, gotLimit)
 			}
 			if resp.Data.PageSize != tc.wantLimit {
 				t.Errorf("expected response page_size=%d, got %d", tc.wantLimit, resp.Data.PageSize)
+			}
+		})
+	}
+}
+
+// TestListConversations_PageSizeInvalidRejected covers the fix for silent
+// page_size substitution: an explicitly supplied out-of-range or non-numeric
+// value now fails the request instead of quietly running with a different
+// page_size than the caller asked for (which broke offset math for callers
+// paginating by page_size).
+func TestListConversations_PageSizeInvalidRejected(t *testing.T) {
+	cases := []string{
+		"page_size=0",
+		"page_size=-5",
+		"page_size=201",
+		"page_size=abc",
+	}
+	for _, query := range cases {
+		t.Run(query, func(t *testing.T) {
+			svc := &mockAgentSvc{
+				listConversations: func(_ context.Context, _ agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error) {
+					t.Fatalf("service should not be called for invalid page_size, got limit=%d", limit)
+					return nil, false, nil
+				},
+			}
+			rec, _ := doListConversations(t, svc, uuid.New().String(), query)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 			}
 		})
 	}

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -29,6 +29,7 @@ func newConversationRouter(svc agentdom.Service) chi.Router {
 	r := chi.NewRouter()
 	r.Route("/projects/{projectId}/conversations", func(r chi.Router) {
 		r.Get("/", h.ListConversations)
+		r.Get("/{conversationId}/events", h.ListConversationEvents)
 	})
 	return r
 }
@@ -137,6 +138,88 @@ func TestListConversations_PageSizeInvalidRejected(t *testing.T) {
 				},
 			}
 			rec, _ := doListConversations(t, svc, uuid.New().String(), query)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListConversationEvents: offset/limit handling
+// ---------------------------------------------------------------------------
+
+func doListConversationEvents(t *testing.T, svc agentdom.Service, projectID, conversationID, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := newConversationRouter(svc)
+	url := "/projects/" + projectID + "/conversations/" + conversationID + "/events"
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestListConversationEvents_OffsetLimitValid(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		wantOffset int
+		wantLimit  int
+	}{
+		{"absent_defaults", "", 0, 50},
+		{"valid_custom_values_kept", "offset=10&limit=25", 10, 25},
+		{"limit_max_boundary_kept", "limit=200", 0, 200},
+		{"limit_min_boundary_kept", "limit=1", 0, 1},
+		{"offset_zero_kept", "offset=0", 0, 50},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotOffset, gotLimit int
+			svc := &mockAgentSvc{
+				listConversationEvents: func(_ context.Context, _ uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+					gotOffset, gotLimit = offset, limit
+					return nil, 0, nil
+				},
+			}
+			rec := doListConversationEvents(t, svc, uuid.New().String(), uuid.New().String(), tc.query)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if gotOffset != tc.wantOffset || gotLimit != tc.wantLimit {
+				t.Errorf("expected service called with offset=%d limit=%d, got offset=%d limit=%d",
+					tc.wantOffset, tc.wantLimit, gotOffset, gotLimit)
+			}
+		})
+	}
+}
+
+// TestListConversationEvents_OffsetLimitInvalidRejected covers the same
+// silent-substitution fix as TestListConversations_PageSizeInvalidRejected,
+// applied to this endpoint's offset/limit pair: an explicitly supplied
+// out-of-range or non-numeric value now fails the request instead of quietly
+// running with a different limit than the caller asked for (which broke
+// offset math for callers advancing offset by their requested limit).
+func TestListConversationEvents_OffsetLimitInvalidRejected(t *testing.T) {
+	cases := []string{
+		"offset=-1",
+		"offset=abc",
+		"limit=0",
+		"limit=-5",
+		"limit=201",
+		"limit=abc",
+	}
+	for _, query := range cases {
+		t.Run(query, func(t *testing.T) {
+			svc := &mockAgentSvc{
+				listConversationEvents: func(_ context.Context, _ uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+					t.Fatalf("service should not be called for invalid offset/limit, got offset=%d limit=%d", offset, limit)
+					return nil, 0, nil
+				},
+			}
+			rec := doListConversationEvents(t, svc, uuid.New().String(), uuid.New().String(), query)
 			if rec.Code != http.StatusBadRequest {
 				t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 			}

--- a/services/api/internal/transport/http/handler/helpers.go
+++ b/services/api/internal/transport/http/handler/helpers.go
@@ -36,15 +36,41 @@ func parsePageSize(r *http.Request, defaultSize, maxSize int) (int, error) {
 	return n, nil
 }
 
-// parseOffsetLimit reads offset and limit query parameters with sensible defaults.
-func parseOffsetLimit(r *http.Request) (offset, limit int) {
-	offset, _ = strconv.Atoi(defaultQuery(r, "offset", "0"))
-	limit, _ = strconv.Atoi(defaultQuery(r, "limit", "50"))
-	if offset < 0 {
+// parsePage reads the page query parameter (1-indexed). An absent param
+// silently falls back to 1 — only an explicitly supplied, invalid value
+// (non-numeric or less than 1) is rejected. See parsePageSize for why.
+func parsePage(r *http.Request) (int, error) {
+	raw := r.URL.Query().Get("page")
+	if raw == "" {
+		return 1, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0, apierr.New(apierr.CodeBadRequest, "page must be a positive integer")
+	}
+	return n, nil
+}
+
+// parseOffsetLimit reads the offset and limit query parameters. Absent
+// params silently fall back to their defaults (0 and 50); only an explicitly
+// supplied, invalid value is rejected — for the same reason parsePageSize
+// rejects one: a caller advancing offset by the limit it requested (e.g.
+// offset += limit) would otherwise get a different limit back with no
+// signal, skipping or duplicating rows against its own math.
+func parseOffsetLimit(r *http.Request) (offset, limit int, err error) {
+	rawOffset := r.URL.Query().Get("offset")
+	if rawOffset == "" {
 		offset = 0
+	} else if offset, err = strconv.Atoi(rawOffset); err != nil || offset < 0 {
+		return 0, 0, apierr.New(apierr.CodeBadRequest, "offset must be a non-negative integer")
 	}
-	if limit < 1 || limit > 200 {
+
+	rawLimit := r.URL.Query().Get("limit")
+	if rawLimit == "" {
 		limit = 50
+	} else if limit, err = strconv.Atoi(rawLimit); err != nil || limit < 1 || limit > 200 {
+		return 0, 0, apierr.New(apierr.CodeBadRequest, "limit must be an integer between 1 and 200")
 	}
-	return offset, limit
+
+	return offset, limit, nil
 }

--- a/services/api/internal/transport/http/handler/helpers.go
+++ b/services/api/internal/transport/http/handler/helpers.go
@@ -17,21 +17,21 @@ func defaultQuery(r *http.Request, key, fallback string) string {
 	return v
 }
 
-// parsePageSize reads the page_size query parameter, capped at max. An
+// parsePageSize reads the page_size query parameter, capped at maxSize. An
 // absent param silently falls back to defaultSize — only an explicitly
 // supplied, invalid value is rejected. This intentionally differs from
 // silently substituting a default: a caller driving pagination off the
 // page_size it requested (e.g. computing the next offset as N * page_size)
 // would otherwise get a smaller page back with no signal, skipping or
 // duplicating rows against its own math.
-func parsePageSize(r *http.Request, defaultSize, max int) (int, error) {
+func parsePageSize(r *http.Request, defaultSize, maxSize int) (int, error) {
 	raw := r.URL.Query().Get("page_size")
 	if raw == "" {
 		return defaultSize, nil
 	}
 	n, err := strconv.Atoi(raw)
-	if err != nil || n < 1 || n > max {
-		return 0, apierr.New(apierr.CodeBadRequest, fmt.Sprintf("page_size must be an integer between 1 and %d", max))
+	if err != nil || n < 1 || n > maxSize {
+		return 0, apierr.New(apierr.CodeBadRequest, fmt.Sprintf("page_size must be an integer between 1 and %d", maxSize))
 	}
 	return n, nil
 }

--- a/services/api/internal/transport/http/handler/helpers.go
+++ b/services/api/internal/transport/http/handler/helpers.go
@@ -1,8 +1,11 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/Paca-AI/api/internal/apierr"
 )
 
 // defaultQuery returns the URL query parameter named key, or fallback if missing/empty.
@@ -12,6 +15,25 @@ func defaultQuery(r *http.Request, key, fallback string) string {
 		return fallback
 	}
 	return v
+}
+
+// parsePageSize reads the page_size query parameter, capped at max. An
+// absent param silently falls back to defaultSize — only an explicitly
+// supplied, invalid value is rejected. This intentionally differs from
+// silently substituting a default: a caller driving pagination off the
+// page_size it requested (e.g. computing the next offset as N * page_size)
+// would otherwise get a smaller page back with no signal, skipping or
+// duplicating rows against its own math.
+func parsePageSize(r *http.Request, defaultSize, max int) (int, error) {
+	raw := r.URL.Query().Get("page_size")
+	if raw == "" {
+		return defaultSize, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 || n > max {
+		return 0, apierr.New(apierr.CodeBadRequest, fmt.Sprintf("page_size must be an integer between 1 and %d", max))
+	}
+	return n, nil
 }
 
 // parseOffsetLimit reads offset and limit query parameters with sensible defaults.

--- a/services/api/internal/transport/http/handler/project_handler.go
+++ b/services/api/internal/transport/http/handler/project_handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"sync"
 
 	"github.com/go-chi/chi/v5"
@@ -349,9 +348,9 @@ func parseProjectID(r *http.Request) (uuid.UUID, error) {
 }
 
 func pagingParams(r *http.Request) (page, pageSize int, err error) {
-	page, _ = strconv.Atoi(defaultQuery(r, "page", "1"))
-	if page < 1 {
-		page = 1
+	page, err = parsePage(r)
+	if err != nil {
+		return 0, 0, err
 	}
 	pageSize, err = parsePageSize(r, 20, 100)
 	return page, pageSize, err

--- a/services/api/internal/transport/http/handler/project_handler.go
+++ b/services/api/internal/transport/http/handler/project_handler.go
@@ -81,12 +81,15 @@ func NewProjectHandler(svc projectdom.Service, authorizer *authz.Authorizer, opt
 // All other authenticated users receive only the projects they are a member of.
 func (h *ProjectHandler) ListProjects(w http.ResponseWriter, r *http.Request) {
 	claims := middleware.ClaimsFrom(r)
-	page, pageSize := pagingParams(r)
+	page, pageSize, err := pagingParams(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
 
 	var (
 		projects []*projectdom.Project
 		total    int64
-		err      error
 	)
 
 	userID, parseErr := uuid.Parse(claims.Subject)
@@ -345,14 +348,11 @@ func parseProjectID(r *http.Request) (uuid.UUID, error) {
 	return id, nil
 }
 
-func pagingParams(r *http.Request) (page, pageSize int) {
+func pagingParams(r *http.Request) (page, pageSize int, err error) {
 	page, _ = strconv.Atoi(defaultQuery(r, "page", "1"))
-	pageSize, _ = strconv.Atoi(defaultQuery(r, "page_size", "20"))
 	if page < 1 {
 		page = 1
 	}
-	if pageSize < 1 || pageSize > 100 {
-		pageSize = 20
-	}
-	return page, pageSize
+	pageSize, err = parsePageSize(r, 20, 100)
+	return page, pageSize, err
 }

--- a/services/api/internal/transport/http/handler/project_handler_test.go
+++ b/services/api/internal/transport/http/handler/project_handler_test.go
@@ -259,6 +259,57 @@ func TestListProjects_ServiceError(t *testing.T) {
 	}
 }
 
+func TestListProjects_PageValid(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		wantPage int
+	}{
+		{"absent_defaults", "", 1},
+		{"valid_custom_page_kept", "page=3", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPage int
+			r := newProjectRouter(&mockProjectSvc{
+				list: func(_ context.Context, page, _ int) ([]*projectdom.Project, int64, error) {
+					gotPage = page
+					return []*projectdom.Project{}, 0, nil
+				},
+			})
+			w := do(t, r, http.MethodGet, "/admin/projects?"+tc.query, nil)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if gotPage != tc.wantPage {
+				t.Errorf("expected service called with page=%d, got %d", tc.wantPage, gotPage)
+			}
+		})
+	}
+}
+
+// TestListProjects_PageInvalidRejected covers the same silent-substitution
+// fix applied to page_size: an explicitly supplied invalid page value now
+// fails the request instead of quietly running with page=1, which would
+// otherwise mask a bug in the caller's own paging logic.
+func TestListProjects_PageInvalidRejected(t *testing.T) {
+	cases := []string{"page=0", "page=-1", "page=abc"}
+	for _, query := range cases {
+		t.Run(query, func(t *testing.T) {
+			r := newProjectRouter(&mockProjectSvc{
+				list: func(_ context.Context, page, _ int) ([]*projectdom.Project, int64, error) {
+					t.Fatalf("service should not be called for invalid page, got page=%d", page)
+					return nil, 0, nil
+				},
+			})
+			w := do(t, r, http.MethodGet, "/admin/projects?"+query, nil)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestGetProject_Success(t *testing.T) {
 	projID := uuid.New()
 	r := newProjectRouter(&mockProjectSvc{

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -464,9 +464,10 @@ func (h *TaskHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pageSize, _ := strconv.Atoi(defaultQuery(r, "page_size", "20"))
-	if pageSize < 1 || pageSize > 200 {
-		pageSize = 20
+	pageSize, err := parsePageSize(r, 20, 200)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
 	}
 	filter := taskdom.TaskFilter{}
 

--- a/services/api/internal/transport/http/handler/user_handler.go
+++ b/services/api/internal/transport/http/handler/user_handler.go
@@ -122,15 +122,13 @@ func (h *UserHandler) GetMyGlobalPermissions(w http.ResponseWriter, r *http.Requ
 // ListUsers handles GET /admin/users — returns a paginated list of all users.
 func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	page, _ := strconv.Atoi(defaultQuery(r, "page", "1"))
-	pageSize, _ := strconv.Atoi(defaultQuery(r, "page_size", "20"))
-
-	// Normalize to match the service's clamping logic so response metadata
-	// reflects the actual query that was executed.
 	if page < 1 {
 		page = 1
 	}
-	if pageSize < 1 || pageSize > 100 {
-		pageSize = 20
+	pageSize, err := parsePageSize(r, 20, 100)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
 	}
 
 	users, total, err := h.svc.List(r.Context(), page, pageSize)

--- a/services/api/internal/transport/http/handler/user_handler.go
+++ b/services/api/internal/transport/http/handler/user_handler.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"strconv"
 
 	"net/http"
 
@@ -121,9 +120,10 @@ func (h *UserHandler) GetMyGlobalPermissions(w http.ResponseWriter, r *http.Requ
 
 // ListUsers handles GET /admin/users — returns a paginated list of all users.
 func (h *UserHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
-	page, _ := strconv.Atoi(defaultQuery(r, "page", "1"))
-	if page < 1 {
-		page = 1
+	page, err := parsePage(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
 	}
 	pageSize, err := parsePageSize(r, 20, 100)
 	if err != nil {

--- a/services/api/internal/transport/http/handler/user_handler_test.go
+++ b/services/api/internal/transport/http/handler/user_handler_test.go
@@ -216,6 +216,60 @@ func TestListUsers_ServiceError(t *testing.T) {
 	}
 }
 
+func TestListUsers_PageValid(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		wantPage int
+	}{
+		{"absent_defaults", "", 1},
+		{"valid_custom_page_kept", "page=3", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPage int
+			svc := &mockUserSvc{
+				list: func(_ context.Context, page, _ int) ([]*domainuser.User, int64, error) {
+					gotPage = page
+					return []*domainuser.User{}, 0, nil
+				},
+			}
+			r := newUserRouter(svc)
+
+			w := do(t, r, http.MethodGet, "/admin/users?"+tc.query, nil)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if gotPage != tc.wantPage {
+				t.Errorf("expected service called with page=%d, got %d", tc.wantPage, gotPage)
+			}
+		})
+	}
+}
+
+// TestListUsers_PageInvalidRejected covers the same silent-substitution fix
+// applied to page_size: an explicitly supplied invalid page value now fails
+// the request instead of quietly running with page=1.
+func TestListUsers_PageInvalidRejected(t *testing.T) {
+	cases := []string{"page=0", "page=-1", "page=abc"}
+	for _, query := range cases {
+		t.Run(query, func(t *testing.T) {
+			svc := &mockUserSvc{
+				list: func(_ context.Context, page, _ int) ([]*domainuser.User, int64, error) {
+					t.Fatalf("service should not be called for invalid page, got page=%d", page)
+					return nil, 0, nil
+				},
+			}
+			r := newUserRouter(svc)
+
+			w := do(t, r, http.MethodGet, "/admin/users?"+query, nil)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetUserByID (admin)
 // ---------------------------------------------------------------------------

--- a/services/api/test/e2e/conversation_pagination_test.go
+++ b/services/api/test/e2e/conversation_pagination_test.go
@@ -362,6 +362,58 @@ func TestE2EListConversationPagination_AgentIDFilter(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestE2EListConversationEvents_OffsetLimitValidation
+// Mirrors the page_size validation coverage above, applied to this sibling
+// endpoint's offset/limit pair: an explicitly supplied out-of-range or
+// non-numeric value must be rejected rather than silently substituted, for
+// the same reason (a caller advancing offset by its requested limit would
+// otherwise skip or duplicate rows against its own math with no signal).
+// The conversation ID need not exist — invalid offset/limit is rejected
+// before the service layer is ever reached.
+// ---------------------------------------------------------------------------
+
+func TestE2EListConversationEvents_OffsetLimitValidation(t *testing.T) {
+	env := newE2EEnv(t)
+	client, token, projID, _, _ := seedConversationFixture(t, env)
+	convID := uuid.NewString()
+
+	eventsURL := func(q url.Values) string {
+		u := fmt.Sprintf("%s/api/v1/projects/%s/conversations/%s/events", env.base, projID, convID)
+		if len(q) > 0 {
+			u += "?" + q.Encode()
+		}
+		return u
+	}
+
+	t.Run("absent_offset_and_limit_default", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(nil), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+	})
+
+	invalidCases := []url.Values{
+		{"offset": {"-1"}},
+		{"offset": {"abc"}},
+		{"limit": {"0"}},
+		{"limit": {"-5"}},
+		{"limit": {"201"}},
+		{"limit": {"abc"}},
+	}
+	for _, q := range invalidCases {
+		t.Run(q.Encode(), func(t *testing.T) {
+			req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(q), nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp := mustDo(t, client, req)
+			defer func() { _ = resp.Body.Close() }()
+			assertStatus(t, resp, http.StatusBadRequest)
+			assertErrorCode(t, resp, "BAD_REQUEST")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TestE2EListConversationPagination_EmptyProject
 // ---------------------------------------------------------------------------
 

--- a/services/api/test/e2e/conversation_pagination_test.go
+++ b/services/api/test/e2e/conversation_pagination_test.go
@@ -207,18 +207,26 @@ func TestE2EListConversationPagination_CursorBased(t *testing.T) {
 		}
 	})
 
-	t.Run("page_size_zero_is_clamped_to_default", func(t *testing.T) {
-		data := listConversationsPage(t, env, client, token, projID, url.Values{"page_size": {"0"}})
-		if ps, _ := data["page_size"].(float64); ps != 20 {
-			t.Errorf("expected page_size=20 when 0 requested (out-of-range clamped), got %v", ps)
-		}
+	t.Run("page_size_zero_is_rejected", func(t *testing.T) {
+		q := url.Values{"page_size": {"0"}}
+		reqURL := fmt.Sprintf("%s/api/v1/projects/%s/conversations?%s", env.base, projID, q.Encode())
+		req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+		assertErrorCode(t, resp, "BAD_REQUEST")
 	})
 
-	t.Run("page_size_over_max_is_clamped_to_default", func(t *testing.T) {
-		data := listConversationsPage(t, env, client, token, projID, url.Values{"page_size": {"201"}})
-		if ps, _ := data["page_size"].(float64); ps != 20 {
-			t.Errorf("expected page_size=20 when 201 requested (over max, clamped), got %v", ps)
-		}
+	t.Run("page_size_over_max_is_rejected", func(t *testing.T) {
+		q := url.Values{"page_size": {"201"}}
+		reqURL := fmt.Sprintf("%s/api/v1/projects/%s/conversations?%s", env.base, projID, q.Encode())
+		req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+		assertErrorCode(t, resp, "BAD_REQUEST")
 	})
 
 	t.Run("invalid_cursor_returns_error", func(t *testing.T) {

--- a/services/api/test/e2e/task_pagination_test.go
+++ b/services/api/test/e2e/task_pagination_test.go
@@ -168,18 +168,26 @@ func TestE2EListTaskPagination_CursorBased(t *testing.T) {
 		}
 	})
 
-	t.Run("page_size_zero_is_clamped_to_default", func(t *testing.T) {
-		data := listTasksPage(t, env, client, token, projID, url.Values{"page_size": {"0"}})
-		if ps, _ := data["page_size"].(float64); ps != 20 {
-			t.Errorf("expected page_size=20 when 0 requested (out-of-range clamped), got %v", ps)
-		}
+	t.Run("page_size_zero_is_rejected", func(t *testing.T) {
+		q := url.Values{"page_size": {"0"}}
+		reqURL := fmt.Sprintf("%s/api/v1/projects/%s/tasks?%s", env.base, projID, q.Encode())
+		req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+		assertErrorCode(t, resp, "BAD_REQUEST")
 	})
 
-	t.Run("page_size_over_max_is_clamped_to_default", func(t *testing.T) {
-		data := listTasksPage(t, env, client, token, projID, url.Values{"page_size": {"201"}})
-		if ps, _ := data["page_size"].(float64); ps != 20 {
-			t.Errorf("expected page_size=20 when 201 requested (over max, clamped), got %v", ps)
-		}
+	t.Run("page_size_over_max_is_rejected", func(t *testing.T) {
+		q := url.Values{"page_size": {"201"}}
+		reqURL := fmt.Sprintf("%s/api/v1/projects/%s/tasks?%s", env.base, projID, q.Encode())
+		req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+		assertErrorCode(t, resp, "BAD_REQUEST")
 	})
 
 	t.Run("invalid_cursor_returns_error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to [discussion #305](https://github.com/orgs/Paca-AI/discussions/305) (first-install feedback from @HCH-hash): fixes the deploy/env-template gaps it identified, plus two doc and code issues found while investigating the ACP-agent credential question in that thread.

### Docs: `docs/ai-agent/overview.md`, `docs/ai-agent/api-design.md`

Both predated the ACP agent feature entirely — they described a single LLM/Docker-sandboxed execution model, a since-removed "Agent Type" template concept, and REST paths/response shapes that no longer match the router (`GET /api/v1/agent-types` 404s; conversations moved from agent-scoped to project-scoped; several envelopes and query params had drifted). Rewrote both against the current router, DTOs, and service layer, including:
- The `agent_type` (`llm`/`acp`) split and where each executes
- The ACP credential model: agents authenticate via the user's own local CLI login through the [`paca-acp-bridge`](https://github.com/Paca-AI/paca/blob/master/apps/acp-bridge/README.md) daemon — never an `AGENT_API_KEY` or `llm_api_key`
- The skill-templates replacement for the old built-in agent types

### Deploy: `deploy/.env.production.example`, `deploy/README.md`

- `PACA_*_IMAGE` defaults were missing the `pacaai/` registry prefix the compose file actually falls back to (bare `paca-api:latest` etc. don't resolve)
- Added `INTERNAL_API_KEY`, `AGENT_API_KEY`, `SITE_ADDRESS`, and `PACA_AI_AGENT_IMAGE`, none of which were in the template despite being referenced by `docker-compose.prod.yml` and the README's own manual-setup instructions
- Documented that `INTERNAL_API_KEY` is unconditionally required by the `api` service at startup — including with `--scale ai-agent=0` — which the README previously implied was conditional on using the AI agent
- Surfaced `PACA_YES=1`, the install script's existing non-interactive/CI mode, which wasn't mentioned anywhere in `deploy/README.md`

### API: pagination + encryption-key visibility

- `task`, `conversation`, `project`, and `user` list handlers silently substituted a default `page_size` for any out-of-range or non-numeric value instead of erroring. A caller driving pagination off the size it requested (e.g. computing the next offset as `N * page_size`) would get a smaller page back with no signal — skipping or duplicating rows against its own math. An absent `page_size` still defaults silently as before; an explicitly supplied invalid value now returns `400` via a new shared `parsePageSize` helper.
- Logs a warning when `ENCRYPTION_KEY` is unset. Previously fully silent: `encryptKey()` falls back to storing the plaintext unchanged, so LLM-type agent API keys and plugin secrets would end up in the database unencrypted with nothing in the logs to explain why. Left as a warning, not a hard failure — ACP-only deployments with no plugins storing secrets have no use for it.
- `AGENT_API_KEY` and `INTERNAL_API_KEY` were also investigated as fail-fast candidates: `INTERNAL_API_KEY` is already a hard `requireEnv` failure at startup, and `AGENT_API_KEY` is correctly optional by design, so neither needed a code change — just the env-template fix above.

## Test plan

- [x] `go build ./...` and `go test ./...` pass in `services/api`
- [x] `gofmt -l` clean on touched Go files
- [ ] Manual: run `install.sh` with `PACA_YES=1` end-to-end against the updated `.env.production.example` guidance
