### PR TITLE
feat: add build argument for PACA_VERSION in Dockerfile and CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,6 +84,8 @@ jobs:
           context: services/api
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            PACA_VERSION=${{ github.event.release.tag_name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -17,6 +17,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOMAXPROCS=1 GOMEMLIMIT=768MiB \
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM alpine:3.21
 
+# Release tag this image was built from (e.g. "v1.2.3"), baked in by CD via
+# --build-arg. Read at startup as PACA_VERSION; defaults to "dev" for local
+# builds. See internal/config/load.go and internal/transport/http/handler/version_handler.go.
+ARG PACA_VERSION=dev
+ENV PACA_VERSION=$PACA_VERSION
+
 RUN apk add --no-cache ca-certificates tzdata su-exec
 
 # Create a dedicated non-root user and group for running the API


### PR DESCRIPTION
## Summary
- API reads its running version from the `PACA_VERSION` env var (defaults to `dev`), used by `/api/version` to power the "new version available" banner — but nothing set it, so self-hosted images always reported `dev`.
- Add `ARG PACA_VERSION=dev` / `ENV PACA_VERSION=$PACA_VERSION` to `services/api/Dockerfile` so the value is baked into the image at build time.
- Pass `PACA_VERSION=${{ github.event.release.tag_name }}` as a build-arg in the `api-image` job of `cd.yml`, so each published GitHub Release stamps its image with the matching tag (e.g. `v1.2.3`).

## Test plan
- [x] `docker build --build-arg PACA_VERSION=v9.9.9-test .` → container reports `PACA_VERSION=v9.9.9-test`
- [x] `docker build .` (no build-arg, as in local/dev) → container reports `PACA_VERSION=dev`