### PR TITLE
fix: include node type in plugin condition/action payload

### DIFF
--- a/apps/web/src/components/projects/automation/automation-canvas.tsx
+++ b/apps/web/src/components/projects/automation/automation-canvas.tsx
@@ -28,7 +28,11 @@ import type {
 	AutomationNode,
 	ConditionConfig,
 } from "@/lib/automation-api";
-import { ELSE_HANDLE } from "@/lib/automation-api";
+import {
+	CONDITION_NODE_TYPE,
+	ELSE_HANDLE,
+	PLUGIN_CONDITION_TRUE_HANDLE,
+} from "@/lib/automation-api";
 import { cn } from "@/lib/utils";
 
 interface BaseNodeData extends Record<string, unknown> {
@@ -110,10 +114,18 @@ function NodeShell({ data }: NodeProps<Node<BaseNodeData>>) {
 						</div>
 						{description && (
 							<div
-								className="truncate text-sm font-semibold text-foreground"
+								className="space-y-0.5 text-sm font-semibold text-foreground"
 								title={description}
 							>
-								{description}
+								{description.split("\n").map((line, i) => (
+									<div
+										// biome-ignore lint/suspicious/noArrayIndexKey: lines are a stable ordered render of a description string, no natural key
+										key={i}
+										className="truncate"
+									>
+										{line}
+									</div>
+								))}
 							</div>
 						)}
 					</div>
@@ -147,8 +159,24 @@ function NodeShell({ data }: NodeProps<Node<BaseNodeData>>) {
 
 function ConditionBranchRows({ node }: { node: AutomationNode }) {
 	const { t } = useTranslation("projects");
+	// A plugin-contributed condition node (e.g. time_logging's
+	// total_minutes_exceeds) isn't the built-in N-branch switch — its config
+	// holds the plugin's own fields, not a Branches array — but the worker
+	// still follows a "matched" edge for it (walkPluginCondition in
+	// automation_consumer.go), via the fixed PLUGIN_CONDITION_TRUE_HANDLE
+	// handle. Render that single synthetic branch here so it has somewhere
+	// to connect to; without it, only the ELSE_HANDLE row below existed and
+	// a plugin condition's "matched" path could never be wired up.
+	const isBuiltinCondition = node.type === CONDITION_NODE_TYPE;
 	const config = node.config as unknown as ConditionConfig;
-	const branches = config?.branches ?? [];
+	const branches: { handle: string; label?: string }[] = isBuiltinCondition
+		? (config?.branches ?? [])
+		: [
+				{
+					handle: PLUGIN_CONDITION_TRUE_HANDLE,
+					label: t("automation.nodeConfig.description.pluginConditionMatched"),
+				},
+			];
 	const updateNodeInternals = useUpdateNodeInternals();
 	// React Flow caches each node's handle positions on mount and only
 	// re-measures when told to — a Condition node's branch handles are added

--- a/apps/web/src/components/projects/automation/automation-node-config-panel.tsx
+++ b/apps/web/src/components/projects/automation/automation-node-config-panel.tsx
@@ -40,6 +40,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useTaskPickerSearch } from "@/hooks/use-task-picker-search";
 import {
@@ -50,9 +51,13 @@ import {
 	type ConditionBranch,
 	type ConditionConfig,
 	type ConditionField,
+	type ConditionLeaf,
 	type ConditionOperator,
 	generateWebhookToken,
 	MULTI_VALUED_TARGET_KINDS,
+	type PluginNodeConfigSchema,
+	type PluginNodeConfigSchemaProperty,
+	type TaskFieldUpdate,
 	type TaskTarget,
 	type TaskTargetKind,
 	TRIGGER_TYPES,
@@ -60,6 +65,7 @@ import {
 } from "@/lib/automation-api";
 import {
 	listAllTasks,
+	sprintsQueryOptions,
 	type Task,
 	taskQueryOptions,
 	tasksPickerInfiniteQueryOptions,
@@ -89,6 +95,12 @@ interface AutomationNodeConfigPanelProps {
 	 * plugin's own manifest — used instead of an i18n lookup when the
 	 * node's type isn't one of the built-ins. */
 	pluginLabel?: string;
+	/** JSON Schema for a plugin-contributed node type's config, from the
+	 * plugin's own manifest (plugin.json's
+	 * automation.{triggers,conditions,actions}[].configSchema). When
+	 * present with properties, drives SchemaConfigForm's UI-field
+	 * rendering instead of GenericConfigForm's raw JSON textarea. */
+	pluginConfigSchema?: PluginNodeConfigSchema;
 }
 
 // The task list API caps page_size at 200, so a full project task picker has
@@ -112,23 +124,98 @@ function taskLabel(task: Task): string {
 	return `#${task.task_number} ${task.title}`;
 }
 
+// Field choices for a condition leaf's Select — matches the domain's Field
+// enum in condition.go. Plugin-contributed conditions are their own
+// standalone condition node type (see AutomationNodeConfigPanel's dispatch
+// on node.type), not a leaf field choice here.
+// Ordered to match how these fields read on the task itself — title first
+// (what a task is), then status/type/assignee (classification & ownership),
+// importance/story_points (planning), tags, reporter, sprint/epic
+// (organization), the two dates, and custom_field last since it's the
+// generic catch-all that needs a second field_key picker.
 const CONDITION_FIELDS: ConditionField[] = [
+	"title",
 	"status_id",
 	"task_type_id",
-	"importance",
 	"assignee_ids",
+	"importance",
+	"story_points",
 	"tags",
+	"reporter_id",
+	"sprint_id",
+	"parent_task_id",
+	"start_date",
+	"due_date",
 	"custom_field",
 ];
 
+// Mirrors validOperatorsByField in domain/automation/condition.go exactly —
+// keep the two in sync.
 const OPERATORS_BY_FIELD: Record<ConditionField, ConditionOperator[]> = {
-	status_id: ["equals", "not_equals"],
-	task_type_id: ["equals", "not_equals"],
+	status_id: ["equals", "not_equals", "is_empty", "is_not_empty"],
+	task_type_id: ["equals", "not_equals", "is_empty", "is_not_empty"],
 	importance: ["equals", "not_equals", "greater_than", "less_than"],
 	assignee_ids: ["contains", "not_equals", "is_empty", "is_not_empty"],
 	tags: ["contains", "not_equals", "is_empty", "is_not_empty"],
-	custom_field: ["equals", "not_equals", "is_empty", "is_not_empty"],
+	custom_field: [
+		"equals",
+		"not_equals",
+		"is_empty",
+		"is_not_empty",
+		"greater_than",
+		"less_than",
+	],
+	title: ["equals", "not_equals", "contains", "is_empty", "is_not_empty"],
+	story_points: [
+		"equals",
+		"not_equals",
+		"greater_than",
+		"less_than",
+		"is_empty",
+		"is_not_empty",
+	],
+	sprint_id: ["equals", "not_equals", "is_empty", "is_not_empty"],
+	parent_task_id: ["equals", "not_equals", "is_empty", "is_not_empty"],
+	reporter_id: ["equals", "not_equals", "is_empty", "is_not_empty"],
+	start_date: [
+		"equals",
+		"not_equals",
+		"greater_than",
+		"less_than",
+		"is_empty",
+		"is_not_empty",
+	],
+	due_date: [
+		"equals",
+		"not_equals",
+		"greater_than",
+		"less_than",
+		"is_empty",
+		"is_not_empty",
+	],
 };
+
+// UpdatableField enumerates every TaskFieldUpdate key with an editor in
+// this form — the same set the "add field" picker offers. Excludes
+// description (rich text, no dedicated editor here). Ordered to match
+// CONDITION_FIELDS above for a consistent field-picking experience across
+// conditions and actions.
+type UpdatableField = Exclude<keyof TaskFieldUpdate, "description">;
+const FIELD_UPDATE_ORDER: UpdatableField[] = [
+	"title",
+	"status_id",
+	"task_type_id",
+	"assignee_ids",
+	"importance",
+	"story_points",
+	"tags",
+	"reporter_id",
+	"sprint_id",
+	"parent_task_id",
+	"start_date",
+	"due_date",
+	"custom_fields",
+];
 
 export function AutomationNodeConfigPanel({
 	node,
@@ -144,6 +231,7 @@ export function AutomationNodeConfigPanel({
 	onRemove,
 	saving,
 	pluginLabel,
+	pluginConfigSchema,
 }: AutomationNodeConfigPanelProps) {
 	const { t } = useTranslation("projects");
 	const [removeOpen, setRemoveOpen] = useState(false);
@@ -183,13 +271,20 @@ export function AutomationNodeConfigPanel({
 						onSave={onSave}
 						saving={saving}
 					/>
-				) : (
-					<GenericConfigForm
+				) : pluginConfigSchema?.properties &&
+					Object.keys(pluginConfigSchema.properties).length > 0 ? (
+					<SchemaConfigForm
+						schema={pluginConfigSchema}
 						config={node.config}
+						projectId={projectId}
+						members={members}
+						nodeKind="trigger"
 						canEdit={canEdit}
 						onSave={onSave}
 						saving={saving}
 					/>
+				) : (
+					<PluginTriggerNoConfigNotice />
 				)}
 				<RemoveDialog
 					open={removeOpen}
@@ -221,6 +316,18 @@ export function AutomationNodeConfigPanel({
 						members={members}
 						customFields={customFields}
 						taskTypes={taskTypes}
+						canEdit={canEdit}
+						onSave={onSave}
+						saving={saving}
+					/>
+				) : pluginConfigSchema?.properties &&
+					Object.keys(pluginConfigSchema.properties).length > 0 ? (
+					<SchemaConfigForm
+						schema={pluginConfigSchema}
+						config={node.config}
+						projectId={projectId}
+						members={members}
+						nodeKind="condition"
 						canEdit={canEdit}
 						onSave={onSave}
 						saving={saving}
@@ -264,6 +371,19 @@ export function AutomationNodeConfigPanel({
 					statuses={statuses}
 					members={members}
 					customFields={customFields}
+					taskTypes={taskTypes}
+					canEdit={canEdit}
+					onSave={onSave}
+					saving={saving}
+				/>
+			) : pluginConfigSchema?.properties &&
+				Object.keys(pluginConfigSchema.properties).length > 0 ? (
+				<SchemaConfigForm
+					schema={pluginConfigSchema}
+					config={node.config}
+					projectId={projectId}
+					members={members}
+					nodeKind="action"
 					canEdit={canEdit}
 					onSave={onSave}
 					saving={saving}
@@ -285,12 +405,341 @@ export function AutomationNodeConfigPanel({
 	);
 }
 
-// GenericConfigForm is the fallback config editor for any plugin-contributed
-// node type: a raw JSON editor. Plugins that want a real UI (a live picker,
-// not a bare textarea) can register a component at the
-// "automation.node.config" frontend extension point once one exists — see
-// the design note in the plugin automation bridge; until then, this is the
-// only surface available for editing a plugin node's config.
+// SchemaConfigForm renders real UI fields (text/number inputs, dropdowns,
+// textareas, date pickers, member pickers) for a plugin-contributed node's
+// config, driven by the JSON Schema the plugin declares at plugin.json's
+// automation.{triggers,conditions,actions}[].configSchema. This is the
+// primary editor for any plugin node that declares a configSchema with
+// properties — GenericConfigForm's raw JSON textarea remains only as a
+// fallback for plugin nodes that declare no schema at all (or one with no
+// properties), so an older/minimal plugin never loses the ability to be
+// configured.
+//
+// Condition and action nodes also get the same "applies to" target picker
+// the built-in condition leaf/action forms have (TaskTargetSelector, plus
+// MatchModeSelector for a condition whose target can resolve to more than
+// one task) — stored as config.target/config.match_mode alongside the
+// plugin's own declared fields, the same JSON shape ConditionLeaf/
+// ActionConfig already use, so the engine picks it up with no
+// plugin-specific handling required. Triggers don't get one: a
+// plugin-contributed trigger fires from whatever task its own eventTopic
+// payload names, not something a user can retarget from the canvas.
+function SchemaConfigForm({
+	schema,
+	config,
+	projectId,
+	members,
+	nodeKind,
+	canEdit,
+	onSave,
+	saving,
+}: {
+	schema: PluginNodeConfigSchema;
+	config: Record<string, unknown>;
+	projectId: string;
+	members: ProjectMember[];
+	nodeKind: "trigger" | "condition" | "action";
+	canEdit: boolean;
+	onSave: (config: Record<string, unknown>) => void;
+	saving?: boolean;
+}) {
+	const { t } = useTranslation("projects");
+	const properties = schema.properties ?? {};
+	const required = useMemo(() => new Set(schema.required ?? []), [schema]);
+	const fieldNames = Object.keys(properties);
+	const showTarget = nodeKind !== "trigger";
+
+	const [values, setValues] = useState<Record<string, string | boolean>>(() => {
+		const initial: Record<string, string | boolean> = {};
+		for (const name of fieldNames) {
+			const prop = properties[name];
+			const raw = config[name];
+			if (prop.type === "boolean") {
+				initial[name] =
+					typeof raw === "boolean" ? raw : Boolean(prop.default ?? false);
+			} else {
+				initial[name] =
+					raw != null
+						? String(raw)
+						: prop.default != null
+							? String(prop.default)
+							: "";
+			}
+		}
+		return initial;
+	});
+	const [target, setTarget] = useState<TaskTarget | undefined>(
+		config.target as TaskTarget | undefined,
+	);
+	const [matchMode, setMatchMode] = useState<"any" | "all" | undefined>(
+		config.match_mode as "any" | "all" | undefined,
+	);
+
+	function setField(name: string, value: string | boolean) {
+		setValues((prev) => ({ ...prev, [name]: value }));
+	}
+
+	const missingRequired = fieldNames.some((name) => {
+		if (!required.has(name)) return false;
+		const prop = properties[name];
+		if (prop.type === "boolean") return false;
+		return !String(values[name] ?? "").trim();
+	});
+
+	function buildConfig(): Record<string, unknown> {
+		const out: Record<string, unknown> = {};
+		for (const name of fieldNames) {
+			const prop = properties[name];
+			const raw = values[name];
+			if (prop.type === "boolean") {
+				out[name] = Boolean(raw);
+				continue;
+			}
+			const strVal = String(raw ?? "").trim();
+			if (!strVal) {
+				if (required.has(name)) out[name] = strVal;
+				continue;
+			}
+			if (prop.type === "integer" || prop.type === "number") {
+				const num = Number(strVal);
+				out[name] = Number.isFinite(num) ? num : strVal;
+			} else {
+				out[name] = strVal;
+			}
+		}
+		if (showTarget) {
+			out.target = target;
+			if (nodeKind === "condition") out.match_mode = matchMode;
+		}
+		return out;
+	}
+
+	if (fieldNames.length === 0 && !showTarget) {
+		return (
+			<GenericConfigForm
+				config={config}
+				canEdit={canEdit}
+				onSave={onSave}
+				saving={saving}
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-3">
+			<SchemaFields
+				properties={properties}
+				required={required}
+				values={values}
+				setField={setField}
+				members={members}
+				canEdit={canEdit}
+			/>
+			{showTarget && (
+				<div className="space-y-1">
+					<Label className="text-[10px] text-muted-foreground">
+						{t("automation.nodeConfig.target.label")}
+					</Label>
+					<TaskTargetSelector
+						projectId={projectId}
+						target={target}
+						onChange={setTarget}
+						canEdit={canEdit}
+					/>
+					{nodeKind === "condition" &&
+						target &&
+						MULTI_VALUED_TARGET_KINDS.includes(target.kind) && (
+							<MatchModeSelector
+								value={matchMode}
+								onChange={setMatchMode}
+								canEdit={canEdit}
+							/>
+						)}
+				</div>
+			)}
+			{canEdit && (
+				<SaveButton
+					saving={saving}
+					disabled={missingRequired}
+					onClick={() => onSave(buildConfig())}
+				/>
+			)}
+		</div>
+	);
+}
+
+// SchemaFields renders one input per JSON-Schema property — shared by
+// SchemaConfigForm and GenericConfigForm's schema-aware sibling for any
+// plugin-contributed node (trigger, condition, or action), so both stay in
+// sync with configSchema's supported shapes (boolean/enum/textarea/date/
+// member/number/text) automatically.
+function SchemaFields({
+	properties,
+	required,
+	values,
+	setField,
+	members,
+	canEdit,
+}: {
+	properties: Record<string, PluginNodeConfigSchemaProperty>;
+	required: Set<string>;
+	values: Record<string, string | boolean>;
+	setField: (name: string, value: string | boolean) => void;
+	members: ProjectMember[];
+	canEdit: boolean;
+}) {
+	const fieldNames = Object.keys(properties);
+	return (
+		<>
+			{fieldNames.map((name) => {
+				const prop = properties[name];
+				const label = prop.title ?? name;
+				const isRequired = required.has(name);
+				const value = values[name];
+
+				if (prop.type === "boolean") {
+					return (
+						<div key={name} className="flex items-center justify-between gap-2">
+							<Label>{label}</Label>
+							<Switch
+								checked={Boolean(value)}
+								onCheckedChange={(checked) => setField(name, checked)}
+								disabled={!canEdit}
+							/>
+						</div>
+					);
+				}
+
+				if (prop.format === "member") {
+					const selected = members.find((m) => m.id === value);
+					return (
+						<div key={name} className="space-y-1.5">
+							<Label>
+								{label}
+								{isRequired && <span className="text-destructive"> *</span>}
+							</Label>
+							<Select
+								value={String(value ?? "")}
+								onValueChange={(v) => v && setField(name, v)}
+								disabled={!canEdit}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue>
+										{selected?.full_name || selected?.username}
+									</SelectValue>
+								</SelectTrigger>
+								<SelectContent>
+									{members.map((m) => (
+										<SelectItem key={m.id} value={m.id}>
+											{m.full_name || m.username}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					);
+				}
+
+				if (prop.enum && prop.enum.length > 0) {
+					return (
+						<div key={name} className="space-y-1.5">
+							<Label>
+								{label}
+								{isRequired && <span className="text-destructive"> *</span>}
+							</Label>
+							<Select
+								value={String(value ?? "")}
+								onValueChange={(v) => v && setField(name, v)}
+								disabled={!canEdit}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue>{String(value ?? "")}</SelectValue>
+								</SelectTrigger>
+								<SelectContent>
+									{prop.enum.map((option: string) => (
+										<SelectItem key={option} value={option}>
+											{option}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					);
+				}
+
+				if (prop.format === "textarea") {
+					return (
+						<div key={name} className="space-y-1.5">
+							<Label>
+								{label}
+								{isRequired && <span className="text-destructive"> *</span>}
+							</Label>
+							<Textarea
+								value={String(value ?? "")}
+								onChange={(e) => setField(name, e.target.value)}
+								rows={4}
+								disabled={!canEdit}
+							/>
+						</div>
+					);
+				}
+
+				const inputType =
+					prop.format === "date"
+						? "date"
+						: prop.type === "integer" || prop.type === "number"
+							? "number"
+							: "text";
+
+				return (
+					<div key={name} className="space-y-1.5">
+						<Label>
+							{label}
+							{isRequired && <span className="text-destructive"> *</span>}
+						</Label>
+						<Input
+							type={inputType}
+							value={String(value ?? "")}
+							onChange={(e) => setField(name, e.target.value)}
+							min={prop.minimum}
+							disabled={!canEdit}
+						/>
+					</div>
+				);
+			})}
+		</>
+	);
+}
+
+// PluginTriggerNoConfigNotice replaces GenericConfigForm's raw-JSON editor
+// for a plugin-contributed trigger that declares no configSchema (or one
+// with no properties). Unlike a condition or action, a trigger's config is
+// never read by the automation engine at all — it matches purely on the
+// manifest's declared eventTopic (see AutomationNodeManifest.EventTopic and
+// validateTriggerConfig's plugin-trigger branch in the core's
+// domain/plugin/entity.go and service/automation/automation_service.go). A
+// plugin wanting per-instance filtering contributes a Condition node
+// instead, placed right after the trigger in the graph — so offering a JSON
+// editor here would just invite the user to configure something that can
+// never take effect. Mirrors the "no config fields" message
+// TriggerConfigForm shows for the built-in task_created/assignee_changed/
+// priority_changed triggers.
+function PluginTriggerNoConfigNotice() {
+	const { t } = useTranslation("projects");
+	return (
+		<p className="text-xs text-muted-foreground">
+			{t("automation.nodeConfig.trigger.noConfigNeeded")}
+		</p>
+	);
+}
+
+// GenericConfigForm is the fallback config editor for a plugin-contributed
+// condition or action node type that declares no configSchema (or one with
+// no properties): a raw JSON editor. Any plugin node with a real
+// configSchema renders through SchemaConfigForm above instead — this
+// remains reachable only so an older or minimal plugin never loses the
+// ability to be configured at all. Not used for triggers — see
+// PluginTriggerNoConfigNotice above.
 function GenericConfigForm({
 	config,
 	canEdit,
@@ -738,7 +1187,7 @@ function TriggerConfigForm({
 	// task_created, assignee_changed, priority_changed — no config fields.
 	return (
 		<p className="text-xs text-muted-foreground">
-			{t("automation.nodeConfig.trigger.anyStatus")}
+			{t("automation.nodeConfig.trigger.noConfigNeeded")}
 		</p>
 	);
 }
@@ -1155,6 +1604,10 @@ function ConditionConfigForm({
 	const [branches, setBranches] = useState<ConditionBranch[]>(
 		config.branches ?? [],
 	);
+	const { data: sprints } = useQuery({
+		...sprintsQueryOptions(projectId),
+		enabled: !!projectId,
+	});
 
 	useEffect(() => {
 		setBranches(config.branches ?? []);
@@ -1166,23 +1619,13 @@ function ConditionConfigForm({
 		);
 	}
 
-	function updateLeaf(
-		index: number,
-		patch: Partial<{
-			field: ConditionField;
-			field_key: string;
-			operator: ConditionOperator;
-			value: unknown;
-			target: TaskTarget | undefined;
-			match_mode: "any" | "all";
-		}>,
-	) {
+	function updateLeaf(index: number, patch: Partial<ConditionLeaf>) {
 		setBranches((prev) =>
 			prev.map((b, i) => {
 				if (i !== index) return b;
-				const current = b.tree ?? {
-					field: "status_id" as ConditionField,
-					operator: "equals" as ConditionOperator,
+				const current: ConditionLeaf = b.tree ?? {
+					field: "status_id",
+					operator: "equals",
 				};
 				return { ...b, tree: { ...current, ...patch } };
 			}),
@@ -1354,7 +1797,7 @@ function ConditionConfigForm({
 										))}
 									</SelectContent>
 								</Select>
-							) : field === "assignee_ids" ? (
+							) : field === "assignee_ids" || field === "reporter_id" ? (
 								<Select
 									value={(leaf?.value as string) ?? ""}
 									onValueChange={(v) => updateLeaf(i, { value: v ?? "" })}
@@ -1380,6 +1823,51 @@ function ConditionConfigForm({
 										))}
 									</SelectContent>
 								</Select>
+							) : field === "sprint_id" ? (
+								<Select
+									value={(leaf?.value as string) ?? ""}
+									onValueChange={(v) => updateLeaf(i, { value: v ?? "" })}
+									disabled={!canEdit}
+								>
+									<SelectTrigger className="h-7 w-full text-xs">
+										<SelectValue
+											placeholder={t("automation.nodeConfig.condition.value")}
+										>
+											{(sprints ?? []).find((s) => s.id === leaf?.value)?.name}
+										</SelectValue>
+									</SelectTrigger>
+									<SelectContent>
+										{(sprints ?? []).map((s) => (
+											<SelectItem key={s.id} value={s.id}>
+												{s.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							) : field === "parent_task_id" ? (
+								<TargetTaskPicker
+									projectId={projectId}
+									value={(leaf?.value as string) ?? ""}
+									onChange={(taskId) => updateLeaf(i, { value: taskId })}
+									canEdit={canEdit}
+								/>
+							) : field === "start_date" || field === "due_date" ? (
+								<Input
+									type="date"
+									value={(leaf?.value as string) ?? ""}
+									onChange={(e) => updateLeaf(i, { value: e.target.value })}
+									disabled={!canEdit}
+									className="h-7 text-xs"
+								/>
+							) : field === "story_points" ? (
+								<Input
+									type="number"
+									value={(leaf?.value as string) ?? ""}
+									onChange={(e) => updateLeaf(i, { value: e.target.value })}
+									placeholder={t("automation.nodeConfig.condition.value")}
+									disabled={!canEdit}
+									className="h-7 text-xs"
+								/>
 							) : field === "custom_field" &&
 								selectedCustomField &&
 								selectedCustomField.options.length > 0 ? (
@@ -1464,6 +1952,7 @@ function ActionConfigForm({
 	statuses,
 	members,
 	customFields,
+	taskTypes,
 	canEdit,
 	onSave,
 	saving,
@@ -1474,20 +1963,13 @@ function ActionConfigForm({
 	statuses: TaskStatus[];
 	members: ProjectMember[];
 	customFields: CustomFieldDefinition[];
+	taskTypes: TaskType[];
 	canEdit: boolean;
 	onSave: (config: Record<string, unknown>) => void;
 	saving?: boolean;
 }) {
 	const { t } = useTranslation("projects");
 	const [target, setTarget] = useState<TaskTarget | undefined>(config.target);
-	const [memberId, setMemberId] = useState(config.member_id ?? "");
-	const [statusId, setStatusId] = useState(config.status_id ?? "");
-	const [priorityBucket, setPriorityBucket] = useState(
-		getImportanceBucket(config.importance ?? 0).toString(),
-	);
-	const [tag, setTag] = useState(config.tag ?? "");
-	const [fieldKey, setFieldKey] = useState(config.field_key ?? "");
-	const [value, setValue] = useState((config.value as string) ?? "");
 	const [message, setMessage] = useState(config.message ?? "");
 	const [method, setMethod] = useState(config.method ?? "GET");
 	const [url, setUrl] = useState(config.url ?? "");
@@ -1503,21 +1985,41 @@ function ActionConfigForm({
 	);
 	const [body, setBody] = useState(config.body ?? "");
 
-	if (type === "assign" || type === "trigger_ai_agent") {
-		const isAiAgentAction = type === "trigger_ai_agent";
-		const assignableMembers = isAiAgentAction
-			? members.filter((m) => m.member_type === "agent")
-			: members;
+	// update_task's fields, each independently enabled — an unset field is
+	// left untouched on the task; only enabled fields are sent.
+	const initialFields = config.update ?? {};
+	const [memberId, setMemberId] = useState(config.member_id ?? "");
+	const [enabled, setEnabled] = useState<Set<keyof TaskFieldUpdate>>(
+		() => new Set(Object.keys(initialFields) as (keyof TaskFieldUpdate)[]),
+	);
+	const [fields, setFields] = useState<TaskFieldUpdate>(initialFields);
+	const { data: sprints } = useQuery({
+		...sprintsQueryOptions(projectId),
+		enabled: !!projectId,
+	});
+
+	function toggleField(key: keyof TaskFieldUpdate, on: boolean) {
+		setEnabled((prev) => {
+			const next = new Set(prev);
+			if (on) next.add(key);
+			else next.delete(key);
+			return next;
+		});
+	}
+
+	function setFieldValue<K extends keyof TaskFieldUpdate>(
+		key: K,
+		value: TaskFieldUpdate[K],
+	) {
+		setFields((prev) => ({ ...prev, [key]: value }));
+	}
+
+	if (type === "trigger_ai_agent") {
+		const assignableMembers = members.filter((m) => m.member_type === "agent");
 		return (
 			<div className="space-y-3">
 				<div className="space-y-1.5">
-					<Label>
-						{t(
-							isAiAgentAction
-								? "automation.nodeConfig.action.agentLabel"
-								: "automation.nodeConfig.action.memberLabel",
-						)}
-					</Label>
+					<Label>{t("automation.nodeConfig.action.agentLabel")}</Label>
 					<Select
 						value={memberId}
 						onValueChange={(v) => setMemberId(v ?? "")}
@@ -1542,18 +2044,16 @@ function ActionConfigForm({
 						</SelectContent>
 					</Select>
 				</div>
-				{type === "trigger_ai_agent" && (
-					<div className="space-y-1.5">
-						<Label>{t("automation.nodeConfig.action.messageLabel")}</Label>
-						<Textarea
-							value={message}
-							onChange={(e) => setMessage(e.target.value)}
-							placeholder={t("automation.nodeConfig.action.messagePlaceholder")}
-							rows={4}
-							disabled={!canEdit}
-						/>
-					</div>
-				)}
+				<div className="space-y-1.5">
+					<Label>{t("automation.nodeConfig.action.messageLabel")}</Label>
+					<Textarea
+						value={message}
+						onChange={(e) => setMessage(e.target.value)}
+						placeholder={t("automation.nodeConfig.action.messagePlaceholder")}
+						rows={4}
+						disabled={!canEdit}
+					/>
+				</div>
 				<div className="space-y-1">
 					<Label className="text-[10px] text-muted-foreground">
 						{t("automation.nodeConfig.target.label")}
@@ -1569,148 +2069,7 @@ function ActionConfigForm({
 					<SaveButton
 						saving={saving}
 						disabled={!memberId}
-						onClick={() =>
-							onSave(
-								type === "trigger_ai_agent"
-									? { member_id: memberId, message, target }
-									: { member_id: memberId, target },
-							)
-						}
-					/>
-				)}
-			</div>
-		);
-	}
-
-	if (type === "set_status") {
-		return (
-			<div className="space-y-3">
-				<div className="space-y-1.5">
-					<Label>{t("automation.nodeConfig.action.statusLabel")}</Label>
-					<Select
-						value={statusId}
-						onValueChange={(v) => setStatusId(v ?? "")}
-						disabled={!canEdit}
-					>
-						<SelectTrigger className="w-full">
-							<SelectValue>
-								{statuses.find((s) => s.id === statusId)?.name}
-							</SelectValue>
-						</SelectTrigger>
-						<SelectContent>
-							{statuses.map((s) => (
-								<SelectItem key={s.id} value={s.id}>
-									{s.name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-				<div className="space-y-1">
-					<Label className="text-[10px] text-muted-foreground">
-						{t("automation.nodeConfig.target.label")}
-					</Label>
-					<TaskTargetSelector
-						projectId={projectId}
-						target={target}
-						onChange={setTarget}
-						canEdit={canEdit}
-					/>
-				</div>
-				{canEdit && (
-					<SaveButton
-						saving={saving}
-						disabled={!statusId}
-						onClick={() => onSave({ status_id: statusId, target })}
-					/>
-				)}
-			</div>
-		);
-	}
-
-	if (type === "set_priority") {
-		return (
-			<div className="space-y-3">
-				<div className="space-y-1.5">
-					<Label>{t("automation.nodeConfig.action.importanceLabel")}</Label>
-					<Select
-						value={priorityBucket}
-						onValueChange={(v) => v && setPriorityBucket(v)}
-						disabled={!canEdit}
-					>
-						<SelectTrigger className="w-full">
-							<SelectValue>
-								{(() => {
-									const level = PRIORITY_LEVELS.find(
-										(l) => l.value.toString() === priorityBucket,
-									);
-									return level ? t(level.labelKey) : undefined;
-								})()}
-							</SelectValue>
-						</SelectTrigger>
-						<SelectContent>
-							{PRIORITY_LEVELS.map((level) => (
-								<SelectItem key={level.value} value={level.value.toString()}>
-									{t(level.labelKey)}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-				<div className="space-y-1">
-					<Label className="text-[10px] text-muted-foreground">
-						{t("automation.nodeConfig.target.label")}
-					</Label>
-					<TaskTargetSelector
-						projectId={projectId}
-						target={target}
-						onChange={setTarget}
-						canEdit={canEdit}
-					/>
-				</div>
-				{canEdit && (
-					<SaveButton
-						saving={saving}
-						onClick={() =>
-							onSave({
-								importance:
-									IMPORTANCE_BUCKET_VALUES[Number(priorityBucket)] ?? 0,
-								target,
-							})
-						}
-					/>
-				)}
-			</div>
-		);
-	}
-
-	if (type === "add_tag") {
-		return (
-			<div className="space-y-3">
-				<div className="space-y-1.5">
-					<Label>{t("automation.nodeConfig.action.tagLabel")}</Label>
-					<Input
-						value={tag}
-						onChange={(e) => setTag(e.target.value)}
-						disabled={!canEdit}
-					/>
-				</div>
-				<div className="space-y-1">
-					<Label className="text-[10px] text-muted-foreground">
-						{t("automation.nodeConfig.target.label")}
-					</Label>
-					<TaskTargetSelector
-						projectId={projectId}
-						target={target}
-						onChange={setTarget}
-						canEdit={canEdit}
-					/>
-				</div>
-				{canEdit && (
-					<SaveButton
-						saving={saving}
-						disabled={!tag.trim()}
-						onClick={() => onSave({ tag: tag.trim(), target })}
+						onClick={() => onSave({ member_id: memberId, message, target })}
 					/>
 				)}
 			</div>
@@ -1850,56 +2209,353 @@ function ActionConfigForm({
 		);
 	}
 
-	// set_custom_field
-	const selectedField = customFields.find((cf) => cf.field_key === fieldKey);
-	return (
-		<div className="space-y-3">
-			<div className="space-y-1.5">
-				<Label>{t("automation.nodeConfig.action.fieldKeyLabel")}</Label>
-				<Select
-					value={fieldKey}
-					onValueChange={(v) => setFieldKey(v ?? "")}
-					disabled={!canEdit}
-				>
-					<SelectTrigger className="w-full">
-						<SelectValue>{selectedField?.display_name}</SelectValue>
-					</SelectTrigger>
-					<SelectContent>
-						{customFields.map((cf) => (
-							<SelectItem key={cf.id} value={cf.field_key}>
-								{cf.display_name}
-							</SelectItem>
-						))}
-					</SelectContent>
-				</Select>
-			</div>
-			<div className="space-y-1.5">
-				<Label>{t("automation.nodeConfig.action.valueLabel")}</Label>
-				{selectedField && selectedField.options.length > 0 ? (
+	// update_task: dynamic field-update rows. Add a field via the picker,
+	// which pairs it with a type-appropriate value editor below; remove it
+	// via the trash icon. Fields never added here are left untouched on
+	// the task (see TaskFieldUpdate — unset ≠ cleared).
+	const selectedCustomFieldKeys = Object.keys(fields.custom_fields ?? {});
+	const addableFields = FIELD_UPDATE_ORDER.filter((k) => !enabled.has(k));
+
+	function fieldLabel(key: UpdatableField): string {
+		if (key === "custom_fields") {
+			return t("automation.nodeConfig.action.customFieldsLabel");
+		}
+		return t(`automation.nodeConfig.condition.fields.${key}`);
+	}
+
+	function renderFieldEditor(key: UpdatableField) {
+		switch (key) {
+			case "title":
+				return (
+					<Input
+						value={fields.title ?? ""}
+						onChange={(e) => setFieldValue("title", e.target.value)}
+						disabled={!canEdit}
+						className="h-7 text-xs"
+					/>
+				);
+			case "status_id":
+				return (
 					<Select
-						value={value}
-						onValueChange={(v) => setValue(v ?? "")}
+						value={fields.status_id ?? ""}
+						onValueChange={(v) => setFieldValue("status_id", v ?? undefined)}
 						disabled={!canEdit}
 					>
-						<SelectTrigger className="w-full">
-							<SelectValue>{value}</SelectValue>
+						<SelectTrigger className="h-7 w-full text-xs">
+							<SelectValue>
+								{statuses.find((s) => s.id === fields.status_id)?.name}
+							</SelectValue>
 						</SelectTrigger>
 						<SelectContent>
-							{selectedField.options.map((opt) => (
-								<SelectItem key={opt} value={opt}>
-									{opt}
+							{statuses.map((s) => (
+								<SelectItem key={s.id} value={s.id}>
+									{s.name}
 								</SelectItem>
 							))}
 						</SelectContent>
 					</Select>
-				) : (
-					<Input
-						value={value}
-						onChange={(e) => setValue(e.target.value)}
+				);
+			case "task_type_id":
+				return (
+					<Select
+						value={fields.task_type_id ?? ""}
+						onValueChange={(v) => setFieldValue("task_type_id", v ?? undefined)}
 						disabled={!canEdit}
+					>
+						<SelectTrigger className="h-7 w-full text-xs">
+							<SelectValue>
+								{taskTypes.find((tt) => tt.id === fields.task_type_id)?.name}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							{taskTypes.map((tt) => (
+								<SelectItem key={tt.id} value={tt.id}>
+									{tt.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				);
+			case "assignee_ids":
+				return (
+					<Select
+						value={fields.assignee_ids?.[0] ?? ""}
+						onValueChange={(v) =>
+							setFieldValue("assignee_ids", v ? [v] : undefined)
+						}
+						disabled={!canEdit}
+					>
+						<SelectTrigger className="h-7 w-full text-xs">
+							<SelectValue>
+								{(() => {
+									const m = members.find(
+										(mem) => mem.id === fields.assignee_ids?.[0],
+									);
+									return m?.full_name || m?.username;
+								})()}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							{members.map((m) => (
+								<SelectItem key={m.id} value={m.id}>
+									{m.full_name || m.username}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				);
+			case "importance":
+				return (
+					<Select
+						value={getImportanceBucket(fields.importance ?? 0).toString()}
+						onValueChange={(v) =>
+							v &&
+							setFieldValue(
+								"importance",
+								IMPORTANCE_BUCKET_VALUES[Number(v)] ?? 0,
+							)
+						}
+						disabled={!canEdit}
+					>
+						<SelectTrigger className="h-7 w-full text-xs">
+							<SelectValue>
+								{(() => {
+									const level = PRIORITY_LEVELS.find(
+										(l) =>
+											l.value.toString() ===
+											getImportanceBucket(fields.importance ?? 0).toString(),
+									);
+									return level ? t(level.labelKey) : undefined;
+								})()}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							{PRIORITY_LEVELS.map((level) => (
+								<SelectItem key={level.value} value={level.value.toString()}>
+									{t(level.labelKey)}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				);
+			case "story_points":
+				return (
+					<Input
+						type="number"
+						value={fields.story_points ?? ""}
+						onChange={(e) =>
+							setFieldValue(
+								"story_points",
+								e.target.value ? Number(e.target.value) : undefined,
+							)
+						}
+						disabled={!canEdit}
+						className="h-7 text-xs"
 					/>
-				)}
-			</div>
+				);
+			case "tags":
+				return (
+					<Input
+						value={(fields.tags ?? []).join(", ")}
+						onChange={(e) =>
+							setFieldValue(
+								"tags",
+								e.target.value
+									.split(",")
+									.map((s) => s.trim())
+									.filter(Boolean),
+							)
+						}
+						placeholder={t("automation.nodeConfig.action.tagLabel")}
+						disabled={!canEdit}
+						className="h-7 text-xs"
+					/>
+				);
+			case "reporter_id":
+				return (
+					<Select
+						value={fields.reporter_id ?? ""}
+						onValueChange={(v) => setFieldValue("reporter_id", v ?? undefined)}
+						disabled={!canEdit}
+					>
+						<SelectTrigger className="h-7 w-full text-xs">
+							<SelectValue>
+								{(() => {
+									const m = members.find(
+										(mem) => mem.id === fields.reporter_id,
+									);
+									return m?.full_name || m?.username;
+								})()}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							{members.map((m) => (
+								<SelectItem key={m.id} value={m.id}>
+									{m.full_name || m.username}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				);
+			case "sprint_id":
+				return (
+					<Select
+						value={fields.sprint_id ?? ""}
+						onValueChange={(v) => setFieldValue("sprint_id", v ?? undefined)}
+						disabled={!canEdit}
+					>
+						<SelectTrigger className="h-7 w-full text-xs">
+							<SelectValue>
+								{(sprints ?? []).find((s) => s.id === fields.sprint_id)?.name}
+							</SelectValue>
+						</SelectTrigger>
+						<SelectContent>
+							{(sprints ?? []).map((s) => (
+								<SelectItem key={s.id} value={s.id}>
+									{s.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				);
+			case "parent_task_id":
+				return (
+					<TargetTaskPicker
+						projectId={projectId}
+						value={fields.parent_task_id ?? ""}
+						onChange={(taskId) => setFieldValue("parent_task_id", taskId)}
+						canEdit={canEdit}
+					/>
+				);
+			case "start_date":
+				return (
+					<Input
+						type="date"
+						value={fields.start_date ?? ""}
+						onChange={(e) => setFieldValue("start_date", e.target.value)}
+						disabled={!canEdit}
+						className="h-7 text-xs"
+					/>
+				);
+			case "due_date":
+				return (
+					<Input
+						type="date"
+						value={fields.due_date ?? ""}
+						onChange={(e) => setFieldValue("due_date", e.target.value)}
+						disabled={!canEdit}
+						className="h-7 text-xs"
+					/>
+				);
+			case "custom_fields":
+				return (
+					<div className="space-y-1.5">
+						<Select
+							value=""
+							onValueChange={(v) => {
+								if (!v) return;
+								setFieldValue("custom_fields", {
+									...fields.custom_fields,
+									[v]: "",
+								});
+							}}
+							disabled={!canEdit}
+						>
+							<SelectTrigger className="h-7 w-full text-xs">
+								<SelectValue
+									placeholder={t("automation.nodeConfig.action.addCustomField")}
+								/>
+							</SelectTrigger>
+							<SelectContent>
+								{customFields
+									.filter(
+										(cf) => !selectedCustomFieldKeys.includes(cf.field_key),
+									)
+									.map((cf) => (
+										<SelectItem key={cf.id} value={cf.field_key}>
+											{cf.display_name}
+										</SelectItem>
+									))}
+							</SelectContent>
+						</Select>
+						{selectedCustomFieldKeys.map((key) => {
+							const def = customFields.find((cf) => cf.field_key === key);
+							return (
+								<div key={key} className="flex items-center gap-1.5">
+									<span className="w-1/3 shrink-0 truncate text-[10px] text-muted-foreground">
+										{def?.display_name ?? key}
+									</span>
+									<Input
+										value={String(fields.custom_fields?.[key] ?? "")}
+										onChange={(e) =>
+											setFieldValue("custom_fields", {
+												...fields.custom_fields,
+												[key]: e.target.value,
+											})
+										}
+										disabled={!canEdit}
+										className="h-7 text-xs"
+									/>
+									{canEdit && (
+										<button
+											type="button"
+											onClick={() => {
+												const next = { ...fields.custom_fields };
+												delete next[key];
+												setFieldValue("custom_fields", next);
+											}}
+											className="shrink-0 text-muted-foreground hover:text-destructive"
+										>
+											<Trash2 className="size-3.5" />
+										</button>
+									)}
+								</div>
+							);
+						})}
+					</div>
+				);
+			default:
+				return null;
+		}
+	}
+
+	return (
+		<div className="space-y-3">
+			<p className="text-xs text-muted-foreground">
+				{t("automation.nodeConfig.action.updateTaskHint")}
+			</p>
+			{canEdit && addableFields.length > 0 && (
+				<Select
+					value=""
+					onValueChange={(v) => {
+						if (!v) return;
+						toggleField(v as UpdatableField, true);
+					}}
+				>
+					<SelectTrigger className="h-7 w-full text-xs">
+						<SelectValue
+							placeholder={t("automation.nodeConfig.action.addFieldToUpdate")}
+						/>
+					</SelectTrigger>
+					<SelectContent>
+						{addableFields.map((key) => (
+							<SelectItem key={key} value={key}>
+								{fieldLabel(key)}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			)}
+			{FIELD_UPDATE_ORDER.filter((key) => enabled.has(key)).map((key) => (
+				<DynamicFieldRow
+					key={key}
+					label={fieldLabel(key)}
+					onRemove={() => toggleField(key, false)}
+					canEdit={canEdit}
+				>
+					{renderFieldEditor(key)}
+				</DynamicFieldRow>
+			))}
 			<div className="space-y-1">
 				<Label className="text-[10px] text-muted-foreground">
 					{t("automation.nodeConfig.target.label")}
@@ -1914,10 +2570,52 @@ function ActionConfigForm({
 			{canEdit && (
 				<SaveButton
 					saving={saving}
-					disabled={!fieldKey}
-					onClick={() => onSave({ field_key: fieldKey, value, target })}
+					disabled={enabled.size === 0}
+					onClick={() => {
+						const savedFields: TaskFieldUpdate = {};
+						for (const key of enabled) {
+							// biome-ignore lint/suspicious/noExplicitAny: TaskFieldUpdate values are heterogeneous per key
+							(savedFields as any)[key] = fields[key];
+						}
+						onSave({ update: savedFields, target });
+					}}
 				/>
 			)}
+		</div>
+	);
+}
+
+// DynamicFieldRow pairs a field's label + value editor with a remove
+// button — matches TaskFieldUpdate's "unset = untouched" semantics: a
+// removed field is never sent, not sent-as-empty. Styled as a small card
+// (mirrors the condition-branch cards above) so a multi-field update
+// reads as a stack of distinct edits rather than a flat form.
+function DynamicFieldRow({
+	label,
+	onRemove,
+	canEdit,
+	children,
+}: {
+	label: string;
+	onRemove: () => void;
+	canEdit: boolean;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="group space-y-1.5 rounded-lg border border-border/60 bg-muted/20 p-2.5 transition-colors hover:border-border">
+			<div className="flex items-center justify-between gap-2">
+				<Label className="text-xs font-medium">{label}</Label>
+				{canEdit && (
+					<button
+						type="button"
+						onClick={onRemove}
+						className="shrink-0 rounded-md p-1 text-muted-foreground opacity-60 transition-opacity hover:bg-destructive/10 hover:text-destructive hover:opacity-100 group-hover:opacity-100"
+					>
+						<Trash2 className="size-3.5" />
+					</button>
+				)}
+			</div>
+			{children}
 		</div>
 	);
 }

--- a/apps/web/src/components/projects/automation/automation-node-config-panel.tsx
+++ b/apps/web/src/components/projects/automation/automation-node-config-panel.tsx
@@ -124,6 +124,19 @@ function taskLabel(task: Task): string {
 	return `#${task.task_number} ${task.title}`;
 }
 
+// <input type="date"> exchanges bare "YYYY-MM-DD" values, but every date
+// leaving this form (start_date/due_date on a condition leaf or an
+// update_task field) is stored as RFC 3339 — matching how dates travel
+// everywhere else in this API (see compareTimePtr's doc comment in
+// condition.go) and the same convention task-detail/property-field/
+// helpers.ts's toISODate uses for the task detail page's own date editor.
+function toDateInputValue(iso?: string): string {
+	return iso ? iso.slice(0, 10) : "";
+}
+function fromDateInputValue(value: string): string {
+	return value ? `${value}T00:00:00Z` : "";
+}
+
 // Field choices for a condition leaf's Select — matches the domain's Field
 // enum in condition.go. Plugin-contributed conditions are their own
 // standalone condition node type (see AutomationNodeConfigPanel's dispatch
@@ -1854,8 +1867,10 @@ function ConditionConfigForm({
 							) : field === "start_date" || field === "due_date" ? (
 								<Input
 									type="date"
-									value={(leaf?.value as string) ?? ""}
-									onChange={(e) => updateLeaf(i, { value: e.target.value })}
+									value={toDateInputValue(leaf?.value as string)}
+									onChange={(e) =>
+										updateLeaf(i, { value: fromDateInputValue(e.target.value) })
+									}
 									disabled={!canEdit}
 									className="h-7 text-xs"
 								/>
@@ -2431,8 +2446,10 @@ function ActionConfigForm({
 				return (
 					<Input
 						type="date"
-						value={fields.start_date ?? ""}
-						onChange={(e) => setFieldValue("start_date", e.target.value)}
+						value={toDateInputValue(fields.start_date)}
+						onChange={(e) =>
+							setFieldValue("start_date", fromDateInputValue(e.target.value))
+						}
 						disabled={!canEdit}
 						className="h-7 text-xs"
 					/>
@@ -2441,8 +2458,10 @@ function ActionConfigForm({
 				return (
 					<Input
 						type="date"
-						value={fields.due_date ?? ""}
-						onChange={(e) => setFieldValue("due_date", e.target.value)}
+						value={toDateInputValue(fields.due_date)}
+						onChange={(e) =>
+							setFieldValue("due_date", fromDateInputValue(e.target.value))
+						}
 						disabled={!canEdit}
 						className="h-7 text-xs"
 					/>

--- a/apps/web/src/components/projects/automation/automation-node-palette.tsx
+++ b/apps/web/src/components/projects/automation/automation-node-palette.tsx
@@ -74,47 +74,40 @@ export function AutomationNodePalette({
 				</DropdownMenuContent>
 			</DropdownMenu>
 
-			{pluginConditions.length > 0 ? (
-				<DropdownMenu>
-					<DropdownMenuTrigger
-						render={
-							<Button variant="outline" size="sm" className="gap-1.5">
-								<GitBranch className="size-3.5" />
-								{t("automation.palette.addCondition")}
-							</Button>
-						}
-					/>
-					<DropdownMenuContent align="start" className="w-56">
-						<DropdownMenuGroup>
+			{/* The built-in N-branch switch is the only "built-in" condition node
+			type — plugin-contributed conditions are their own separate
+			condition node type, listed in a "Plugins" section below it,
+			exactly like plugin triggers/actions. */}
+			<DropdownMenu>
+				<DropdownMenuTrigger
+					render={
+						<Button variant="outline" size="sm" className="gap-1.5">
+							<GitBranch className="size-3.5" />
+							{t("automation.palette.addCondition")}
+						</Button>
+					}
+				/>
+				<DropdownMenuContent align="start" className="w-56">
+					<DropdownMenuGroup>
+						{pluginConditions.length > 0 && (
 							<DropdownMenuLabel>
 								{t("automation.palette.builtIn")}
 							</DropdownMenuLabel>
-							<DropdownMenuItem
-								onClick={() => onAddCondition(CONDITION_NODE_TYPE)}
-							>
-								{t("automation.nodeKind.condition")}
-							</DropdownMenuItem>
-						</DropdownMenuGroup>
+						)}
+						<DropdownMenuItem
+							onClick={() => onAddCondition(CONDITION_NODE_TYPE)}
+						>
+							{t("automation.nodeKind.condition")}
+						</DropdownMenuItem>
+					</DropdownMenuGroup>
+					{pluginConditions.length > 0 && (
 						<PluginTypeGroup
 							items={pluginConditions}
 							onSelect={onAddCondition}
 						/>
-					</DropdownMenuContent>
-				</DropdownMenu>
-			) : (
-				// Exactly one built-in condition type exists (the N-branch switch)
-				// and no plugin has contributed another, so there's nothing to
-				// choose between — a dropdown here would just be a single-item menu.
-				<Button
-					variant="outline"
-					size="sm"
-					className="gap-1.5"
-					onClick={() => onAddCondition(CONDITION_NODE_TYPE)}
-				>
-					<GitBranch className="size-3.5" />
-					{t("automation.palette.addCondition")}
-				</Button>
-			)}
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
 
 			<DropdownMenu>
 				<DropdownMenuTrigger

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "Assign",
-			"set_status": "Set status",
-			"set_priority": "Set priority",
-			"add_tag": "Add tag",
-			"set_custom_field": "Set custom field",
+			"update_task": "Update task",
 			"trigger_ai_agent": "Trigger AI agent",
 			"call_api": "Call API"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "Remove node",
 			"removeConfirmBody": "This removes the node from the graph, along with any of its connections.",
 			"removeConfirmAction": "Remove",
-			"genericFormHint": "This node type comes from a plugin. Edit its config as JSON — plugins can register a richer editor here in a future release.",
+			"genericFormHint": "This node type comes from a plugin that hasn't declared a config schema, so its settings are edited as raw JSON. Plugins that declare a configSchema in their manifest show UI fields here instead.",
 			"trigger": {
 				"anyStatus": "Any status",
+				"noConfigNeeded": "This trigger needs no configuration — it fires automatically whenever the event occurs.",
 				"statusLabel": "Status",
 				"tagLabel": "Tag",
 				"anyTag": "Any tag",
@@ -1370,7 +1367,14 @@
 					"importance": "Priority",
 					"assignee_ids": "Assignee",
 					"tags": "Tags",
-					"custom_field": "Custom field"
+					"custom_field": "Custom field",
+					"title": "Title",
+					"story_points": "Story points",
+					"sprint_id": "Sprint",
+					"parent_task_id": "Parent task",
+					"reporter_id": "Reporter",
+					"start_date": "Start date",
+					"due_date": "Due date"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "Header name",
 				"headerValuePlaceholder": "Value",
 				"addHeader": "Add header",
-				"bodyLabel": "Body"
+				"bodyLabel": "Body",
+				"updateTaskHint": "Only the fields you enable below are changed — everything else on the task is left untouched.",
+				"addFieldToUpdate": "Add field to update…",
+				"customFieldsLabel": "Custom field",
+				"enableField": "Set {{field}}",
+				"titleLabel": "Title",
+				"storyPointsLabel": "Story points",
+				"sprintLabel": "Sprint",
+				"parentTaskLabel": "Parent task",
+				"reporterLabel": "Reporter",
+				"startDateLabel": "Start date",
+				"dueDateLabel": "Due date",
+				"tagsLabel": "Tags",
+				"tagsPlaceholder": "Add a tag…",
+				"assigneesLabel": "Assignees",
+				"noSprint": "No sprint",
+				"pluginConditionLabel": "Plugin condition",
+				"pluginConditionHint": "Delegates this branch's match to a plugin-contributed condition instead of comparing a task field.",
+				"selectPluginPlaceholder": "Select a plugin condition…",
+				"addCustomField": "Add custom field…"
 			},
 			"target": {
 				"label": "Applies to",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "{{minutes}}m after due date",
 				"branches": "{{count}} branch(es)",
 				"priority": "Priority: {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "Unassigned",
 				"notConfigured": "Not configured",
 				"elseShort": "Else",
+				"pluginConditionMatched": "Matched",
 				"branchFallback": "Branch {{n}}",
 				"cronSchedule": "Runs {{expression}}",
 				"webhookReady": "Webhook configured",

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "Asignar",
-			"set_status": "Establecer estado",
-			"set_priority": "Establecer prioridad",
-			"add_tag": "Añadir etiqueta",
-			"set_custom_field": "Establecer campo personalizado",
+			"update_task": "Actualizar tarea",
 			"trigger_ai_agent": "Activar agente de IA",
 			"call_api": "Llamar API"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "Eliminar nodo",
 			"removeConfirmBody": "Esto elimina el nodo del gráfico, junto con todas sus conexiones.",
 			"removeConfirmAction": "Eliminar",
-			"genericFormHint": "Este tipo de nodo proviene de un plugin. Edita su configuración como JSON — los plugins podrán registrar un editor más completo aquí en una futura versión.",
+			"genericFormHint": "Este tipo de nodo proviene de un plugin que no ha declarado un esquema de configuración, por lo que su configuración se edita como JSON en bruto. Los plugins que declaran un configSchema en su manifiesto muestran campos de interfaz aquí en su lugar.",
 			"trigger": {
 				"anyStatus": "Cualquier estado",
+				"noConfigNeeded": "Este disparador no necesita configuración: se activa automáticamente cuando ocurre el evento.",
 				"statusLabel": "Estado",
 				"tagLabel": "Etiqueta",
 				"anyTag": "Cualquier etiqueta",
@@ -1370,7 +1367,14 @@
 					"importance": "Prioridad",
 					"assignee_ids": "Asignado",
 					"tags": "Etiquetas",
-					"custom_field": "Campo personalizado"
+					"custom_field": "Campo personalizado",
+					"title": "Título",
+					"story_points": "Puntos de historia",
+					"sprint_id": "Sprint",
+					"parent_task_id": "Tarea principal",
+					"reporter_id": "Reportero",
+					"start_date": "Fecha de inicio",
+					"due_date": "Fecha de vencimiento"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "Nombre de la cabecera",
 				"headerValuePlaceholder": "Valor",
 				"addHeader": "Añadir cabecera",
-				"bodyLabel": "Cuerpo"
+				"bodyLabel": "Cuerpo",
+				"updateTaskHint": "Solo se cambian los campos que habilites a continuación; el resto de la tarea permanece intacto.",
+				"addFieldToUpdate": "Añadir campo para actualizar…",
+				"customFieldsLabel": "Campo personalizado",
+				"enableField": "Establecer {{field}}",
+				"titleLabel": "Título",
+				"storyPointsLabel": "Puntos de historia",
+				"sprintLabel": "Sprint",
+				"parentTaskLabel": "Tarea principal",
+				"reporterLabel": "Reportero",
+				"startDateLabel": "Fecha de inicio",
+				"dueDateLabel": "Fecha de vencimiento",
+				"tagsLabel": "Etiquetas",
+				"tagsPlaceholder": "Añadir una etiqueta…",
+				"assigneesLabel": "Asignados",
+				"noSprint": "Sin sprint",
+				"pluginConditionLabel": "Condición de plugin",
+				"pluginConditionHint": "Delega la coincidencia de esta rama a una condición de plugin en lugar de comparar un campo de la tarea.",
+				"selectPluginPlaceholder": "Selecciona una condición de plugin…",
+				"addCustomField": "Añadir campo personalizado…"
 			},
 			"target": {
 				"label": "Se aplica a",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "{{minutes}} min después de la fecha límite",
 				"branches": "{{count}} rama(s)",
 				"priority": "Prioridad: {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "Sin asignar",
 				"notConfigured": "Sin configurar",
 				"elseShort": "Si no",
+				"pluginConditionMatched": "Coincide",
 				"branchFallback": "Rama {{n}}",
 				"cronSchedule": "Se ejecuta {{expression}}",
 				"webhookReady": "Webhook configurado",

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "Assigner",
-			"set_status": "Définir le statut",
-			"set_priority": "Définir la priorité",
-			"add_tag": "Ajouter une étiquette",
-			"set_custom_field": "Définir un champ personnalisé",
+			"update_task": "Mettre à jour la tâche",
 			"trigger_ai_agent": "Déclencher l'agent IA",
 			"call_api": "Appeler l'API"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "Supprimer le nœud",
 			"removeConfirmBody": "Cela supprime le nœud du graphe, ainsi que toutes ses connexions.",
 			"removeConfirmAction": "Supprimer",
-			"genericFormHint": "Ce type de nœud provient d'un plugin. Modifiez sa configuration en JSON — les plugins pourront proposer un éditeur plus riche ici dans une future version.",
+			"genericFormHint": "Ce type de nœud provient d'un plugin qui n'a pas déclaré de schéma de configuration, ses paramètres sont donc modifiés en JSON brut. Les plugins qui déclarent un configSchema dans leur manifeste affichent plutôt des champs d'interface ici.",
 			"trigger": {
 				"anyStatus": "N'importe quel statut",
+				"noConfigNeeded": "Ce déclencheur ne nécessite aucune configuration : il se déclenche automatiquement dès que l'événement se produit.",
 				"statusLabel": "Statut",
 				"tagLabel": "Étiquette",
 				"anyTag": "N'importe quelle étiquette",
@@ -1370,7 +1367,14 @@
 					"importance": "Priorité",
 					"assignee_ids": "Assigné",
 					"tags": "Étiquettes",
-					"custom_field": "Champ personnalisé"
+					"custom_field": "Champ personnalisé",
+					"title": "Titre",
+					"story_points": "Story points",
+					"sprint_id": "Sprint",
+					"parent_task_id": "Tâche parente",
+					"reporter_id": "Rapporteur",
+					"start_date": "Date de début",
+					"due_date": "Date d'échéance"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "Nom de l'en-tête",
 				"headerValuePlaceholder": "Valeur",
 				"addHeader": "Ajouter un en-tête",
-				"bodyLabel": "Corps"
+				"bodyLabel": "Corps",
+				"updateTaskHint": "Seuls les champs que vous activez ci-dessous sont modifiés — le reste de la tâche n'est pas touché.",
+				"addFieldToUpdate": "Ajouter un champ à mettre à jour…",
+				"customFieldsLabel": "Champ personnalisé",
+				"enableField": "Définir {{field}}",
+				"titleLabel": "Titre",
+				"storyPointsLabel": "Story points",
+				"sprintLabel": "Sprint",
+				"parentTaskLabel": "Tâche parente",
+				"reporterLabel": "Rapporteur",
+				"startDateLabel": "Date de début",
+				"dueDateLabel": "Date d'échéance",
+				"tagsLabel": "Étiquettes",
+				"tagsPlaceholder": "Ajouter une étiquette…",
+				"assigneesLabel": "Assignés",
+				"noSprint": "Aucun sprint",
+				"pluginConditionLabel": "Condition de plugin",
+				"pluginConditionHint": "Délègue la correspondance de cette branche à une condition fournie par un plugin plutôt qu'à une comparaison de champ de tâche.",
+				"selectPluginPlaceholder": "Sélectionner une condition de plugin…",
+				"addCustomField": "Ajouter un champ personnalisé…"
 			},
 			"target": {
 				"label": "S'applique à",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "{{minutes}} min après l'échéance",
 				"branches": "{{count}} branche(s)",
 				"priority": "Priorité : {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "Non assigné",
 				"notConfigured": "Non configuré",
 				"elseShort": "Sinon",
+				"pluginConditionMatched": "Correspond",
 				"branchFallback": "Branche {{n}}",
 				"cronSchedule": "S'exécute {{expression}}",
 				"webhookReady": "Webhook configuré",

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "担当者を割り当て",
-			"set_status": "ステータスを設定",
-			"set_priority": "優先度を設定",
-			"add_tag": "タグを追加",
-			"set_custom_field": "カスタムフィールドを設定",
+			"update_task": "タスクを更新",
 			"trigger_ai_agent": "AIエージェントを起動",
 			"call_api": "APIを呼び出し"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "ノードを削除",
 			"removeConfirmBody": "グラフからこのノードと、そのすべての接続が削除されます。",
 			"removeConfirmAction": "削除",
-			"genericFormHint": "このノードタイプはプラグインによって提供されています。設定はJSONとして編集してください — 将来のリリースでプラグインがより高度なエディタを登録できるようになります。",
+			"genericFormHint": "このノードタイプは設定スキーマを宣言していないプラグインによって提供されているため、設定は生のJSONとして編集します。マニフェストでconfigSchemaを宣言しているプラグインは、代わりにUIフィールドをここに表示します。",
 			"trigger": {
 				"anyStatus": "任意のステータス",
+				"noConfigNeeded": "このトリガーに設定は不要です。イベントが発生すると自動的に実行されます。",
 				"statusLabel": "ステータス",
 				"tagLabel": "タグ",
 				"anyTag": "任意のタグ",
@@ -1370,7 +1367,14 @@
 					"importance": "優先度",
 					"assignee_ids": "担当者",
 					"tags": "タグ",
-					"custom_field": "カスタムフィールド"
+					"custom_field": "カスタムフィールド",
+					"title": "タイトル",
+					"story_points": "ストーリーポイント",
+					"sprint_id": "スプリント",
+					"parent_task_id": "親タスク",
+					"reporter_id": "報告者",
+					"start_date": "開始日",
+					"due_date": "期日"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "ヘッダー名",
 				"headerValuePlaceholder": "値",
 				"addHeader": "ヘッダーを追加",
-				"bodyLabel": "本文"
+				"bodyLabel": "本文",
+				"updateTaskHint": "以下で有効にしたフィールドのみが変更されます。その他のタスクの内容は変更されません。",
+				"addFieldToUpdate": "更新するフィールドを追加…",
+				"customFieldsLabel": "カスタムフィールド",
+				"enableField": "{{field}} を設定",
+				"titleLabel": "タイトル",
+				"storyPointsLabel": "ストーリーポイント",
+				"sprintLabel": "スプリント",
+				"parentTaskLabel": "親タスク",
+				"reporterLabel": "報告者",
+				"startDateLabel": "開始日",
+				"dueDateLabel": "期日",
+				"tagsLabel": "タグ",
+				"tagsPlaceholder": "タグを追加…",
+				"assigneesLabel": "担当者",
+				"noSprint": "スプリントなし",
+				"pluginConditionLabel": "プラグイン条件",
+				"pluginConditionHint": "タスクフィールドの比較の代わりに、このブランチの判定をプラグイン提供の条件に委任します。",
+				"selectPluginPlaceholder": "プラグイン条件を選択…",
+				"addCustomField": "カスタムフィールドを追加…"
 			},
 			"target": {
 				"label": "適用先",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "期日の{{minutes}}分後",
 				"branches": "{{count}}件の分岐",
 				"priority": "優先度：{{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "未割り当て",
 				"notConfigured": "未設定",
 				"elseShort": "それ以外",
+				"pluginConditionMatched": "一致",
 				"branchFallback": "分岐{{n}}",
 				"cronSchedule": "{{expression}} に実行",
 				"webhookReady": "Webhook設定済み",

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "웹훅"
 		},
 		"actionTypes": {
-			"assign": "담당자 지정",
-			"set_status": "상태 설정",
-			"set_priority": "우선순위 설정",
-			"add_tag": "태그 추가",
-			"set_custom_field": "사용자 지정 필드 설정",
+			"update_task": "작업 업데이트",
 			"trigger_ai_agent": "AI 에이전트 실행",
 			"call_api": "API 호출"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "노드 삭제",
 			"removeConfirmBody": "그래프에서 이 노드와 그에 연결된 모든 연결이 삭제됩니다.",
 			"removeConfirmAction": "삭제",
-			"genericFormHint": "이 노드 유형은 플러그인에서 제공됩니다. 설정을 JSON으로 편집하세요 — 향후 릴리스에서 플러그인이 더 풍부한 편집기를 여기에 등록할 수 있게 됩니다.",
+			"genericFormHint": "이 노드 유형은 구성 스키마를 선언하지 않은 플러그인에서 제공되므로, 설정을 원시 JSON으로 편집합니다. 매니페스트에 configSchema를 선언한 플러그인은 대신 여기에 UI 필드를 표시합니다.",
 			"trigger": {
 				"anyStatus": "모든 상태",
+				"noConfigNeeded": "이 트리거는 구성이 필요하지 않습니다. 이벤트가 발생하면 자동으로 실행됩니다.",
 				"statusLabel": "상태",
 				"tagLabel": "태그",
 				"anyTag": "모든 태그",
@@ -1370,7 +1367,14 @@
 					"importance": "우선순위",
 					"assignee_ids": "담당자",
 					"tags": "태그",
-					"custom_field": "사용자 지정 필드"
+					"custom_field": "사용자 지정 필드",
+					"title": "제목",
+					"story_points": "스토리 포인트",
+					"sprint_id": "스프린트",
+					"parent_task_id": "상위 작업",
+					"reporter_id": "보고자",
+					"start_date": "시작일",
+					"due_date": "마감일"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "헤더 이름",
 				"headerValuePlaceholder": "값",
 				"addHeader": "헤더 추가",
-				"bodyLabel": "본문"
+				"bodyLabel": "본문",
+				"updateTaskHint": "아래에서 활성화한 필드만 변경됩니다. 나머지 작업 내용은 그대로 유지됩니다.",
+				"addFieldToUpdate": "업데이트할 필드 추가…",
+				"customFieldsLabel": "사용자 지정 필드",
+				"enableField": "{{field}} 설정",
+				"titleLabel": "제목",
+				"storyPointsLabel": "스토리 포인트",
+				"sprintLabel": "스프린트",
+				"parentTaskLabel": "상위 작업",
+				"reporterLabel": "보고자",
+				"startDateLabel": "시작일",
+				"dueDateLabel": "마감일",
+				"tagsLabel": "태그",
+				"tagsPlaceholder": "태그 추가…",
+				"assigneesLabel": "담당자",
+				"noSprint": "스프린트 없음",
+				"pluginConditionLabel": "플러그인 조건",
+				"pluginConditionHint": "작업 필드를 비교하는 대신 이 분기의 일치 여부를 플러그인 제공 조건에 위임합니다.",
+				"selectPluginPlaceholder": "플러그인 조건 선택…",
+				"addCustomField": "사용자 지정 필드 추가…"
 			},
 			"target": {
 				"label": "적용 대상",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "마감일 {{minutes}}분 후",
 				"branches": "분기 {{count}}개",
 				"priority": "우선순위: {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "담당자 없음",
 				"notConfigured": "설정되지 않음",
 				"elseShort": "그 외",
+				"pluginConditionMatched": "일치",
 				"branchFallback": "분기 {{n}}",
 				"cronSchedule": "{{expression}} 에 실행",
 				"webhookReady": "웹훅 설정됨",

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "Atribuir",
-			"set_status": "Definir status",
-			"set_priority": "Definir prioridade",
-			"add_tag": "Adicionar tag",
-			"set_custom_field": "Definir campo personalizado",
+			"update_task": "Atualizar tarefa",
 			"trigger_ai_agent": "Acionar agente de IA",
 			"call_api": "Chamar API"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "Remover nó",
 			"removeConfirmBody": "Isso remove o nó do gráfico, junto com todas as suas conexões.",
 			"removeConfirmAction": "Remover",
-			"genericFormHint": "Este tipo de nó vem de um plugin. Edite sua configuração como JSON — plugins poderão registrar um editor mais completo aqui em uma versão futura.",
+			"genericFormHint": "Este tipo de nó vem de um plugin que não declarou um esquema de configuração, então suas configurações são editadas como JSON bruto. Plugins que declaram um configSchema em seu manifesto exibem campos de interface aqui.",
 			"trigger": {
 				"anyStatus": "Qualquer status",
+				"noConfigNeeded": "Este gatilho não precisa de configuração — ele é acionado automaticamente quando o evento ocorre.",
 				"statusLabel": "Status",
 				"tagLabel": "Tag",
 				"anyTag": "Qualquer tag",
@@ -1370,7 +1367,14 @@
 					"importance": "Prioridade",
 					"assignee_ids": "Responsável",
 					"tags": "Tags",
-					"custom_field": "Campo personalizado"
+					"custom_field": "Campo personalizado",
+					"title": "Título",
+					"story_points": "Story points",
+					"sprint_id": "Sprint",
+					"parent_task_id": "Tarefa pai",
+					"reporter_id": "Relator",
+					"start_date": "Data de início",
+					"due_date": "Data de entrega"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "Nome do cabeçalho",
 				"headerValuePlaceholder": "Valor",
 				"addHeader": "Adicionar cabeçalho",
-				"bodyLabel": "Corpo"
+				"bodyLabel": "Corpo",
+				"updateTaskHint": "Somente os campos habilitados abaixo são alterados — o restante da tarefa permanece intacto.",
+				"addFieldToUpdate": "Adicionar campo para atualizar…",
+				"customFieldsLabel": "Campo personalizado",
+				"enableField": "Definir {{field}}",
+				"titleLabel": "Título",
+				"storyPointsLabel": "Story points",
+				"sprintLabel": "Sprint",
+				"parentTaskLabel": "Tarefa pai",
+				"reporterLabel": "Relator",
+				"startDateLabel": "Data de início",
+				"dueDateLabel": "Data de entrega",
+				"tagsLabel": "Tags",
+				"tagsPlaceholder": "Adicionar uma tag…",
+				"assigneesLabel": "Responsáveis",
+				"noSprint": "Sem sprint",
+				"pluginConditionLabel": "Condição de plugin",
+				"pluginConditionHint": "Delega a correspondência deste ramo a uma condição fornecida por um plugin em vez de comparar um campo da tarefa.",
+				"selectPluginPlaceholder": "Selecione uma condição de plugin…",
+				"addCustomField": "Adicionar campo personalizado…"
 			},
 			"target": {
 				"label": "Aplica-se a",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "{{minutes}} min depois do prazo",
 				"branches": "{{count}} ramificação(ões)",
 				"priority": "Prioridade: {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "Sem responsável",
 				"notConfigured": "Não configurado",
 				"elseShort": "Senão",
+				"pluginConditionMatched": "Corresponde",
 				"branchFallback": "Ramificação {{n}}",
 				"cronSchedule": "Executa {{expression}}",
 				"webhookReady": "Webhook configurado",

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -1321,11 +1321,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "Назначить",
-			"set_status": "Установить статус",
-			"set_priority": "Установить приоритет",
-			"add_tag": "Добавить тег",
-			"set_custom_field": "Установить настраиваемое поле",
+			"update_task": "Обновить задачу",
 			"trigger_ai_agent": "Запустить ИИ-агента",
 			"call_api": "Вызвать API"
 		},
@@ -1336,9 +1332,10 @@
 			"removeConfirmTitle": "Удалить узел",
 			"removeConfirmBody": "Это удалит узел из графа вместе со всеми его связями.",
 			"removeConfirmAction": "Удалить",
-			"genericFormHint": "Этот тип узла предоставлен плагином. Редактируйте его настройки как JSON — в будущих версиях плагины смогут регистрировать здесь более удобный редактор.",
+			"genericFormHint": "Этот тип узла предоставлен плагином, который не объявил схему настроек, поэтому его параметры редактируются как необработанный JSON. Плагины, объявляющие configSchema в манифесте, вместо этого показывают здесь поля интерфейса.",
 			"trigger": {
 				"anyStatus": "Любой статус",
+				"noConfigNeeded": "Этот триггер не требует настройки — он срабатывает автоматически при наступлении события.",
 				"statusLabel": "Статус",
 				"tagLabel": "Тег",
 				"anyTag": "Любой тег",
@@ -1390,7 +1387,14 @@
 					"importance": "Приоритет",
 					"assignee_ids": "Исполнитель",
 					"tags": "Теги",
-					"custom_field": "Настраиваемое поле"
+					"custom_field": "Настраиваемое поле",
+					"title": "Название",
+					"story_points": "Story points",
+					"sprint_id": "Спринт",
+					"parent_task_id": "Родительская задача",
+					"reporter_id": "Автор",
+					"start_date": "Дата начала",
+					"due_date": "Срок"
 				}
 			},
 			"action": {
@@ -1410,7 +1414,26 @@
 				"headerKeyPlaceholder": "Имя заголовка",
 				"headerValuePlaceholder": "Значение",
 				"addHeader": "Добавить заголовок",
-				"bodyLabel": "Тело запроса"
+				"bodyLabel": "Тело запроса",
+				"updateTaskHint": "Изменяются только поля, включённые ниже — остальная часть задачи остаётся без изменений.",
+				"addFieldToUpdate": "Добавить поле для обновления…",
+				"customFieldsLabel": "Пользовательское поле",
+				"enableField": "Установить {{field}}",
+				"titleLabel": "Название",
+				"storyPointsLabel": "Story points",
+				"sprintLabel": "Спринт",
+				"parentTaskLabel": "Родительская задача",
+				"reporterLabel": "Автор",
+				"startDateLabel": "Дата начала",
+				"dueDateLabel": "Срок",
+				"tagsLabel": "Теги",
+				"tagsPlaceholder": "Добавить тег…",
+				"assigneesLabel": "Исполнители",
+				"noSprint": "Без спринта",
+				"pluginConditionLabel": "Условие плагина",
+				"pluginConditionHint": "Передаёт проверку этой ветки условию из плагина вместо сравнения поля задачи.",
+				"selectPluginPlaceholder": "Выберите условие плагина…",
+				"addCustomField": "Добавить настраиваемое поле…"
 			},
 			"target": {
 				"label": "Применяется к",
@@ -1436,10 +1459,11 @@
 				"dueDateAfter": "через {{minutes}} мин после срока",
 				"branches": "Ветвей: {{count}}",
 				"priority": "Приоритет: {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "Не назначено",
 				"notConfigured": "Не настроено",
 				"elseShort": "Иначе",
+				"pluginConditionMatched": "Совпадает",
 				"branchFallback": "Ветвь {{n}}",
 				"cronSchedule": "Выполняется {{expression}}",
 				"webhookReady": "Webhook настроен",

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "Giao việc",
-			"set_status": "Đặt trạng thái",
-			"set_priority": "Đặt độ ưu tiên",
-			"add_tag": "Thêm nhãn",
-			"set_custom_field": "Đặt trường tùy chỉnh",
+			"update_task": "Cập nhật công việc",
 			"trigger_ai_agent": "Kích hoạt tác nhân AI",
 			"call_api": "Gọi API"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "Xóa nút",
 			"removeConfirmBody": "Thao tác này sẽ xóa nút khỏi sơ đồ, cùng với tất cả các kết nối của nó.",
 			"removeConfirmAction": "Xóa",
-			"genericFormHint": "Loại nút này đến từ một plugin. Hãy chỉnh sửa cấu hình của nó dưới dạng JSON — các plugin có thể đăng ký một trình chỉnh sửa phong phú hơn ở đây trong bản phát hành tương lai.",
+			"genericFormHint": "Loại nút này đến từ một plugin chưa khai báo schema cấu hình, nên cài đặt của nó được chỉnh sửa dưới dạng JSON thô. Các plugin khai báo configSchema trong manifest sẽ hiển thị các trường giao diện ở đây thay vào đó.",
 			"trigger": {
 				"anyStatus": "Bất kỳ trạng thái nào",
+				"noConfigNeeded": "Trình kích hoạt này không cần cấu hình — nó tự động chạy khi sự kiện xảy ra.",
 				"statusLabel": "Trạng thái",
 				"tagLabel": "Nhãn",
 				"anyTag": "Bất kỳ nhãn nào",
@@ -1370,7 +1367,14 @@
 					"importance": "Độ ưu tiên",
 					"assignee_ids": "Người được giao",
 					"tags": "Nhãn",
-					"custom_field": "Trường tùy chỉnh"
+					"custom_field": "Trường tùy chỉnh",
+					"title": "Tiêu đề",
+					"story_points": "Story points",
+					"sprint_id": "Sprint",
+					"parent_task_id": "Công việc cha",
+					"reporter_id": "Người báo cáo",
+					"start_date": "Ngày bắt đầu",
+					"due_date": "Ngày đến hạn"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "Tên tiêu đề",
 				"headerValuePlaceholder": "Giá trị",
 				"addHeader": "Thêm tiêu đề",
-				"bodyLabel": "Nội dung"
+				"bodyLabel": "Nội dung",
+				"updateTaskHint": "Chỉ những trường bạn bật dưới đây mới bị thay đổi — phần còn lại của công việc không bị ảnh hưởng.",
+				"addFieldToUpdate": "Thêm trường cần cập nhật…",
+				"customFieldsLabel": "Trường tùy chỉnh",
+				"enableField": "Đặt {{field}}",
+				"titleLabel": "Tiêu đề",
+				"storyPointsLabel": "Story points",
+				"sprintLabel": "Sprint",
+				"parentTaskLabel": "Công việc cha",
+				"reporterLabel": "Người báo cáo",
+				"startDateLabel": "Ngày bắt đầu",
+				"dueDateLabel": "Ngày đến hạn",
+				"tagsLabel": "Nhãn",
+				"tagsPlaceholder": "Thêm nhãn…",
+				"assigneesLabel": "Người được giao",
+				"noSprint": "Không có sprint",
+				"pluginConditionLabel": "Điều kiện plugin",
+				"pluginConditionHint": "Giao việc khớp của nhánh này cho một điều kiện do plugin cung cấp thay vì so sánh trường công việc.",
+				"selectPluginPlaceholder": "Chọn điều kiện plugin…",
+				"addCustomField": "Thêm trường tùy chỉnh…"
 			},
 			"target": {
 				"label": "Áp dụng cho",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "{{minutes}} phút sau hạn chót",
 				"branches": "{{count}} nhánh",
 				"priority": "Độ ưu tiên: {{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "Chưa giao",
 				"notConfigured": "Chưa cấu hình",
 				"elseShort": "Trường hợp khác",
+				"pluginConditionMatched": "Khớp",
 				"branchFallback": "Nhánh {{n}}",
 				"cronSchedule": "Chạy {{expression}}",
 				"webhookReady": "Đã cấu hình webhook",

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -1301,11 +1301,7 @@
 			"api_trigger": "Webhook"
 		},
 		"actionTypes": {
-			"assign": "指派",
-			"set_status": "设置状态",
-			"set_priority": "设置优先级",
-			"add_tag": "添加标签",
-			"set_custom_field": "设置自定义字段",
+			"update_task": "更新任务",
 			"trigger_ai_agent": "触发 AI 代理",
 			"call_api": "调用 API"
 		},
@@ -1316,9 +1312,10 @@
 			"removeConfirmTitle": "删除节点",
 			"removeConfirmBody": "这将从图谱中删除该节点及其所有连接。",
 			"removeConfirmAction": "删除",
-			"genericFormHint": "此节点类型来自插件。请以 JSON 格式编辑其配置 — 未来版本中插件将可以在此注册更完善的编辑器。",
+			"genericFormHint": "此节点类型来自尚未声明配置架构的插件，因此其设置以原始 JSON 形式编辑。若插件在其清单中声明了 configSchema，则会在此显示界面字段。",
 			"trigger": {
 				"anyStatus": "任意状态",
+				"noConfigNeeded": "此触发器无需配置——事件发生时会自动触发。",
 				"statusLabel": "状态",
 				"tagLabel": "标签",
 				"anyTag": "任意标签",
@@ -1370,7 +1367,14 @@
 					"importance": "优先级",
 					"assignee_ids": "负责人",
 					"tags": "标签",
-					"custom_field": "自定义字段"
+					"custom_field": "自定义字段",
+					"title": "标题",
+					"story_points": "故事点",
+					"sprint_id": "冲刺",
+					"parent_task_id": "父任务",
+					"reporter_id": "报告人",
+					"start_date": "开始日期",
+					"due_date": "截止日期"
 				}
 			},
 			"action": {
@@ -1390,7 +1394,26 @@
 				"headerKeyPlaceholder": "请求头名称",
 				"headerValuePlaceholder": "值",
 				"addHeader": "添加请求头",
-				"bodyLabel": "请求体"
+				"bodyLabel": "请求体",
+				"updateTaskHint": "只有下方启用的字段会被更改——任务的其余部分保持不变。",
+				"addFieldToUpdate": "添加要更新的字段…",
+				"customFieldsLabel": "自定义字段",
+				"enableField": "设置{{field}}",
+				"titleLabel": "标题",
+				"storyPointsLabel": "故事点",
+				"sprintLabel": "冲刺",
+				"parentTaskLabel": "父任务",
+				"reporterLabel": "报告人",
+				"startDateLabel": "开始日期",
+				"dueDateLabel": "截止日期",
+				"tagsLabel": "标签",
+				"tagsPlaceholder": "添加标签…",
+				"assigneesLabel": "负责人",
+				"noSprint": "无冲刺",
+				"pluginConditionLabel": "插件条件",
+				"pluginConditionHint": "将此分支的匹配委托给插件提供的条件，而不是比较任务字段。",
+				"selectPluginPlaceholder": "选择插件条件…",
+				"addCustomField": "添加自定义字段…"
 			},
 			"target": {
 				"label": "作用对象",
@@ -1416,10 +1439,11 @@
 				"dueDateAfter": "截止日期后 {{minutes}} 分钟",
 				"branches": "{{count}} 个分支",
 				"priority": "优先级：{{level}}",
-				"fieldValue": "{{field}} = {{value}}",
+				"fieldValue": "{{field}} → {{value}}",
 				"unassigned": "未指派",
 				"notConfigured": "未配置",
 				"elseShort": "否则",
+				"pluginConditionMatched": "匹配",
 				"branchFallback": "分支 {{n}}",
 				"cronSchedule": "运行时间：{{expression}}",
 				"webhookReady": "已配置 Webhook",

--- a/apps/web/src/lib/automation-api.ts
+++ b/apps/web/src/lib/automation-api.ts
@@ -21,11 +21,7 @@ export const TRIGGER_TYPES = [
 export type TriggerType = (typeof TRIGGER_TYPES)[number];
 
 export const ACTION_TYPES = [
-	"assign",
-	"set_status",
-	"set_priority",
-	"add_tag",
-	"set_custom_field",
+	"update_task",
 	"trigger_ai_agent",
 	"call_api",
 ] as const;
@@ -103,12 +99,41 @@ export interface DependencyMapEntry {
 	watched_task_ids: string[];
 }
 
+// A single field within a plugin node's configSchema (JSON Schema, draft-07
+// subset). Only the shape the config-panel's SchemaConfigForm knows how to
+// render is modeled here — plugins are expected to stick to this subset for
+// their automation node configSchema (see paca-plugin-github/time-logging's
+// plugin.json for real examples).
+export interface PluginNodeConfigSchemaProperty {
+	type?: "string" | "integer" | "number" | "boolean";
+	title?: string;
+	/** Rendered as a Select dropdown when present. */
+	enum?: string[];
+	/** "textarea" -> multi-line Textarea, "date" -> <input type="date">,
+	 * "member" -> a project-member picker Select (options come from the
+	 * config panel's own members list, not this schema — the plugin just
+	 * asks for a member ID instead of asking the user to type one in). */
+	format?: string;
+	minimum?: number;
+	default?: string | number | boolean;
+}
+
+// A plugin node's config shape, declared under plugin.json's
+// automation.{triggers,conditions,actions}[].configSchema. Drives
+// SchemaConfigForm's UI-field rendering in automation-node-config-panel.tsx
+// instead of the raw-JSON fallback.
+export interface PluginNodeConfigSchema {
+	type?: string;
+	required?: string[];
+	properties?: Record<string, PluginNodeConfigSchemaProperty>;
+}
+
 // A plugin-contributed node type — Type is reverse-DNS namespaced (e.g.
 // "com.acme.github.pr_merged") and doubles as its own registry key.
 export interface PluginNodeType {
 	type: string;
 	label: string;
-	configSchema?: Record<string, unknown>;
+	configSchema?: PluginNodeConfigSchema;
 	eventTopic?: string;
 }
 
@@ -152,7 +177,14 @@ export type ConditionField =
 	| "importance"
 	| "assignee_ids"
 	| "tags"
-	| "custom_field";
+	| "custom_field"
+	| "title"
+	| "story_points"
+	| "sprint_id"
+	| "parent_task_id"
+	| "reporter_id"
+	| "start_date"
+	| "due_date";
 
 /** Which task a condition leaf or action operates on, relative to the
  * walk's own bound task — "self" (or omitted) is the walk's own task, the
@@ -192,7 +224,7 @@ export interface TaskTarget {
 export interface ConditionLeaf {
 	field: ConditionField;
 	field_key?: string;
-	operator: ConditionOperator;
+	operator?: ConditionOperator;
 	value?: unknown;
 	/** Retargets this leaf onto a task other than the walk's own bound task
 	 * (omitted/self = evaluated against the walk's task directly). */
@@ -206,6 +238,13 @@ export interface ConditionLeaf {
 
 export const ELSE_HANDLE = "else";
 
+// PLUGIN_CONDITION_TRUE_HANDLE is the source handle a plugin-contributed
+// condition node's "matched" edge uses — mirrors the worker's
+// pluginConditionTrueHandle (automation_consumer.go): a plugin condition is
+// a boolean gate (Matched: true/false), not an N-branch switch, so it only
+// ever needs this one handle plus the shared ELSE_HANDLE fallback.
+export const PLUGIN_CONDITION_TRUE_HANDLE = "true";
+
 export interface ConditionBranch {
 	handle: string;
 	label?: string;
@@ -216,14 +255,35 @@ export interface ConditionConfig {
 	branches: ConditionBranch[];
 }
 
-export interface ActionConfig {
-	member_id?: string;
+/** ActionUpdateTask's config: every field change to apply, in one node —
+ * replaces the old one-node-per-field actions (assign/set_status/
+ * set_priority/add_tag/set_custom_field). A field left unset means "don't
+ * touch it"; tags/custom_fields are full replacements, not merges (mirrors
+ * the Go worker's TaskFieldUpdate). */
+export interface TaskFieldUpdate {
+	task_type_id?: string;
 	status_id?: string;
+	sprint_id?: string;
+	parent_task_id?: string;
+	title?: string;
+	description?: unknown;
 	importance?: number;
-	tag?: string;
-	field_key?: string;
-	value?: unknown;
+	story_points?: number;
+	assignee_ids?: string[];
+	reporter_id?: string;
+	custom_fields?: Record<string, unknown>;
+	start_date?: string;
+	due_date?: string;
+	tags?: string[];
+}
+
+export interface ActionConfig {
+	/** trigger_ai_agent: who runs the agent conversation — distinct from
+	 * update.assignee_ids, which reassigns the task itself. */
+	member_id?: string;
 	message?: string;
+	/** update_task: every task-field change to apply, in one node. */
+	update?: TaskFieldUpdate;
 	/** call_api: the outbound request to make when the walk reaches this node. */
 	method?: string;
 	url?: string;

--- a/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
@@ -35,6 +35,7 @@ import {
 	automationQueryOptions,
 	automationRunsQueryOptions,
 	type ConditionConfig,
+	type PluginNodeConfigSchema,
 	pluginNodeTypesQueryOptions,
 	removeAutomationEdge,
 	removeAutomationNode,
@@ -45,6 +46,7 @@ import {
 	updateAutomation,
 	updateAutomationNode,
 } from "@/lib/automation-api";
+import { sprintsQueryOptions } from "@/lib/interaction-api";
 import {
 	customFieldsQueryOptions,
 	projectMembersQueryOptions,
@@ -96,6 +98,7 @@ function AutomationBuilderPage() {
 		customFieldsQueryOptions(projectId),
 	);
 	const { data: taskTypes = [] } = useQuery(taskTypesQueryOptions(projectId));
+	const { data: sprints = [] } = useQuery(sprintsQueryOptions(projectId));
 	const { data: runs = [] } = useQuery(
 		automationRunsQueryOptions(projectId, automationId),
 	);
@@ -154,6 +157,23 @@ function AutomationBuilderPage() {
 		const node = graph?.nodes.find((n) => n.id === nodeId);
 		if (!node) return nodeId;
 		return labelForType(node.kind, node.type);
+	}
+
+	// Looks up the plugin-declared configSchema for a plugin-contributed
+	// node type — undefined for built-in node types (which use their own
+	// dedicated config forms, not the plugin schema path) or plugin types
+	// that declare no configSchema.
+	function configSchemaForType(
+		kind: "trigger" | "condition" | "action",
+		type: string,
+	): PluginNodeConfigSchema | undefined {
+		const pluginList =
+			kind === "trigger"
+				? pluginTypes?.triggers
+				: kind === "condition"
+					? pluginTypes?.conditions
+					: pluginTypes?.actions;
+		return pluginList?.find((p) => p.type === type)?.configSchema;
 	}
 
 	// Mirrors the backend's NodeRequiresTask/validateTaskReachability
@@ -266,7 +286,6 @@ function AutomationBuilderPage() {
 		if (node.kind === "action") {
 			const cfg = node.config as ActionConfig;
 			switch (node.type) {
-				case "assign":
 				case "trigger_ai_agent": {
 					if (!cfg.member_id) {
 						return t("automation.nodeConfig.description.unassigned");
@@ -274,27 +293,72 @@ function AutomationBuilderPage() {
 					const member = members.find((m) => m.id === cfg.member_id);
 					return member?.full_name || member?.username;
 				}
-				case "set_status":
-					return cfg.status_id
-						? statuses.find((s) => s.id === cfg.status_id)?.name
-						: t("automation.nodeConfig.description.notConfigured");
-				case "set_priority":
-					return t("automation.nodeConfig.description.priority", {
-						level: t(getPriority(cfg.importance ?? 0).labelKey),
-					});
-				case "add_tag":
-					return cfg.tag
-						? `#${cfg.tag}`
-						: t("automation.nodeConfig.description.notConfigured");
-				case "set_custom_field": {
-					if (!cfg.field_key) {
-						return t("automation.nodeConfig.description.notConfigured");
+				case "update_task": {
+					const fields = cfg.update ?? {};
+					const parts: string[] = [];
+					const FIELD_LABEL_KEYS = {
+						title: "automation.nodeConfig.condition.fields.title",
+						status_id: "automation.nodeConfig.condition.fields.status_id",
+						task_type_id: "automation.nodeConfig.condition.fields.task_type_id",
+						assignee_ids: "automation.nodeConfig.condition.fields.assignee_ids",
+						importance: "automation.nodeConfig.condition.fields.importance",
+						story_points: "automation.nodeConfig.condition.fields.story_points",
+						tags: "automation.nodeConfig.condition.fields.tags",
+						reporter_id: "automation.nodeConfig.condition.fields.reporter_id",
+						sprint_id: "automation.nodeConfig.condition.fields.sprint_id",
+						start_date: "automation.nodeConfig.condition.fields.start_date",
+						due_date: "automation.nodeConfig.condition.fields.due_date",
+					} as const;
+					const pushField = (
+						fieldKey: keyof typeof FIELD_LABEL_KEYS,
+						value: string | undefined,
+					) => {
+						if (!value) return;
+						parts.push(
+							t("automation.nodeConfig.description.fieldValue", {
+								field: t(FIELD_LABEL_KEYS[fieldKey]),
+								value,
+							}),
+						);
+					};
+					pushField("title", fields.title);
+					pushField(
+						"status_id",
+						statuses.find((s) => s.id === fields.status_id)?.name,
+					);
+					pushField(
+						"task_type_id",
+						taskTypes.find((tt) => tt.id === fields.task_type_id)?.name,
+					);
+					if (fields.assignee_ids?.length) {
+						const member = members.find(
+							(m) => m.id === fields.assignee_ids?.[0],
+						);
+						pushField("assignee_ids", member?.full_name || member?.username);
 					}
-					const field = customFields.find((f) => f.field_key === cfg.field_key);
-					return t("automation.nodeConfig.description.fieldValue", {
-						field: field?.display_name ?? cfg.field_key,
-						value: String(cfg.value ?? ""),
-					});
+					if (fields.importance !== undefined) {
+						pushField("importance", t(getPriority(fields.importance).labelKey));
+					}
+					if (fields.story_points !== undefined) {
+						pushField("story_points", String(fields.story_points));
+					}
+					if (fields.tags?.length) {
+						pushField("tags", fields.tags.map((tag) => `#${tag}`).join(" "));
+					}
+					pushField(
+						"reporter_id",
+						members.find((m) => m.id === fields.reporter_id)?.full_name ||
+							members.find((m) => m.id === fields.reporter_id)?.username,
+					);
+					pushField(
+						"sprint_id",
+						sprints.find((s) => s.id === fields.sprint_id)?.name,
+					);
+					pushField("start_date", fields.start_date);
+					pushField("due_date", fields.due_date);
+					return parts.length > 0
+						? parts.join("\n")
+						: t("automation.nodeConfig.description.notConfigured");
 				}
 				case "call_api": {
 					if (!cfg.method || !cfg.url) {
@@ -657,6 +721,10 @@ function AutomationBuilderPage() {
 							canEdit={canEditGraph}
 							saving={updateNodeMutation.isPending}
 							pluginLabel={labelForType(selectedNode.kind, selectedNode.type)}
+							pluginConfigSchema={configSchemaForType(
+								selectedNode.kind,
+								selectedNode.type,
+							)}
 							onSave={(config) =>
 								updateNodeMutation.mutate({ nodeId: selectedNode.id, config })
 							}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
@@ -354,8 +354,8 @@ function AutomationBuilderPage() {
 						"sprint_id",
 						sprints.find((s) => s.id === fields.sprint_id)?.name,
 					);
-					pushField("start_date", fields.start_date);
-					pushField("due_date", fields.due_date);
+					pushField("start_date", fields.start_date?.slice(0, 10));
+					pushField("due_date", fields.due_date?.slice(0, 10));
 					return parts.length > 0
 						? parts.join("\n")
 						: t("automation.nodeConfig.description.notConfigured");

--- a/services/api/internal/domain/automation/condition.go
+++ b/services/api/internal/domain/automation/condition.go
@@ -3,6 +3,7 @@ package automationdom
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -26,7 +27,10 @@ const (
 // Field is a leaf's comparison target on the task.
 type Field string
 
-// Built-in comparison targets.
+// Built-in comparison targets. A plugin-contributed condition is its own
+// standalone condition node type (see ConditionNodeType's doc comment and
+// the plugin automation bridge) — never one of these Field values — so no
+// "plugin" sentinel exists here.
 const (
 	FieldStatus      Field = "status_id"
 	FieldTaskType    Field = "task_type_id"
@@ -34,6 +38,13 @@ const (
 	FieldAssignee    Field = "assignee_ids"
 	FieldTag         Field = "tags"
 	FieldCustomField Field = "custom_field"
+	FieldTitle       Field = "title"
+	FieldStoryPoints Field = "story_points"
+	FieldSprint      Field = "sprint_id"
+	FieldParentTask  Field = "parent_task_id"
+	FieldReporter    Field = "reporter_id"
+	FieldStartDate   Field = "start_date"
+	FieldDueDate     Field = "due_date"
 )
 
 // ConditionLeaf is a single comparison against one field of the task — the
@@ -43,7 +54,7 @@ type ConditionLeaf struct {
 	// FieldKey names the custom-field definition key when Field is
 	// FieldCustomField; unused otherwise.
 	FieldKey string   `json:"field_key,omitempty"`
-	Operator Operator `json:"operator"`
+	Operator Operator `json:"operator,omitempty"`
 	Value    any      `json:"value,omitempty"`
 	// Target retargets this leaf onto a task other than the walk's own
 	// bound task (nil/self = today's behavior, evaluated via Evaluate
@@ -84,6 +95,23 @@ func (l *ConditionLeaf) Evaluate(task *taskdom.Task) bool {
 			return l.Operator == OpIsEmpty
 		}
 		return compareAny(v, l.Operator, l.Value)
+	case FieldTitle:
+		return compareAny(task.Title, l.Operator, l.Value)
+	case FieldStoryPoints:
+		if task.StoryPoints == nil {
+			return l.Operator == OpIsEmpty
+		}
+		return compareInt(*task.StoryPoints, l.Operator, l.Value)
+	case FieldSprint:
+		return compareUUIDPtr(task.SprintID, l.Operator, l.Value)
+	case FieldParentTask:
+		return compareUUIDPtr(task.ParentTaskID, l.Operator, l.Value)
+	case FieldReporter:
+		return compareUUIDPtr(task.ReporterID, l.Operator, l.Value)
+	case FieldStartDate:
+		return compareTimePtr(task.StartDate, l.Operator, l.Value)
+	case FieldDueDate:
+		return compareTimePtr(task.DueDate, l.Operator, l.Value)
 	default:
 		return false
 	}
@@ -119,11 +147,11 @@ func (l *ConditionLeaf) EvaluateAgainstTasks(tasks []*taskdom.Task, matchMode st
 
 // validOperatorsByField is the set of operators each field's compare
 // function (below) actually implements. Kept in sync with compareUUIDPtr,
-// compareInt, compareStringSlice, and compareAny — an operator not listed
-// here for a given field falls to that function's `default: return false`
-// case, silently and permanently evaluating false rather than erroring, so
-// Validate rejects the combination up front instead of letting it through
-// to a defense-in-depth-only runtime no-op.
+// compareInt, compareStringSlice, compareAny, and compareTimePtr — an
+// operator not listed here for a given field falls to that function's
+// `default: return false` case, silently and permanently evaluating false
+// rather than erroring, so Validate rejects the combination up front
+// instead of letting it through to a defense-in-depth-only runtime no-op.
 var validOperatorsByField = map[Field]map[Operator]bool{
 	FieldStatus:      {OpEquals: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
 	FieldTaskType:    {OpEquals: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
@@ -131,6 +159,13 @@ var validOperatorsByField = map[Field]map[Operator]bool{
 	FieldAssignee:    {OpContains: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
 	FieldTag:         {OpContains: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
 	FieldCustomField: {OpEquals: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true, OpGreaterThan: true, OpLessThan: true},
+	FieldTitle:       {OpEquals: true, OpNotEquals: true, OpContains: true, OpIsEmpty: true, OpIsNotEmpty: true},
+	FieldStoryPoints: {OpEquals: true, OpNotEquals: true, OpGreaterThan: true, OpLessThan: true, OpIsEmpty: true, OpIsNotEmpty: true},
+	FieldSprint:      {OpEquals: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
+	FieldParentTask:  {OpEquals: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
+	FieldReporter:    {OpEquals: true, OpNotEquals: true, OpIsEmpty: true, OpIsNotEmpty: true},
+	FieldStartDate:   {OpEquals: true, OpNotEquals: true, OpGreaterThan: true, OpLessThan: true, OpIsEmpty: true, OpIsNotEmpty: true},
+	FieldDueDate:     {OpEquals: true, OpNotEquals: true, OpGreaterThan: true, OpLessThan: true, OpIsEmpty: true, OpIsNotEmpty: true},
 }
 
 // Validate reports whether the leaf is well-formed: it has a recognized
@@ -266,5 +301,42 @@ func toFloat(v any) (float64, bool) {
 		return float64(n), true
 	default:
 		return 0, false
+	}
+}
+
+// compareTimePtr compares field (nil = unset) against value, which must be
+// an RFC 3339 string (matching how dates travel over JSON everywhere else
+// in this API) — anything else fails every comparator except is_empty/
+// is_not_empty, same defensive-false-not-panic posture as compareInt for a
+// mistyped numeric value.
+func compareTimePtr(field *time.Time, op Operator, value any) bool {
+	switch op {
+	case OpIsEmpty:
+		return field == nil
+	case OpIsNotEmpty:
+		return field != nil
+	}
+	if field == nil {
+		return false
+	}
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+	target, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return false
+	}
+	switch op {
+	case OpEquals:
+		return field.Equal(target)
+	case OpNotEquals:
+		return !field.Equal(target)
+	case OpGreaterThan:
+		return field.After(target)
+	case OpLessThan:
+		return field.Before(target)
+	default:
+		return false
 	}
 }

--- a/services/api/internal/domain/automation/condition.go
+++ b/services/api/internal/domain/automation/condition.go
@@ -315,6 +315,9 @@ func compareTimePtr(field *time.Time, op Operator, value any) bool {
 		return field == nil
 	case OpIsNotEmpty:
 		return field != nil
+	default:
+		// Handled below: OpEquals/OpNotEquals/OpGreaterThan/OpLessThan all
+		// need the parsed target time first.
 	}
 	if field == nil {
 		return false

--- a/services/api/internal/domain/automation/condition_test.go
+++ b/services/api/internal/domain/automation/condition_test.go
@@ -2,6 +2,7 @@ package automationdom
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -103,6 +104,66 @@ func TestConditionLeaf_Evaluate_CustomField(t *testing.T) {
 	missing := &ConditionLeaf{Field: FieldCustomField, FieldKey: "not_set", Operator: OpIsEmpty}
 	if !missing.Evaluate(task) {
 		t.Fatal("expected is_empty true for a custom field key that isn't set")
+	}
+}
+
+// Dates travel over the wire as RFC 3339 strings everywhere else in this
+// API (see compareTimePtr's doc comment) — the automation config panel's
+// start_date/due_date pickers must send that shape, not a bare
+// "YYYY-MM-DD" (what a plain <input type="date"> produces), or every
+// comparison here silently evaluates false.
+func TestConditionLeaf_Evaluate_DueDateComparisons(t *testing.T) {
+	due := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	task := &taskdom.Task{DueDate: &due}
+
+	cases := []struct {
+		op    Operator
+		value string
+		want  bool
+	}{
+		{OpEquals, "2026-08-03T00:00:00Z", true},
+		{OpEquals, "2026-08-04T00:00:00Z", false},
+		{OpNotEquals, "2026-08-04T00:00:00Z", true},
+		{OpGreaterThan, "2026-08-02T00:00:00Z", true},
+		{OpGreaterThan, "2026-08-04T00:00:00Z", false},
+		{OpLessThan, "2026-08-04T00:00:00Z", true},
+		{OpLessThan, "2026-08-02T00:00:00Z", false},
+	}
+	for _, c := range cases {
+		got := leaf(FieldDueDate, c.op, c.value).Evaluate(task)
+		if got != c.want {
+			t.Errorf("due_date=2026-08-03 %s %v: got %v, want %v", c.op, c.value, got, c.want)
+		}
+	}
+}
+
+func TestConditionLeaf_Evaluate_DueDateIsEmpty(t *testing.T) {
+	task := &taskdom.Task{DueDate: nil}
+	if !leaf(FieldDueDate, OpIsEmpty, nil).Evaluate(task) {
+		t.Fatal("expected is_empty true for nil due_date")
+	}
+	if leaf(FieldDueDate, OpIsNotEmpty, nil).Evaluate(task) {
+		t.Fatal("expected is_not_empty false for nil due_date")
+	}
+
+	due := time.Now()
+	set := &taskdom.Task{DueDate: &due}
+	if leaf(FieldDueDate, OpIsEmpty, nil).Evaluate(set) {
+		t.Fatal("expected is_empty false when due_date is set")
+	}
+}
+
+// TestConditionLeaf_Evaluate_DateFieldRejectsNonRFC3339Value guards against
+// the exact regression this once had: a bare "YYYY-MM-DD" value (what a
+// native <input type="date"> produces) must not silently match — it isn't
+// a valid RFC 3339 string, so time.Parse fails and the comparator falls
+// back to its documented not-found-not-panic false, same as a mistyped
+// numeric value would for compareInt.
+func TestConditionLeaf_Evaluate_DateFieldRejectsNonRFC3339Value(t *testing.T) {
+	due := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	task := &taskdom.Task{DueDate: &due}
+	if leaf(FieldDueDate, OpEquals, "2026-08-03").Evaluate(task) {
+		t.Fatal("expected a bare date-only value (not RFC 3339) to fail to match, not silently succeed")
 	}
 }
 

--- a/services/api/internal/domain/automation/entity.go
+++ b/services/api/internal/domain/automation/entity.go
@@ -120,11 +120,11 @@ type ActionType string
 
 // Built-in action types.
 const (
-	ActionAssign         ActionType = "assign"
-	ActionSetStatus      ActionType = "set_status"
-	ActionSetPriority    ActionType = "set_priority"
-	ActionAddTag         ActionType = "add_tag"
-	ActionSetCustomField ActionType = "set_custom_field"
+	// ActionUpdateTask sets one or more task fields at once (ActionConfig's
+	// Update) — replaces the old one-node-per-field actions (assign,
+	// set_status, set_priority, add_tag, set_custom_field), each of which
+	// could only ever touch a single field per node.
+	ActionUpdateTask     ActionType = "update_task"
 	ActionTriggerAIAgent ActionType = "trigger_ai_agent"
 	// ActionCallAPI makes an outbound HTTP request (ActionConfig's
 	// Method/URL/Headers/Body) when the graph walk reaches it. Unlike every
@@ -135,11 +135,7 @@ const (
 
 // ValidBuiltinActionTypes is the set of built-in action type values.
 var ValidBuiltinActionTypes = map[ActionType]bool{
-	ActionAssign:         true,
-	ActionSetStatus:      true,
-	ActionSetPriority:    true,
-	ActionAddTag:         true,
-	ActionSetCustomField: true,
+	ActionUpdateTask:     true,
 	ActionTriggerAIAgent: true,
 	ActionCallAPI:        true,
 }
@@ -209,6 +205,16 @@ type Node struct {
 // ElseHandle is the reserved branch handle a Condition node's fallback edge
 // uses when none of its branches match.
 const ElseHandle = "else"
+
+// PluginConditionTrueHandle is the source handle a plugin-contributed
+// condition node's "matched" edge uses. Unlike the built-in Condition node
+// (an N-branch switch backed by ConditionConfig.Branches), a plugin
+// condition is a simple boolean gate — EvaluateCondition returns
+// Matched: true/false — so it only ever needs this one handle plus the
+// shared ElseHandle fallback. Used by both the worker (walkPluginCondition
+// in automation_consumer.go) and edge-handle validation (validateEdgeHandle
+// in automation_service.go), which must agree on the same string.
+const PluginConditionTrueHandle = "true"
 
 // Edge is a directed link between two nodes in the same automation.
 // SourceHandle is nil for Trigger/Action sources (a single outgoing path)
@@ -387,21 +393,26 @@ type TaskTarget struct {
 // relevant to a node's Type are set. Marshaled into Node.Config for
 // kind=action nodes.
 type ActionConfig struct {
-	MemberID   *uuid.UUID `json:"member_id,omitempty"`  // assign, trigger_ai_agent
-	StatusID   *uuid.UUID `json:"status_id,omitempty"`  // set_status
-	Importance *int       `json:"importance,omitempty"` // set_priority
-	Tag        string     `json:"tag,omitempty"`        // add_tag
-	FieldKey   string     `json:"field_key,omitempty"`  // set_custom_field
-	Value      any        `json:"value,omitempty"`      // set_custom_field
-	Message    string     `json:"message,omitempty"`    // trigger_ai_agent: free-text instruction for the agent
+	// Message is trigger_ai_agent's free-text instruction for the agent.
+	Message string `json:"message,omitempty"`
+	// MemberID is trigger_ai_agent's target agent — who runs the agent
+	// conversation, unrelated to Update.AssigneeIDs (which reassigns the
+	// task itself when Type is ActionUpdateTask).
+	MemberID *uuid.UUID `json:"member_id,omitempty"`
+
+	// Update carries every task-field change to apply when Type is
+	// ActionUpdateTask — one node settable across any number of fields at
+	// once (see TaskFieldUpdate), replacing the old one-node-per-field
+	// actions (assign/set_status/set_priority/add_tag/set_custom_field).
+	Update *TaskFieldUpdate `json:"update,omitempty"`
 
 	// call_api: the outbound request to make when the walk reaches this
 	// node. Headers/Body are stored and returned verbatim like every other
-	// config field today (e.g. set_custom_field's Value) — anyone with
-	// project read access to the automation can see them, including any
-	// secret a user puts in an Authorization header. Not a new gap, but
-	// worth noting since this is the first action whose config plausibly
-	// holds a live secret.
+	// config field today (e.g. TaskFieldUpdate's CustomFields values) —
+	// anyone with project read access to the automation can see them,
+	// including any secret a user puts in an Authorization header. Not a
+	// new gap, but worth noting since this is the first action whose
+	// config plausibly holds a live secret.
 	Method  string            `json:"method,omitempty"`  // call_api: GET/POST/PUT/PATCH/DELETE
 	URL     string            `json:"url,omitempty"`     // call_api
 	Headers map[string]string `json:"headers,omitempty"` // call_api
@@ -413,6 +424,31 @@ type ActionConfig struct {
 	// resolves more than one task, the action fans out — applied once per
 	// resolved task (see the worker's runAction).
 	Target *TaskTarget `json:"target,omitempty"`
+}
+
+// TaskFieldUpdate is the sparse "which fields to set" payload for
+// ActionUpdateTask — same field set as taskdom's UpdateTaskInput (see
+// services/api/internal/domain/task/service.go), minus its **T
+// explicit-clear plumbing: a nil field here means "leave this field
+// alone," matching how every one of the old single-field actions already
+// worked (set_status could set a status but never clear one, etc.) — this
+// merge doesn't add or remove that capability, just lets one action node
+// touch several fields instead of exactly one.
+type TaskFieldUpdate struct {
+	TaskTypeID   *uuid.UUID      `json:"task_type_id,omitempty"`
+	StatusID     *uuid.UUID      `json:"status_id,omitempty"`
+	SprintID     *uuid.UUID      `json:"sprint_id,omitempty"`
+	ParentTaskID *uuid.UUID      `json:"parent_task_id,omitempty"`
+	Title        string          `json:"title,omitempty"`
+	Description  json.RawMessage `json:"description,omitempty"`
+	Importance   *int            `json:"importance,omitempty"`
+	StoryPoints  *int            `json:"story_points,omitempty"`
+	AssigneeIDs  []uuid.UUID     `json:"assignee_ids,omitempty"`
+	ReporterID   *uuid.UUID      `json:"reporter_id,omitempty"`
+	CustomFields map[string]any  `json:"custom_fields,omitempty"`
+	StartDate    *time.Time      `json:"start_date,omitempty"`
+	DueDate      *time.Time      `json:"due_date,omitempty"`
+	Tags         []string        `json:"tags,omitempty"`
 }
 
 // ConditionConfig holds a Condition node's ordered branches. Marshaled into

--- a/services/api/internal/domain/automation/entity_test.go
+++ b/services/api/internal/domain/automation/entity_test.go
@@ -13,8 +13,7 @@ func TestNodeRequiresTask(t *testing.T) {
 		{"plugin condition", KindCondition, "com.acme.some_condition", true},
 		{"call_api action does not require a task", KindAction, string(ActionCallAPI), false},
 		{"trigger_ai_agent action does not require a task", KindAction, string(ActionTriggerAIAgent), false},
-		{"assign action requires a task", KindAction, string(ActionAssign), true},
-		{"set_status action requires a task", KindAction, string(ActionSetStatus), true},
+		{"update_task action requires a task", KindAction, string(ActionUpdateTask), true},
 		{"plugin action conservatively requires a task", KindAction, "com.acme.some_action", true},
 		{"trigger never requires a task itself", KindTrigger, string(TriggerCron), false},
 	}

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -42,6 +42,20 @@ const StreamPluginEvents = "paca.plugin_events"
 // the walk to finish.
 const StreamAutomationExternalTriggers = "paca.automation_external_triggers"
 
+// StreamPluginTriggerEvents is the Valkey Stream key a plugin's own
+// EmitEvent call (the plugin SDK's event_emit host function) appends to,
+// but only when at least one loaded plugin has actually declared a Trigger
+// node for that event's topic (platform/plugin.Runtime.TriggersForTopic) —
+// a plugin emitting some other, non-trigger-sourcing event never touches
+// this stream, keeping its volume proportional to automation-relevant
+// topics only. worker.AutomationConsumer reads it the same way it reads
+// StreamAutomationExternalTriggers: resolve which project's automations to
+// consider and which task (if any) to bind the walk to from the event's own
+// payload (every plugin trigger's payload is expected to carry project_id,
+// and task_id when the event concerns a specific task — see
+// pluginTriggerEventPayload in automation_consumer.go), then execute.
+const StreamPluginTriggerEvents = "paca.plugin_trigger_events"
+
 // Event type constants used in both Pub/Sub messages and Stream entries.
 const (
 	// --- Auth events --------------------------------------------------------

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -1718,6 +1718,17 @@ func (r *Runtime) registerEventFunctions(b wazero.HostModuleBuilder, p plugindom
 					stack[0] = 0
 					return
 				}
+				// Also durably queue this event for the automation engine,
+				// but only when some loaded plugin actually declared a
+				// Trigger for this topic — TriggersForTopic is the exact
+				// same lookup worker.AutomationConsumer uses when it reads
+				// this entry back, so a plugin emitting an event nobody
+				// automates on never touches this stream.
+				if len(r.TriggersForTopic(topic)) > 0 {
+					if err := r.services.Publisher.Append(ctx, events.StreamPluginTriggerEvents, topic, v); err != nil {
+						r.log.Error("paca.event_emit: append to automation trigger stream", "plugin", p.Name, "topic", topic, "error", err)
+					}
+				}
 			}
 			stack[0] = 1
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64},

--- a/services/api/internal/service/automation/automation_service.go
+++ b/services/api/internal/service/automation/automation_service.go
@@ -897,14 +897,8 @@ func (s *Service) validateActionConfig(ctx context.Context, projectID uuid.UUID,
 		return err
 	}
 	switch t {
-	case automationdom.ActionAssign:
-		if cfg.MemberID == nil {
-			if strict {
-				return fmt.Errorf("%w: assign requires member_id", automationdom.ErrNodeConfigInvalid)
-			}
-			return nil
-		}
-		return s.assertMemberInProject(ctx, projectID, *cfg.MemberID)
+	case automationdom.ActionUpdateTask:
+		return s.validateTaskFieldUpdate(ctx, projectID, cfg.Update, strict)
 	case automationdom.ActionTriggerAIAgent:
 		if cfg.MemberID == nil {
 			if strict {
@@ -913,26 +907,6 @@ func (s *Service) validateActionConfig(ctx context.Context, projectID uuid.UUID,
 			return nil
 		}
 		return s.assertMemberInProject(ctx, projectID, *cfg.MemberID)
-	case automationdom.ActionSetStatus:
-		if cfg.StatusID == nil {
-			if strict {
-				return fmt.Errorf("%w: set_status requires status_id", automationdom.ErrNodeConfigInvalid)
-			}
-			return nil
-		}
-		return s.assertStatusInProject(ctx, projectID, *cfg.StatusID)
-	case automationdom.ActionSetPriority:
-		if strict && cfg.Importance == nil {
-			return fmt.Errorf("%w: set_priority requires importance", automationdom.ErrNodeConfigInvalid)
-		}
-	case automationdom.ActionAddTag:
-		if strict && strings.TrimSpace(cfg.Tag) == "" {
-			return fmt.Errorf("%w: add_tag requires tag", automationdom.ErrNodeConfigInvalid)
-		}
-	case automationdom.ActionSetCustomField:
-		if strict && strings.TrimSpace(cfg.FieldKey) == "" {
-			return fmt.Errorf("%w: set_custom_field requires field_key", automationdom.ErrNodeConfigInvalid)
-		}
 	case automationdom.ActionCallAPI:
 		if cfg.Method != "" && !validCallAPIMethods[strings.ToUpper(cfg.Method)] {
 			return fmt.Errorf("%w: call_api method must be one of GET, POST, PUT, PATCH, DELETE", automationdom.ErrNodeConfigInvalid)
@@ -953,6 +927,72 @@ func (s *Service) validateActionConfig(ctx context.Context, projectID uuid.UUID,
 		}
 	}
 	return nil
+}
+
+// validateTaskFieldUpdate validates ActionUpdateTask's config: a
+// referenced status/reporter/assignee/parent-task must exist and belong to
+// projectID, and in strict mode at least one field must actually be set —
+// an update_task node with nothing to update is almost certainly an
+// author mistake (no built-in action before this one could be created
+// config-less and silently do nothing). task_type_id and sprint_id aren't
+// FK-checked here, matching this package's existing precedent (e.g.
+// validateTriggerConfig never checks a trigger's task_type_id either) —
+// an invalid ID just fails later at the task service's own FK layer when
+// the action actually runs.
+func (s *Service) validateTaskFieldUpdate(ctx context.Context, projectID uuid.UUID, upd *automationdom.TaskFieldUpdate, strict bool) error {
+	if upd == nil {
+		if strict {
+			return fmt.Errorf("%w: update_task requires at least one field to update", automationdom.ErrNodeConfigInvalid)
+		}
+		return nil
+	}
+	if strict && !taskFieldUpdateHasAnyField(upd) {
+		return fmt.Errorf("%w: update_task requires at least one field to update", automationdom.ErrNodeConfigInvalid)
+	}
+	if upd.StatusID != nil {
+		if err := s.assertStatusInProject(ctx, projectID, *upd.StatusID); err != nil {
+			return err
+		}
+	}
+	for _, memberID := range upd.AssigneeIDs {
+		if err := s.assertMemberInProject(ctx, projectID, memberID); err != nil {
+			return err
+		}
+	}
+	if upd.ReporterID != nil {
+		if err := s.assertMemberInProject(ctx, projectID, *upd.ReporterID); err != nil {
+			return err
+		}
+	}
+	if upd.ParentTaskID != nil {
+		parent, err := s.taskRepo.FindTaskByID(ctx, *upd.ParentTaskID)
+		if err != nil {
+			return err
+		}
+		if parent.ProjectID != projectID {
+			return automationdom.ErrNodeCrossProject
+		}
+	}
+	return nil
+}
+
+// taskFieldUpdateHasAnyField reports whether upd sets at least one field —
+// used only to reject a config-less update_task node in strict mode.
+func taskFieldUpdateHasAnyField(upd *automationdom.TaskFieldUpdate) bool {
+	return upd.TaskTypeID != nil ||
+		upd.StatusID != nil ||
+		upd.SprintID != nil ||
+		upd.ParentTaskID != nil ||
+		upd.Title != "" ||
+		len(upd.Description) > 0 ||
+		upd.Importance != nil ||
+		upd.StoryPoints != nil ||
+		len(upd.AssigneeIDs) > 0 ||
+		upd.ReporterID != nil ||
+		len(upd.CustomFields) > 0 ||
+		upd.StartDate != nil ||
+		upd.DueDate != nil ||
+		len(upd.Tags) > 0
 }
 
 var validCallAPIMethods = map[string]bool{
@@ -989,9 +1029,15 @@ func handlesEqual(a, b *string) bool {
 }
 
 // validateEdgeHandle enforces: a condition-sourced edge must specify a
-// handle that is one of the source's declared branches or the reserved
-// "else" fallback; a trigger/action-sourced edge must not specify a handle
-// at all (it has exactly one outgoing path).
+// handle that is valid for that condition node, or the reserved "else"
+// fallback; a trigger/action-sourced edge must not specify a handle at all
+// (it has exactly one outgoing path). A condition node's valid non-else
+// handles depend on its Type: the built-in N-branch switch (Type ==
+// ConditionNodeType) accepts any handle declared in its own
+// ConditionConfig.Branches, while a plugin-contributed condition — a
+// boolean gate, not a switch — accepts exactly one, PluginConditionTrueHandle
+// (mirrors walker.walkPluginCondition in automation_consumer.go, which is
+// the only handle it ever follows on a match).
 func validateEdgeHandle(source *automationdom.Node, handle *string) error {
 	if source.Kind != automationdom.KindCondition {
 		if handle != nil {
@@ -1004,6 +1050,12 @@ func validateEdgeHandle(source *automationdom.Node, handle *string) error {
 	}
 	if *handle == automationdom.ElseHandle {
 		return nil
+	}
+	if source.Type != automationdom.ConditionNodeType {
+		if *handle == automationdom.PluginConditionTrueHandle {
+			return nil
+		}
+		return fmt.Errorf("%w: %q is not a valid handle for a plugin condition node", automationdom.ErrNodeConfigInvalid, *handle)
 	}
 	var cfg automationdom.ConditionConfig
 	if len(source.Config) > 0 {

--- a/services/api/internal/service/automation/automation_service_test.go
+++ b/services/api/internal/service/automation/automation_service_test.go
@@ -118,22 +118,25 @@ func TestValidateEdgeHandle_ConditionSourceRejectsUndeclaredHandle(t *testing.T)
 	}
 }
 
-// TestValidateEdgeHandle_PluginConditionSourceHasNoBranchesToCheck covers a
-// plugin-contributed condition node (Type != ConditionNodeType): its config
-// is opaque to this package, so the only two valid handles are "true" and
-// "else" — anything else should still be rejected the same way a bogus
-// built-in branch handle would be, since the branch-list check silently no-ops
-// (an empty ConditionConfig unmarshal) rather than special-casing plugin
-// node types.
+// TestValidateEdgeHandle_PluginConditionSource covers a plugin-contributed
+// condition node (Type != ConditionNodeType): its config is opaque to this
+// package (no Branches to check against, unlike the built-in switch), so the
+// only two valid handles are PluginConditionTrueHandle ("true") — the handle
+// walker.walkPluginCondition follows on a match — and the shared ElseHandle
+// fallback. Anything else must still be rejected.
 func TestValidateEdgeHandle_PluginConditionSource(t *testing.T) {
 	source := newNode(automationdom.KindCondition, "com.acme.github.pr_status", `{"repo":"acme/widgets"}`)
-	trueHandle := "true"
-	if err := validateEdgeHandle(source, &trueHandle); err == nil {
-		t.Fatal("expected 'true' to be rejected since it isn't a declared branch in the (empty) ConditionConfig for a plugin node's opaque config")
+	trueHandle := automationdom.PluginConditionTrueHandle
+	if err := validateEdgeHandle(source, &trueHandle); err != nil {
+		t.Fatalf("expected the plugin condition's true handle to be valid, got %v", err)
 	}
 	elseHandle := automationdom.ElseHandle
 	if err := validateEdgeHandle(source, &elseHandle); err != nil {
 		t.Fatalf("expected else handle to remain valid for a plugin condition node, got %v", err)
+	}
+	bogusHandle := "not_a_real_handle"
+	if err := validateEdgeHandle(source, &bogusHandle); err == nil {
+		t.Fatal("expected an arbitrary, undeclared handle to be rejected for a plugin condition node")
 	}
 }
 
@@ -214,6 +217,10 @@ func TestService_ValidateNodeTypeAndConfig_PluginActionFallthrough(t *testing.T)
 	}
 }
 
+// TestService_ValidateNodeTypeAndConfig_PluginConditionFallthrough covers a
+// plugin-contributed condition node: its own node type (KindCondition, not
+// the built-in ConditionNodeType), validated opaquely once the resolver
+// confirms it's registered.
 func TestService_ValidateNodeTypeAndConfig_PluginConditionFallthrough(t *testing.T) {
 	svc := &Service{}
 	svc.WithPluginNodeResolver(&stubPluginResolver{conditions: map[string]bool{"com.acme.github.pr_status": true}})
@@ -373,11 +380,11 @@ func TestValidateTaskReachability_TaskLessTriggerToCondition_Rejected(t *testing
 
 func TestValidateTaskReachability_TaskLessTriggerToNonCallAPIAction_Rejected(t *testing.T) {
 	trigger := taskLessTriggerNode(t, automationdom.TriggerAPITrigger)
-	action := newNode(automationdom.KindAction, string(automationdom.ActionSetStatus), "{}")
+	action := newNode(automationdom.KindAction, string(automationdom.ActionUpdateTask), "{}")
 	nodes := []*automationdom.Node{trigger, action}
 	edges := []*automationdom.Edge{newEdge(trigger.ID, action.ID)}
 	if err := validateTaskReachability(nodes, edges); err == nil {
-		t.Fatal("expected a task-less api_trigger reaching a set_status action to be rejected")
+		t.Fatal("expected a task-less api_trigger reaching an update_task action to be rejected")
 	}
 }
 
@@ -498,14 +505,14 @@ func TestValidateActionConfig_CallAPI_RejectsTarget(t *testing.T) {
 	}
 }
 
-func TestValidateActionConfig_AddTag_AcceptsTarget(t *testing.T) {
+func TestValidateActionConfig_UpdateTask_AcceptsTarget(t *testing.T) {
 	svc := &Service{}
 	cfg, _ := json.Marshal(automationdom.ActionConfig{
-		Tag:    "x",
+		Update: &automationdom.TaskFieldUpdate{Tags: []string{"x"}},
 		Target: &automationdom.TaskTarget{Kind: automationdom.TaskTargetChildren},
 	})
-	if err := svc.validateActionConfig(context.Background(), uuid.New(), automationdom.ActionAddTag, cfg, true); err != nil {
-		t.Fatalf("expected add_tag to accept a children target, got %v", err)
+	if err := svc.validateActionConfig(context.Background(), uuid.New(), automationdom.ActionUpdateTask, cfg, true); err != nil {
+		t.Fatalf("expected update_task to accept a children target, got %v", err)
 	}
 }
 

--- a/services/api/internal/worker/automation_consumer.go
+++ b/services/api/internal/worker/automation_consumer.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -103,7 +104,8 @@ type automationMemberReader interface {
 // TriggerTaskAssigned for a task-bound trigger (see
 // applyTriggerAIAgentOnTask). Neither method touches the task's assignee —
 // trigger_ai_agent's job is to get the agent looking at the task, not to
-// transfer ownership of it; that's what the separate "assign" action is for.
+// transfer ownership of it; that's what update_task's AssigneeIDs field is
+// for.
 type automationAgentMessenger interface {
 	TriggerDirectMessage(ctx context.Context, projectID, agentID uuid.UUID, triggeredByMemberID *uuid.UUID, message string) (*agentdom.AgentConversation, error)
 	TriggerTaskAssigned(ctx context.Context, projectID, agentID, taskID uuid.UUID, triggeredByMemberID *uuid.UUID, note string) (*agentdom.AgentConversation, error)
@@ -1288,13 +1290,6 @@ func pluginNodePayload(nodeType string, config json.RawMessage, projectID uuid.U
 	return payload
 }
 
-// applyAssign reassigns task to memberID, recording an activity and
-// publishing the shared task.assigned event so the existing
-// notification/agent-trigger pipeline picks it up uniformly (including
-// triggering an agent conversation, when memberID resolves to an agent —
-// this is the "assign" action; trigger_ai_agent uses
-// applyTriggerAIAgentOnTask instead, which starts a conversation without
-// this reassignment).
 // applyTriggerAIAgentOnTask starts an agent conversation scoped to task,
 // without changing its assignee. trigger_ai_agent's job is to get the agent
 // looking at the task — not to transfer ownership of it, which is what the
@@ -1376,7 +1371,7 @@ func triggerAIAgentNote(automationName, agentMessage string) string {
 // applyDirectAgentMessage fires message straight at the agent behind
 // memberID, no task involved — used when trigger_ai_agent's walk has no
 // task (a cron/api_trigger/predecessor_done trigger with no
-// target_task_id), since there's nothing to assign. Unlike applyAssign,
+// target_task_id), since there's nothing to assign. Unlike applyUpdateTask,
 // there's no "already in target state" check to make — every visit sends a
 // fresh message, and it always reports "applied" on success.
 func (c *AutomationConsumer) applyDirectAgentMessage(ctx context.Context, projectID uuid.UUID, memberID uuid.UUID, message string) (bool, error) {
@@ -1440,7 +1435,7 @@ func (c *AutomationConsumer) applyUpdateTask(ctx context.Context, projectID uuid
 		in.Title = title
 		changed["title"] = title
 	}
-	if len(upd.Description) > 0 {
+	if len(upd.Description) > 0 && !bytes.Equal(upd.Description, task.Description) {
 		desc := upd.Description
 		in.Description = &desc
 		changed["description"] = true

--- a/services/api/internal/worker/automation_consumer.go
+++ b/services/api/internal/worker/automation_consumer.go
@@ -17,6 +17,7 @@ import (
 
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
 	automationdom "github.com/Paca-AI/api/internal/domain/automation"
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
 	userdom "github.com/Paca-AI/api/internal/domain/user"
@@ -76,14 +77,17 @@ type automationActivityRecorder interface {
 }
 
 // automationPluginRuntime is the minimal plugin-runtime surface the engine
-// needs to dispatch plugin-contributed condition/action nodes. Both calls
+// needs to dispatch plugin-contributed condition/action nodes (both calls
 // use the exact same WASM calling convention as HandleRequest — see
-// platform/plugin.Runtime.EvaluateCondition/RunAction.
+// platform/plugin.Runtime.EvaluateCondition/RunAction) plus resolve a
+// plugin-contributed Trigger node type for a plugin-emitted event's topic
+// (see TriggersForTopic and handlePluginTriggerEvent).
 type automationPluginRuntime interface {
 	ResolveAutomationCondition(nodeType string) (pluginName string, ok bool)
 	ResolveAutomationAction(nodeType string) (pluginName string, ok bool)
 	EvaluateCondition(ctx context.Context, pluginName string, payload []byte) ([]byte, error)
 	RunAction(ctx context.Context, pluginName string, payload []byte) ([]byte, error)
+	TriggersForTopic(topic string) []plugindom.AutomationNodeManifest
 }
 
 // automationMemberReader resolves a project_members.id to its full record —
@@ -220,7 +224,7 @@ func (c *AutomationConsumer) Start(ctx context.Context) {
 }
 
 func (c *AutomationConsumer) ensureGroup(ctx context.Context) error {
-	for _, stream := range []string{events.StreamTaskActivities, events.StreamAutomationExternalTriggers} {
+	for _, stream := range []string{events.StreamTaskActivities, events.StreamAutomationExternalTriggers, events.StreamPluginTriggerEvents} {
 		err := c.client.XGroupCreateMkStream(ctx, stream, c.groupName, c.groupStartID).Err()
 		if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
 			return err
@@ -253,7 +257,7 @@ func (c *AutomationConsumer) run() {
 		msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
 			Group:    c.groupName,
 			Consumer: c.consumerName,
-			Streams:  []string{events.StreamTaskActivities, events.StreamAutomationExternalTriggers, ">", ">"},
+			Streams:  []string{events.StreamTaskActivities, events.StreamAutomationExternalTriggers, events.StreamPluginTriggerEvents, ">", ">", ">"},
 			Count:    automationReadCount,
 			Block:    automationReadBlock,
 		}).Result()
@@ -280,14 +284,18 @@ func (c *AutomationConsumer) run() {
 // dispatchMessages routes each message to the right handler based on which
 // stream it came from — StreamAutomationExternalTriggers messages already
 // know exactly which node/task to run (resolved by the webhook handler
-// before publishing), everything else goes through the task-activity
-// trigger-matching path.
+// before publishing); StreamPluginTriggerEvents messages carry a plugin's
+// own event topic, matched against plugin-declared Trigger nodes by topic;
+// everything else goes through the task-activity trigger-matching path.
 func (c *AutomationConsumer) dispatchMessages(msgs []redis.XStream) {
 	for _, stream := range msgs {
 		for _, msg := range stream.Messages {
-			if stream.Stream == events.StreamAutomationExternalTriggers {
+			switch stream.Stream {
+			case events.StreamAutomationExternalTriggers:
 				c.handleExternalTrigger(msg)
-			} else {
+			case events.StreamPluginTriggerEvents:
+				c.handlePluginTriggerEvent(msg)
+			default:
 				c.handle(msg)
 			}
 		}
@@ -298,7 +306,7 @@ func (c *AutomationConsumer) processPending(ctx context.Context) {
 	msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
 		Group:    c.groupName,
 		Consumer: c.consumerName,
-		Streams:  []string{events.StreamTaskActivities, events.StreamAutomationExternalTriggers, "0", "0"},
+		Streams:  []string{events.StreamTaskActivities, events.StreamAutomationExternalTriggers, events.StreamPluginTriggerEvents, "0", "0", "0"},
 		Count:    automationReadCount,
 	}).Result()
 	if err != nil && err != redis.Nil {
@@ -456,6 +464,96 @@ func (c *AutomationConsumer) handleExternalTrigger(msg redis.XMessage) {
 		return
 	}
 	c.ack(ctx, events.StreamAutomationExternalTriggers, msg.ID)
+}
+
+// pluginTriggerEventPayload is the payload contract a plugin's own
+// EmitEvent call must satisfy when its topic is declared as a Trigger
+// node's eventTopic in the plugin's manifest: project_id (which project's
+// automations to consider — plugin trigger types are namespaced per plugin,
+// not per project, so every project with a matching enabled trigger node
+// runs) and, when the event concerns a specific task, task_id to bind the
+// walk to. task_id is optional the same way api_trigger's is (see
+// automationExternalTriggerPayload above): absent means this run may only
+// reach a Call API or Trigger AI agent action downstream
+// (validateTaskReachability enforces that at edge-creation time). Every
+// plugin trigger emitted so far (time_logging.entry_created,
+// github.pr_linked, github.branch_linked, github.pr_state_changed) includes
+// both fields — see each plugin's EmitEvent call sites.
+type pluginTriggerEventPayload struct {
+	ProjectID string `json:"project_id"`
+	TaskID    string `json:"task_id"`
+}
+
+// handlePluginTriggerEvent matches a plugin-emitted event's topic against
+// every plugin-declared Trigger node type sharing that eventTopic
+// (Runtime.TriggersForTopic — the same lookup event_emit itself used to
+// decide whether to append this message at all), then within the event's
+// own project, every enabled node of each matching type — exactly like a
+// built-in trigger's topic-based matching, just sourced from a plugin's own
+// event instead of the task-activity stream.
+func (c *AutomationConsumer) handlePluginTriggerEvent(msg redis.XMessage) {
+	ctx := context.Background()
+
+	topic, _ := msg.Values["type"].(string)
+	raw, ok := msg.Values["payload"].(string)
+	if topic == "" || !ok {
+		c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
+		return
+	}
+
+	if c.pluginRuntime == nil {
+		c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
+		return
+	}
+	manifests := c.pluginRuntime.TriggersForTopic(topic)
+	if len(manifests) == 0 {
+		// The set of loaded plugins/declared triggers can change between
+		// event_emit's own check and this read (a plugin unloaded, a
+		// trigger type renamed) — drop rather than retry forever.
+		c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
+		return
+	}
+
+	var p pluginTriggerEventPayload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		c.log.Warn("automation consumer: failed to decode plugin trigger payload", "id", msg.ID, "topic", topic, "err", err)
+		c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
+		return
+	}
+	projectID, err := uuid.Parse(p.ProjectID)
+	if err != nil {
+		c.log.Warn("automation consumer: plugin trigger event missing/invalid project_id", "id", msg.ID, "topic", topic)
+		c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
+		return
+	}
+
+	var task *taskdom.Task
+	if p.TaskID != "" {
+		taskID, err := uuid.Parse(p.TaskID)
+		if err != nil {
+			c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
+			return
+		}
+		task, err = c.taskRepo.FindTaskByID(ctx, taskID)
+		if err != nil {
+			c.log.Error("automation consumer: plugin trigger find task", "id", msg.ID, "task_id", taskID, "err", err)
+			return // not acked — retried via processPending
+		}
+	}
+
+	for _, manifest := range manifests {
+		nodes, err := c.repo.ListEnabledTriggerNodesByType(ctx, projectID, automationdom.TriggerType(manifest.Type))
+		if err != nil {
+			c.log.Error("automation consumer: list plugin trigger nodes", "type", manifest.Type, "err", err)
+			continue
+		}
+		for _, node := range nodes {
+			if err := c.executeRun(ctx, projectID, node, task); err != nil {
+				c.log.Error("automation consumer: plugin trigger run failed", "node_id", node.ID, "err", err)
+			}
+		}
+	}
+	c.ack(ctx, events.StreamPluginTriggerEvents, msg.ID)
 }
 
 // processEvent fetches the authoritative task once, then matches it against
@@ -695,14 +793,6 @@ func (w *walker) walk(ctx context.Context, nodeID uuid.UUID) {
 	}
 }
 
-// pluginConditionTrueHandle / pluginConditionFalseHandle are the two
-// branch handles a plugin-contributed condition node's edges use — a
-// plugin condition is a simple boolean gate, not an N-branch switch, so it
-// doesn't need the built-in condition node's Branches config shape.
-const (
-	pluginConditionTrueHandle = "true"
-)
-
 func (w *walker) walkCondition(ctx context.Context, node *automationdom.Node) {
 	if node.Type != automationdom.ConditionNodeType {
 		w.walkPluginCondition(ctx, node)
@@ -820,14 +910,43 @@ func (c *AutomationConsumer) resolveTargetTasks(ctx context.Context, projectID u
 	}
 }
 
+// pluginConditionTarget is the subset of a plugin condition node's config
+// this package reads directly — the "applies to" target/match_mode fields
+// SchemaConfigForm adds alongside whatever the plugin's own configSchema
+// declares (automation-node-config-panel.tsx), same JSON shape as
+// ConditionLeaf.Target/MatchMode. The plugin's own handler never sees these
+// two keys reinterpreted — Config is still forwarded to it verbatim,
+// unchanged from before Target existed — this is purely how the walker
+// decides *which task(s)* to ask the plugin to evaluate against.
+type pluginConditionTarget struct {
+	Target    *automationdom.TaskTarget `json:"target,omitempty"`
+	MatchMode string                    `json:"match_mode,omitempty"`
+}
+
 // walkPluginCondition dispatches a plugin-contributed condition node via
 // the plugin runtime's EvaluateCondition bridge, then follows the "true"
 // edge if matched or the "else" edge otherwise — the same edge-following
 // logic as the built-in condition node, just with exactly two possible
 // outcomes instead of N branches.
+//
+// cfg.Target (nil/self = every plugin condition's behavior before Target
+// existed) retargets the evaluation onto a task other than the walk's own
+// bound task, exactly like a built-in condition leaf: resolved via the same
+// resolveTargetTasks, then combined across however many tasks that resolves
+// to via cfg.MatchMode (mirrors ConditionLeaf.EvaluateAgainstTasks) — "all"
+// requires every resolved task to match, anything else requires only one.
 func (w *walker) walkPluginCondition(ctx context.Context, node *automationdom.Node) {
-	input, _ := json.Marshal(pluginNodePayload(node.Type, node.Config, w.task, ""))
-	matched, err := w.consumer.evaluatePluginCondition(ctx, node, input)
+	var cfg pluginConditionTarget
+	_ = json.Unmarshal(node.Config, &cfg)
+
+	tasks, err := w.consumer.resolveTargetTasks(ctx, w.projectID, w.task, cfg.Target)
+	if err != nil {
+		w.failed = true
+		w.recordStep(ctx, node.ID, automationdom.RunStepFailed, nil, nil, err.Error())
+		return
+	}
+
+	matched, input, err := w.consumer.evaluatePluginConditionAgainstTasks(ctx, w.projectID, node, tasks, cfg.MatchMode)
 	if err != nil {
 		w.failed = true
 		w.recordStep(ctx, node.ID, automationdom.RunStepFailed, input, nil, err.Error())
@@ -835,7 +954,7 @@ func (w *walker) walkPluginCondition(ctx context.Context, node *automationdom.No
 	}
 	matchedHandle := automationdom.ElseHandle
 	if matched {
-		matchedHandle = pluginConditionTrueHandle
+		matchedHandle = automationdom.PluginConditionTrueHandle
 	}
 	output, _ := json.Marshal(map[string]any{"matched_handle": matchedHandle})
 	w.recordStep(ctx, node.ID, automationdom.RunStepCompleted, input, output, "")
@@ -991,32 +1110,15 @@ func (c *AutomationConsumer) runAction(ctx context.Context, projectID uuid.UUID,
 // ever reached, since neither operates on a task at all.
 func (c *AutomationConsumer) applyActionForTask(ctx context.Context, projectID uuid.UUID, node *automationdom.Node, actionType automationdom.ActionType, cfg automationdom.ActionConfig, task *taskdom.Task, automationName string, runID uuid.UUID) (bool, error) {
 	switch actionType {
-	case automationdom.ActionAssign:
-		if cfg.MemberID == nil {
-			return false, fmt.Errorf("assign: missing member_id")
-		}
-		return c.applyAssign(ctx, projectID, task, *cfg.MemberID, automationName)
+	case automationdom.ActionUpdateTask:
+		return c.applyUpdateTask(ctx, projectID, task, cfg.Update, automationName)
 	case automationdom.ActionTriggerAIAgent:
 		if cfg.MemberID == nil {
 			return false, fmt.Errorf("trigger_ai_agent: missing member_id")
 		}
 		return c.applyTriggerAIAgentOnTask(ctx, projectID, task, *cfg.MemberID, automationName, cfg.Message)
-	case automationdom.ActionSetStatus:
-		if cfg.StatusID == nil {
-			return false, fmt.Errorf("set_status: missing status_id")
-		}
-		return c.applySetStatus(ctx, projectID, task, *cfg.StatusID)
-	case automationdom.ActionSetPriority:
-		if cfg.Importance == nil {
-			return false, fmt.Errorf("set_priority: missing importance")
-		}
-		return c.applySetPriority(ctx, projectID, task, *cfg.Importance)
-	case automationdom.ActionAddTag:
-		return c.applyAddTag(ctx, projectID, task, cfg.Tag)
-	case automationdom.ActionSetCustomField:
-		return c.applySetCustomField(ctx, projectID, task, cfg.FieldKey, cfg.Value)
 	default:
-		return c.runPluginAction(ctx, node, task, runID)
+		return c.runPluginAction(ctx, projectID, node, task, runID)
 	}
 }
 
@@ -1072,7 +1174,7 @@ func (c *AutomationConsumer) applyCallAPI(ctx context.Context, cfg automationdom
 // something stable to dedupe against in their own schema-isolated tables if
 // they choose to, since the platform can't enforce idempotency inside
 // someone else's WASM code.
-func (c *AutomationConsumer) runPluginAction(ctx context.Context, node *automationdom.Node, task *taskdom.Task, runID uuid.UUID) (bool, error) {
+func (c *AutomationConsumer) runPluginAction(ctx context.Context, projectID uuid.UUID, node *automationdom.Node, task *taskdom.Task, runID uuid.UUID) (bool, error) {
 	if c.pluginRuntime == nil {
 		return false, fmt.Errorf("unknown action type %q", node.Type)
 	}
@@ -1081,7 +1183,7 @@ func (c *AutomationConsumer) runPluginAction(ctx context.Context, node *automati
 		return false, fmt.Errorf("unknown action type %q", node.Type)
 	}
 	idempotencyKey := fmt.Sprintf("%s:%s", runID, node.ID)
-	payload, _ := json.Marshal(pluginNodePayload(node.Type, node.Config, task, idempotencyKey))
+	payload, _ := json.Marshal(pluginNodePayload(node.Type, node.Config, projectID, task, idempotencyKey))
 	resp, err := c.pluginRuntime.RunAction(ctx, pluginName, payload)
 	if err != nil {
 		return false, fmt.Errorf("plugin action %q: %w", node.Type, err)
@@ -1122,16 +1224,55 @@ func (c *AutomationConsumer) evaluatePluginCondition(ctx context.Context, node *
 	return result.Matched, nil
 }
 
+// evaluatePluginConditionAgainstTasks evaluates node's plugin condition once
+// per task in tasks — a plugin condition's Matched result is inherently
+// per-task (each dispatch gets its own TaskSnapshot), unlike a built-in
+// ConditionLeaf, which evaluates client-side against a task struct already
+// in memory — then combines the results the same way
+// ConditionLeaf.EvaluateAgainstTasks does: matchMode "all" requires every
+// task to match, anything else (including "" and "any") requires only one.
+// An empty tasks slice is always false regardless of matchMode, same
+// reasoning as EvaluateAgainstTasks — nothing to check, so the condition
+// can't be considered satisfied either way. Returns the last dispatched
+// payload alongside the result, for the run step's audit trail — mirrors
+// evaluatePluginCondition's caller already recording its own input.
+func (c *AutomationConsumer) evaluatePluginConditionAgainstTasks(ctx context.Context, projectID uuid.UUID, node *automationdom.Node, tasks []*taskdom.Task, matchMode string) (bool, []byte, error) {
+	if len(tasks) == 0 {
+		return false, nil, nil
+	}
+	var lastInput []byte
+	requireAll := matchMode == "all"
+	for _, t := range tasks {
+		input, _ := json.Marshal(pluginNodePayload(node.Type, node.Config, projectID, t, ""))
+		lastInput = input
+		matched, err := c.evaluatePluginCondition(ctx, node, input)
+		if err != nil {
+			return false, input, err
+		}
+		if requireAll && !matched {
+			return false, input, nil
+		}
+		if !requireAll && matched {
+			return true, input, nil
+		}
+	}
+	return requireAll, lastInput, nil
+}
+
 // pluginNodePayload builds the JSON bundle handed to a plugin's
 // EvaluateCondition/RunAction export: the node's own type (so a plugin
 // declaring more than one Condition/Action node type can dispatch
-// internally) and config, plus enough task context for the plugin to
-// decide, plus an idempotency key (RunAction only; empty for
-// EvaluateCondition since evaluation has no side effects to dedupe).
-func pluginNodePayload(nodeType string, config json.RawMessage, task *taskdom.Task, idempotencyKey string) map[string]any {
+// internally), config, enough task context for the plugin to decide, the
+// project the automation run belongs to (so a plugin never has to ask a
+// user to type a project_id into its node config just to know its own
+// scope — see plugin-sdk-go's ConditionRequest.ProjectID/
+// ActionRequest.ProjectID), plus an idempotency key (RunAction only; empty
+// for EvaluateCondition since evaluation has no side effects to dedupe).
+func pluginNodePayload(nodeType string, config json.RawMessage, projectID uuid.UUID, task *taskdom.Task, idempotencyKey string) map[string]any {
 	payload := map[string]any{
-		"node_type": nodeType,
-		"config":    json.RawMessage(config),
+		"node_type":  nodeType,
+		"config":     json.RawMessage(config),
+		"project_id": projectID,
 		"task": map[string]any{
 			"id":            task.ID,
 			"status_id":     task.StatusID,
@@ -1154,37 +1295,14 @@ func pluginNodePayload(nodeType string, config json.RawMessage, task *taskdom.Ta
 // this is the "assign" action; trigger_ai_agent uses
 // applyTriggerAIAgentOnTask instead, which starts a conversation without
 // this reassignment).
-func (c *AutomationConsumer) applyAssign(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, memberID uuid.UUID, automationName string) (bool, error) {
-	if len(task.AssigneeIDs) == 1 && task.AssigneeIDs[0] == memberID {
-		return false, nil
-	}
-	oldAssignees := task.AssigneeIDs
-	newIDs := []uuid.UUID{memberID}
-	if _, err := c.taskSvc.UpdateTask(ctx, projectID, task.ID, taskdom.UpdateTaskInput{AssigneeIDs: &newIDs}); err != nil {
-		return false, fmt.Errorf("update assignee: %w", err)
-	}
-	task.AssigneeIDs = newIDs
-
-	c.recordAppliedActivity(ctx, projectID, task.ID, automationName, map[string]any{
-		"old_assignees": oldAssignees,
-		"new_assignee":  memberID,
-	})
-
-	if !slices.Contains(oldAssignees, memberID) {
-		extra := map[string]any{"automation_name": automationName}
-		_ = events.PublishAssignmentChanged(ctx, c.publisher, task.ID, projectID, memberID, nil, userdom.SystemActorUserID, extra)
-	}
-	return true, nil
-}
-
 // applyTriggerAIAgentOnTask starts an agent conversation scoped to task,
 // without changing its assignee. trigger_ai_agent's job is to get the agent
 // looking at the task — not to transfer ownership of it, which is what the
-// separate "assign" action is for and which would otherwise clobber whoever
-// the task is actually assigned to just to route it to an agent. Unlike
-// applyAssign there's no "already in target state" check to make: no task
-// state is being mutated here, so — same as applyDirectAgentMessage — every
-// visit starts a fresh conversation.
+// update_task action's AssigneeIDs field is for and which would otherwise
+// clobber whoever the task is actually assigned to just to route it to an
+// agent. Unlike applyUpdateTask there's no "already in target state" check
+// to make: no task state is being mutated here, so — same as
+// applyDirectAgentMessage — every visit starts a fresh conversation.
 func (c *AutomationConsumer) applyTriggerAIAgentOnTask(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, memberID uuid.UUID, automationName, agentMessage string) (bool, error) {
 	if c.memberRepo == nil || c.agentMessenger == nil {
 		return false, fmt.Errorf("trigger_ai_agent: agent dispatch not configured")
@@ -1285,59 +1403,190 @@ func (c *AutomationConsumer) applyDirectAgentMessage(ctx context.Context, projec
 	return true, nil
 }
 
-func (c *AutomationConsumer) applySetStatus(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, statusID uuid.UUID) (bool, error) {
-	if task.StatusID != nil && *task.StatusID == statusID {
+func (c *AutomationConsumer) applyUpdateTask(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, upd *automationdom.TaskFieldUpdate, automationName string) (bool, error) {
+	if upd == nil {
+		return false, fmt.Errorf("update_task: missing update config")
+	}
+	in := taskdom.UpdateTaskInput{}
+	changed := map[string]any{}
+	oldAssignees := task.AssigneeIDs
+
+	if upd.TaskTypeID != nil && (task.TaskTypeID == nil || *task.TaskTypeID != *upd.TaskTypeID) {
+		id := *upd.TaskTypeID
+		ptr := &id
+		in.TaskTypeID = &ptr
+		changed["task_type_id"] = id
+	}
+	if upd.StatusID != nil && (task.StatusID == nil || *task.StatusID != *upd.StatusID) {
+		id := *upd.StatusID
+		ptr := &id
+		in.StatusID = &ptr
+		changed["status_id"] = id
+	}
+	if upd.SprintID != nil && (task.SprintID == nil || *task.SprintID != *upd.SprintID) {
+		id := *upd.SprintID
+		ptr := &id
+		in.SprintID = &ptr
+		changed["sprint_id"] = id
+	}
+	if upd.ParentTaskID != nil && (task.ParentTaskID == nil || *task.ParentTaskID != *upd.ParentTaskID) {
+		id := *upd.ParentTaskID
+		ptr := &id
+		in.ParentTaskID = &ptr
+		changed["parent_task_id"] = id
+	}
+	if upd.Title != "" && upd.Title != task.Title {
+		title := upd.Title
+		in.Title = title
+		changed["title"] = title
+	}
+	if len(upd.Description) > 0 {
+		desc := upd.Description
+		in.Description = &desc
+		changed["description"] = true
+	}
+	if upd.Importance != nil && *upd.Importance != task.Importance {
+		importance := *upd.Importance
+		in.Importance = &importance
+		changed["importance"] = importance
+	}
+	if upd.StoryPoints != nil && (task.StoryPoints == nil || *task.StoryPoints != *upd.StoryPoints) {
+		sp := *upd.StoryPoints
+		ptr := &sp
+		in.StoryPoints = &ptr
+		changed["story_points"] = sp
+	}
+	if upd.AssigneeIDs != nil && !slices.Equal(sortedUUIDs(task.AssigneeIDs), sortedUUIDs(upd.AssigneeIDs)) {
+		ids := upd.AssigneeIDs
+		in.AssigneeIDs = &ids
+		changed["assignee_ids"] = ids
+	}
+	if upd.ReporterID != nil && (task.ReporterID == nil || *task.ReporterID != *upd.ReporterID) {
+		id := *upd.ReporterID
+		ptr := &id
+		in.ReporterID = &ptr
+		changed["reporter_id"] = id
+	}
+	if len(upd.CustomFields) > 0 {
+		newFields := make(map[string]any, len(task.CustomFields)+len(upd.CustomFields))
+		for k, v := range task.CustomFields {
+			newFields[k] = v
+		}
+		anyDiff := false
+		for k, v := range upd.CustomFields {
+			if existing, ok := task.CustomFields[k]; !ok || fmt.Sprintf("%v", existing) != fmt.Sprintf("%v", v) {
+				anyDiff = true
+			}
+			newFields[k] = v
+		}
+		if anyDiff {
+			in.CustomFields = &newFields
+			changed["custom_fields"] = upd.CustomFields
+		}
+	}
+	if upd.StartDate != nil && (task.StartDate == nil || !task.StartDate.Equal(*upd.StartDate)) {
+		d := *upd.StartDate
+		ptr := &d
+		in.StartDate = &ptr
+		changed["start_date"] = d
+	}
+	if upd.DueDate != nil && (task.DueDate == nil || !task.DueDate.Equal(*upd.DueDate)) {
+		d := *upd.DueDate
+		ptr := &d
+		in.DueDate = &ptr
+		changed["due_date"] = d
+	}
+	if len(upd.Tags) > 0 && !slices.Equal(sortedStrings(task.Tags), sortedStrings(upd.Tags)) {
+		tags := upd.Tags
+		in.Tags = &tags
+		changed["tags"] = tags
+	}
+
+	if len(changed) == 0 {
 		return false, nil
 	}
-	id := statusID
-	ptr := &id
-	if _, err := c.taskSvc.UpdateTask(ctx, projectID, task.ID, taskdom.UpdateTaskInput{StatusID: &ptr}); err != nil {
-		return false, fmt.Errorf("update status: %w", err)
+	updated, err := c.taskSvc.UpdateTask(ctx, projectID, task.ID, in)
+	if err != nil {
+		return false, fmt.Errorf("update_task: %w", err)
 	}
-	task.StatusID = &id
+	_ = updated
+
+	// Mutate task's fields directly from what we asked for (mirrors the old
+	// per-field actions' behavior of updating the in-memory task themselves
+	// rather than trusting whatever UpdateTask happens to return) — later
+	// leaves/actions in the same walk see these changes immediately.
+	if in.TaskTypeID != nil {
+		task.TaskTypeID = *in.TaskTypeID
+	}
+	if in.StatusID != nil {
+		task.StatusID = *in.StatusID
+	}
+	if in.SprintID != nil {
+		task.SprintID = *in.SprintID
+	}
+	if in.ParentTaskID != nil {
+		task.ParentTaskID = *in.ParentTaskID
+	}
+	if in.Title != "" {
+		task.Title = in.Title
+	}
+	if in.Description != nil {
+		task.Description = *in.Description
+	}
+	if in.Importance != nil {
+		task.Importance = *in.Importance
+	}
+	if in.StoryPoints != nil {
+		task.StoryPoints = *in.StoryPoints
+	}
+	if in.AssigneeIDs != nil {
+		task.AssigneeIDs = *in.AssigneeIDs
+	}
+	if in.ReporterID != nil {
+		task.ReporterID = *in.ReporterID
+	}
+	if in.CustomFields != nil {
+		task.CustomFields = *in.CustomFields
+	}
+	if in.StartDate != nil {
+		task.StartDate = *in.StartDate
+	}
+	if in.DueDate != nil {
+		task.DueDate = *in.DueDate
+	}
+	if in.Tags != nil {
+		task.Tags = *in.Tags
+	}
+
+	c.recordAppliedActivity(ctx, projectID, task.ID, automationName, changed)
+	if in.AssigneeIDs != nil {
+		for _, memberID := range *in.AssigneeIDs {
+			if !slices.Contains(oldAssignees, memberID) {
+				extra := map[string]any{"automation_name": automationName}
+				_ = events.PublishAssignmentChanged(ctx, c.publisher, task.ID, projectID, memberID, nil, userdom.SystemActorUserID, extra)
+			}
+		}
+	}
 	return true, nil
 }
 
-func (c *AutomationConsumer) applySetPriority(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, importance int) (bool, error) {
-	if task.Importance == importance {
-		return false, nil
-	}
-	if _, err := c.taskSvc.UpdateTask(ctx, projectID, task.ID, taskdom.UpdateTaskInput{Importance: &importance}); err != nil {
-		return false, fmt.Errorf("update priority: %w", err)
-	}
-	task.Importance = importance
-	return true, nil
+// sortedUUIDs and sortedStrings give applyUpdateTask a stable comparison
+// order — the task's current AssigneeIDs/Tags and an update's requested
+// values are semantically sets, but []uuid.UUID/[]string equality (via
+// slices.Equal) is order-sensitive, so an update carrying the same members
+// in a different order would otherwise register as a "change" and fire a
+// no-op UpdateTask + a spurious assignment-changed event every time this
+// action re-runs.
+func sortedUUIDs(ids []uuid.UUID) []uuid.UUID {
+	out := append([]uuid.UUID{}, ids...)
+	slices.SortFunc(out, func(a, b uuid.UUID) int { return strings.Compare(a.String(), b.String()) })
+	return out
 }
 
-func (c *AutomationConsumer) applyAddTag(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, tag string) (bool, error) {
-	if tag == "" || slices.Contains(task.Tags, tag) {
-		return false, nil
-	}
-	newTags := append(append([]string{}, task.Tags...), tag)
-	if _, err := c.taskSvc.UpdateTask(ctx, projectID, task.ID, taskdom.UpdateTaskInput{Tags: &newTags}); err != nil {
-		return false, fmt.Errorf("add tag: %w", err)
-	}
-	task.Tags = newTags
-	return true, nil
-}
-
-func (c *AutomationConsumer) applySetCustomField(ctx context.Context, projectID uuid.UUID, task *taskdom.Task, fieldKey string, value any) (bool, error) {
-	if fieldKey == "" {
-		return false, fmt.Errorf("set_custom_field: missing field_key")
-	}
-	if existing, ok := task.CustomFields[fieldKey]; ok && fmt.Sprintf("%v", existing) == fmt.Sprintf("%v", value) {
-		return false, nil
-	}
-	newFields := make(map[string]any, len(task.CustomFields)+1)
-	for k, v := range task.CustomFields {
-		newFields[k] = v
-	}
-	newFields[fieldKey] = value
-	if _, err := c.taskSvc.UpdateTask(ctx, projectID, task.ID, taskdom.UpdateTaskInput{CustomFields: &newFields}); err != nil {
-		return false, fmt.Errorf("set custom field: %w", err)
-	}
-	task.CustomFields = newFields
-	return true, nil
+func sortedStrings(s []string) []string {
+	out := append([]string{}, s...)
+	slices.Sort(out)
+	return out
 }
 
 func (c *AutomationConsumer) recordAppliedActivity(ctx context.Context, projectID, taskID uuid.UUID, automationName string, extra map[string]any) {

--- a/services/api/internal/worker/automation_consumer.go
+++ b/services/api/internal/worker/automation_consumer.go
@@ -826,7 +826,7 @@ func (c *AutomationConsumer) resolveTargetTasks(ctx context.Context, projectID u
 // logic as the built-in condition node, just with exactly two possible
 // outcomes instead of N branches.
 func (w *walker) walkPluginCondition(ctx context.Context, node *automationdom.Node) {
-	input, _ := json.Marshal(pluginNodePayload(node.Config, w.task, ""))
+	input, _ := json.Marshal(pluginNodePayload(node.Type, node.Config, w.task, ""))
 	matched, err := w.consumer.evaluatePluginCondition(ctx, node, input)
 	if err != nil {
 		w.failed = true
@@ -1081,7 +1081,7 @@ func (c *AutomationConsumer) runPluginAction(ctx context.Context, node *automati
 		return false, fmt.Errorf("unknown action type %q", node.Type)
 	}
 	idempotencyKey := fmt.Sprintf("%s:%s", runID, node.ID)
-	payload, _ := json.Marshal(pluginNodePayload(node.Config, task, idempotencyKey))
+	payload, _ := json.Marshal(pluginNodePayload(node.Type, node.Config, task, idempotencyKey))
 	resp, err := c.pluginRuntime.RunAction(ctx, pluginName, payload)
 	if err != nil {
 		return false, fmt.Errorf("plugin action %q: %w", node.Type, err)
@@ -1123,13 +1123,15 @@ func (c *AutomationConsumer) evaluatePluginCondition(ctx context.Context, node *
 }
 
 // pluginNodePayload builds the JSON bundle handed to a plugin's
-// EvaluateCondition/RunAction export: the node's own config plus enough task
-// context for the plugin to decide, plus an idempotency key (RunAction
-// only; empty for EvaluateCondition since evaluation has no side effects to
-// dedupe).
-func pluginNodePayload(config json.RawMessage, task *taskdom.Task, idempotencyKey string) map[string]any {
+// EvaluateCondition/RunAction export: the node's own type (so a plugin
+// declaring more than one Condition/Action node type can dispatch
+// internally) and config, plus enough task context for the plugin to
+// decide, plus an idempotency key (RunAction only; empty for
+// EvaluateCondition since evaluation has no side effects to dedupe).
+func pluginNodePayload(nodeType string, config json.RawMessage, task *taskdom.Task, idempotencyKey string) map[string]any {
 	payload := map[string]any{
-		"config": json.RawMessage(config),
+		"node_type": nodeType,
+		"config":    json.RawMessage(config),
 		"task": map[string]any{
 			"id":            task.ID,
 			"status_id":     task.StatusID,

--- a/services/api/internal/worker/automation_consumer_test.go
+++ b/services/api/internal/worker/automation_consumer_test.go
@@ -8,11 +8,15 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
 	automationdom "github.com/Paca-AI/api/internal/domain/automation"
+	plugindom "github.com/Paca-AI/api/internal/domain/plugin"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
 )
@@ -84,36 +88,36 @@ func TestTriggerMatches_UnconditionalTypesAlwaysMatch(t *testing.T) {
 	}
 }
 
-func TestApplyAssign_IdempotentWhenAlreadyAssigned(t *testing.T) {
+func TestApplyUpdateTask_Assign_IdempotentWhenAlreadyAssigned(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	memberID := uuid.New()
 	task := &taskdom.Task{ID: uuid.New(), AssigneeIDs: []uuid.UUID{memberID}}
 
-	applied, err := c.applyAssign(context.Background(), uuid.New(), task, memberID, "test-automation")
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{AssigneeIDs: []uuid.UUID{memberID}}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if applied {
-		t.Fatal("expected applyAssign to be a no-op when already assigned to memberID")
+		t.Fatal("expected applyUpdateTask to be a no-op when already assigned to memberID")
 	}
 	if updater.calls != 0 {
 		t.Fatalf("expected no UpdateTask call, got %d", updater.calls)
 	}
 }
 
-func TestApplyAssign_AppliesWhenNotAssigned(t *testing.T) {
+func TestApplyUpdateTask_Assign_AppliesWhenNotAssigned(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	memberID := uuid.New()
 	task := &taskdom.Task{ID: uuid.New(), AssigneeIDs: nil}
 
-	applied, err := c.applyAssign(context.Background(), uuid.New(), task, memberID, "test-automation")
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{AssigneeIDs: []uuid.UUID{memberID}}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !applied {
-		t.Fatal("expected applyAssign to apply when not already assigned")
+		t.Fatal("expected applyUpdateTask to apply when not already assigned")
 	}
 	if updater.calls != 1 {
 		t.Fatalf("expected exactly one UpdateTask call, got %d", updater.calls)
@@ -377,13 +381,13 @@ func TestWalk_NilTaskReachingTriggerAIAgent_ProceedsAndSucceeds(t *testing.T) {
 	}
 }
 
-func TestApplySetStatus_IdempotentWhenAlreadySet(t *testing.T) {
+func TestApplyUpdateTask_Status_IdempotentWhenAlreadySet(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	statusID := uuid.New()
 	task := &taskdom.Task{ID: uuid.New(), StatusID: &statusID}
 
-	applied, err := c.applySetStatus(context.Background(), uuid.New(), task, statusID)
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{StatusID: &statusID}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -392,13 +396,13 @@ func TestApplySetStatus_IdempotentWhenAlreadySet(t *testing.T) {
 	}
 }
 
-func TestApplySetStatus_AppliesWhenDifferent(t *testing.T) {
+func TestApplyUpdateTask_Status_AppliesWhenDifferent(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	oldStatus, newStatus := uuid.New(), uuid.New()
 	task := &taskdom.Task{ID: uuid.New(), StatusID: &oldStatus}
 
-	applied, err := c.applySetStatus(context.Background(), uuid.New(), task, newStatus)
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{StatusID: &newStatus}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -410,12 +414,13 @@ func TestApplySetStatus_AppliesWhenDifferent(t *testing.T) {
 	}
 }
 
-func TestApplySetPriority_IdempotentWhenAlreadySet(t *testing.T) {
+func TestApplyUpdateTask_Priority_IdempotentWhenAlreadySet(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	task := &taskdom.Task{ID: uuid.New(), Importance: 5}
 
-	applied, err := c.applySetPriority(context.Background(), uuid.New(), task, 5)
+	importance := 5
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{Importance: &importance}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -424,12 +429,12 @@ func TestApplySetPriority_IdempotentWhenAlreadySet(t *testing.T) {
 	}
 }
 
-func TestApplyAddTag_IdempotentWhenTagAlreadyPresent(t *testing.T) {
+func TestApplyUpdateTask_Tags_IdempotentWhenSameSet(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	task := &taskdom.Task{ID: uuid.New(), Tags: []string{"urgent"}}
 
-	applied, err := c.applyAddTag(context.Background(), uuid.New(), task, "urgent")
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{Tags: []string{"urgent"}}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -438,12 +443,12 @@ func TestApplyAddTag_IdempotentWhenTagAlreadyPresent(t *testing.T) {
 	}
 }
 
-func TestApplyAddTag_AppliesWhenTagMissing(t *testing.T) {
+func TestApplyUpdateTask_Tags_AppliesWhenDifferent(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	task := &taskdom.Task{ID: uuid.New(), Tags: []string{"bug"}}
 
-	applied, err := c.applyAddTag(context.Background(), uuid.New(), task, "urgent")
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{Tags: []string{"bug", "urgent"}}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -451,16 +456,16 @@ func TestApplyAddTag_AppliesWhenTagMissing(t *testing.T) {
 		t.Fatalf("expected applied=true, 1 call, got applied=%v calls=%d", applied, updater.calls)
 	}
 	if len(task.Tags) != 2 {
-		t.Fatalf("expected tag appended in place, got %v", task.Tags)
+		t.Fatalf("expected tags replaced in place, got %v", task.Tags)
 	}
 }
 
-func TestApplySetCustomField_IdempotentWhenValueAlreadyMatches(t *testing.T) {
+func TestApplyUpdateTask_CustomField_IdempotentWhenValueAlreadyMatches(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	task := &taskdom.Task{ID: uuid.New(), CustomFields: map[string]any{"release_tag": "v2"}}
 
-	applied, err := c.applySetCustomField(context.Background(), uuid.New(), task, "release_tag", "v2")
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{CustomFields: map[string]any{"release_tag": "v2"}}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -469,12 +474,12 @@ func TestApplySetCustomField_IdempotentWhenValueAlreadyMatches(t *testing.T) {
 	}
 }
 
-func TestApplySetCustomField_AppliesWhenValueDiffers(t *testing.T) {
+func TestApplyUpdateTask_CustomField_AppliesWhenValueDiffers(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := newTestConsumer(updater)
 	task := &taskdom.Task{ID: uuid.New(), CustomFields: map[string]any{"release_tag": "v1"}}
 
-	applied, err := c.applySetCustomField(context.Background(), uuid.New(), task, "release_tag", "v2")
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{CustomFields: map[string]any{"release_tag": "v2"}}, "test-automation")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -492,7 +497,24 @@ type fakePluginRuntime struct {
 	conditionPlugin, actionPlugin string
 	hasCondition, hasAction       bool
 	conditionResp, actionResp     []byte
-	err                           error
+	// conditionResponses, when non-empty, overrides conditionResp: each
+	// call to EvaluateCondition returns the next entry in order (clamped to
+	// the last one past the end) — lets a test drive
+	// evaluatePluginConditionAgainstTasks through more than one task with a
+	// different Matched result per task.
+	conditionResponses [][]byte
+	conditionCalls     int
+	err                error
+	// triggerManifests backs TriggersForTopic — keyed by topic, mirroring
+	// how the real Runtime looks up plugin-declared Trigger manifests by
+	// their eventTopic.
+	triggerManifests map[string][]plugindom.AutomationNodeManifest
+	// lastConditionPayload/lastActionPayload capture the raw JSON most
+	// recently dispatched to EvaluateCondition/RunAction, so a test can
+	// assert on payload contents (e.g. node_type) rather than only on the
+	// plugin's response.
+	lastConditionPayload []byte
+	lastActionPayload    []byte
 }
 
 func (f *fakePluginRuntime) ResolveAutomationCondition(nodeType string) (string, bool) {
@@ -501,11 +523,27 @@ func (f *fakePluginRuntime) ResolveAutomationCondition(nodeType string) (string,
 func (f *fakePluginRuntime) ResolveAutomationAction(nodeType string) (string, bool) {
 	return f.actionPlugin, f.hasAction
 }
-func (f *fakePluginRuntime) EvaluateCondition(_ context.Context, _ string, _ []byte) ([]byte, error) {
-	return f.conditionResp, f.err
+func (f *fakePluginRuntime) EvaluateCondition(_ context.Context, _ string, payload []byte) ([]byte, error) {
+	f.lastConditionPayload = payload
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.conditionResponses) > 0 {
+		i := f.conditionCalls
+		if i >= len(f.conditionResponses) {
+			i = len(f.conditionResponses) - 1
+		}
+		f.conditionCalls++
+		return f.conditionResponses[i], nil
+	}
+	return f.conditionResp, nil
 }
-func (f *fakePluginRuntime) RunAction(_ context.Context, _ string, _ []byte) ([]byte, error) {
+func (f *fakePluginRuntime) RunAction(_ context.Context, _ string, payload []byte) ([]byte, error) {
+	f.lastActionPayload = payload
 	return f.actionResp, f.err
+}
+func (f *fakePluginRuntime) TriggersForTopic(topic string) []plugindom.AutomationNodeManifest {
+	return f.triggerManifests[topic]
 }
 
 func TestRunAction_UnknownTypeWithoutPluginRuntimeFails(t *testing.T) {
@@ -519,11 +557,12 @@ func TestRunAction_UnknownTypeWithoutPluginRuntimeFails(t *testing.T) {
 
 func TestRunAction_DispatchesToRegisteredPluginAction(t *testing.T) {
 	c := newTestConsumer(&fakeTaskUpdater{})
-	c.pluginRuntime = &fakePluginRuntime{
+	runtime := &fakePluginRuntime{
 		actionPlugin: "com.acme.github",
 		hasAction:    true,
 		actionResp:   []byte(`{"applied":true}`),
 	}
+	c.pluginRuntime = runtime
 	node := &automationdom.Node{Type: "com.acme.github.comment_on_pr", Config: json.RawMessage(`{"template":"lgtm"}`)}
 	applied, _, err := c.runAction(context.Background(), uuid.New(), node, &taskdom.Task{ID: uuid.New()}, "automation", uuid.New())
 	if err != nil {
@@ -531,6 +570,15 @@ func TestRunAction_DispatchesToRegisteredPluginAction(t *testing.T) {
 	}
 	if !applied {
 		t.Fatal("expected applied=true from the plugin's response")
+	}
+	var sent struct {
+		NodeType string `json:"node_type"`
+	}
+	if err := json.Unmarshal(runtime.lastActionPayload, &sent); err != nil {
+		t.Fatalf("decode payload dispatched to RunAction: %v", err)
+	}
+	if sent.NodeType != node.Type {
+		t.Fatalf("expected node_type %q in the payload dispatched to RunAction, got %q", node.Type, sent.NodeType)
 	}
 }
 
@@ -548,6 +596,298 @@ func TestEvaluatePluginCondition_DispatchesToRegisteredPlugin(t *testing.T) {
 	}
 	if !matched {
 		t.Fatal("expected matched=true from the plugin's response")
+	}
+}
+
+func TestEvaluatePluginConditionAgainstTasks_PayloadIncludesNodeType(t *testing.T) {
+	c := newTestConsumer(&fakeTaskUpdater{})
+	runtime := &fakePluginRuntime{
+		conditionPlugin: "com.acme.github",
+		hasCondition:    true,
+		conditionResp:   []byte(`{"matched":true}`),
+	}
+	c.pluginRuntime = runtime
+	node := &automationdom.Node{Type: "com.acme.github.pr_status", Config: json.RawMessage(`{}`)}
+	tasks := []*taskdom.Task{{ID: uuid.New()}}
+	if _, _, err := c.evaluatePluginConditionAgainstTasks(context.Background(), uuid.New(), node, tasks, "any"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var sent struct {
+		NodeType string `json:"node_type"`
+	}
+	if err := json.Unmarshal(runtime.lastConditionPayload, &sent); err != nil {
+		t.Fatalf("decode payload dispatched to EvaluateCondition: %v", err)
+	}
+	if sent.NodeType != node.Type {
+		t.Fatalf("expected node_type %q in the payload dispatched to EvaluateCondition, got %q", node.Type, sent.NodeType)
+	}
+}
+
+// --- Plugin condition "applies to" target/match_mode -------------------------
+//
+// These exercise evaluatePluginConditionAgainstTasks directly against a
+// hand-built tasks slice, the same combination logic
+// ConditionLeaf.EvaluateAgainstTasks already has tests for — walkPluginCondition
+// itself only adds resolveTargetTasks in front of this, which is exercised
+// by the built-in condition's own target tests.
+
+func TestEvaluatePluginConditionAgainstTasks_EmptyTasksIsFalse(t *testing.T) {
+	c := newTestConsumer(&fakeTaskUpdater{})
+	c.pluginRuntime = &fakePluginRuntime{conditionPlugin: "com.acme.github", hasCondition: true}
+	node := &automationdom.Node{Type: "com.acme.github.pr_status", Config: json.RawMessage(`{}`)}
+	matched, _, err := c.evaluatePluginConditionAgainstTasks(context.Background(), uuid.New(), node, nil, "any")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Fatal("expected an empty tasks slice to never match, regardless of match_mode")
+	}
+}
+
+func TestEvaluatePluginConditionAgainstTasks_AnyModeMatchesOnFirstHit(t *testing.T) {
+	c := newTestConsumer(&fakeTaskUpdater{})
+	c.pluginRuntime = &fakePluginRuntime{
+		conditionPlugin: "com.acme.github",
+		hasCondition:    true,
+		conditionResponses: [][]byte{
+			[]byte(`{"matched":false}`),
+			[]byte(`{"matched":true}`),
+		},
+	}
+	node := &automationdom.Node{Type: "com.acme.github.pr_status", Config: json.RawMessage(`{}`)}
+	tasks := []*taskdom.Task{{ID: uuid.New()}, {ID: uuid.New()}, {ID: uuid.New()}}
+	matched, _, err := c.evaluatePluginConditionAgainstTasks(context.Background(), uuid.New(), node, tasks, "any")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Fatal("expected any-mode to match once the second task matches, without needing the third")
+	}
+}
+
+func TestEvaluatePluginConditionAgainstTasks_AllModeRequiresEveryMatch(t *testing.T) {
+	c := newTestConsumer(&fakeTaskUpdater{})
+	c.pluginRuntime = &fakePluginRuntime{
+		conditionPlugin: "com.acme.github",
+		hasCondition:    true,
+		conditionResponses: [][]byte{
+			[]byte(`{"matched":true}`),
+			[]byte(`{"matched":false}`),
+		},
+	}
+	node := &automationdom.Node{Type: "com.acme.github.pr_status", Config: json.RawMessage(`{}`)}
+	tasks := []*taskdom.Task{{ID: uuid.New()}, {ID: uuid.New()}}
+	matched, _, err := c.evaluatePluginConditionAgainstTasks(context.Background(), uuid.New(), node, tasks, "all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matched {
+		t.Fatal("expected all-mode to fail as soon as one task doesn't match")
+	}
+}
+
+func TestEvaluatePluginConditionAgainstTasks_AllModeTrueWhenEveryTaskMatches(t *testing.T) {
+	c := newTestConsumer(&fakeTaskUpdater{})
+	c.pluginRuntime = &fakePluginRuntime{
+		conditionPlugin:    "com.acme.github",
+		hasCondition:       true,
+		conditionResponses: [][]byte{[]byte(`{"matched":true}`)},
+	}
+	node := &automationdom.Node{Type: "com.acme.github.pr_status", Config: json.RawMessage(`{}`)}
+	tasks := []*taskdom.Task{{ID: uuid.New()}, {ID: uuid.New()}}
+	matched, _, err := c.evaluatePluginConditionAgainstTasks(context.Background(), uuid.New(), node, tasks, "all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !matched {
+		t.Fatal("expected all-mode to succeed when every resolved task matches")
+	}
+}
+
+// --- Plugin-emitted trigger events --------------------------------------------
+
+// fakePluginTriggerRepo implements automationGraphReader with just enough
+// behavior to drive handlePluginTriggerEvent and the executeRun call it
+// makes on a match: ListEnabledTriggerNodesByType is keyed by the requested
+// trigger type (mirrors how the real repo filters by n.type), everything
+// else is a single fixed automation/no-op run bookkeeping, same shape as
+// fakeCronRepo/fakeDueDateRepo in the sibling scheduler test files.
+type fakePluginTriggerRepo struct {
+	nodesByType map[string][]*automationdom.Node
+	automation  *automationdom.Automation
+	listCalls   []string
+	createRuns  int
+}
+
+func (f *fakePluginTriggerRepo) ListEnabledTriggerNodesByType(_ context.Context, _ uuid.UUID, triggerType automationdom.TriggerType) ([]*automationdom.Node, error) {
+	f.listCalls = append(f.listCalls, string(triggerType))
+	return f.nodesByType[string(triggerType)], nil
+}
+func (f *fakePluginTriggerRepo) ListPredecessorTriggersWatching(context.Context, uuid.UUID) ([]*automationdom.Node, error) {
+	return nil, nil
+}
+func (f *fakePluginTriggerRepo) FindAutomationByNodeID(context.Context, uuid.UUID) (*automationdom.Automation, error) {
+	return f.automation, nil
+}
+func (f *fakePluginTriggerRepo) FindNodeByID(context.Context, uuid.UUID) (*automationdom.Node, error) {
+	return nil, automationdom.ErrNodeNotFound
+}
+func (f *fakePluginTriggerRepo) LoadGraph(context.Context, uuid.UUID) (*automationdom.Graph, error) {
+	return &automationdom.Graph{Automation: f.automation}, nil
+}
+func (f *fakePluginTriggerRepo) CreateRun(context.Context, *automationdom.Run) error {
+	f.createRuns++
+	return nil
+}
+func (f *fakePluginTriggerRepo) UpdateRun(context.Context, *automationdom.Run) error { return nil }
+func (f *fakePluginTriggerRepo) CreateRunStep(context.Context, *automationdom.RunStep) error {
+	return nil
+}
+func (f *fakePluginTriggerRepo) ListDueDateCandidates(context.Context) ([]automationdom.DueDateCandidate, error) {
+	return nil, nil
+}
+func (f *fakePluginTriggerRepo) RecordDueDateFire(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error {
+	return nil
+}
+func (f *fakePluginTriggerRepo) ListCronCandidates(context.Context) ([]automationdom.CronCandidate, error) {
+	return nil, nil
+}
+func (f *fakePluginTriggerRepo) RecordCronFire(context.Context, uuid.UUID, uuid.UUID, time.Time) error {
+	return nil
+}
+
+type fakePluginTriggerTaskReader struct {
+	task      *taskdom.Task
+	findCalls int
+}
+
+func (f *fakePluginTriggerTaskReader) FindTaskByID(context.Context, uuid.UUID) (*taskdom.Task, error) {
+	f.findCalls++
+	return f.task, nil
+}
+func (f *fakePluginTriggerTaskReader) FindTaskStatusByID(context.Context, uuid.UUID) (*taskdom.TaskStatus, error) {
+	return nil, nil
+}
+func (f *fakePluginTriggerTaskReader) ListChildTasks(context.Context, uuid.UUID, uuid.UUID) ([]*taskdom.Task, error) {
+	return nil, nil
+}
+func (f *fakePluginTriggerTaskReader) ListTaskLinks(context.Context, uuid.UUID) ([]*taskdom.TaskLink, error) {
+	return nil, nil
+}
+
+// newTestConsumerWithRedis builds a real *AutomationConsumer backed by a
+// miniredis instance (handlePluginTriggerEvent's ack path calls c.client.XAck,
+// unlike the plugin-condition/action tests above which never touch Redis).
+func newTestConsumerWithRedis(t *testing.T, repo automationGraphReader, taskReader automationTaskReader, pluginRuntime automationPluginRuntime) (*AutomationConsumer, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	c := NewAutomationConsumer(client, repo, taskReader, &fakeTaskUpdater{}, nil, nil, discardLogger())
+	c.pluginRuntime = pluginRuntime
+	return c, client
+}
+
+func TestHandlePluginTriggerEvent_NoMatchingManifestsSkipsRepoLookup(t *testing.T) {
+	repo := &fakePluginTriggerRepo{}
+	runtime := &fakePluginRuntime{} // triggerManifests left empty: no plugin declares this topic
+	c, client := newTestConsumerWithRedis(t, repo, &fakePluginTriggerTaskReader{}, runtime)
+	defer func() { _ = client.Close() }()
+
+	msg := redis.XMessage{ID: "1-1", Values: map[string]any{
+		"type":    "github.pr_linked",
+		"payload": `{"project_id":"` + uuid.New().String() + `","task_id":"` + uuid.New().String() + `"}`,
+	}}
+	c.handlePluginTriggerEvent(msg)
+
+	if len(repo.listCalls) != 0 {
+		t.Fatalf("expected no repo lookups when no plugin declares a trigger for this topic, got %v", repo.listCalls)
+	}
+}
+
+func TestHandlePluginTriggerEvent_ExecutesMatchingNodeWithTaskFromPayload(t *testing.T) {
+	projectID := uuid.New()
+	taskID := uuid.New()
+	node := &automationdom.Node{ID: uuid.New(), Kind: automationdom.KindTrigger, Type: "github.pr_linked", Config: json.RawMessage(`{}`)}
+	repo := &fakePluginTriggerRepo{
+		nodesByType: map[string][]*automationdom.Node{"github.pr_linked": {node}},
+		automation:  &automationdom.Automation{ID: uuid.New(), ProjectID: projectID, Status: automationdom.StatusActive},
+	}
+	taskReader := &fakePluginTriggerTaskReader{task: &taskdom.Task{ID: taskID}}
+	runtime := &fakePluginRuntime{
+		triggerManifests: map[string][]plugindom.AutomationNodeManifest{
+			"github.pr_linked": {{Type: "github.pr_linked", EventTopic: "github.pr_linked"}},
+		},
+	}
+	c, client := newTestConsumerWithRedis(t, repo, taskReader, runtime)
+	defer func() { _ = client.Close() }()
+
+	msg := redis.XMessage{ID: "1-1", Values: map[string]any{
+		"type":    "github.pr_linked",
+		"payload": fmt.Sprintf(`{"project_id":%q,"task_id":%q}`, projectID, taskID),
+	}}
+	c.handlePluginTriggerEvent(msg)
+
+	if len(repo.listCalls) != 1 || repo.listCalls[0] != "github.pr_linked" {
+		t.Fatalf("expected exactly one lookup for type github.pr_linked, got %v", repo.listCalls)
+	}
+	if repo.createRuns != 1 {
+		t.Fatalf("expected the matched node to execute exactly once, got %d runs", repo.createRuns)
+	}
+	if taskReader.findCalls != 1 {
+		t.Fatalf("expected the walk to resolve the task named in the event payload, got %d lookups", taskReader.findCalls)
+	}
+}
+
+func TestHandlePluginTriggerEvent_MissingTaskIDRunsWithNilTask(t *testing.T) {
+	projectID := uuid.New()
+	node := &automationdom.Node{ID: uuid.New(), Kind: automationdom.KindTrigger, Type: "github.pr_linked", Config: json.RawMessage(`{}`)}
+	repo := &fakePluginTriggerRepo{
+		nodesByType: map[string][]*automationdom.Node{"github.pr_linked": {node}},
+		automation:  &automationdom.Automation{ID: uuid.New(), ProjectID: projectID, Status: automationdom.StatusActive},
+	}
+	taskReader := &fakePluginTriggerTaskReader{}
+	runtime := &fakePluginRuntime{
+		triggerManifests: map[string][]plugindom.AutomationNodeManifest{
+			"github.pr_linked": {{Type: "github.pr_linked", EventTopic: "github.pr_linked"}},
+		},
+	}
+	c, client := newTestConsumerWithRedis(t, repo, taskReader, runtime)
+	defer func() { _ = client.Close() }()
+
+	msg := redis.XMessage{ID: "1-1", Values: map[string]any{
+		"type":    "github.pr_linked",
+		"payload": fmt.Sprintf(`{"project_id":%q}`, projectID),
+	}}
+	c.handlePluginTriggerEvent(msg)
+
+	if repo.createRuns != 1 {
+		t.Fatalf("expected the run to still execute without a task_id, got %d runs", repo.createRuns)
+	}
+	if taskReader.findCalls != 0 {
+		t.Fatalf("expected no task lookup when the event payload has no task_id, got %d", taskReader.findCalls)
+	}
+}
+
+func TestHandlePluginTriggerEvent_MissingProjectIDSkipsWithoutRunning(t *testing.T) {
+	repo := &fakePluginTriggerRepo{
+		nodesByType: map[string][]*automationdom.Node{"github.pr_linked": {{ID: uuid.New(), Kind: automationdom.KindTrigger, Type: "github.pr_linked"}}},
+	}
+	runtime := &fakePluginRuntime{
+		triggerManifests: map[string][]plugindom.AutomationNodeManifest{
+			"github.pr_linked": {{Type: "github.pr_linked", EventTopic: "github.pr_linked"}},
+		},
+	}
+	c, client := newTestConsumerWithRedis(t, repo, &fakePluginTriggerTaskReader{}, runtime)
+	defer func() { _ = client.Close() }()
+
+	msg := redis.XMessage{ID: "1-1", Values: map[string]any{
+		"type":    "github.pr_linked",
+		"payload": `{"task_id":"` + uuid.New().String() + `"}`,
+	}}
+	c.handlePluginTriggerEvent(msg)
+
+	if repo.createRuns != 0 {
+		t.Fatalf("expected no run when the event payload has no project_id, got %d", repo.createRuns)
 	}
 }
 
@@ -689,7 +1029,7 @@ func TestWalk_NilTaskReachingCondition_FailsStepInsteadOfPanicking(t *testing.T)
 }
 
 func TestWalk_NilTaskReachingNonCallAPIAction_FailsStepInsteadOfPanicking(t *testing.T) {
-	action := &automationdom.Node{ID: uuid.New(), Kind: automationdom.KindAction, Type: string(automationdom.ActionSetStatus), Config: json.RawMessage(`{}`)}
+	action := &automationdom.Node{ID: uuid.New(), Kind: automationdom.KindAction, Type: string(automationdom.ActionUpdateTask), Config: json.RawMessage(`{}`)}
 	w := &walker{
 		consumer:  &AutomationConsumer{repo: &fakeCronRepo{}, log: discardLogger()},
 		task:      nil,
@@ -699,7 +1039,7 @@ func TestWalk_NilTaskReachingNonCallAPIAction_FailsStepInsteadOfPanicking(t *tes
 	}
 	w.walk(context.Background(), action.ID)
 	if !w.failed {
-		t.Fatal("expected a nil task reaching a set_status action to mark the walk failed")
+		t.Fatal("expected a nil task reaching an update_task action to mark the walk failed")
 	}
 }
 
@@ -857,8 +1197,8 @@ func TestRunAction_NoTarget_BehavesExactlyAsBeforeWithNilDetail(t *testing.T) {
 	updater := &fakeTaskUpdater{}
 	c := &AutomationConsumer{taskSvc: updater, taskRepo: &fakeAutomationTaskReader{}, log: discardLogger()}
 	tag := "x"
-	cfg, _ := json.Marshal(automationdom.ActionConfig{Tag: tag})
-	node := &automationdom.Node{Type: string(automationdom.ActionAddTag), Config: cfg}
+	cfg, _ := json.Marshal(automationdom.ActionConfig{Update: &automationdom.TaskFieldUpdate{Tags: []string{tag}}})
+	node := &automationdom.Node{Type: string(automationdom.ActionUpdateTask), Config: cfg}
 	task := &taskdom.Task{ID: uuid.New()}
 
 	applied, detail, err := c.runAction(context.Background(), uuid.New(), node, task, "test", uuid.New())
@@ -878,8 +1218,8 @@ func TestRunAction_FanOut_AppliesToEveryResolvedChild(t *testing.T) {
 		},
 		log: discardLogger(),
 	}
-	cfg, _ := json.Marshal(automationdom.ActionConfig{Tag: "x", Target: &automationdom.TaskTarget{Kind: automationdom.TaskTargetChildren}})
-	node := &automationdom.Node{Type: string(automationdom.ActionAddTag), Config: cfg}
+	cfg, _ := json.Marshal(automationdom.ActionConfig{Update: &automationdom.TaskFieldUpdate{Tags: []string{"x"}}, Target: &automationdom.TaskTarget{Kind: automationdom.TaskTargetChildren}})
+	node := &automationdom.Node{Type: string(automationdom.ActionUpdateTask), Config: cfg}
 
 	applied, detail, err := c.runAction(context.Background(), uuid.New(), node, &taskdom.Task{ID: baseID}, "test", uuid.New())
 	if err != nil {
@@ -911,8 +1251,8 @@ func TestRunAction_FanOut_EmptyTargetsSkipsWithoutError(t *testing.T) {
 		taskRepo: &fakeAutomationTaskReader{children: map[uuid.UUID][]*taskdom.Task{}},
 		log:      discardLogger(),
 	}
-	cfg, _ := json.Marshal(automationdom.ActionConfig{Tag: "x", Target: &automationdom.TaskTarget{Kind: automationdom.TaskTargetChildren}})
-	node := &automationdom.Node{Type: string(automationdom.ActionAddTag), Config: cfg}
+	cfg, _ := json.Marshal(automationdom.ActionConfig{Update: &automationdom.TaskFieldUpdate{Tags: []string{"x"}}, Target: &automationdom.TaskTarget{Kind: automationdom.TaskTargetChildren}})
+	node := &automationdom.Node{Type: string(automationdom.ActionUpdateTask), Config: cfg}
 
 	applied, detail, err := c.runAction(context.Background(), uuid.New(), node, &taskdom.Task{ID: baseID}, "test", uuid.New())
 	if err != nil || applied || detail != nil {
@@ -928,10 +1268,10 @@ func TestRunAction_FanOut_StopsAtFirstError(t *testing.T) {
 		},
 		log: discardLogger(),
 	}
-	// set_status with no status_id configured — applyActionForTask errors
-	// immediately for every resolved task.
+	// update_task with no fields set at all — applyActionForTask errors
+	// immediately for every resolved task (missing update config).
 	cfg, _ := json.Marshal(automationdom.ActionConfig{Target: &automationdom.TaskTarget{Kind: automationdom.TaskTargetChildren}})
-	node := &automationdom.Node{Type: string(automationdom.ActionSetStatus), Config: cfg}
+	node := &automationdom.Node{Type: string(automationdom.ActionUpdateTask), Config: cfg}
 
 	_, _, err := c.runAction(context.Background(), uuid.New(), node, &taskdom.Task{ID: baseID}, "test", uuid.New())
 	if err == nil {

--- a/services/api/internal/worker/automation_consumer_test.go
+++ b/services/api/internal/worker/automation_consumer_test.go
@@ -491,6 +491,85 @@ func TestApplyUpdateTask_CustomField_AppliesWhenValueDiffers(t *testing.T) {
 	}
 }
 
+func TestApplyUpdateTask_DueDate_IdempotentWhenAlreadySet(t *testing.T) {
+	updater := &fakeTaskUpdater{}
+	c := newTestConsumer(updater)
+	due := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	task := &taskdom.Task{ID: uuid.New(), DueDate: &due}
+
+	sameDue := due
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{DueDate: &sameDue}, "test-automation")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if applied || updater.calls != 0 {
+		t.Fatalf("expected no-op, got applied=%v calls=%d", applied, updater.calls)
+	}
+}
+
+func TestApplyUpdateTask_DueDate_AppliesWhenDifferent(t *testing.T) {
+	updater := &fakeTaskUpdater{}
+	c := newTestConsumer(updater)
+	oldDue := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	newDue := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	task := &taskdom.Task{ID: uuid.New(), DueDate: &oldDue}
+
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{DueDate: &newDue}, "test-automation")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !applied || updater.calls != 1 {
+		t.Fatalf("expected applied=true, 1 call, got applied=%v calls=%d", applied, updater.calls)
+	}
+	if !task.DueDate.Equal(newDue) {
+		t.Fatalf("expected due date updated in place, got %v", task.DueDate)
+	}
+}
+
+// TestApplyUpdateTask_DueDate_JSONRoundTrip guards the exact regression this
+// once had: TaskFieldUpdate.DueDate is a *time.Time, whose JSON unmarshaling
+// requires a full RFC 3339 string — the config-panel's date picker must
+// produce that shape (e.g. "2026-08-03T00:00:00Z"), not the bare
+// "YYYY-MM-DD" a native <input type="date"> emits, or saving an update_task
+// action with a due date set fails to unmarshal entirely.
+func TestApplyUpdateTask_DueDate_JSONRoundTrip(t *testing.T) {
+	var cfg automationdom.TaskFieldUpdate
+	if err := json.Unmarshal([]byte(`{"due_date":"2026-08-03T00:00:00Z"}`), &cfg); err != nil {
+		t.Fatalf("expected RFC 3339 due_date to unmarshal cleanly, got %v", err)
+	}
+	if cfg.DueDate == nil || cfg.DueDate.UTC().Format("2006-01-02") != "2026-08-03" {
+		t.Fatalf("expected due_date 2026-08-03, got %v", cfg.DueDate)
+	}
+}
+
+func TestApplyUpdateTask_Description_IdempotentWhenAlreadyMatches(t *testing.T) {
+	updater := &fakeTaskUpdater{}
+	c := newTestConsumer(updater)
+	task := &taskdom.Task{ID: uuid.New(), Description: json.RawMessage(`{"text":"hello"}`)}
+
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{Description: json.RawMessage(`{"text":"hello"}`)}, "test-automation")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if applied || updater.calls != 0 {
+		t.Fatalf("expected no-op when description already matches, got applied=%v calls=%d", applied, updater.calls)
+	}
+}
+
+func TestApplyUpdateTask_Description_AppliesWhenDifferent(t *testing.T) {
+	updater := &fakeTaskUpdater{}
+	c := newTestConsumer(updater)
+	task := &taskdom.Task{ID: uuid.New(), Description: json.RawMessage(`{"text":"old"}`)}
+
+	applied, err := c.applyUpdateTask(context.Background(), uuid.New(), task, &automationdom.TaskFieldUpdate{Description: json.RawMessage(`{"text":"new"}`)}, "test-automation")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !applied || updater.calls != 1 {
+		t.Fatalf("expected applied=true, 1 call, got applied=%v calls=%d", applied, updater.calls)
+	}
+}
+
 // --- Plugin action dispatch --------------------------------------------------
 
 type fakePluginRuntime struct {

--- a/services/api/internal/worker/notification_consumer.go
+++ b/services/api/internal/worker/notification_consumer.go
@@ -170,10 +170,11 @@ func (c *NotificationConsumer) processPending(ctx context.Context) {
 // assignmentStreamPayload mirrors the JSON shape produced by the task
 // handler / automation engine when they append to StreamTaskAssignments.
 // AutomationName is populated whenever the assignment was made by the
-// automation engine's "assign" action (see worker.AutomationConsumer) —
-// trigger_ai_agent doesn't reassign the task at all, so it never publishes
-// to this stream; see AutomationConsumer.applyTriggerAIAgentOnTask, which
-// starts the agent conversation directly instead.
+// automation engine's update_task action setting AssigneeIDs (see
+// worker.AutomationConsumer.applyUpdateTask) — trigger_ai_agent doesn't
+// reassign the task at all, so it never publishes to this stream; see
+// AutomationConsumer.applyTriggerAIAgentOnTask, which starts the agent
+// conversation directly instead.
 type assignmentStreamPayload struct {
 	TaskID              string `json:"task_id"`
 	ProjectID           string `json:"project_id"`
@@ -234,7 +235,7 @@ func sanitizeAgentMessage(s string) string {
 }
 
 // agentAssignmentNote builds the note appended to an agent's initial prompt
-// when it was auto-assigned via an active automation's "assign" action
+// when it was auto-assigned via an active automation's update_task action
 // (trigger_ai_agent doesn't reassign the task — see triggerAIAgentNote in
 // automation_consumer.go for its equivalent). Returns "" when the assignment
 // did not come from the automation engine.

--- a/services/api/migrations/000029_migrate_legacy_automation_actions.sql
+++ b/services/api/migrations/000029_migrate_legacy_automation_actions.sql
@@ -1,0 +1,99 @@
+-- 000029_migrate_legacy_automation_actions.sql
+-- The single-field action types (assign, set_status, set_priority, add_tag,
+-- set_custom_field) were replaced by one update_task action that can touch
+-- any number of fields at once (see ActionUpdateTask/TaskFieldUpdate in
+-- domain/automation/entity.go). ValidBuiltinActionTypes and
+-- AutomationConsumer.applyActionForTask no longer recognize the old type
+-- strings at all, so without this migration any automation_nodes row still
+-- carrying one of them would start failing every run with "unknown action
+-- type" the moment this deploys. Rewrite them in place instead.
+--
+-- Each old action's own config fields become update_task's equivalent
+-- TaskFieldUpdate field, and any existing "target" (task-retarget) config is
+-- carried over unchanged since ActionConfig.Target isn't part of what
+-- changed.
+--
+-- add_tag -> tags is the one lossy conversion here: add_tag appended a
+-- single tag to whatever tags a task already had; update_task's tags field
+-- is a full replacement, not a merge (see TaskFieldUpdate's doc comment).
+-- There's no way to express "append" in the new shape, so a migrated add_tag
+-- node will, on its next run, replace the task's tags with just the one tag
+-- it used to add instead of adding it alongside the existing ones. That's a
+-- real behavior change, but the alternative — leaving the node with an
+-- unrecognized type — means it never runs at all, which is strictly worse.
+-- Any project relying on add_tag's append semantics should review those
+-- automations after this deploys.
+
+BEGIN;
+
+-- assign -> update_task { update: { assignee_ids: [member_id] } }
+UPDATE automation_nodes
+SET type = 'update_task',
+    config = (CASE WHEN config ? 'target'
+                   THEN jsonb_build_object('target', config->'target')
+                   ELSE '{}'::jsonb
+              END)
+           || (CASE WHEN config ? 'member_id'
+                    THEN jsonb_build_object('update',
+                             jsonb_build_object('assignee_ids', jsonb_build_array(config->'member_id')))
+                    ELSE '{}'::jsonb
+               END)
+WHERE kind = 'action' AND type = 'assign';
+
+-- set_status -> update_task { update: { status_id: status_id } }
+UPDATE automation_nodes
+SET type = 'update_task',
+    config = (CASE WHEN config ? 'target'
+                   THEN jsonb_build_object('target', config->'target')
+                   ELSE '{}'::jsonb
+              END)
+           || (CASE WHEN config ? 'status_id'
+                    THEN jsonb_build_object('update', jsonb_build_object('status_id', config->'status_id'))
+                    ELSE '{}'::jsonb
+               END)
+WHERE kind = 'action' AND type = 'set_status';
+
+-- set_priority -> update_task { update: { importance: importance } }
+UPDATE automation_nodes
+SET type = 'update_task',
+    config = (CASE WHEN config ? 'target'
+                   THEN jsonb_build_object('target', config->'target')
+                   ELSE '{}'::jsonb
+              END)
+           || (CASE WHEN config ? 'importance'
+                    THEN jsonb_build_object('update', jsonb_build_object('importance', config->'importance'))
+                    ELSE '{}'::jsonb
+               END)
+WHERE kind = 'action' AND type = 'set_priority';
+
+-- add_tag -> update_task { update: { tags: [tag] } } — see the lossy-append
+-- caveat in the header comment above.
+UPDATE automation_nodes
+SET type = 'update_task',
+    config = (CASE WHEN config ? 'target'
+                   THEN jsonb_build_object('target', config->'target')
+                   ELSE '{}'::jsonb
+              END)
+           || (CASE WHEN config ? 'tag'
+                    THEN jsonb_build_object('update',
+                             jsonb_build_object('tags', jsonb_build_array(config->'tag')))
+                    ELSE '{}'::jsonb
+               END)
+WHERE kind = 'action' AND type = 'add_tag';
+
+-- set_custom_field -> update_task { update: { custom_fields: { field_key: value } } }
+UPDATE automation_nodes
+SET type = 'update_task',
+    config = (CASE WHEN config ? 'target'
+                   THEN jsonb_build_object('target', config->'target')
+                   ELSE '{}'::jsonb
+              END)
+           || (CASE WHEN config ? 'field_key' AND config->>'field_key' <> ''
+                    THEN jsonb_build_object('update',
+                             jsonb_build_object('custom_fields',
+                                 jsonb_build_object(config->>'field_key', config->'value')))
+                    ELSE '{}'::jsonb
+               END)
+WHERE kind = 'action' AND type = 'set_custom_field';
+
+COMMIT;

--- a/services/api/test/e2e/automation_engine_test.go
+++ b/services/api/test/e2e/automation_engine_test.go
@@ -458,7 +458,7 @@ func TestE2EAutomation_CreateNodesEdgesAndFetchGraph(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": todoID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "todo-reached"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"todo-reached"}}})
 
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -485,7 +485,7 @@ func TestE2EAutomation_EdgeIntoTriggerRejected(t *testing.T) {
 	projID := createProjectForTasksViaAPI(t, env, ownerClient, ownerToken)
 
 	automationID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Edge Validation Automation")
-	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "add_tag", map[string]any{"tag": "x"})
+	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"x"}}})
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "trigger", "task_created", nil)
 
 	actionID, _ := action["id"].(string)
@@ -505,8 +505,8 @@ func TestE2EAutomation_CycleRejected(t *testing.T) {
 	projID := createProjectForTasksViaAPI(t, env, ownerClient, ownerToken)
 
 	automationID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Cycle Test Automation")
-	a1 := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "add_tag", map[string]any{"tag": "a"})
-	a2 := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "add_tag", map[string]any{"tag": "b"})
+	a1 := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"a"}}})
+	a2 := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"b"}}})
 	a1ID, _ := a1["id"].(string)
 	a2ID, _ := a2["id"].(string)
 
@@ -536,7 +536,7 @@ func TestE2EAutomation_ActivateRequiresTriggerAndAction(t *testing.T) {
 	// Trigger + action, connected — must succeed.
 	completeID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Complete Automation")
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, completeID, "trigger", "task_created", nil)
-	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, completeID, "action", "add_tag", map[string]any{"tag": "new"})
+	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, completeID, "action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"new"}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, completeID, triggerID, actionID)
@@ -559,10 +559,10 @@ func TestE2EAutomation_CreateEmptyActionNodeThenConfigure(t *testing.T) {
 
 	automationID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Empty Then Configure")
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "trigger", "task_created", nil)
-	// Creating an add_tag action with no config must succeed — this used to
+	// Creating an update_task action with no config must succeed — this used to
 	// fail with AUTOMATION_NODE_CONFIG_INVALID ("add_tag requires tag"),
 	// which made it impossible to ever add this node type from the canvas.
-	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "add_tag", nil)
+	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "action", "update_task", nil)
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -571,7 +571,7 @@ func TestE2EAutomation_CreateEmptyActionNodeThenConfigure(t *testing.T) {
 	activateAutomationViaAPIExpect(t, env, ownerClient, ownerToken, projID, automationID, http.StatusBadRequest)
 
 	// Configure it for real, then Activate should succeed.
-	updateAutomationNodeConfigViaAPIExpect(t, env, ownerClient, ownerToken, projID, automationID, actionID, map[string]any{"tag": "ready"}, http.StatusOK)
+	updateAutomationNodeConfigViaAPIExpect(t, env, ownerClient, ownerToken, projID, automationID, actionID, map[string]any{"update": map[string]any{"tags": []string{"ready"}}}, http.StatusOK)
 	activateAutomationViaAPI(t, env, ownerClient, ownerToken, projID, automationID)
 }
 
@@ -601,7 +601,7 @@ func TestE2EAutomationEngine_StatusChangedReassignsTask(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": secondMemberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{secondMemberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -637,7 +637,7 @@ func TestE2EAutomationEngine_MultipleTriggersShareOneChain(t *testing.T) {
 	tagTrigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "tag_added", map[string]any{"tag": "urgent"})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 
 	priorityTriggerID, _ := priorityTrigger["id"].(string)
 	tagTriggerID, _ := tagTrigger["id"].(string)
@@ -699,9 +699,9 @@ func TestE2EAutomationEngine_ConditionBranchesToCorrectAction(t *testing.T) {
 			},
 		})
 	highPriorityAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": bugMemberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{bugMemberID}}})
 	elseAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": elseMemberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{elseMemberID}}})
 
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
@@ -748,7 +748,7 @@ func TestE2EAutomationEngine_PredecessorDoneWaitsForAllWatchedTasks(t *testing.T
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "predecessor_done", map[string]any{"watched_task_ids": []string{taskA, taskB}, "target_task_id": taskC})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -792,7 +792,7 @@ func TestE2EAutomationEngine_CronTriggerFiresOnSchedule(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "cron", map[string]any{"cron_expression": "* * * * *", "target_task_id": taskID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -849,7 +849,7 @@ func TestE2EAutomation_WebhookTriggerTokenLifecycle(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "api_trigger", map[string]any{"target_task_id": taskID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1059,12 +1059,12 @@ func TestE2EAutomation_UpdateNode_ClearingTargetTaskRejectedWhenDownstreamNeedsT
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "cron", map[string]any{"cron_expression": "* * * * *", "target_task_id": taskID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "x"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"x"}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
 
-	// add_tag needs a task — clearing this trigger's target_task_id now
+	// update_task needs a task — clearing this trigger's target_task_id now
 	// (omitting it from the replacement config entirely) would leave that
 	// edge unrunnable, so it must be rejected.
 	updateAutomationNodeConfigViaAPIExpect(t, env, ownerClient, ownerToken, projID, automationID, triggerID,
@@ -1174,9 +1174,9 @@ func TestE2EAutomationEngine_ActionRetargetedToChildren_FansOutToEveryChild(t *t
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "set_status", map[string]any{
-			"status_id": doneID,
-			"target":    map[string]any{"kind": "children"},
+		"action", "update_task", map[string]any{
+			"update": map[string]any{"status_id": doneID},
+			"target": map[string]any{"kind": "children"},
 		})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1247,7 +1247,7 @@ func TestE2EAutomationEngine_ConditionRetargetedToBlockingTask(t *testing.T) {
 			},
 		})
 	tagAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "unblocked"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"unblocked"}}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	tagActionID, _ := tagAction["id"].(string)
@@ -1292,7 +1292,7 @@ func TestE2EAutomationEngine_TaskCreatedTriggerFires(t *testing.T) {
 	automationID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Task Created Automation")
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "trigger", "task_created", nil)
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1320,7 +1320,7 @@ func TestE2EAutomationEngine_AssigneeChangedTriggerFires(t *testing.T) {
 	automationID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Assignee Changed Automation")
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "trigger", "assignee_changed", nil)
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "reassigned"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"reassigned"}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1348,7 +1348,7 @@ func TestE2EAutomationEngine_PriorityChangedTriggerFiresOnItsOwn(t *testing.T) {
 	automationID := createAutomationViaAPI(t, env, ownerClient, ownerToken, projID, "Priority Changed Automation")
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, "trigger", "priority_changed", nil)
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "priority-touched"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"priority-touched"}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1384,7 +1384,7 @@ func TestE2EAutomationEngine_DueDateReachedTriggerFires(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "due_date_reached", map[string]any{"due_date_offset_minutes": 0})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1401,8 +1401,9 @@ func TestE2EAutomationEngine_DueDateReachedTriggerFires(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // Engine: every remaining built-in action type actually applies
-// (assign, add_tag, and call_api are covered above; this fills in
-// set_priority, set_custom_field, and trigger_ai_agent's task-bound path)
+// (assignee_ids, tags, and call_api are covered above; this fills in
+// importance, custom_fields, and trigger_ai_agent's task-bound path — all via
+// the unified update_task action type)
 // ---------------------------------------------------------------------------
 
 func TestE2EAutomationEngine_SetPriorityActionApplies(t *testing.T) {
@@ -1425,7 +1426,7 @@ func TestE2EAutomationEngine_SetPriorityActionApplies(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "set_priority", map[string]any{"importance": 9})
+		"action", "update_task", map[string]any{"update": map[string]any{"importance": 9}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1462,7 +1463,7 @@ func TestE2EAutomationEngine_SetCustomFieldActionApplies(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "set_custom_field", map[string]any{"field_key": "triage", "value": "reviewed"})
+		"action", "update_task", map[string]any{"update": map[string]any{"custom_fields": map[string]any{"triage": "reviewed"}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -1478,7 +1479,7 @@ func TestE2EAutomationEngine_SetCustomFieldActionApplies(t *testing.T) {
 
 // TestE2EAutomationEngine_TriggerAIAgentStartsConversationWithoutReassigning
 // pins down a deliberate behavior change: trigger_ai_agent used to reuse the
-// "assign" action's code path, reassigning the triggering task to the agent
+// update_task's assignee_ids code path, reassigning the triggering task to the agent
 // as a side effect of starting its conversation. That silently overwrote
 // whoever the task was actually assigned to. trigger_ai_agent's job is only
 // to get the agent looking at the task — ownership is unaffected, same as
@@ -1587,7 +1588,7 @@ func TestE2EAutomationEngine_ConditionOnTaskType(t *testing.T) {
 			},
 		})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "bug-flagged"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"bug-flagged"}}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1634,7 +1635,7 @@ func TestE2EAutomationEngine_ConditionOnAssigneeContains(t *testing.T) {
 			},
 		})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "watched-assignee"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"watched-assignee"}}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1678,7 +1679,7 @@ func TestE2EAutomationEngine_ConditionOnTagsContains(t *testing.T) {
 			},
 		})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "set_priority", map[string]any{"importance": 10})
+		"action", "update_task", map[string]any{"update": map[string]any{"importance": 10}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1727,7 +1728,7 @@ func TestE2EAutomationEngine_ConditionOnCustomFieldEquals(t *testing.T) {
 			},
 		})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "critical-flagged"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"critical-flagged"}}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1768,7 +1769,7 @@ func TestE2EAutomationEngine_ConditionIsEmptyOperator(t *testing.T) {
 			},
 		})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "needs-owner"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"needs-owner"}}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1818,9 +1819,9 @@ func TestE2EAutomationEngine_ConditionElseBranchFiresWhenNoBranchMatches(t *test
 			},
 		})
 	highPriorityAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": bugMemberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{bugMemberID}}})
 	elseAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": elseMemberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{elseMemberID}}})
 
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
@@ -1862,9 +1863,9 @@ func TestE2EAutomationEngine_ActionChainContinuesPastFirstAction(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	firstAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "step1"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"step1"}}})
 	secondAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "set_priority", map[string]any{"importance": 10})
+		"action", "update_task", map[string]any{"update": map[string]any{"importance": 10}})
 	triggerID, _ := trigger["id"].(string)
 	firstActionID, _ := firstAction["id"].(string)
 	secondActionID, _ := secondAction["id"].(string)
@@ -1904,7 +1905,7 @@ func TestE2EAutomationEngine_IdempotentAssignSkipsRunStepOnSecondFire(t *testing
 	priorityTrigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "priority_changed", nil)
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	statusTriggerID, _ := statusTrigger["id"].(string)
 	priorityTriggerID, _ := priorityTrigger["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -1968,7 +1969,7 @@ func TestE2EAutomation_ArchivedAutomationDoesNotFire(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -2008,7 +2009,7 @@ func TestE2EAutomation_RevertToDraftStopsFiringThenReactivateResumes(t *testing.
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": memberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{memberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -2049,7 +2050,7 @@ func TestE2EAutomation_DeletingEdgeStopsDownstreamFiring(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "should-not-appear"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"should-not-appear"}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	edge := addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -2093,7 +2094,7 @@ func TestE2EAutomation_UpdatingActiveActionConfigAffectsNextFire(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "assign", map[string]any{"member_id": firstMemberID})
+		"action", "update_task", map[string]any{"update": map[string]any{"assignee_ids": []string{firstMemberID}}})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
 	addAutomationEdgeViaAPI(t, env, ownerClient, ownerToken, projID, automationID, triggerID, actionID)
@@ -2104,7 +2105,7 @@ func TestE2EAutomation_UpdatingActiveActionConfigAffectsNextFire(t *testing.T) {
 
 	// Edit the action's config WHILE the automation stays active.
 	updateAutomationNodeConfigViaAPIExpect(t, env, ownerClient, ownerToken, projID, automationID, actionID,
-		map[string]any{"member_id": secondMemberID}, http.StatusOK)
+		map[string]any{"update": map[string]any{"assignee_ids": []string{secondMemberID}}}, http.StatusOK)
 
 	// A fresh status transition (Done -> In Progress again) must now assign
 	// the NEW member, proving the live edit took effect.
@@ -2141,8 +2142,8 @@ func TestE2EAutomationEngine_ActionRetargetedToParent(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{
-			"tag": "child-touched-parent", "target": map[string]any{"kind": "parent"},
+		"action", "update_task", map[string]any{
+			"update": map[string]any{"tags": []string{"child-touched-parent"}}, "target": map[string]any{"kind": "parent"},
 		})
 	triggerID, _ := trigger["id"].(string)
 	actionID, _ := action["id"].(string)
@@ -2183,8 +2184,8 @@ func TestE2EAutomationEngine_ActionRetargetedToOtherExplicitTask(t *testing.T) {
 	trigger := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
 		"trigger", "status_changed", map[string]any{"status_id": inProgressID})
 	action := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{
-			"tag":    "touched-via-other",
+		"action", "update_task", map[string]any{
+			"update": map[string]any{"tags": []string{"touched-via-other"}},
 			"target": map[string]any{"kind": "other", "other_task_id": otherTask},
 		})
 	triggerID, _ := trigger["id"].(string)
@@ -2239,9 +2240,9 @@ func TestE2EAutomationEngine_ConditionMatchModeAllRequiresEveryChildToMatch(t *t
 			},
 		})
 	allDoneAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "all-done"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"all-done"}}})
 	notAllAction := addAutomationNodeViaAPI(t, env, ownerClient, ownerToken, projID, automationID,
-		"action", "add_tag", map[string]any{"tag": "not-all-done"})
+		"action", "update_task", map[string]any{"update": map[string]any{"tags": []string{"not-all-done"}}})
 	triggerID, _ := trigger["id"].(string)
 	conditionID, _ := condition["id"].(string)
 	allDoneActionID, _ := allDoneAction["id"].(string)


### PR DESCRIPTION
pluginNodePayload previously omitted the automation node's own Type, so a plugin binary that registers handlers for more than one Condition or Action node type had no way to know which one the host was asking it to evaluate/run - it could only guess from the config shape, which is fragile and breaks down when two node types share overlapping config fields.

Adds node_type to the JSON payload sent to plugins via EvaluateCondition/RunAction, alongside the existing config and task fields. Updates both call sites (evaluatePluginConditionAgainstTasks, runPluginAction).

Paired with the plugin-sdk-go change that adds NodeType to ConditionRequest/ActionRequest and dispatches plugin-side handlers by node type (see Paca-AI/plugin-sdk-go#<branch:
feat/automation-condition-action-nodes>).

Verified: go build ./... clean on services/api; go test passes on internal/worker, internal/service/automation, internal/domain/plugin, internal/platform/plugin. Added assertions in automation_consumer_test.go confirming node_type actually lands in the JSON dispatched to EvaluateCondition/RunAction, not just that dispatch succeeds.
