### PR TITLE
feat(agent): multi-turn conversations — resume an ended conversation on a new message

### DIFF
--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -707,14 +707,40 @@ func (s *Service) Heartbeat(ctx context.Context, projectID, conversationID uuid.
 	})
 }
 
-// SendConversationMessage publishes a chat message to an active conversation.
+// SendConversationMessage posts a message into a conversation. A conversation that
+// is mid-turn takes the message straight away; one whose previous turn has ENDED is
+// resumed for another turn, so a chat can continue past a single exchange instead of
+// dead-ending with AGENT_CONVERSATION_NOT_RUNNING.
+//
+// This mirrors SendChatMessage's turn model, but keyed by conversation_id rather than
+// chat session: the agent runtimes hold their session keyed by conversation_id (the
+// ACP bridge keeps the conversation object alive across turns; an LLM chat sandbox
+// stays warm while paused), so re-dispatching the SAME conversation_id resumes with
+// prior context where it is still available and continues cleanly otherwise.
 func (s *Service) SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID) error {
 	c, err := s.GetConversation(ctx, projectID, conversationID)
 	if err != nil {
 		return err
 	}
-	if agentdom.ConversationStatus(c.Status) != agentdom.ConversationStatusRunning {
-		return agentdom.ErrConversationNotRunning
+	switch agentdom.ConversationStatus(c.Status) {
+	case agentdom.ConversationStatusRunning:
+		// Mid-turn: the message joins the turn already in flight (unchanged).
+	case agentdom.ConversationStatusQueued:
+		// Dispatched but not yet picked up by a worker — don't race a second turn
+		// onto the same conversation; the caller should retry shortly.
+		return agentdom.ErrConversationBusy
+	default:
+		// Paused or terminal (finished / failed / stopped): RESUME for another turn.
+		// Claim the status atomically (→ running) so two concurrent replies can't both
+		// re-dispatch the same conversation_id; the loser is told to retry as busy.
+		claimed, err := s.repo.ClaimConversationStatus(ctx, conversationID,
+			c.Status, string(agentdom.ConversationStatusRunning))
+		if err != nil {
+			return err
+		}
+		if !claimed {
+			return agentdom.ErrConversationBusy
+		}
 	}
 	return s.publishTrigger(ctx, events.TopicAgentChatMessage, map[string]any{
 		"conversation_id": conversationID.String(),

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -1002,28 +1002,75 @@ func TestSendConversationMessage_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSendConversationMessage_NotRunning(t *testing.T) {
+// A conversation whose previous turn has ENDED (finished/failed/stopped/paused) is
+// resumed for another turn: the status is claimed atomically and the trigger is
+// re-published, rather than dead-ending with AGENT_CONVERSATION_NOT_RUNNING.
+func TestSendConversationMessage_ResumesEndedConversation(t *testing.T) {
+	for _, status := range []string{"finished", "failed", "stopped", "paused"} {
+		t.Run(status, func(t *testing.T) {
+			projectID := uuid.New()
+			conversationID := uuid.New()
+			conversation := &agentdom.AgentConversation{
+				ID: conversationID, ProjectID: projectID, Status: status,
+			}
+			var claimedFrom, claimedTo string
+			repo := &mockAgentRepo{
+				findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+					return conversation, nil
+				},
+				claimConversationStatus: func(_ context.Context, _ uuid.UUID, from, to string) (bool, error) {
+					claimedFrom, claimedTo = from, to
+					return true, nil
+				},
+			}
+			svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+			err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "another turn", uuid.New())
+
+			assert.NoError(t, err)
+			assert.Equal(t, status, claimedFrom)  // claimed FROM the ended status…
+			assert.Equal(t, "running", claimedTo) // …TO running, ready to re-dispatch
+		})
+	}
+}
+
+// If the atomic claim loses the race (another reply already resumed the same
+// conversation), the caller is told to retry rather than double-dispatching.
+func TestSendConversationMessage_BusyWhenClaimLost(t *testing.T) {
 	projectID := uuid.New()
 	conversationID := uuid.New()
-	conversation := &agentdom.AgentConversation{
-		ID:        conversationID,
-		ProjectID: projectID,
-		Status:    "finished",
+	conversation := &agentdom.AgentConversation{ID: conversationID, ProjectID: projectID, Status: "finished"}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+		claimConversationStatus: func(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+			return false, nil // lost the CAS
+		},
 	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "msg", uuid.New())
+
+	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
+}
+
+// A queued conversation (dispatched but not yet picked up) is reported busy, so we
+// never race a second turn onto it.
+func TestSendConversationMessage_BusyWhenQueued(t *testing.T) {
+	projectID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{ID: conversationID, ProjectID: projectID, Status: "queued"}
 	repo := &mockAgentRepo{
 		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return conversation, nil
 		},
 	}
-	projRepo := &mockProjectRepo{}
-	pluginRepo := &mockPluginRepo{}
-	svc := New(repo, projRepo, nil, pluginRepo)
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
-	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "test message", uuid.New())
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "msg", uuid.New())
 
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, agentdom.ErrConversationNotRunning)
+	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
 
 func TestStopConversation_Success(t *testing.T) {


### PR DESCRIPTION
## Problem

Posting a message into an agent **conversation** whose previous turn has ended returns `AGENT_CONVERSATION_NOT_RUNNING`, so a chat with an agent dead-ends after a single exchange — there's no way to reply and continue.

`SendConversationMessage` required the conversation to be `running`:

```go
if agentdom.ConversationStatus(c.Status) != agentdom.ConversationStatusRunning {
    return agentdom.ErrConversationNotRunning
}
```

An agent's turn ends non-`running`, so every follow-up on `POST /projects/{p}/conversations/{c}/messages` fails.

## Change

Bring `SendConversationMessage` in line with the turn model `SendChatMessage` already uses (resume-on-`paused`), keyed by `conversation_id`:

- **running** → message joins the in-flight turn (unchanged)
- **queued** → `ErrConversationBusy` (don't race a second turn onto a not-yet-picked-up conversation)
- **paused / finished / failed / stopped** → **resume**: atomically `ClaimConversationStatus(→ running)` and re-publish the trigger on the **same `conversation_id`**

Re-dispatching the same `conversation_id` lets the runtimes resume **with prior context**: the ACP bridge keeps its `Conversation` object across turns (its `start_turn` resume branch replies on the object from the earlier turn, and it already rejects a concurrent turn), and an LLM chat sandbox stays warm while `paused`. The atomic claim prevents two concurrent replies from double-dispatching one conversation.

No schema change — the `paused` state and per-conversation history already exist.

## Tests

`services/api/internal/service/agent/agent_service_test.go`: resume from finished/failed/stopped/paused, busy on a lost claim race, busy when queued. `go build`, `go vet`, and the `agent` package tests pass.
