### PR TITLE
fix: build Web image builder stage on native platform

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM oven/bun:1-alpine AS builder
+# Runs on the build platform (not the target platform): the output is
+# architecture-independent static assets, so cross-arch runs would otherwise
+# execute bun under QEMU emulation for no benefit, which has been known to
+# corrupt native-binary tarball extraction (e.g. @biomejs/cli-linux-arm64).
+FROM --platform=$BUILDPLATFORM oven/bun:1-alpine AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- The v0.10.6 CD run's [Web image build failed](https://github.com/Paca-AI/paca/actions/runs/30189260645/job/89759328669): `bun install --frozen-lockfile` errored with `Fail extracting tarball for "@biomejs/cli-linux-arm64"` while building the `linux/arm64` target under QEMU emulation.
- `apps/web`'s builder stage only produces architecture-independent static assets (`tsc -b && vite build`), and never runs `biome` (it's an unused devDependency at build time), so there's no reason to emulate arm64 for that stage at all.
- Pin the builder stage to `--platform=$BUILDPLATFORM` so `bun install`/`bun run build` always run natively on the runner's arch, sidestepping the QEMU-related tarball corruption. Only the final `caddy` runtime stage remains multi-arch (a plain `COPY` of static files, so no emulation needed there either).

## Test plan
- [x] `docker buildx build --platform linux/amd64 -f apps/web/Dockerfile apps/web` succeeds locally with the fix.
- [ ] Next release's CD run builds & pushes the Web image successfully for both `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)