### PR TITLE
fix: compute conversation iteration count live from events instead of a stale stored column

### DIFF
--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -576,8 +576,16 @@ func (r *AgentRepository) DeleteEnvVar(ctx context.Context, id uuid.UUID) error 
 // Conversations
 // -------------------------------------------------------------------------
 
+// iteration_count is computed live from agent_conversation_events rather
+// than stored: one ActionEvent == one agent reasoning step/action, and
+// counting them here means the "N iterations" pill can never drift out of
+// sync the way a separately-incremented counter did (see migration
+// 000026_drop_conversation_iteration_count.sql).
 const conversationCols = `id, agent_id, project_id, trigger_type, task_id, comment_id, chat_session_id,
-	triggered_by_member_id, status, container_id, host_port, iteration_count, error_message,
+	triggered_by_member_id, status, container_id, host_port,
+	(SELECT COUNT(*) FROM agent_conversation_events e
+	 WHERE e.conversation_id = agent_conversations.id AND e.event_type = 'ActionEvent') AS iteration_count,
+	error_message,
 	repo_plugin_id, repo_clone_url, branch_name, pr_url, persistence_dir,
 	started_at, finished_at, created_at, updated_at`
 
@@ -676,12 +684,12 @@ func (r *AgentRepository) CreateConversation(ctx context.Context, c *agentdom.Ag
 	rec := conversationToRecord(c)
 	_, err := r.db.ExecContext(ctx, `
 		INSERT INTO agent_conversations (id, agent_id, project_id, trigger_type, task_id, comment_id, chat_session_id,
-		  triggered_by_member_id, status, container_id, host_port, iteration_count, error_message,
+		  triggered_by_member_id, status, container_id, host_port, error_message,
 		  repo_plugin_id, repo_clone_url, branch_name, pr_url, persistence_dir,
 		  started_at, finished_at, created_at, updated_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)`,
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)`,
 		rec.ID, rec.AgentID, rec.ProjectID, rec.TriggerType, rec.TaskID, rec.CommentID, rec.ChatSessionID,
-		rec.TriggeredByMemberID, rec.Status, rec.ContainerID, rec.HostPort, rec.IterationCount, rec.ErrorMessage,
+		rec.TriggeredByMemberID, rec.Status, rec.ContainerID, rec.HostPort, rec.ErrorMessage,
 		rec.RepoPluginID, rec.RepoCloneURL, rec.BranchName, rec.PRUrl, rec.PersistenceDir,
 		rec.StartedAt, rec.FinishedAt, rec.CreatedAt, rec.UpdatedAt,
 	)
@@ -717,12 +725,12 @@ func (r *AgentRepository) UpdateConversation(ctx context.Context, c *agentdom.Ag
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE agent_conversations SET
 		  agent_id=$1, project_id=$2, trigger_type=$3, task_id=$4, comment_id=$5, chat_session_id=$6,
-		  triggered_by_member_id=$7, status=$8, container_id=$9, host_port=$10, iteration_count=$11,
-		  error_message=$12, repo_plugin_id=$13, repo_clone_url=$14, branch_name=$15, pr_url=$16,
-		  persistence_dir=$17, started_at=$18, finished_at=$19, updated_at=$20
-		WHERE id=$21`,
+		  triggered_by_member_id=$7, status=$8, container_id=$9, host_port=$10,
+		  error_message=$11, repo_plugin_id=$12, repo_clone_url=$13, branch_name=$14, pr_url=$15,
+		  persistence_dir=$16, started_at=$17, finished_at=$18, updated_at=$19
+		WHERE id=$20`,
 		rec.AgentID, rec.ProjectID, rec.TriggerType, rec.TaskID, rec.CommentID, rec.ChatSessionID,
-		rec.TriggeredByMemberID, rec.Status, rec.ContainerID, rec.HostPort, rec.IterationCount,
+		rec.TriggeredByMemberID, rec.Status, rec.ContainerID, rec.HostPort,
 		rec.ErrorMessage, rec.RepoPluginID, rec.RepoCloneURL, rec.BranchName, rec.PRUrl,
 		rec.PersistenceDir, rec.StartedAt, rec.FinishedAt, rec.UpdatedAt, rec.ID,
 	)
@@ -1065,7 +1073,6 @@ func conversationToRecord(c *agentdom.AgentConversation) agentConversationRecord
 		Status:         c.Status,
 		ContainerID:    c.ContainerID,
 		HostPort:       c.HostPort,
-		IterationCount: c.IterationCount,
 		ErrorMessage:   c.ErrorMessage,
 		RepoCloneURL:   c.RepoCloneURL,
 		BranchName:     c.BranchName,

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -91,7 +91,7 @@ type agentConversationRecord struct {
 	Status              string     `db:"status"`
 	ContainerID         *string    `db:"container_id"`
 	HostPort            *int       `db:"host_port"`
-	IterationCount      int        `db:"iteration_count"`
+	IterationCount      int64      `db:"iteration_count"`
 	ErrorMessage        *string    `db:"error_message"`
 	RepoPluginID        *string    `db:"repo_plugin_id"`
 	RepoCloneURL        *string    `db:"repo_clone_url"`
@@ -576,11 +576,9 @@ func (r *AgentRepository) DeleteEnvVar(ctx context.Context, id uuid.UUID) error 
 // Conversations
 // -------------------------------------------------------------------------
 
-// iteration_count is computed live from agent_conversation_events rather
-// than stored: one ActionEvent == one agent reasoning step/action, and
-// counting them here means the "N iterations" pill can never drift out of
-// sync the way a separately-incremented counter did (see migration
-// 000026_drop_conversation_iteration_count.sql).
+// iteration_count is computed live from agent_conversation_events (one
+// ActionEvent per agent step) rather than stored: see #314 and migration
+// 000026_drop_conversation_iteration_count.sql for why.
 const conversationCols = `id, agent_id, project_id, trigger_type, task_id, comment_id, chat_session_id,
 	triggered_by_member_id, status, container_id, host_port,
 	(SELECT COUNT(*) FROM agent_conversation_events e
@@ -1030,7 +1028,7 @@ func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversa
 		Status:         rec.Status,
 		ContainerID:    rec.ContainerID,
 		HostPort:       rec.HostPort,
-		IterationCount: rec.IterationCount,
+		IterationCount: int(rec.IterationCount),
 		ErrorMessage:   rec.ErrorMessage,
 		RepoCloneURL:   rec.RepoCloneURL,
 		BranchName:     rec.BranchName,

--- a/services/api/migrations/000026_drop_conversation_iteration_count.sql
+++ b/services/api/migrations/000026_drop_conversation_iteration_count.sql
@@ -1,0 +1,8 @@
+-- iteration_count was a stored counter that nothing on any runtime path ever
+-- incremented (the only writer, AgentRepository.UpdateConversation, is only
+-- called from tests), so it stayed at its default 0 forever and the "N
+-- iterations" pill never reflected reality. Rather than wire up a new writer
+-- that could drift out of sync again, the API now computes the count live
+-- from agent_conversation_events (see agent_repository.go's conversationCols),
+-- so the stored column is no longer needed.
+ALTER TABLE agent_conversations DROP COLUMN IF EXISTS iteration_count;

--- a/services/api/test/e2e/conversation_pagination_test.go
+++ b/services/api/test/e2e/conversation_pagination_test.go
@@ -433,3 +433,71 @@ func TestE2EListConversationPagination_EmptyProject(t *testing.T) {
 		t.Error("expected no next_cursor for an empty result set")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestE2EConversationIterationCount
+// ---------------------------------------------------------------------------
+
+// createConversationEvent inserts a conversation event directly via the
+// repository, mirroring how the ai-agent service persists SDK events.
+func createConversationEvent(t *testing.T, env *e2eEnv, convID string, index int, eventType string) {
+	t.Helper()
+	e := &agentdom.AgentConversationEvent{
+		ID:             uuid.New(),
+		ConversationID: uuid.MustParse(convID),
+		EventIndex:     index,
+		EventType:      eventType,
+		EventSource:    "agent",
+		Payload:        map[string]any{},
+	}
+	if err := env.agentRepo.CreateConversationEvent(env.ctx, e); err != nil {
+		t.Fatalf("create conversation event: %v", err)
+	}
+}
+
+// Regression coverage for https://github.com/Paca-AI/paca/issues/314: the
+// "N iterations" pill rendered agent_conversations.iteration_count, a
+// column no runtime path ever wrote (only AgentRepository.UpdateConversation
+// did, and that's only called from tests), so it stayed at its default 0
+// forever. The fix computes the count live from persisted ActionEvent rows
+// instead of trusting a stored counter — this test seeds events directly,
+// the same way the ai-agent service would, and asserts both the list and
+// single-conversation endpoints reflect the real count.
+func TestE2EConversationIterationCount(t *testing.T) {
+	env := newE2EEnv(t)
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+
+	convID := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Now())
+	createConversationEvent(t, env, convID, 0, "SystemPromptEvent")
+	createConversationEvent(t, env, convID, 1, "ActionEvent")
+	createConversationEvent(t, env, convID, 2, "ObservationEvent")
+	createConversationEvent(t, env, convID, 3, "ActionEvent")
+	createConversationEvent(t, env, convID, 4, "ActionEvent")
+
+	t.Run("list_endpoint_reflects_action_event_count", func(t *testing.T) {
+		data := listConversationsPage(t, env, client, token, projID, nil)
+		items, _ := data["items"].([]any)
+		if len(items) != 1 {
+			t.Fatalf("expected 1 conversation, got %d", len(items))
+		}
+		item, _ := items[0].(map[string]any)
+		if got := item["iteration_count"]; got != float64(3) {
+			t.Errorf("expected iteration_count=3, got %v", got)
+		}
+	})
+
+	t.Run("get_endpoint_reflects_action_event_count", func(t *testing.T) {
+		reqURL := fmt.Sprintf("%s/api/v1/projects/%s/conversations/%s", env.base, projID, convID)
+		req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+		var envResp envelope
+		decodeJSON(t, resp, &envResp)
+		data := assertDataMap(t, envResp)
+		if got := data["iteration_count"]; got != float64(3) {
+			t.Errorf("expected iteration_count=3, got %v", got)
+		}
+	})
+}

--- a/services/api/test/e2e/conversation_pagination_test.go
+++ b/services/api/test/e2e/conversation_pagination_test.go
@@ -455,14 +455,11 @@ func createConversationEvent(t *testing.T, env *e2eEnv, convID string, index int
 	}
 }
 
-// Regression coverage for https://github.com/Paca-AI/paca/issues/314: the
-// "N iterations" pill rendered agent_conversations.iteration_count, a
-// column no runtime path ever wrote (only AgentRepository.UpdateConversation
-// did, and that's only called from tests), so it stayed at its default 0
-// forever. The fix computes the count live from persisted ActionEvent rows
-// instead of trusting a stored counter — this test seeds events directly,
-// the same way the ai-agent service would, and asserts both the list and
-// single-conversation endpoints reflect the real count.
+// Regression coverage for https://github.com/Paca-AI/paca/issues/314 — see
+// conversationCols in agent_repository.go for the fix. Asserts the list and
+// single-conversation endpoints, plus the two other conversationCols call
+// sites, all reflect the live ActionEvent count rather than a stale stored
+// counter.
 func TestE2EConversationIterationCount(t *testing.T) {
 	env := newE2EEnv(t)
 	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
@@ -498,6 +495,67 @@ func TestE2EConversationIterationCount(t *testing.T) {
 		data := assertDataMap(t, envResp)
 		if got := data["iteration_count"]; got != float64(3) {
 			t.Errorf("expected iteration_count=3, got %v", got)
+		}
+	})
+
+	// FindLatestConversationByChatSession has no lightweight read-only HTTP
+	// endpoint of its own (it backs SendChatMessage's resume path, which
+	// needs a running conversation to resume), so it's checked directly
+	// against the repository instead — it shares conversationCols with the
+	// two HTTP-backed cases above, but exercises the WHERE chat_session_id
+	// = ... path rather than WHERE id = ... .
+	t.Run("find_latest_by_chat_session_reflects_action_event_count", func(t *testing.T) {
+		session := &agentdom.AgentChatSession{
+			ID:        uuid.New(),
+			AgentID:   agentID,
+			ProjectID: uuid.MustParse(projID),
+			MemberID:  memberID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		if err := env.agentRepo.CreateChatSession(env.ctx, session); err != nil {
+			t.Fatalf("create chat session: %v", err)
+		}
+
+		conv := &agentdom.AgentConversation{
+			ID:            uuid.New(),
+			AgentID:       agentID,
+			ProjectID:     uuid.MustParse(projID),
+			TriggerType:   "chat_message",
+			ChatSessionID: &session.ID,
+			Status:        "paused",
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		if err := env.agentRepo.CreateConversation(env.ctx, conv); err != nil {
+			t.Fatalf("create conversation: %v", err)
+		}
+		createConversationEvent(t, env, conv.ID.String(), 0, "ActionEvent")
+		createConversationEvent(t, env, conv.ID.String(), 1, "ObservationEvent")
+		createConversationEvent(t, env, conv.ID.String(), 2, "ActionEvent")
+
+		got, err := env.agentRepo.FindLatestConversationByChatSession(env.ctx, session.ID)
+		if err != nil {
+			t.Fatalf("find latest by chat session: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a conversation, got nil")
+		}
+		if got.IterationCount != 2 {
+			t.Errorf("expected iteration_count=2, got %d", got.IterationCount)
+		}
+	})
+
+	t.Run("conversation_with_no_action_events_has_zero_iteration_count", func(t *testing.T) {
+		zeroConvID := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Now())
+		createConversationEvent(t, env, zeroConvID, 0, "SystemPromptEvent")
+
+		got, err := env.agentRepo.FindConversationByID(env.ctx, uuid.MustParse(zeroConvID))
+		if err != nil {
+			t.Fatalf("find conversation: %v", err)
+		}
+		if got.IterationCount != 0 {
+			t.Errorf("expected iteration_count=0, got %d", got.IterationCount)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #314 — the "N iterations" pill on conversation rows always showed 0.

**Root cause:** `agent_conversations.iteration_count` was a stored counter that no runtime path ever incremented. The only writer of the full row, `AgentRepository.UpdateConversation`, is called exclusively from tests — the real runtime paths (executor, ACP dispatch, bridge, realtime) all go through `UpdateConversationStatus`, which never touches `iteration_count`. So the column stayed at its default `0` forever, regardless of how many steps a conversation actually took.

**Fix:** instead of wiring up a new writer in the ai-agent service (which risks drifting out of sync again, and needs a backfill for historical conversations), the count is now computed live in the API layer from data that's already authoritative: `agent_conversation_events`. One persisted `ActionEvent` corresponds to one agent reasoning step/action, so `iteration_count` is a correlated `COUNT(*)` subquery over that table, scoped to `event_type = 'ActionEvent'`.

## Changes

- **`services/api/migrations/000026_drop_conversation_iteration_count.sql`** — drops the now-unused stored column.
- **`services/api/internal/repository/postgres/agent_repository.go`** — `conversationCols` (used by `ListConversations`, `FindConversationByID`, `FindLatestConversationByChatSession`) computes `iteration_count` via a correlated subquery instead of reading the stored column; `CreateConversation`/`UpdateConversation` no longer write to it.
- **`services/api/test/e2e/conversation_pagination_test.go`** — adds `TestE2EConversationIterationCount`, seeding a mix of event types and asserting both the list and single-conversation endpoints return the correct `ActionEvent` count.

## Why compute-on-read instead of increment-on-write

A stored counter needs a writer, and that writer needs to run on every event-persistence path (in-process SDK executor *and* the ACP bridge daemon) to stay correct — which is exactly the kind of drift that caused this bug in the first place. Computing it from `agent_conversation_events` at read time means there's a single source of truth, no new write path to keep in sync, and no backfill migration needed for conversations that already ran.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all Go unit tests)
- [x] `PACA_E2E=1 go test ./test/e2e/...` passes against real Postgres/Redis/MinIO via testcontainers, including the new `TestE2EConversationIterationCount` (seeds `SystemPromptEvent`/`ActionEvent`/`ObservationEvent` rows and confirms `iteration_count` reflects only the `ActionEvent` count, on both the list and get-by-id endpoints)
- [x] `python -m pytest` passes in `services/ai-agent` (untouched — no changes needed there)
