### PR TITLE
fix: add key prop to AutomationNodeConfigPanel for selectedNode

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
@@ -646,6 +646,7 @@ function AutomationBuilderPage() {
 					/>
 					{selectedNode && (
 						<AutomationNodeConfigPanel
+							key={selectedNode.id}
 							node={selectedNode}
 							projectId={projectId}
 							automationId={automationId}


### PR DESCRIPTION
## Summary
- Fixes the automation settings panel showing stale data when switching between two nodes of the same kind/type.
- `AutomationNodeConfigPanel` (and the `TriggerConfigForm`/`ActionConfigForm`/`ConditionConfigForm` it renders) seed their fields via `useState(config.xxx)`, which only initializes on mount. Without a `key`, selecting a different node of the same type reused the existing component instance instead of remounting it, so the previously selected node's local state stuck around instead of resetting to the newly selected node's `config`.
- Adding `key={selectedNode.id}` forces React to fully unmount/remount the panel whenever the selected node changes, guaranteeing the form fields always re-initialize from the correct node's data.

## Test plan
- [x] In the automation builder, add two nodes of the same type (e.g. two `set_status` actions) with different config.
- [x] Select the first node, confirm its config shows correctly.
- [x] Select the second node, confirm the panel now shows the second node's config (not the first's).
- [x] `tsc -b --noEmit` passes.