### PR TITLE
fix: include .env.production.example in release assets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,7 @@ name: cd
 #     upgrade.sh         — upgrades an existing installation in place
 #     docker-compose.yml — standalone compose (no source tree required)
 #     Caddyfile          — Caddy gateway configuration
+#     .env.production.example — environment variable template
 
 on:
   release:
@@ -448,6 +449,7 @@ jobs:
           # Rename files to the names end-users will download.
           cp deploy/docker-compose.prod.yml        docker-compose.yml
           cp deploy/caddy/Caddyfile                Caddyfile
+          cp deploy/.env.production.example        .env.production.example
           cp scripts/install.sh                    install.sh
           cp scripts/upgrade.sh                    upgrade.sh
           chmod +x install.sh upgrade.sh
@@ -461,4 +463,5 @@ jobs:
             upgrade.sh \
             docker-compose.yml \
             Caddyfile \
+            .env.production.example \
             --clobber


### PR DESCRIPTION
Fixes #330

The `release-assets` CI job uploads `docker-compose.yml` and `Caddyfile` to GitHub Releases but omits `deploy/.env.production.example`, causing the `curl` command in the quick-start docs to return 404.

Changes:
- Copy `deploy/.env.production.example` to the staging area in the "Prepare assets" step
- Add it to the `gh release upload` call
- Document it in the header comment