### PR TITLE
feat: enhance WASI reactor module instantiation with real OS clock su…

### DIFF
--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -228,8 +228,16 @@ func (r *Runtime) Load(ctx context.Context, p plugindom.Plugin) error {
 		_ = wasmRT.Close(ctx)
 		return fmt.Errorf("runtime load %q: compile: %w", p.Name, err)
 	}
-	// For WASI reactor builds, _initialize must be called before exported functions
-	mod, err := wasmRT.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().WithName(p.Name).WithStartFunctions("_initialize"))
+	// For WASI reactor builds, _initialize must be called before exported functions.
+	// WithSysWalltime/WithSysNanotime wire the module's clock to the real OS
+	// clock; without them wazero silently falls back to a fake clock frozen at
+	// 1970-01-01 (nanotime) / 2022-01-01 (walltime), which is what plugins would
+	// otherwise observe from time.Now() — see issue #339.
+	mod, err := wasmRT.InstantiateModule(ctx, compiled, wazero.NewModuleConfig().
+		WithName(p.Name).
+		WithStartFunctions("_initialize").
+		WithSysWalltime().
+		WithSysNanotime())
 	if err != nil {
 		_ = wasmRT.Close(ctx)
 		return fmt.Errorf("runtime load %q: instantiate: %w", p.Name, err)


### PR DESCRIPTION
## Summary
- WASI reactor plugin modules were instantiated without `WithSysWalltime()` / `WithSysNanotime()`, so wazero silently fell back to its fake, deterministic clock — nanotime pinned to `1970-01-01`, walltime pinned to `2022-01-01` — instead of the real OS clock. Any plugin code reading the time (`time.Now()` and friends) observed this frozen value.
- `Runtime.Load` now passes `WithSysWalltime()` and `WithSysNanotime()` into `wazero.NewModuleConfig()`, so every WASI reactor plugin gets real wall-clock/monotonic time.

## Fixes #339
Root cause of `com.paca.webhook` recording deliveries with `created_at` frozen at `2022-01-01 00:00:00` while reporting fake `success=true, status_code=202` results that never actually reached the destination. Verified end-to-end: with the real OS clock wired in, deliveries now reach the destination and are recorded with accurate timestamps.

Fixes #339

## Related
Ships alongside Paca-AI/paca-plugin-webhook#7 (merged), which adds `Warn`/`Info` logging around each webhook delivery attempt so future delivery problems show up in plugin logs instead of only as a silent row in `webhook_deliveries`.

## Test plan
- [x] CI — Build, Lint, Unit & integration tests, E2E tests passing
- [x] Manually verified webhook deliveries reach their destination with correct timestamps after this fix
