### PR TITLE
fix: gate BranchPicker and edit pencil on runtime capabilities

### DIFF
--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -537,16 +537,24 @@ const UserActionBar: FC = () => {
 			autohide="not-last"
 			className="aui-user-action-bar-root flex flex-col items-end"
 		>
-			<ActionBarPrimitive.Edit
-				render={
-					<TooltipIconButton
-						tooltip={t("agents.thread.edit")}
-						className="aui-user-action-edit"
-					/>
-				}
-			>
-				<PencilIcon />
-			</ActionBarPrimitive.Edit>
+			{/* assistant-ui's edit button doesn't check the runtime's `edit`
+			 * capability on its own — it renders whenever a message isn't
+			 * already being edited. Our runtimes never wire up `onEdit`
+			 * (see conversation-view.tsx / ai-chat-float.tsx), so without this
+			 * gate the pencil shows up on every message and throws
+			 * "Runtime does not support editing messages" when clicked. */}
+			<AuiIf condition={(s) => s.thread.capabilities.edit}>
+				<ActionBarPrimitive.Edit
+					render={
+						<TooltipIconButton
+							tooltip={t("agents.thread.edit")}
+							className="aui-user-action-edit"
+						/>
+					}
+				>
+					<PencilIcon />
+				</ActionBarPrimitive.Edit>
+			</AuiIf>
 		</ActionBarPrimitive.Root>
 	);
 };
@@ -592,27 +600,35 @@ const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({
 }) => {
 	const { t } = useTranslation("projects");
 	return (
-		<BranchPickerPrimitive.Root
-			hideWhenSingleBranch
-			className={cn(
-				"aui-branch-picker-root text-muted-foreground -ms-2 me-2 inline-flex items-center text-xs",
-				className,
-			)}
-			{...rest}
-		>
-			<BranchPickerPrimitive.Previous
-				render={<TooltipIconButton tooltip={t("agents.thread.previous")} />}
+		// `hideWhenSingleBranch` only hides per-message when a message
+		// happens to have one branch; it doesn't know the runtime can't
+		// switch branches at all. Our runtimes never wire up `setMessages`
+		// (see conversation-view.tsx / ai-chat-float.tsx), so gate on the
+		// capability too — otherwise Previous/Next render and throw "Runtime
+		// does not support switching branches" when clicked.
+		<AuiIf condition={(s) => s.thread.capabilities.switchToBranch}>
+			<BranchPickerPrimitive.Root
+				hideWhenSingleBranch
+				className={cn(
+					"aui-branch-picker-root text-muted-foreground -ms-2 me-2 inline-flex items-center text-xs",
+					className,
+				)}
+				{...rest}
 			>
-				<ChevronLeftIcon />
-			</BranchPickerPrimitive.Previous>
-			<span className="aui-branch-picker-state font-medium">
-				<BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
-			</span>
-			<BranchPickerPrimitive.Next
-				render={<TooltipIconButton tooltip={t("agents.thread.next")} />}
-			>
-				<ChevronRightIcon />
-			</BranchPickerPrimitive.Next>
-		</BranchPickerPrimitive.Root>
+				<BranchPickerPrimitive.Previous
+					render={<TooltipIconButton tooltip={t("agents.thread.previous")} />}
+				>
+					<ChevronLeftIcon />
+				</BranchPickerPrimitive.Previous>
+				<span className="aui-branch-picker-state font-medium">
+					<BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
+				</span>
+				<BranchPickerPrimitive.Next
+					render={<TooltipIconButton tooltip={t("agents.thread.next")} />}
+				>
+					<ChevronRightIcon />
+				</BranchPickerPrimitive.Next>
+			</BranchPickerPrimitive.Root>
+		</AuiIf>
 	);
 };


### PR DESCRIPTION
## Summary
- The `BranchPicker` and the user message's edit pencil in `thread.tsx` rendered unconditionally, regardless of whether the runtime actually supports switching branches or editing — assistant-ui's underlying hooks only check local UI state, not `thread.capabilities`.
- Neither `conversation-view.tsx` nor `ai-chat-float.tsx` wire up `onEdit`/`setMessages` on `useExternalStoreRuntime`, so those capabilities are always `false` there — yet the controls showed up anyway on every message, and clicking them would throw a runtime error ("Runtime does not support switching branches" / "...editing messages").
- Wrapped both in `<AuiIf condition={(s) => s.thread.capabilities.switchToBranch}>` and `<AuiIf condition={(s) => s.thread.capabilities.edit}>` so they only render when a runtime genuinely supports them.

Fixes #313

## Test plan
- [x] `npx vitest run` in `apps/web` — 315 tests passing
- [x] `npx tsc -b` — no type errors
- [x] Verified via a runtime harness that `capabilities.edit` and `capabilities.switchToBranch` are `false` for the exact `useExternalStoreRuntime` config used in `conversation-view.tsx` / `ai-chat-float.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)