### PR TITLE
feat: implement diff handling for tool calls and enhance error detail…

### DIFF
--- a/apps/web/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/web/src/components/assistant-ui/tool-fallback.tsx
@@ -19,14 +19,17 @@ import {
 } from "lucide-react";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { DiffLineRow } from "@/components/shared/content-diff";
+import {
+	DiffCollapsedRow,
+	DiffLineRow,
+} from "@/components/shared/content-diff";
 import { Button } from "@/components/ui/button";
 import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { computeLineDiff } from "@/lib/diff-utils";
+import { collapseUnchangedContext, computeLineDiff } from "@/lib/diff-utils";
 import { cn } from "@/lib/utils";
 
 const ANIMATION_DURATION = 200;
@@ -269,6 +272,15 @@ interface ToolFallbackDiffBlock {
 	newText: string;
 }
 
+// computeLineDiff is O(oldLines * newLines) time and space (a full DP
+// matrix) — fine for the small BlockNote documents content-diff.tsx was
+// originally written for, but file_editor/ACP diffs can carry a full
+// multi-thousand-line file as old/new text. Skip the computation above this
+// threshold rather than risk freezing the tab or spiking memory on a large
+// file edit; capping the inputs also bounds the number of rendered rows,
+// since diff output length can't exceed oldLines.length + newLines.length.
+const MAX_DIFF_LINES_PER_SIDE = 2000;
+
 // `artifact` is assistant-ui's generic "UI-only" side channel on a tool-call
 // part (not part of the model-visible args/result) — untyped at the library
 // level, so the shape produced by conversation-to-thread-messages.ts for ACP
@@ -293,15 +305,24 @@ function getToolDiffs(artifact: unknown): ToolFallbackDiffBlock[] | undefined {
 
 function ToolFallbackDiffBlockView({ diff }: { diff: ToolFallbackDiffBlock }) {
 	const { t } = useTranslation("shared");
-	const lines = useMemo(
-		() =>
-			computeLineDiff(
-				(diff.oldText ?? "").split("\n"),
-				diff.newText.split("\n"),
-			),
-		[diff.oldText, diff.newText],
+	const oldLines = useMemo(
+		() => (diff.oldText ?? "").split("\n"),
+		[diff.oldText],
 	);
-	const hasChanges = lines.some((line) => line.type !== "unchanged");
+	const newLines = useMemo(() => diff.newText.split("\n"), [diff.newText]);
+	const isTooLarge =
+		oldLines.length > MAX_DIFF_LINES_PER_SIDE ||
+		newLines.length > MAX_DIFF_LINES_PER_SIDE;
+	const lines = useMemo(
+		() => (isTooLarge ? [] : computeLineDiff(oldLines, newLines)),
+		[isTooLarge, oldLines, newLines],
+	);
+	const hasChanges =
+		!isTooLarge && lines.some((line) => line.type !== "unchanged");
+	// Collapse long unchanged runs down to a few lines of context around each
+	// change, the way `git diff` hunks do — a single-line edit to a large
+	// file should not render every unchanged line around it.
+	const rows = useMemo(() => collapseUnchangedContext(lines), [lines]);
 
 	return (
 		<div className="aui-tool-fallback-diff-block flex flex-col gap-1">
@@ -310,12 +331,23 @@ function ToolFallbackDiffBlockView({ diff }: { diff: ToolFallbackDiffBlock }) {
 					{diff.path}
 				</p>
 			)}
-			{hasChanges ? (
+			{isTooLarge ? (
+				<p className="text-muted-foreground/40 text-xs italic">
+					{t("contentDiff.diffTooLarge", {
+						lines: Math.max(oldLines.length, newLines.length),
+					})}
+				</p>
+			) : hasChanges ? (
 				<div className="rounded-md border border-border/30 overflow-hidden bg-muted/5">
-					{lines.map((line, idx) => (
-						// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
-						<DiffLineRow key={idx} line={line} />
-					))}
+					{rows.map((row, idx) =>
+						row.type === "collapsed" ? (
+							// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
+							<DiffCollapsedRow key={idx} count={row.count} />
+						) : (
+							// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
+							<DiffLineRow key={idx} line={row} />
+						),
+					)}
 				</div>
 			) : (
 				<p className="text-muted-foreground/40 text-xs italic">
@@ -342,7 +374,8 @@ function ToolFallbackDiffs({
 			{...props}
 		>
 			{diffs.map((diff, idx) => (
-				<ToolFallbackDiffBlockView key={diff.path ?? idx} diff={diff} />
+				// biome-ignore lint/suspicious/noArrayIndexKey: diff order is stable per render; path alone isn't guaranteed unique/present
+				<ToolFallbackDiffBlockView key={idx} diff={diff} />
 			))}
 		</div>
 	);

--- a/apps/web/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/web/src/components/assistant-ui/tool-fallback.tsx
@@ -17,14 +17,16 @@ import {
 	LoaderIcon,
 	XCircleIcon,
 } from "lucide-react";
-import { memo, useCallback, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { DiffLineRow } from "@/components/shared/content-diff";
 import { Button } from "@/components/ui/button";
 import {
 	Collapsible,
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { computeLineDiff } from "@/lib/diff-utils";
 import { cn } from "@/lib/utils";
 
 const ANIMATION_DURATION = 200;
@@ -257,6 +259,91 @@ function ToolFallbackArgs({
 			<pre className="aui-tool-fallback-args-value bg-muted/50 text-foreground/90 rounded-md p-2.5 text-xs whitespace-pre-wrap">
 				{argsText}
 			</pre>
+		</div>
+	);
+}
+
+interface ToolFallbackDiffBlock {
+	path?: string;
+	oldText: string | null;
+	newText: string;
+}
+
+// `artifact` is assistant-ui's generic "UI-only" side channel on a tool-call
+// part (not part of the model-visible args/result) — untyped at the library
+// level, so the shape produced by conversation-to-thread-messages.ts for ACP
+// edit/write tool calls has to be verified at runtime rather than assumed.
+function getToolDiffs(artifact: unknown): ToolFallbackDiffBlock[] | undefined {
+	if (typeof artifact !== "object" || artifact === null) return undefined;
+	const diffs = (artifact as { diffs?: unknown }).diffs;
+	if (!Array.isArray(diffs)) return undefined;
+	const result: ToolFallbackDiffBlock[] = [];
+	for (const d of diffs) {
+		if (typeof d !== "object" || d === null) continue;
+		const { path, oldText, newText } = d as Record<string, unknown>;
+		if (typeof newText !== "string") continue;
+		result.push({
+			path: typeof path === "string" ? path : undefined,
+			oldText: typeof oldText === "string" ? oldText : null,
+			newText,
+		});
+	}
+	return result.length > 0 ? result : undefined;
+}
+
+function ToolFallbackDiffBlockView({ diff }: { diff: ToolFallbackDiffBlock }) {
+	const { t } = useTranslation("shared");
+	const lines = useMemo(
+		() =>
+			computeLineDiff(
+				(diff.oldText ?? "").split("\n"),
+				diff.newText.split("\n"),
+			),
+		[diff.oldText, diff.newText],
+	);
+	const hasChanges = lines.some((line) => line.type !== "unchanged");
+
+	return (
+		<div className="aui-tool-fallback-diff-block flex flex-col gap-1">
+			{diff.path && (
+				<p className="aui-tool-fallback-diff-path text-muted-foreground/70 font-mono text-[11px]">
+					{diff.path}
+				</p>
+			)}
+			{hasChanges ? (
+				<div className="rounded-md border border-border/30 overflow-hidden bg-muted/5">
+					{lines.map((line, idx) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
+						<DiffLineRow key={idx} line={line} />
+					))}
+				</div>
+			) : (
+				<p className="text-muted-foreground/40 text-xs italic">
+					{t("contentDiff.noDifferences")}
+				</p>
+			)}
+		</div>
+	);
+}
+
+function ToolFallbackDiffs({
+	diffs,
+	className,
+	...props
+}: React.ComponentProps<"div"> & {
+	diffs: ToolFallbackDiffBlock[];
+}) {
+	if (diffs.length === 0) return null;
+
+	return (
+		<div
+			data-slot="tool-fallback-diffs"
+			className={cn("aui-tool-fallback-diffs flex flex-col gap-3", className)}
+			{...props}
+		>
+			{diffs.map((diff, idx) => (
+				<ToolFallbackDiffBlockView key={diff.path ?? idx} diff={diff} />
+			))}
 		</div>
 	);
 }
@@ -576,6 +663,7 @@ function ToolFallbackApproval({
 const ToolFallbackImpl: ToolCallMessagePartComponent = ({
 	toolName,
 	argsText,
+	artifact,
 	result,
 	isError,
 	status,
@@ -588,6 +676,7 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
 	const isCancelled =
 		status?.type === "incomplete" && status.reason === "cancelled";
 	const isRequiresAction = status?.type === "requires-action";
+	const diffs = getToolDiffs(artifact);
 
 	const [open, setOpen] = useState(isRequiresAction);
 	const [prevRequiresAction, setPrevRequiresAction] =
@@ -606,10 +695,17 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
 			/>
 			<ToolFallbackContent>
 				<ToolFallbackError status={status} />
-				<ToolFallbackArgs
-					argsText={argsText}
-					className={cn(isCancelled && "opacity-60")}
-				/>
+				{diffs ? (
+					<ToolFallbackDiffs
+						diffs={diffs}
+						className={cn(isCancelled && "opacity-60")}
+					/>
+				) : (
+					<ToolFallbackArgs
+						argsText={argsText}
+						className={cn(isCancelled && "opacity-60")}
+					/>
+				)}
 				{isRequiresAction && (
 					<ToolFallbackApproval
 						addResult={addResult}
@@ -634,6 +730,7 @@ const ToolFallback = memo(
 	Trigger: typeof ToolFallbackTrigger;
 	Content: typeof ToolFallbackContent;
 	Args: typeof ToolFallbackArgs;
+	Diffs: typeof ToolFallbackDiffs;
 	Result: typeof ToolFallbackResult;
 	Error: typeof ToolFallbackError;
 	Approval: typeof ToolFallbackApproval;
@@ -644,6 +741,7 @@ ToolFallback.Root = ToolFallbackRoot;
 ToolFallback.Trigger = ToolFallbackTrigger;
 ToolFallback.Content = ToolFallbackContent;
 ToolFallback.Args = ToolFallbackArgs;
+ToolFallback.Diffs = ToolFallbackDiffs;
 ToolFallback.Result = ToolFallbackResult;
 ToolFallback.Error = ToolFallbackError;
 ToolFallback.Approval = ToolFallbackApproval;
@@ -653,6 +751,7 @@ export {
 	ToolFallbackApproval,
 	ToolFallbackArgs,
 	ToolFallbackContent,
+	ToolFallbackDiffs,
 	ToolFallbackError,
 	ToolFallbackResult,
 	ToolFallbackRoot,

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
@@ -70,6 +70,39 @@ function observationEvent(opts: {
 	};
 }
 
+function fileEditorObservationEvent(opts: {
+	toolCallId: string;
+	path: string;
+	command: string;
+	oldContent?: string | null;
+	newContent?: string | null;
+	prevExist?: boolean;
+	isError?: boolean;
+}): AgentConversationEvent {
+	return {
+		id: `evt-${nextIndex}`,
+		conversation_id: "conv-1",
+		event_index: nextIndex++,
+		event_type: "ObservationEvent",
+		event_source: "agent",
+		payload: {
+			tool_call_id: opts.toolCallId,
+			tool_name: "file_editor",
+			observation: {
+				kind: "FileEditorObservation",
+				command: opts.command,
+				path: opts.path,
+				prev_exist: opts.prevExist ?? true,
+				old_content: opts.oldContent ?? null,
+				new_content: opts.newContent ?? null,
+				is_error: opts.isError ?? false,
+				content: "edited",
+			},
+		},
+		created_at: "2026-01-01T00:00:03.000Z",
+	};
+}
+
 function agentErrorEvent(opts: {
 	toolCallId: string;
 	toolName: string;
@@ -156,6 +189,7 @@ function acpToolCallEvent(opts: {
 	status?: string;
 	rawInput?: unknown;
 	rawOutput?: unknown;
+	content?: unknown;
 	isError?: boolean;
 }): AgentConversationEvent {
 	return {
@@ -170,7 +204,7 @@ function acpToolCallEvent(opts: {
 			status: opts.status ?? null,
 			raw_input: opts.rawInput ?? null,
 			raw_output: opts.rawOutput ?? null,
-			content: null,
+			content: opts.content ?? null,
 			is_error: opts.isError ?? false,
 		},
 		created_at: "2026-01-01T00:00:06.000Z",
@@ -505,5 +539,236 @@ describe("eventsToThreadMessages", () => {
 			result: "No such file or directory",
 			isError: true,
 		});
+	});
+
+	it("extracts a patch-edit diff block into the tool-call's artifact", () => {
+		const events = [
+			acpToolCallEvent({
+				toolCallId: "acp-edit-1",
+				title: "Edit: src/foo.ts",
+				status: "completed",
+				content: [
+					{
+						type: "diff",
+						path: "src/foo.ts",
+						old_text: "const a = 1;",
+						new_text: "const a = 2;",
+					},
+				],
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "acp-edit-1",
+			artifact: {
+				diffs: [
+					{
+						path: "src/foo.ts",
+						oldText: "const a = 1;",
+						newText: "const a = 2;",
+					},
+				],
+			},
+		});
+	});
+
+	it("extracts a full-file write diff block with a null oldText", () => {
+		const events = [
+			acpToolCallEvent({
+				toolCallId: "acp-write-1",
+				title: "Write: src/new-file.ts",
+				status: "completed",
+				content: [
+					{
+						type: "diff",
+						path: "src/new-file.ts",
+						old_text: null,
+						new_text: "export const x = 1;",
+					},
+				],
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "acp-write-1",
+			artifact: {
+				diffs: [
+					{
+						path: "src/new-file.ts",
+						oldText: null,
+						newText: "export const x = 1;",
+					},
+				],
+			},
+		});
+	});
+
+	it("keeps a diff captured on an earlier update when a later update carries no content", () => {
+		const events = [
+			acpToolCallEvent({
+				toolCallId: "acp-edit-2",
+				title: "Edit: src/bar.ts",
+				status: "pending",
+				content: [
+					{
+						type: "diff",
+						path: "src/bar.ts",
+						old_text: "old",
+						new_text: "new",
+					},
+				],
+			}),
+			acpToolCallEvent({
+				toolCallId: "acp-edit-2",
+				title: "Edit: src/bar.ts",
+				status: "completed",
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "acp-edit-2",
+			artifact: {
+				diffs: [{ path: "src/bar.ts", oldText: "old", newText: "new" }],
+			},
+		});
+	});
+
+	it("does not attach an artifact for non-edit ACP tool calls", () => {
+		const events = [
+			acpToolCallEvent({
+				toolCallId: "acp-1",
+				title: "Bash: ls -la",
+				status: "completed",
+				rawOutput: "file1\nfile2",
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).not.toHaveProperty("artifact");
+	});
+
+	it("extracts a diff for a native file_editor str_replace call", () => {
+		const events = [
+			actionEvent({ toolCallId: "fe-1", toolName: "file_editor" }),
+			fileEditorObservationEvent({
+				toolCallId: "fe-1",
+				path: "/workspace/repo/app/models/user.py",
+				command: "str_replace",
+				oldContent: "old body",
+				newContent: "new body",
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "fe-1",
+			artifact: {
+				diffs: [
+					{
+						path: "/workspace/repo/app/models/user.py",
+						oldText: "old body",
+						newText: "new body",
+					},
+				],
+			},
+		});
+	});
+
+	it("extracts a diff with a null oldText for a native file_editor create call", () => {
+		const events = [
+			actionEvent({ toolCallId: "fe-2", toolName: "file_editor" }),
+			fileEditorObservationEvent({
+				toolCallId: "fe-2",
+				path: "/workspace/repo/app/new_file.py",
+				command: "create",
+				newContent: "file body",
+				prevExist: false,
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).toMatchObject({
+			type: "tool-call",
+			toolCallId: "fe-2",
+			artifact: {
+				diffs: [
+					{
+						path: "/workspace/repo/app/new_file.py",
+						oldText: null,
+						newText: "file body",
+					},
+				],
+			},
+		});
+	});
+
+	it("does not attach an artifact for a native file_editor view call", () => {
+		const events = [
+			actionEvent({ toolCallId: "fe-3", toolName: "file_editor" }),
+			fileEditorObservationEvent({
+				toolCallId: "fe-3",
+				path: "/workspace/repo",
+				command: "view",
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).not.toHaveProperty("artifact");
+	});
+
+	it("does not attach an artifact for a failed file_editor edit", () => {
+		const events = [
+			actionEvent({ toolCallId: "fe-4", toolName: "file_editor" }),
+			fileEditorObservationEvent({
+				toolCallId: "fe-4",
+				path: "/workspace/repo/app/models/user.py",
+				command: "str_replace",
+				oldContent: "old body",
+				newContent: "new body",
+				isError: true,
+			}),
+		];
+
+		const messages = eventsToThreadMessages(events, false);
+
+		const parts = messages[0].content as unknown as Array<
+			Record<string, unknown>
+		>;
+		expect(parts[0]).not.toHaveProperty("artifact");
 	});
 });

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
@@ -21,6 +21,84 @@ export function extractContentText(content: unknown): string | null {
 	return null;
 }
 
+export interface ToolDiffBlock {
+	path?: string;
+	oldText: string | null;
+	newText: string;
+}
+
+// ACP-spec edit tools (Claude Code / Codex / Gemini CLI) report file changes as
+// `{type: "diff", path, old_text, new_text}` content blocks rather than
+// exposing before/after text through `raw_input` directly — see
+// ACPToolCallEvent.is_patch_edit in the SDK. `old_text` is snake_case as
+// written by the backend's `model_dump(mode="json")` (no alias), but ACP's own
+// JSON wire format uses camelCase, so both are checked for robustness.
+function extractDiffBlocks(content: unknown): ToolDiffBlock[] | null {
+	if (!Array.isArray(content)) return null;
+	const diffs: ToolDiffBlock[] = [];
+	for (const block of content) {
+		if (typeof block !== "object" || block === null) continue;
+		const b = block as Record<string, unknown>;
+		if (b.type !== "diff") continue;
+		const newText =
+			typeof b.new_text === "string"
+				? b.new_text
+				: typeof b.newText === "string"
+					? b.newText
+					: null;
+		if (newText === null) continue;
+		const oldText =
+			typeof b.old_text === "string"
+				? b.old_text
+				: typeof b.oldText === "string"
+					? b.oldText
+					: null;
+		diffs.push({
+			path: typeof b.path === "string" ? b.path : undefined,
+			oldText,
+			newText,
+		});
+	}
+	return diffs.length > 0 ? diffs : null;
+}
+
+// Native OpenHands SDK `file_editor` tool (regular, non-ACP agent
+// conversations) reports edits via `old_content`/`new_content` on the
+// FileEditorObservation that follows the ActionEvent, not through a
+// diff-type content block the way ACPToolCallEvent does. Mirrors the SDK's
+// own FileEditorObservation._has_meaningful_diff so `view` calls, errors,
+// and no-op edits don't render an empty/misleading diff.
+function extractFileEditorDiff(
+	obs: Record<string, unknown> | undefined,
+): ToolDiffBlock | null {
+	if (!obs || obs.kind !== "FileEditorObservation") return null;
+	if (obs.is_error === true) return null;
+	const path = typeof obs.path === "string" ? obs.path : null;
+	if (!path) return null;
+
+	const oldContent =
+		typeof obs.old_content === "string" ? obs.old_content : null;
+	const newContent =
+		typeof obs.new_content === "string" ? obs.new_content : null;
+
+	if (obs.command === "create") {
+		if (!newContent || obs.prev_exist === true) return null;
+		return { path, oldText: null, newText: newContent };
+	}
+
+	if (
+		obs.command === "str_replace" ||
+		obs.command === "insert" ||
+		obs.command === "undo_edit"
+	) {
+		if (oldContent === null || newContent === null) return null;
+		if (oldContent === newContent) return null;
+		return { path, oldText: oldContent, newText: newContent };
+	}
+
+	return null;
+}
+
 type MutableToolCallPart = {
 	type: "tool-call";
 	toolCallId: string;
@@ -28,6 +106,9 @@ type MutableToolCallPart = {
 	argsText: string;
 	result?: unknown;
 	isError?: boolean;
+	// UI-only: lets ToolFallback render a real diff instead of the raw args
+	// JSON for ACP edit/write tool calls.
+	artifact?: { diffs: ToolDiffBlock[] };
 };
 
 type MutablePart =
@@ -209,9 +290,13 @@ export function eventsToThreadMessages(
 					? current.openToolCalls.get(toolCallId)
 					: undefined;
 
+			const fileEditorDiff =
+				p.tool_name === "file_editor" ? extractFileEditorDiff(obs) : null;
+
 			if (openPart) {
 				openPart.result = resultText;
 				if (isError) openPart.isError = true;
+				if (fileEditorDiff) openPart.artifact = { diffs: [fileEditorDiff] };
 			} else {
 				// No matching open tool-call in this turn (history gap) — append
 				// a standalone, already-complete tool-call part.
@@ -225,6 +310,7 @@ export function eventsToThreadMessages(
 					argsText: "",
 					result: resultText,
 					...(isError ? { isError: true } : {}),
+					...(fileEditorDiff ? { artifact: { diffs: [fileEditorDiff] } } : {}),
 				});
 			}
 			continue;
@@ -255,14 +341,22 @@ export function eventsToThreadMessages(
 						? JSON.stringify(rawInput, null, 2)
 						: "";
 
+			// Diff content can arrive on the initial notification (edit tools
+			// typically propose the full diff upfront) or only once the call
+			// completes, depending on provider — check on every update but
+			// never clear a diff already captured from an earlier update.
+			const diffs = extractDiffBlocks(p.content);
+
 			let part = current.openToolCalls.get(toolCallId);
 			if (!part) {
 				part = { type: "tool-call", toolCallId, toolName, argsText };
+				if (diffs) part.artifact = { diffs };
 				current.parts.push(part);
 				current.openToolCalls.set(toolCallId, part);
 			} else {
 				part.toolName = toolName;
 				if (argsText) part.argsText = argsText;
+				if (diffs) part.artifact = { diffs };
 			}
 
 			const status = typeof p.status === "string" ? p.status : null;

--- a/apps/web/src/components/shared/content-diff.tsx
+++ b/apps/web/src/components/shared/content-diff.tsx
@@ -7,12 +7,25 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { type DiffLine, diffBlockNoteContent } from "@/lib/diff-utils";
+import {
+	collapseUnchangedContext,
+	type DiffLine,
+	diffBlockNoteContent,
+} from "@/lib/diff-utils";
 import { cn } from "@/lib/utils";
 
 interface ContentDiffProps {
 	oldContent: unknown;
 	newContent: unknown;
+}
+
+export function DiffCollapsedRow({ count }: { count: number }) {
+	const { t } = useTranslation("shared");
+	return (
+		<div className="flex items-center justify-center px-3 py-1 font-mono text-[11px] text-muted-foreground/40 bg-muted/10 border-y border-border/20">
+			{t("contentDiff.collapsedLines", { count })}
+		</div>
+	);
 }
 
 export function DiffLineRow({ line }: { line: DiffLine }) {
@@ -48,8 +61,11 @@ export function ContentDiff({ oldContent, newContent }: ContentDiffProps) {
 		() => diffBlockNoteContent(oldContent, newContent),
 		[oldContent, newContent],
 	);
-
 	const hasChanges = lines.some((l) => l.type !== "unchanged");
+	// Collapse long unchanged runs down to a few lines of context around each
+	// change — a small edit to a long doc/task description shouldn't render
+	// every unchanged paragraph around it.
+	const rows = useMemo(() => collapseUnchangedContext(lines), [lines]);
 
 	if (!hasChanges) {
 		return (
@@ -62,10 +78,15 @@ export function ContentDiff({ oldContent, newContent }: ContentDiffProps) {
 
 	return (
 		<div className="rounded-lg border border-border/30 overflow-hidden bg-muted/5">
-			{lines.map((line, idx) => (
-				// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
-				<DiffLineRow key={idx} line={line} />
-			))}
+			{rows.map((row, idx) =>
+				row.type === "collapsed" ? (
+					// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
+					<DiffCollapsedRow key={idx} count={row.count} />
+				) : (
+					// biome-ignore lint/suspicious/noArrayIndexKey: stable diff output
+					<DiffLineRow key={idx} line={row} />
+				),
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/components/shared/content-diff.tsx
+++ b/apps/web/src/components/shared/content-diff.tsx
@@ -15,7 +15,7 @@ interface ContentDiffProps {
 	newContent: unknown;
 }
 
-function DiffLineRow({ line }: { line: DiffLine }) {
+export function DiffLineRow({ line }: { line: DiffLine }) {
 	const { t } = useTranslation("shared");
 	return (
 		<div

--- a/apps/web/src/i18n/locales/en/shared.json
+++ b/apps/web/src/i18n/locales/en/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(empty line)",
 		"noDifferences": "No text differences",
+		"diffTooLarge": "Diff too large to preview ({{lines}} lines)",
+		"collapsedLines": "{{count}} unchanged lines hidden",
 		"changeDiff": "Change diff",
 		"removed": "Removed",
 		"added": "Added"

--- a/apps/web/src/i18n/locales/es/shared.json
+++ b/apps/web/src/i18n/locales/es/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(línea vacía)",
 		"noDifferences": "No hay diferencias de texto",
+		"diffTooLarge": "Diferencia demasiado grande para previsualizar ({{lines}} líneas)",
+		"collapsedLines": "{{count}} líneas sin cambios ocultas",
 		"changeDiff": "Diferencias del cambio",
 		"removed": "Eliminado",
 		"added": "Añadido"

--- a/apps/web/src/i18n/locales/fr/shared.json
+++ b/apps/web/src/i18n/locales/fr/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(ligne vide)",
 		"noDifferences": "Aucune différence de texte",
+		"diffTooLarge": "Différence trop volumineuse pour un aperçu ({{lines}} lignes)",
+		"collapsedLines": "{{count}} lignes inchangées masquées",
 		"changeDiff": "Différences des modifications",
 		"removed": "Supprimé",
 		"added": "Ajouté"

--- a/apps/web/src/i18n/locales/ja/shared.json
+++ b/apps/web/src/i18n/locales/ja/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "（空行）",
 		"noDifferences": "テキストの差分はありません",
+		"diffTooLarge": "差分が大きすぎてプレビューできません（{{lines}} 行）",
+		"collapsedLines": "変更のない{{count}}行を非表示",
 		"changeDiff": "変更差分",
 		"removed": "削除",
 		"added": "追加"

--- a/apps/web/src/i18n/locales/ko/shared.json
+++ b/apps/web/src/i18n/locales/ko/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(빈 줄)",
 		"noDifferences": "텍스트 차이가 없습니다",
+		"diffTooLarge": "차이가 너무 커서 미리볼 수 없습니다 ({{lines}}줄)",
+		"collapsedLines": "변경되지 않은 {{count}}줄 숨김",
 		"changeDiff": "변경 내용 차이",
 		"removed": "삭제됨",
 		"added": "추가됨"

--- a/apps/web/src/i18n/locales/pt-BR/shared.json
+++ b/apps/web/src/i18n/locales/pt-BR/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(linha vazia)",
 		"noDifferences": "Nenhuma diferença de texto",
+		"diffTooLarge": "Diferença muito grande para pré-visualizar ({{lines}} linhas)",
+		"collapsedLines": "{{count}} linhas inalteradas ocultas",
 		"changeDiff": "Alterar diferenças",
 		"removed": "Removido",
 		"added": "Adicionado"

--- a/apps/web/src/i18n/locales/ru/shared.json
+++ b/apps/web/src/i18n/locales/ru/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(пустая строка)",
 		"noDifferences": "Текстовых отличий нет",
+		"diffTooLarge": "Слишком большой diff для предпросмотра ({{lines}} строк)",
+		"collapsedLines": "Скрыто {{count}} неизменённых строк",
 		"changeDiff": "Diff изменений",
 		"removed": "Удалено",
 		"added": "Добавлено"

--- a/apps/web/src/i18n/locales/vi/shared.json
+++ b/apps/web/src/i18n/locales/vi/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "(dòng trống)",
 		"noDifferences": "Không có khác biệt về văn bản",
+		"diffTooLarge": "Khác biệt quá lớn để xem trước ({{lines}} dòng)",
+		"collapsedLines": "Đã ẩn {{count}} dòng không thay đổi",
 		"changeDiff": "Thay đổi nội dung",
 		"removed": "Đã xóa",
 		"added": "Đã thêm"

--- a/apps/web/src/i18n/locales/zh-CN/shared.json
+++ b/apps/web/src/i18n/locales/zh-CN/shared.json
@@ -18,6 +18,8 @@
 	"contentDiff": {
 		"emptyLine": "（空行）",
 		"noDifferences": "无文本差异",
+		"diffTooLarge": "差异过大，无法预览（{{lines}} 行）",
+		"collapsedLines": "已隐藏 {{count}} 行未更改内容",
 		"changeDiff": "更改差异",
 		"removed": "已删除",
 		"added": "已添加"

--- a/apps/web/src/lib/diff-utils.test.ts
+++ b/apps/web/src/lib/diff-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { collapseUnchangedContext, type DiffLine } from "./diff-utils";
 
 function unchanged(texts: string[]): DiffLine[] {

--- a/apps/web/src/lib/diff-utils.test.ts
+++ b/apps/web/src/lib/diff-utils.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { collapseUnchangedContext, type DiffLine } from "./diff-utils";
+
+function unchanged(texts: string[]): DiffLine[] {
+	return texts.map((text) => ({ type: "unchanged", text }));
+}
+
+describe("collapseUnchangedContext", () => {
+	it("leaves short unchanged runs untouched", () => {
+		const lines: DiffLine[] = [
+			...unchanged(["a", "b"]),
+			{ type: "removed", text: "old" },
+			{ type: "added", text: "new" },
+			...unchanged(["c", "d"]),
+		];
+
+		expect(collapseUnchangedContext(lines, 3)).toEqual(lines);
+	});
+
+	it("collapses a long unchanged run between two changes into one marker with context on both sides", () => {
+		const lines: DiffLine[] = [
+			{ type: "removed", text: "first-old" },
+			{ type: "added", text: "first-new" },
+			...unchanged([
+				"u1",
+				"u2",
+				"u3",
+				"u4",
+				"u5",
+				"u6",
+				"u7",
+				"u8",
+				"u9",
+				"u10",
+			]),
+			{ type: "removed", text: "second-old" },
+			{ type: "added", text: "second-new" },
+		];
+
+		const rows = collapseUnchangedContext(lines, 2);
+
+		expect(rows).toEqual([
+			{ type: "removed", text: "first-old" },
+			{ type: "added", text: "first-new" },
+			{ type: "unchanged", text: "u1" },
+			{ type: "unchanged", text: "u2" },
+			{ type: "collapsed", count: 6 },
+			{ type: "unchanged", text: "u9" },
+			{ type: "unchanged", text: "u10" },
+			{ type: "removed", text: "second-old" },
+			{ type: "added", text: "second-new" },
+		]);
+	});
+
+	it("drops leading context entirely since there is nothing before the file start to show", () => {
+		const lines: DiffLine[] = [
+			...unchanged(["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8"]),
+			{ type: "added", text: "new" },
+		];
+
+		const rows = collapseUnchangedContext(lines, 2);
+
+		expect(rows[0]).toEqual({ type: "collapsed", count: 6 });
+		expect(rows[1]).toEqual({ type: "unchanged", text: "u7" });
+		expect(rows[2]).toEqual({ type: "unchanged", text: "u8" });
+		expect(rows[3]).toEqual({ type: "added", text: "new" });
+	});
+
+	it("drops trailing context entirely since there is nothing after the file end to show", () => {
+		const lines: DiffLine[] = [
+			{ type: "removed", text: "old" },
+			...unchanged(["u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8"]),
+		];
+
+		const rows = collapseUnchangedContext(lines, 2);
+
+		expect(rows[0]).toEqual({ type: "removed", text: "old" });
+		expect(rows[1]).toEqual({ type: "unchanged", text: "u1" });
+		expect(rows[2]).toEqual({ type: "unchanged", text: "u2" });
+		expect(rows[3]).toEqual({ type: "collapsed", count: 6 });
+	});
+
+	it("merges two changes separated by a short unchanged gap without collapsing", () => {
+		const lines: DiffLine[] = [
+			{ type: "removed", text: "first-old" },
+			...unchanged(["u1", "u2", "u3"]),
+			{ type: "added", text: "second-new" },
+		];
+
+		expect(collapseUnchangedContext(lines, 2)).toEqual(lines);
+	});
+
+	it("returns an empty array for an empty diff", () => {
+		expect(collapseUnchangedContext([], 3)).toEqual([]);
+	});
+});

--- a/apps/web/src/lib/diff-utils.ts
+++ b/apps/web/src/lib/diff-utils.ts
@@ -85,3 +85,52 @@ export function diffBlockNoteContent(
 		blockNoteToLines(newContent),
 	);
 }
+
+export type DiffRow = DiffLine | { type: "collapsed"; count: number };
+
+const DEFAULT_CONTEXT_LINES = 3;
+
+/**
+ * Collapses long runs of unchanged lines into a single `{type: "collapsed"}`
+ * marker, keeping `contextLines` of surrounding context around each change —
+ * the same "hunk" convention as `git diff`/unified diff. Without this, a
+ * one-line edit to a large file renders every unchanged line in the file,
+ * which buries the actual change and (for very large files) is a real
+ * rendering cost on its own.
+ */
+export function collapseUnchangedContext(
+	lines: DiffLine[],
+	contextLines: number = DEFAULT_CONTEXT_LINES,
+): DiffRow[] {
+	const rows: DiffRow[] = [];
+	let i = 0;
+	while (i < lines.length) {
+		const line = lines[i];
+		if (line.type !== "unchanged") {
+			rows.push(line);
+			i++;
+			continue;
+		}
+
+		let j = i;
+		while (j < lines.length && lines[j].type === "unchanged") j++;
+		const runLength = j - i;
+		// No change before this run (start of file) or after it (end of
+		// file) means there's nothing to provide context for on that side.
+		const keepBefore = i === 0 ? 0 : contextLines;
+		const keepAfter = j === lines.length ? 0 : contextLines;
+
+		if (runLength <= keepBefore + keepAfter) {
+			rows.push(...lines.slice(i, j));
+		} else {
+			rows.push(...lines.slice(i, i + keepBefore));
+			rows.push({
+				type: "collapsed",
+				count: runLength - keepBefore - keepAfter,
+			});
+			rows.push(...lines.slice(j - keepAfter, j));
+		}
+		i = j;
+	}
+	return rows;
+}

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -92,14 +92,16 @@ def _wait_for_done_or_stop(
     reconcile,
     poll_interval: float = 2.0,
     timeout: float = 3600.0,
-) -> tuple[bool, bool, bool]:
+) -> tuple[bool, bool, bool, str | None]:
     """Poll the remote conversation until it finishes or a stop/pause is signaled.
 
-    Returns (stopped, errored, shutdown):
-      stopped  — True if the loop exited because stop_event or pause_event fired.
-      errored  — True if the conversation ended with ERROR or STUCK status.
-      shutdown — True if it was stop_event (full shutdown) rather than
-                 pause_event (interrupt-only) that fired.
+    Returns (stopped, errored, shutdown, error_detail):
+      stopped      — True if the loop exited because stop_event or pause_event fired.
+      errored      — True if the conversation ended with ERROR or STUCK status.
+      shutdown     — True if it was stop_event (full shutdown) rather than
+                     pause_event (interrupt-only) that fired.
+      error_detail — The ConversationErrorEvent detail when errored is True,
+                     else None.
     """
     start = time.monotonic()
     last_reconcile = start
@@ -125,13 +127,13 @@ def _wait_for_done_or_stop(
             # Catch up on anything the dead WS thread missed before we stop
             # watching this conversation entirely.
             reconcile(conversation)
-            return True, False, shutdown
+            return True, False, shutdown, None
 
         now = time.monotonic()
         if now - start > timeout:
             logger.warning("Conversation polling timed out after %.0f seconds", timeout)
             reconcile(conversation)
-            return False, False, False
+            return False, False, False, None
 
         if now - last_status_check < poll_interval:
             continue
@@ -160,8 +162,8 @@ def _wait_for_done_or_stop(
 
             if status.is_terminal():
                 errored = status in _ERROR_STATUSES
+                detail = _get_conversation_error_detail(conversation) if errored else None
                 if errored:
-                    detail = _get_conversation_error_detail(conversation)
                     logger.error(
                         "Conversation ended with status %s — %s",
                         status.value,
@@ -170,7 +172,7 @@ def _wait_for_done_or_stop(
                 # Final catch-up so the run never ends with an un-persisted
                 # tail from the last reconcile_interval stretch.
                 reconcile(conversation)
-                return False, errored, False
+                return False, errored, False, detail
         except Exception as exc:
             logger.debug("Failed to read conversation execution status: %s", exc)
 
@@ -599,8 +601,8 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
             system_suffix += build_trigger_suffix(trigger, all_repos_info)
         agent_context = AgentContext(skills=skills, system_message_suffix=system_suffix)
 
-        def _run_sync() -> tuple[bool, bool, bool]:
-            """Returns (stopped, errored, shutdown) — see `_wait_for_done_or_stop`."""
+        def _run_sync() -> tuple[bool, bool, bool, str | None]:
+            """Returns (stopped, errored, shutdown, error_detail) — see `_wait_for_done_or_stop`."""
             if resume_state is not None:
                 handle = resume_state.handle
             else:
@@ -670,7 +672,7 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                     # SDK timeout.
                     conversation.run(blocking=False)
                     reconcile = _make_reconciler(trigger, loop, counter, seen_events)
-                    stopped, errored, shutdown = _wait_for_done_or_stop(
+                    stopped, errored, shutdown, error_detail = _wait_for_done_or_stop(
                         conversation, stop_event, pause_event, reconcile
                     )
                 finally:
@@ -708,14 +710,18 @@ async def run_conversation(trigger: TriggerMessage, agent_config: AgentConfig) -
                 chat_sandboxes.pop(trigger.conversation_id, None)
                 stop_sandbox(handle)
 
-            return stopped, errored, shutdown
+            return stopped, errored, shutdown, error_detail
 
-        stopped, errored, shutdown = await asyncio.get_event_loop().run_in_executor(None, _run_sync)
+        stopped, errored, shutdown, error_detail = await asyncio.get_event_loop().run_in_executor(
+            None, _run_sync
+        )
         result = _post_turn_status(is_chat, stopped, errored, shutdown)
         if result is not None:
             status, event_type = result
             await conversation_repository.update_conversation_status(
-                trigger.conversation_id, status
+                trigger.conversation_id,
+                status,
+                error_message=error_detail if errored else None,
             )
             await stream_store.publish_realtime(
                 project_id=trigger.project_id,

--- a/services/ai-agent/tests/e2e/test_run_conversation_e2e.py
+++ b/services/ai-agent/tests/e2e/test_run_conversation_e2e.py
@@ -189,7 +189,9 @@ async def test_agent_reply_is_persisted_through_real_sandbox(make_fake_llm, pers
 
         # Chat conversations pause (not finish) after a natural per-turn
         # completion — the sandbox stays alive for the next reply.
-        persistence.update_status.assert_any_call(trigger.conversation_id, "paused")
+        persistence.update_status.assert_any_call(
+            trigger.conversation_id, "paused", error_message=None
+        )
     finally:
         await executor.teardown_paused_chat_sandbox(trigger.conversation_id)
 
@@ -228,7 +230,9 @@ async def test_agent_tool_call_then_reply_persists_full_flow(make_fake_llm, pers
 
         # Chat conversations pause (not finish) after a natural per-turn
         # completion — the sandbox stays alive for the next reply.
-        persistence.update_status.assert_any_call(trigger.conversation_id, "paused")
+        persistence.update_status.assert_any_call(
+            trigger.conversation_id, "paused", error_message=None
+        )
     finally:
         await executor.teardown_paused_chat_sandbox(trigger.conversation_id)
 
@@ -242,7 +246,19 @@ async def test_llm_failure_marks_conversation_failed(make_fake_llm, persistence)
 
     await executor.run_conversation(trigger, _agent_config(base_url))
 
-    persistence.update_status.assert_any_call(trigger.conversation_id, "failed")
+    failed_calls = [
+        call
+        for call in persistence.update_status.call_args_list
+        if call.args[:2] == (trigger.conversation_id, "failed")
+    ]
+    assert failed_calls, (
+        f"no 'failed' status update recorded: {persistence.update_status.call_args_list}"
+    )
+    error_message = failed_calls[0].kwargs.get("error_message")
+    assert error_message and "fake upstream failure" in error_message, (
+        f"error detail was not propagated to error_message: {error_message!r}"
+    )
+
     failed_events = [
         call
         for call in persistence.publish_realtime.call_args_list

--- a/services/ai-agent/tests/test_executor.py
+++ b/services/ai-agent/tests/test_executor.py
@@ -445,11 +445,11 @@ def test_wait_for_done_or_stop_pause_event_interrupts_without_shutdown():
     pause_event.set()
     reconcile = Mock()
 
-    stopped, errored, shutdown = _wait_for_done_or_stop(
+    stopped, errored, shutdown, error_detail = _wait_for_done_or_stop(
         conversation, stop_event, pause_event, reconcile
     )
 
-    assert (stopped, errored, shutdown) == (True, False, False)
+    assert (stopped, errored, shutdown, error_detail) == (True, False, False, None)
     conversation.interrupt.assert_called_once()
     reconcile.assert_called_once_with(conversation)
 
@@ -462,9 +462,58 @@ def test_wait_for_done_or_stop_stop_event_signals_shutdown():
     stop_event.set()
     reconcile = Mock()
 
-    stopped, errored, shutdown = _wait_for_done_or_stop(
+    stopped, errored, shutdown, error_detail = _wait_for_done_or_stop(
         conversation, stop_event, pause_event, reconcile
     )
 
-    assert (stopped, errored, shutdown) == (True, False, True)
+    assert (stopped, errored, shutdown, error_detail) == (True, False, True, None)
     conversation.interrupt.assert_called_once()
+
+
+class _FakeStateForError:
+    def __init__(self, events: list) -> None:
+        from openhands.sdk.conversation.state import ConversationExecutionStatus
+
+        self.execution_status = ConversationExecutionStatus.ERROR
+        self.events = events
+
+    def refresh_from_server(self) -> None:
+        pass
+
+
+class _FakeConversationForError:
+    def __init__(self, events: list) -> None:
+        self.state = _FakeStateForError(events)
+        self.interrupt = Mock()
+
+
+def test_wait_for_done_or_stop_returns_error_detail_on_terminal_error():
+    """When the remote conversation ends in ERROR status, the detail from its
+    ConversationErrorEvent must be returned so callers (run_conversation) can
+    persist it as agent_conversations.error_message — regressed by a bug
+    where this detail was only ever logged, never propagated, leaving
+    error_message NULL for every conversation that failed this way."""
+    from openhands.sdk.event.conversation_error import ConversationErrorEvent
+
+    error_event = ConversationErrorEvent(
+        source="environment",
+        code="LLMBadRequestError",
+        detail=(
+            "litellm.BadRequestError: MistralException - Assistant message must "
+            "have either content or tool_calls, but not none."
+        ),
+    )
+    conversation = _FakeConversationForError([error_event])
+    stop_event = threading.Event()
+    pause_event = threading.Event()
+    reconcile = Mock()
+
+    stopped, errored, shutdown, error_detail = _wait_for_done_or_stop(
+        conversation, stop_event, pause_event, reconcile, poll_interval=0.0
+    )
+
+    assert (stopped, errored, shutdown) == (False, True, False)
+    assert error_detail == (
+        "LLMBadRequestError: litellm.BadRequestError: MistralException - "
+        "Assistant message must have either content or tool_calls, but not none."
+    )


### PR DESCRIPTION
## Summary
- Agent `Edit`/`Write`-style tool calls rendered as raw stringified JSON args instead of a readable diff. `ToolFallback` now renders a real line-by-line diff (reusing `DiffLineRow` from `content-diff.tsx`) whenever a tool-call part carries diff data, falling back to the existing JSON view otherwise.
- `eventsToThreadMessages` now extracts diff content from two distinct event shapes, since edits can come from either backend path:
  - **ACP-backed agents** (Claude Code / Codex / Gemini CLI): `ACPToolCallEvent`s that report edits as `{type: "diff", path, old_text, new_text}` content blocks.
  - **Native OpenHands SDK agents**: the `file_editor` tool's `str_replace`/`create`/`insert` commands, which report before/after content as `old_content`/`new_content` on the `FileEditorObservation` that follows the `ActionEvent` — a completely different shape with no `diff`-typed content block. Mirrors the SDK's own `FileEditorObservation._has_meaningful_diff` so `view` calls, errors, and no-op edits correctly fall back to the plain args view instead of showing an empty/misleading diff.
- `services/ai-agent`: `_wait_for_done_or_stop` now returns the `ConversationErrorEvent` detail alongside `(stopped, errored, shutdown)` so `run_conversation` can persist it to `agent_conversations.error_message` on a terminal `ERROR`/`STUCK` status. Previously this detail was only logged, leaving `error_message` `NULL` for every conversation that failed this way.

Fixes #315

## Test plan
- [x] `bun run test` in `apps/web` — 323 tests passing (incl. new coverage for both the ACP diff-block path and the native `file_editor` path: `str_replace`, `create`, `view`, and error cases)
- [x] `pytest tests/test_executor.py` in `services/ai-agent` — 29 tests passing (incl. new coverage for `error_detail` propagation on a terminal `ERROR` status)
- [x] `tsc --noEmit` / `biome check` on the changed frontend files — clean
- [x] Replayed the real event stream of a conversation that uses the native (non-ACP) agent path, pulled from a local dev DB — confirmed 22 of 42 `file_editor` tool calls (the actual edits) now produce a diff artifact, while `view` calls and no-ops correctly do not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
