### PR TITLE
fix(migrations): make 000001 username index re-run-safe (crash-loop on soft-deleted duplicate username)

### DIFF
--- a/services/api/migrations/000001_init.sql
+++ b/services/api/migrations/000001_init.sql
@@ -40,7 +40,13 @@ CREATE TABLE IF NOT EXISTS users (
         ON DELETE RESTRICT
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS uni_users_username ON users (username);
+-- Scoped to ACTIVE users (deleted_at IS NULL) so this init migration is safe to
+-- re-run on every boot (RunMigrations replays all files, relying on idempotency)
+-- once a username has a soft-deleted duplicate — which becomes legal at 000016.
+-- A FULL unique index here instead fails with 23505 the moment a user is deleted
+-- and the name reused, crash-looping the API on its next restart. This matches the
+-- final state 000016 (scope_username_unique_to_active) establishes anyway.
+CREATE UNIQUE INDEX IF NOT EXISTS uni_users_username ON users (username) WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_users_deleted_at ON users (deleted_at) WHERE deleted_at IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_users_role_id    ON users (role_id);
 


### PR DESCRIPTION
## Problem

`RunMigrations` replays **every** `*.sql` file on **every boot** (by design — the runner's doc comment requires migrations to be idempotent). But `000001_init.sql` builds a **full** unique index on `users.username`:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS uni_users_username ON users (username);
```

`000016_scope_username_unique_to_active.sql` later drops that and creates a **partial** index (`… WHERE deleted_at IS NULL`) so a username freed by a **soft-deleted** account can be reused. That's the intended final state.

The bug: once a user is soft-deleted and the username reused (perfectly legal under the partial index), the **next API restart** replays `000001` first — and its *full* index hits the duplicate:

```
auto-migrate: migrations: exec "000001_init.sql": ERROR: could not create unique index "uni_users_username" (SQLSTATE 23505)
```

The API then **crash-loops and won't start** until the duplicate is removed by hand. It's a latent landmine: everything runs fine until any restart after a delete-and-recreate. (Confirmed on v0.10.1 and still present on latest.)

## Fix

Scope the `000001` index to active users from the start — one line, matching what `000016` already establishes:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS uni_users_username ON users (username) WHERE deleted_at IS NULL;
```

`users.deleted_at` already exists in the `000001` table definition, so this is valid at that point. Now the replay is idempotent even with a soft-deleted duplicate; `000016` still runs (drops `uni_users_username`, creates `uni_users_username_active`) so existing databases converge identically. Fresh installs reach the same end state — the only change is the momentary in-between index is partial instead of full, and there are no soft-deleted rows on a fresh DB anyway.
