### PR TITLE
feat: add conversation filters and search functionality

### DIFF
--- a/apps/web/src/components/projects/agents/conversation-filters.tsx
+++ b/apps/web/src/components/projects/agents/conversation-filters.tsx
@@ -1,0 +1,338 @@
+import { Search, SlidersHorizontal, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Calendar } from "@/components/ui/calendar";
+import { Input } from "@/components/ui/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
+import {
+	CONVERSATION_STATUS_COLORS,
+	CONVERSATION_STATUS_LABELS,
+	CONVERSATION_TRIGGER_TYPE_LABELS,
+	type ConversationFilters as ConversationFiltersState,
+	type ConversationStatus,
+	type ConversationTriggerType,
+} from "@/lib/agent-api";
+import { cn } from "@/lib/utils";
+
+const ALL_STATUSES: ConversationStatus[] = [
+	"queued",
+	"running",
+	"paused",
+	"finished",
+	"failed",
+	"stopped",
+];
+
+const ALL_TRIGGER_TYPES: ConversationTriggerType[] = [
+	"task_assigned",
+	"comment_mention",
+	"chat_message",
+	"description_write",
+	"automation_message",
+];
+
+function parseDateOnly(s?: string): Date | undefined {
+	if (!s) return undefined;
+	const [y, m, d] = s.split("-").map(Number);
+	if (!y || !m || !d) return undefined;
+	return new Date(y, m - 1, d);
+}
+
+function toDateOnlyString(date: Date): string {
+	const y = date.getFullYear();
+	const m = String(date.getMonth() + 1).padStart(2, "0");
+	const d = String(date.getDate()).padStart(2, "0");
+	return `${y}-${m}-${d}`;
+}
+
+const dateTriggerClassName = (active: boolean) =>
+	cn(
+		"inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-all duration-150",
+		active
+			? "border-primary/40 bg-primary/8 text-primary"
+			: "border-border/25 bg-muted/25 text-muted-foreground hover:border-border/50 hover:bg-muted/40",
+	);
+
+// ── Popover section building blocks ──────────────────────────────────────────
+
+function FilterSectionLabel({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="px-0.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60">
+			{children}
+		</p>
+	);
+}
+
+function CheckListRow({
+	label,
+	checked,
+	onChange,
+	dotClassName,
+}: {
+	label: string;
+	checked: boolean;
+	onChange: () => void;
+	dotClassName?: string;
+}) {
+	return (
+		<label className="flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-muted/40">
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={onChange}
+				className="size-3.5 shrink-0 cursor-pointer rounded accent-primary"
+			/>
+			{dotClassName && (
+				<span className={cn("size-1.5 shrink-0 rounded-full", dotClassName)} />
+			)}
+			<span className="flex-1 truncate">{label}</span>
+		</label>
+	);
+}
+
+// ── Date range ────────────────────────────────────────────────────────────────
+
+function DateRangeFilter({
+	createdAfter,
+	createdBefore,
+	onChange,
+}: {
+	createdAfter?: string;
+	createdBefore?: string;
+	onChange: (next: { createdAfter?: string; createdBefore?: string }) => void;
+}) {
+	const { t } = useTranslation("projects");
+	return (
+		<div className="flex items-center gap-1.5">
+			<Popover>
+				<PopoverTrigger
+					type="button"
+					className={dateTriggerClassName(!!createdAfter)}
+				>
+					{createdAfter ?? t("conversationsPage.filters.dateFrom")}
+				</PopoverTrigger>
+				<PopoverContent className="w-auto p-2" align="start">
+					<Calendar
+						mode="single"
+						selected={parseDateOnly(createdAfter)}
+						onSelect={(d) =>
+							onChange({ createdAfter: d ? toDateOnlyString(d) : undefined })
+						}
+					/>
+				</PopoverContent>
+			</Popover>
+			<Popover>
+				<PopoverTrigger
+					type="button"
+					className={dateTriggerClassName(!!createdBefore)}
+				>
+					{createdBefore ?? t("conversationsPage.filters.dateTo")}
+				</PopoverTrigger>
+				<PopoverContent className="w-auto p-2" align="start">
+					<Calendar
+						mode="single"
+						selected={parseDateOnly(createdBefore)}
+						onSelect={(d) =>
+							onChange({ createdBefore: d ? toDateOnlyString(d) : undefined })
+						}
+					/>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}
+
+// ── Filter bar ────────────────────────────────────────────────────────────────
+
+export interface ConversationFiltersProps {
+	agents: { id: string; name: string }[];
+	filters: ConversationFiltersState;
+	onFiltersChange: (next: ConversationFiltersState) => void;
+}
+
+export function ConversationFilters({
+	agents,
+	filters,
+	onFiltersChange,
+}: ConversationFiltersProps) {
+	const { t } = useTranslation("projects");
+	const [searchInput, setSearchInput] = useState(filters.search ?? "");
+	const [filtersOpen, setFiltersOpen] = useState(false);
+
+	const debouncedSetSearch = useDebouncedCallback((value: string) => {
+		onFiltersChange({ ...filters, search: value || undefined });
+	}, 300);
+
+	// Keeps the visible input in sync when search is cleared/changed from
+	// outside this component (e.g. the "clear all" button below).
+	useEffect(() => {
+		setSearchInput(filters.search ?? "");
+	}, [filters.search]);
+
+	const activeFilterCount =
+		((filters.agentIds?.length ?? 0) ? 1 : 0) +
+		((filters.statuses?.length ?? 0) ? 1 : 0) +
+		((filters.triggerTypes?.length ?? 0) ? 1 : 0) +
+		(filters.createdAfter || filters.createdBefore ? 1 : 0);
+	const hasAnyActive = activeFilterCount > 0 || !!filters.search;
+
+	const toggle = <T extends string>(
+		field: "agentIds" | "statuses" | "triggerTypes",
+		value: T,
+		current: T[] | undefined,
+	) => {
+		const next = current?.includes(value)
+			? current.filter((v) => v !== value)
+			: [...(current ?? []), value];
+		onFiltersChange({
+			...filters,
+			[field]: next.length > 0 ? next : undefined,
+		});
+	};
+
+	return (
+		<div className="flex items-center gap-1.5 border-b border-border/50 px-2 py-2">
+			<div className="relative min-w-0 flex-1">
+				<Search className="absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground/60" />
+				<Input
+					value={searchInput}
+					onChange={(e) => {
+						setSearchInput(e.target.value);
+						debouncedSetSearch(e.target.value);
+					}}
+					placeholder={t("conversationsPage.filters.searchPlaceholder")}
+					className="h-7 pl-6 text-xs"
+				/>
+			</div>
+
+			<Popover open={filtersOpen} onOpenChange={setFiltersOpen}>
+				<PopoverTrigger
+					type="button"
+					aria-label={t("conversationsPage.filters.title")}
+					className={cn(
+						"relative flex size-7 shrink-0 items-center justify-center rounded-md transition-all duration-150",
+						filtersOpen || activeFilterCount > 0
+							? "bg-primary/8 text-primary/80"
+							: "text-muted-foreground/60 hover:text-foreground hover:bg-muted/60",
+					)}
+				>
+					<SlidersHorizontal className="size-3.5" />
+					{activeFilterCount > 0 && (
+						<span className="absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground">
+							{activeFilterCount}
+						</span>
+					)}
+				</PopoverTrigger>
+				<PopoverContent
+					side="bottom"
+					align="end"
+					sideOffset={6}
+					className="w-72 rounded-xl border border-border/40 p-0 shadow-xl"
+				>
+					<div className="border-b border-border/30 bg-muted/20 px-3 py-2">
+						<p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+							{t("conversationsPage.filters.title")}
+						</p>
+					</div>
+					<div className="max-h-[60vh] space-y-3 overflow-y-auto p-3">
+						{agents.length > 0 && (
+							<>
+								<section>
+									<FilterSectionLabel>
+										{t("conversationsPage.filters.agent")}
+									</FilterSectionLabel>
+									<div className="flex flex-col gap-0.5">
+										{agents.map((a) => (
+											<CheckListRow
+												key={a.id}
+												label={a.name}
+												checked={filters.agentIds?.includes(a.id) ?? false}
+												onChange={() =>
+													toggle("agentIds", a.id, filters.agentIds)
+												}
+											/>
+										))}
+									</div>
+								</section>
+								<div className="border-t border-border/20" />
+							</>
+						)}
+
+						<section>
+							<FilterSectionLabel>
+								{t("conversationsPage.filters.status")}
+							</FilterSectionLabel>
+							<div className="flex flex-col gap-0.5">
+								{ALL_STATUSES.map((s) => (
+									<CheckListRow
+										key={s}
+										label={CONVERSATION_STATUS_LABELS[s]}
+										checked={filters.statuses?.includes(s) ?? false}
+										onChange={() => toggle("statuses", s, filters.statuses)}
+										dotClassName={CONVERSATION_STATUS_COLORS[s].replace(
+											"text-",
+											"bg-",
+										)}
+									/>
+								))}
+							</div>
+						</section>
+
+						<div className="border-t border-border/20" />
+
+						<section>
+							<FilterSectionLabel>
+								{t("conversationsPage.filters.type")}
+							</FilterSectionLabel>
+							<div className="flex flex-col gap-0.5">
+								{ALL_TRIGGER_TYPES.map((tt) => (
+									<CheckListRow
+										key={tt}
+										label={CONVERSATION_TRIGGER_TYPE_LABELS[tt]}
+										checked={filters.triggerTypes?.includes(tt) ?? false}
+										onChange={() =>
+											toggle("triggerTypes", tt, filters.triggerTypes)
+										}
+									/>
+								))}
+							</div>
+						</section>
+
+						<div className="border-t border-border/20" />
+
+						<section>
+							<FilterSectionLabel>
+								{t("conversationsPage.filters.dateRange")}
+							</FilterSectionLabel>
+							<DateRangeFilter
+								createdAfter={filters.createdAfter}
+								createdBefore={filters.createdBefore}
+								onChange={(range) => onFiltersChange({ ...filters, ...range })}
+							/>
+						</section>
+					</div>
+				</PopoverContent>
+			</Popover>
+
+			{hasAnyActive && (
+				<button
+					type="button"
+					onClick={() => {
+						setSearchInput("");
+						onFiltersChange({});
+					}}
+					aria-label={t("conversationsPage.filters.clearAll")}
+					title={t("conversationsPage.filters.clearAll")}
+					className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-all duration-150 hover:bg-muted/60 hover:text-foreground"
+				>
+					<X className="size-3.5" />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}} iteration",
 		"iterations_other": "{{count}} iterations",
 		"prOpened": "PR opened",
+		"filters": {
+			"title": "Filters",
+			"agent": "Agent",
+			"status": "Status",
+			"type": "Type",
+			"dateRange": "Date range",
+			"searchPlaceholder": "Search messages…",
+			"dateFrom": "From",
+			"dateTo": "To",
+			"clearAll": "Clear filters"
+		},
 		"list": {
 			"empty": {
 				"title": "No conversations yet",
 				"description": "Conversations start when a task is assigned to an agent or someone messages one."
+			},
+			"emptyFiltered": {
+				"title": "No matching conversations",
+				"description": "Try adjusting or clearing your filters."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}} iteración",
 		"iterations_other": "{{count}} iteraciones",
 		"prOpened": "PR abierto",
+		"filters": {
+			"title": "Filtros",
+			"agent": "Agente",
+			"status": "Estado",
+			"type": "Tipo",
+			"dateRange": "Rango de fechas",
+			"searchPlaceholder": "Buscar mensajes…",
+			"dateFrom": "Desde",
+			"dateTo": "Hasta",
+			"clearAll": "Borrar filtros"
+		},
 		"list": {
 			"empty": {
 				"title": "Aún no hay conversaciones",
 				"description": "Las conversaciones comienzan cuando se asigna una tarea a un agente o alguien le envía un mensaje."
+			},
+			"emptyFiltered": {
+				"title": "No hay conversaciones que coincidan",
+				"description": "Intenta ajustar o borrar tus filtros."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}} itération",
 		"iterations_other": "{{count}} itérations",
 		"prOpened": "PR ouverte",
+		"filters": {
+			"title": "Filtres",
+			"agent": "Agent",
+			"status": "Statut",
+			"type": "Type",
+			"dateRange": "Plage de dates",
+			"searchPlaceholder": "Rechercher des messages…",
+			"dateFrom": "Du",
+			"dateTo": "Au",
+			"clearAll": "Effacer les filtres"
+		},
 		"list": {
 			"empty": {
 				"title": "Aucune conversation pour le moment",
 				"description": "Les conversations démarrent lorsqu'une tâche est attribuée à un agent ou que quelqu'un lui envoie un message."
+			},
+			"emptyFiltered": {
+				"title": "Aucune conversation correspondante",
+				"description": "Essayez d'ajuster ou d'effacer vos filtres."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}}回の反復",
 		"iterations_other": "{{count}}回の反復",
 		"prOpened": "PRを作成しました",
+		"filters": {
+			"title": "フィルター",
+			"agent": "エージェント",
+			"status": "ステータス",
+			"type": "タイプ",
+			"dateRange": "日付範囲",
+			"searchPlaceholder": "メッセージを検索…",
+			"dateFrom": "開始日",
+			"dateTo": "終了日",
+			"clearAll": "フィルターをクリア"
+		},
 		"list": {
 			"empty": {
 				"title": "会話はまだありません",
 				"description": "タスクがエージェントに割り当てられるか、誰かがメッセージを送ると会話が始まります。"
+			},
+			"emptyFiltered": {
+				"title": "一致する会話がありません",
+				"description": "フィルターを調整するかクリアしてみてください。"
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}}회 반복",
 		"iterations_other": "{{count}}회 반복",
 		"prOpened": "PR 열림",
+		"filters": {
+			"title": "필터",
+			"agent": "에이전트",
+			"status": "상태",
+			"type": "유형",
+			"dateRange": "날짜 범위",
+			"searchPlaceholder": "메시지 검색…",
+			"dateFrom": "시작일",
+			"dateTo": "종료일",
+			"clearAll": "필터 초기화"
+		},
 		"list": {
 			"empty": {
 				"title": "아직 대화가 없습니다",
 				"description": "에이전트에게 작업이 배정되거나 누군가 메시지를 보내면 대화가 시작됩니다."
+			},
+			"emptyFiltered": {
+				"title": "일치하는 대화가 없습니다",
+				"description": "필터를 조정하거나 초기화해 보세요."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}} iteração",
 		"iterations_other": "{{count}} iterações",
 		"prOpened": "PR aberto",
+		"filters": {
+			"title": "Filtros",
+			"agent": "Agente",
+			"status": "Status",
+			"type": "Tipo",
+			"dateRange": "Intervalo de datas",
+			"searchPlaceholder": "Pesquisar mensagens…",
+			"dateFrom": "De",
+			"dateTo": "Até",
+			"clearAll": "Limpar filtros"
+		},
 		"list": {
 			"empty": {
 				"title": "Nenhuma conversa ainda",
 				"description": "As conversas começam quando uma tarefa é atribuída a um agente ou quando alguém envia uma mensagem a ele."
+			},
+			"emptyFiltered": {
+				"title": "Nenhuma conversa correspondente",
+				"description": "Tente ajustar ou limpar seus filtros."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -1015,10 +1015,25 @@
 		"iterations_many": "{{count}} итераций",
 		"iterations_other": "{{count}} итерации",
 		"prOpened": "PR открыт",
+		"filters": {
+			"title": "Фильтры",
+			"agent": "Агент",
+			"status": "Статус",
+			"type": "Тип",
+			"dateRange": "Диапазон дат",
+			"searchPlaceholder": "Поиск сообщений…",
+			"dateFrom": "С",
+			"dateTo": "По",
+			"clearAll": "Сбросить фильтры"
+		},
 		"list": {
 			"empty": {
 				"title": "Диалогов пока нет",
 				"description": "Диалоги начинаются, когда задача назначена агенту или кто-то пишет ему сообщение."
+			},
+			"emptyFiltered": {
+				"title": "Нет подходящих диалогов",
+				"description": "Попробуйте изменить или сбросить фильтры."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}} lượt lặp",
 		"iterations_other": "{{count}} lượt lặp",
 		"prOpened": "PR đã mở",
+		"filters": {
+			"title": "Bộ lọc",
+			"agent": "Tác nhân",
+			"status": "Trạng thái",
+			"type": "Loại",
+			"dateRange": "Khoảng thời gian",
+			"searchPlaceholder": "Tìm kiếm tin nhắn…",
+			"dateFrom": "Từ ngày",
+			"dateTo": "Đến ngày",
+			"clearAll": "Xóa bộ lọc"
+		},
 		"list": {
 			"empty": {
 				"title": "Chưa có hội thoại nào",
 				"description": "Hội thoại bắt đầu khi một nhiệm vụ được giao cho agent hoặc khi có ai đó nhắn tin cho agent đó."
+			},
+			"emptyFiltered": {
+				"title": "Không có hội thoại phù hợp",
+				"description": "Hãy thử điều chỉnh hoặc xóa bộ lọc của bạn."
 			}
 		},
 		"detail": {

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -997,10 +997,25 @@
 		"iterations_one": "{{count}} 次迭代",
 		"iterations_other": "{{count}} 次迭代",
 		"prOpened": "PR 已创建",
+		"filters": {
+			"title": "筛选",
+			"agent": "代理",
+			"status": "状态",
+			"type": "类型",
+			"dateRange": "日期范围",
+			"searchPlaceholder": "搜索消息…",
+			"dateFrom": "起始日期",
+			"dateTo": "结束日期",
+			"clearAll": "清除筛选"
+		},
 		"list": {
 			"empty": {
 				"title": "暂无对话",
 				"description": "当任务分配给某个智能体或有人向其发送消息时，对话将开始。"
+			},
+			"emptyFiltered": {
+				"title": "没有匹配的对话",
+				"description": "请尝试调整或清除筛选条件。"
 			}
 		},
 		"detail": {

--- a/apps/web/src/lib/agent-api.test.ts
+++ b/apps/web/src/lib/agent-api.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet } = vi.hoisted(() => ({
+	mockGet: vi.fn(),
+}));
+
+vi.mock("./api-client", () => ({
+	apiClient: {
+		instance: {
+			get: mockGet,
+		},
+	},
+}));
+
+import { listConversations } from "./agent-api";
+
+const PROJECT_ID = "proj-1";
+
+function ok<T>(data: T) {
+	return { data: { data, success: true } };
+}
+
+function emptyPage() {
+	return ok({ items: [], page_size: 20, next_cursor: null });
+}
+
+function paramsOf(callIndex = 0) {
+	const [, config] = mockGet.mock.calls[callIndex] as [
+		string,
+		{ params: Record<string, unknown> },
+	];
+	return config.params ?? {};
+}
+
+describe("agent-api", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("listConversations", () => {
+		it("defaults to page_size=20 with no other params when called without options", async () => {
+			mockGet.mockResolvedValue(emptyPage());
+
+			await listConversations(PROJECT_ID);
+
+			expect(mockGet).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/conversations`,
+				{ params: { page_size: 20 } },
+			);
+		});
+
+		it("joins multi-value filters into comma-separated params", async () => {
+			mockGet.mockResolvedValue(emptyPage());
+
+			await listConversations(PROJECT_ID, {
+				agentIds: ["agent-a", "agent-b"],
+				statuses: ["running", "paused"],
+				triggerTypes: ["task_assigned", "chat_message"],
+			});
+
+			const params = paramsOf();
+			expect(params.agent_id).toBe("agent-a,agent-b");
+			expect(params.status).toBe("running,paused");
+			expect(params.trigger_type).toBe("task_assigned,chat_message");
+		});
+
+		it("omits array params when the array is empty", async () => {
+			mockGet.mockResolvedValue(emptyPage());
+
+			await listConversations(PROJECT_ID, {
+				agentIds: [],
+				statuses: [],
+				triggerTypes: [],
+			});
+
+			const params = paramsOf();
+			expect(params.agent_id).toBeUndefined();
+			expect(params.status).toBeUndefined();
+			expect(params.trigger_type).toBeUndefined();
+		});
+
+		it("converts createdAfter/createdBefore to UTC-instant boundaries of the local day", async () => {
+			mockGet.mockResolvedValue(emptyPage());
+
+			await listConversations(PROJECT_ID, {
+				createdAfter: "2026-01-01",
+				createdBefore: "2026-01-31",
+			});
+
+			// Computed the same way the implementation does (local Y/M/D ->
+			// Date -> ISO) rather than hardcoding a UTC string, so this test
+			// is correct regardless of the runner's local timezone.
+			const wantAfter = new Date(2026, 0, 1, 0, 0, 0, 0).toISOString();
+			const wantBefore = new Date(2026, 0, 31 + 1, 0, 0, 0, 0).toISOString();
+
+			const params = paramsOf();
+			expect(params.created_after).toBe(wantAfter);
+			expect(params.created_before).toBe(wantBefore);
+		});
+
+		it("trims the search param and omits it when blank", async () => {
+			mockGet.mockResolvedValue(emptyPage());
+
+			await listConversations(PROJECT_ID, { search: "  login bug  " });
+			expect(paramsOf().search).toBe("login bug");
+
+			mockGet.mockClear();
+			mockGet.mockResolvedValue(emptyPage());
+			await listConversations(PROJECT_ID, { search: "   " });
+			expect(paramsOf().search).toBeUndefined();
+		});
+
+		it("forwards cursor and a custom pageSize", async () => {
+			mockGet.mockResolvedValue(emptyPage());
+
+			await listConversations(PROJECT_ID, {
+				cursor: "opaque-cursor",
+				pageSize: 50,
+			});
+
+			const params = paramsOf();
+			expect(params.cursor).toBe("opaque-cursor");
+			expect(params.page_size).toBe(50);
+		});
+	});
+});

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -143,16 +143,18 @@ export type ConversationStatus =
 	| "failed"
 	| "stopped";
 
+export type ConversationTriggerType =
+	| "task_assigned"
+	| "comment_mention"
+	| "chat_message"
+	| "description_write"
+	| "automation_message";
+
 export interface AgentConversation {
 	id: string;
 	agent_id: string;
 	project_id: string;
-	trigger_type:
-		| "task_assigned"
-		| "comment_mention"
-		| "chat_message"
-		| "description_write"
-		| "automation_message";
+	trigger_type: ConversationTriggerType;
 	task_id?: string | null;
 	comment_id?: string | null;
 	chat_session_id?: string | null;
@@ -485,15 +487,68 @@ export interface ConversationListResult {
 
 export const CONVERSATIONS_PAGE_SIZE = 20;
 
+export interface ListConversationsOptions {
+	agentIds?: string[];
+	statuses?: ConversationStatus[];
+	triggerTypes?: ConversationTriggerType[];
+	/**
+	 * Inclusive/exclusive created_at range, as local calendar dates
+	 * ("YYYY-MM-DD") in the browser's own timezone — e.g. from the date
+	 * picker. Converted to precise UTC-instant boundaries for the request
+	 * (see localDateStartISO/localDateExclusiveEndISO) so the filtered range
+	 * matches the user's local day rather than a UTC calendar day.
+	 */
+	createdAfter?: string;
+	createdBefore?: string;
+	/** Free-text search matched server-side against conversation event content. */
+	search?: string;
+	cursor?: string;
+	pageSize?: number;
+}
+
+/** Start of the local calendar day `dateStr` ("YYYY-MM-DD"), as a UTC instant. */
+function localDateStartISO(dateStr: string): string {
+	const [y, m, d] = dateStr.split("-").map(Number);
+	return new Date(y, m - 1, d, 0, 0, 0, 0).toISOString();
+}
+
+/**
+ * Exclusive end of the local calendar day `dateStr` — i.e. the start of the
+ * next local day — as a UTC instant. Sending this (rather than the bare
+ * date) means a range picked in the user's local timezone covers the same
+ * wall-clock day server-side, instead of being reinterpreted as a UTC day.
+ */
+function localDateExclusiveEndISO(dateStr: string): string {
+	const [y, m, d] = dateStr.split("-").map(Number);
+	return new Date(y, m - 1, d + 1, 0, 0, 0, 0).toISOString();
+}
+
+function buildConversationQueryParams(opts: ListConversationsOptions = {}) {
+	const params: Record<string, string | number> = {};
+	params.page_size = opts.pageSize ?? CONVERSATIONS_PAGE_SIZE;
+	if (opts.cursor) params.cursor = opts.cursor;
+	if (opts.agentIds && opts.agentIds.length > 0)
+		params.agent_id = opts.agentIds.join(",");
+	if (opts.statuses && opts.statuses.length > 0)
+		params.status = opts.statuses.join(",");
+	if (opts.triggerTypes && opts.triggerTypes.length > 0)
+		params.trigger_type = opts.triggerTypes.join(",");
+	if (opts.createdAfter)
+		params.created_after = localDateStartISO(opts.createdAfter);
+	if (opts.createdBefore)
+		params.created_before = localDateExclusiveEndISO(opts.createdBefore);
+	if (opts.search?.trim()) params.search = opts.search.trim();
+	return params;
+}
+
 export async function listConversations(
 	projectId: string,
-	options?: { agentId?: string; cursor?: string; pageSize?: number },
+	options?: ListConversationsOptions,
 ): Promise<ConversationListResult> {
-	const { agentId, cursor, pageSize = CONVERSATIONS_PAGE_SIZE } = options ?? {};
 	const { data } = await apiClient.instance.get<
 		SuccessEnvelope<ConversationListResult>
 	>(`/projects/${projectId}/conversations`, {
-		params: { agent_id: agentId, cursor, page_size: pageSize },
+		params: buildConversationQueryParams(options),
 	});
 	return data.data;
 }
@@ -655,15 +710,20 @@ export const acpBridgeStatusQueryOptions = (
 // every "agent.*" event instead of polling. Cursor-paginated — each page
 // carries the opaque cursor to resume after its last item, so fetchNextPage
 // just forwards the backend's next_cursor until it comes back null.
+export type ConversationFilters = Omit<
+	ListConversationsOptions,
+	"cursor" | "pageSize"
+>;
+
 export const conversationsQueryOptions = (
 	projectId: string,
-	agentId?: string,
+	filters: ConversationFilters = {},
 ) =>
 	infiniteQueryOptions({
-		queryKey: ["projects", projectId, "conversations", { agentId }],
+		queryKey: ["projects", projectId, "conversations", filters],
 		queryFn: ({ pageParam }: { pageParam: string | undefined }) =>
 			listConversations(projectId, {
-				agentId,
+				...filters,
 				cursor: pageParam,
 				pageSize: CONVERSATIONS_PAGE_SIZE,
 			}),
@@ -742,4 +802,15 @@ export const CONVERSATION_STATUS_COLORS: Record<ConversationStatus, string> = {
 	finished: "text-emerald-500",
 	failed: "text-destructive",
 	stopped: "text-muted-foreground",
+};
+
+export const CONVERSATION_TRIGGER_TYPE_LABELS: Record<
+	ConversationTriggerType,
+	string
+> = {
+	task_assigned: "Task Assigned",
+	comment_mention: "Comment Mention",
+	chat_message: "Chat Message",
+	description_write: "Description Write",
+	automation_message: "Automation",
 };

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
@@ -6,8 +6,9 @@ import {
 	useParams,
 } from "@tanstack/react-router";
 import { Clock, MessageSquare, Zap } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ConversationFilters } from "@/components/projects/agents/conversation-filters";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -18,6 +19,7 @@ import {
 	agentsQueryOptions,
 	CONVERSATION_STATUS_COLORS,
 	CONVERSATION_STATUS_LABELS,
+	type ConversationFilters as ConversationFiltersState,
 	conversationsQueryOptions,
 } from "@/lib/agent-api";
 import { cn } from "@/lib/utils";
@@ -126,8 +128,10 @@ function ConversationsLayout() {
 
 	useProjectRealtime(projectId);
 
+	const [filters, setFilters] = useState<ConversationFiltersState>({});
+
 	const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
-		useInfiniteQuery(conversationsQueryOptions(projectId));
+		useInfiniteQuery(conversationsQueryOptions(projectId, filters));
 	const { data: agents = [] } = useQuery(agentsQueryOptions(projectId));
 	const agentsById = new Map(agents.map((a) => [a.id, a]));
 
@@ -135,6 +139,9 @@ function ConversationsLayout() {
 	// DESC on the backend), so concatenating them in fetch order already
 	// yields the correct display order — no client-side re-sort needed.
 	const conversations = data?.pages.flatMap((page) => page.items) ?? [];
+	const hasActiveFilters = Object.values(filters).some((v) =>
+		Array.isArray(v) ? v.length > 0 : !!v,
+	);
 
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -164,6 +171,11 @@ function ConversationsLayout() {
 						{t("conversationsPage.title")}
 					</h2>
 				</div>
+				<ConversationFilters
+					agents={agents}
+					filters={filters}
+					onFiltersChange={setFilters}
+				/>
 				<div
 					ref={scrollContainerRef}
 					className="flex-1 overflow-y-auto p-2 space-y-1.5"
@@ -177,10 +189,14 @@ function ConversationsLayout() {
 						<div className="flex flex-col items-center justify-center gap-3 py-14 px-3 text-center">
 							<MessageSquare className="size-8 text-muted-foreground/40" />
 							<p className="text-sm text-muted-foreground">
-								{t("conversationsPage.list.empty.title")}
+								{hasActiveFilters
+									? t("conversationsPage.list.emptyFiltered.title")
+									: t("conversationsPage.list.empty.title")}
 							</p>
 							<p className="text-xs text-muted-foreground max-w-xs">
-								{t("conversationsPage.list.empty.description")}
+								{hasActiveFilters
+									? t("conversationsPage.list.emptyFiltered.description")
+									: t("conversationsPage.list.empty.description")}
 							</p>
 						</div>
 					) : (

--- a/services/api/internal/domain/agent/repository.go
+++ b/services/api/internal/domain/agent/repository.go
@@ -2,6 +2,7 @@ package agentdom
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -96,9 +97,22 @@ type ChatSessionRepository interface {
 
 // ListConversationsFilter carries optional filters for listing conversations.
 type ListConversationsFilter struct {
-	AgentID     *uuid.UUID
-	ProjectID   *uuid.UUID
-	TaskID      *uuid.UUID
-	Status      *string
+	AgentIDs     []uuid.UUID
+	ProjectID    *uuid.UUID
+	TaskID       *uuid.UUID
+	Statuses     []string
+	TriggerTypes []string
+	// CreatedAfter/CreatedBefore bound created_at as [CreatedAfter,
+	// CreatedBefore) — inclusive lower bound, exclusive upper bound. Both are
+	// resolved to absolute instants by the handler (see
+	// parseCreatedAfterBound/parseCreatedBeforeBound) before reaching here,
+	// so the query can compare them directly against the TIMESTAMPTZ column
+	// without any date-cast/timezone ambiguity.
+	CreatedAfter  *time.Time
+	CreatedBefore *time.Time
+	// Search matches conversations that have at least one event whose
+	// extracted text (see agent_conversation_event_search_text in migration
+	// 000028) contains this text.
+	Search      *string
 	CursorAfter *string // opaque base64 cursor; when set, resumes after this conversation
 }

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -592,47 +593,73 @@ const conversationCols = `id, agent_id, project_id, trigger_type, task_id, comme
 // the filter, ordered newest-first. It fetches one row beyond limit to detect
 // whether more pages remain, without a separate COUNT query.
 func (r *AgentRepository) ListConversations(ctx context.Context, in agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error) {
-	// Build dynamic WHERE clause
-	where := "WHERE 1=1"
-	args := []interface{}{}
-	idx := 1
+	b := newQueryBuilder()
 
-	if in.AgentID != nil {
-		where += fmt.Sprintf(" AND agent_id = $%d", idx)
-		args = append(args, in.AgentID.String())
-		idx++
+	if len(in.AgentIDs) > 0 {
+		b.addInClause("agent_id", uuidSliceToStrSlice(in.AgentIDs))
 	}
 	if in.ProjectID != nil {
-		where += fmt.Sprintf(" AND project_id = $%d", idx)
-		args = append(args, in.ProjectID.String())
-		idx++
+		p := b.placeholder()
+		b.args = append(b.args, in.ProjectID.String())
+		b.whereClauses = append(b.whereClauses, "project_id = "+p)
 	}
 	if in.TaskID != nil {
-		where += fmt.Sprintf(" AND task_id = $%d", idx)
-		args = append(args, in.TaskID.String())
-		idx++
+		p := b.placeholder()
+		b.args = append(b.args, in.TaskID.String())
+		b.whereClauses = append(b.whereClauses, "task_id = "+p)
 	}
-	if in.Status != nil {
-		where += fmt.Sprintf(" AND status = $%d", idx)
-		args = append(args, *in.Status)
-		idx++
+	if len(in.Statuses) > 0 {
+		b.addInClause("status", in.Statuses)
+	}
+	if len(in.TriggerTypes) > 0 {
+		b.addInClause("trigger_type", in.TriggerTypes)
+	}
+	if in.CreatedAfter != nil {
+		p := b.placeholder()
+		b.args = append(b.args, *in.CreatedAfter)
+		b.whereClauses = append(b.whereClauses, "created_at >= "+p)
+	}
+	if in.CreatedBefore != nil {
+		p := b.placeholder()
+		b.args = append(b.args, *in.CreatedBefore)
+		b.whereClauses = append(b.whereClauses, "created_at < "+p)
+	}
+	if in.Search != nil {
+		if q := strings.TrimSpace(*in.Search); q != "" {
+			p := b.placeholder()
+			b.args = append(b.args, q)
+			// Matches conversations with at least one event whose extracted
+			// text (agent_conversation_event_search_text, migration 000028)
+			// contains the search terms. plainto_tsquery (not to_tsquery) so
+			// arbitrary user input never raises a tsquery syntax error.
+			b.whereClauses = append(b.whereClauses,
+				"EXISTS (SELECT 1 FROM agent_conversation_events e WHERE e.conversation_id = agent_conversations.id "+
+					"AND to_tsvector('simple', agent_conversation_event_search_text(e.payload)) @@ plainto_tsquery('simple', "+p+"))")
+		}
 	}
 	if in.CursorAfter != nil {
 		cur, err := agentdom.DecodeConversationCursor(*in.CursorAfter)
 		if err != nil {
 			return nil, false, fmt.Errorf("%w: %s", agentdom.ErrConversationInvalidCursor, err)
 		}
-		where += fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", idx, idx+1)
-		args = append(args, cur.CreatedAt, cur.ID)
-		idx += 2
+		p1 := b.placeholder()
+		p2 := b.placeholder()
+		b.args = append(b.args, cur.CreatedAt, cur.ID)
+		b.whereClauses = append(b.whereClauses, fmt.Sprintf("(created_at, id) < (%s, %s)", p1, p2))
 	}
 
-	limitP := idx
-	args = append(args, limit+1)
+	limitP := b.placeholder()
+	b.args = append(b.args, limit+1)
+
+	whereSQL := "1=1"
+	if len(b.whereClauses) > 0 {
+		whereSQL += " AND " + strings.Join(b.whereClauses, " AND ")
+	}
 
 	var recs []agentConversationRecord
-	if err := r.db.SelectContext(ctx, &recs, `SELECT `+conversationCols+` FROM agent_conversations `+where+
-		fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT $%d`, limitP), args...); err != nil {
+	query := `SELECT ` + conversationCols + ` FROM agent_conversations WHERE ` + whereSQL +
+		fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %s`, limitP)
+	if err := r.db.SelectContext(ctx, &recs, query, b.args...); err != nil {
 		return nil, false, err
 	}
 

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -954,7 +954,7 @@ func TestListConversations_Success(t *testing.T) {
 	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
 	cursor := "some-cursor"
-	filter := agentdom.ListConversationsFilter{ProjectID: &projectID, AgentID: &agentID, CursorAfter: &cursor}
+	filter := agentdom.ListConversationsFilter{ProjectID: &projectID, AgentIDs: []uuid.UUID{agentID}, CursorAfter: &cursor}
 	result, hasMore, err := svc.ListConversations(context.Background(), filter, 20)
 
 	assert.NoError(t, err)
@@ -962,7 +962,7 @@ func TestListConversations_Success(t *testing.T) {
 	assert.Equal(t, convs, result)
 	assert.Equal(t, 20, gotLimit)
 	assert.Equal(t, &projectID, gotFilter.ProjectID)
-	assert.Equal(t, &agentID, gotFilter.AgentID)
+	assert.Equal(t, []uuid.UUID{agentID}, gotFilter.AgentIDs)
 	assert.Equal(t, &cursor, gotFilter.CursorAfter)
 }
 

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -3,14 +3,65 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/Paca-AI/api/internal/apierr"
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
 	"github.com/Paca-AI/api/internal/transport/http/dto"
 	"github.com/Paca-AI/api/internal/transport/http/middleware"
 	"github.com/Paca-AI/api/internal/transport/http/presenter"
 )
+
+// validConversationStatuses/validConversationTriggerTypes mirror the
+// agent_conversations.status/trigger_type CHECK constraints (see migrations
+// 000008 and 000011/000027). Rejecting unknown values here with a 400 gives
+// callers a clear signal instead of a filter that silently matches nothing.
+var (
+	validConversationStatuses = []string{
+		"queued", "running", "paused", "finished", "failed", "stopped",
+	}
+	validConversationTriggerTypes = []string{
+		"task_assigned", "comment_mention", "chat_message", "description_write", "automation_message",
+	}
+)
+
+// parseCreatedAfterBound parses a created_after query value into an
+// inclusive lower bound on created_at. It accepts either a bare
+// "YYYY-MM-DD" date — treated as UTC midnight of that day, for simple direct
+// API use — or a full RFC3339 timestamp, which the frontend sends as the
+// precise UTC instant marking the start of the user's local calendar day
+// (avoiding the mismatch a bare date would have against a TIMESTAMPTZ
+// column for users outside UTC).
+func parseCreatedAfterBound(raw string) (*time.Time, bool) {
+	if t, err := time.Parse("2006-01-02", raw); err == nil {
+		return &t, true
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return &t, true
+	}
+	return nil, false
+}
+
+// parseCreatedBeforeBound parses a created_before query value into an
+// exclusive upper bound on created_at. A bare "YYYY-MM-DD" date is treated
+// as the whole UTC day inclusive, i.e. the bound is pushed to midnight the
+// *following* UTC day. A full RFC3339 timestamp is used exactly as given —
+// the frontend computes that exclusive boundary itself, from the start of
+// the local day after the one the user picked.
+func parseCreatedBeforeBound(raw string) (*time.Time, bool) {
+	if t, err := time.Parse("2006-01-02", raw); err == nil {
+		t = t.AddDate(0, 0, 1)
+		return &t, true
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return &t, true
+	}
+	return nil, false
+}
 
 // ConversationHandler handles agent conversation endpoints.
 type ConversationHandler struct {
@@ -23,6 +74,16 @@ func NewConversationHandler(svc agentdom.Service) *ConversationHandler {
 }
 
 // ListConversations handles GET /projects/:projectId/conversations.
+//
+// Supported query params (all optional, combine with AND):
+//   - agent_id=<uuid>|<uuid,uuid,...>       filter by one or more agents
+//   - status=<status>|<status,status,...>   filter by one or more statuses
+//   - trigger_type=<type>|<type,type,...>   filter by one or more trigger types
+//   - created_after=<YYYY-MM-DD|RFC3339>     conversations created on/after this date/instant
+//   - created_before=<YYYY-MM-DD|RFC3339>   conversations created on/before this date/instant
+//   - search=<text>                         matches conversations with an event
+//     containing this text (see agent_conversation_event_search_text)
+//   - cursor=<opaque>, page_size=<1-200>    keyset pagination (see next_cursor in response)
 func (h *ConversationHandler) ListConversations(w http.ResponseWriter, r *http.Request) {
 	projectID, err := parseProjectID(r)
 	if err != nil {
@@ -39,13 +100,51 @@ func (h *ConversationHandler) ListConversations(w http.ResponseWriter, r *http.R
 	filter := agentdom.ListConversationsFilter{
 		ProjectID: &projectID,
 	}
-	if agentIDStr := r.URL.Query().Get("agent_id"); agentIDStr != "" {
-		if id, err := uuid.Parse(agentIDStr); err == nil {
-			filter.AgentID = &id
+	if agentIDsRaw := r.URL.Query().Get("agent_id"); agentIDsRaw != "" {
+		for _, s := range strings.Split(agentIDsRaw, ",") {
+			if id, err := uuid.Parse(strings.TrimSpace(s)); err == nil {
+				filter.AgentIDs = append(filter.AgentIDs, id)
+			}
 		}
 	}
-	if statusStr := r.URL.Query().Get("status"); statusStr != "" {
-		filter.Status = &statusStr
+	if statusesRaw := r.URL.Query().Get("status"); statusesRaw != "" {
+		statuses := splitCommaList(statusesRaw)
+		for _, s := range statuses {
+			if !slices.Contains(validConversationStatuses, s) {
+				presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid status: "+s))
+				return
+			}
+		}
+		filter.Statuses = statuses
+	}
+	if triggerTypesRaw := r.URL.Query().Get("trigger_type"); triggerTypesRaw != "" {
+		triggerTypes := splitCommaList(triggerTypesRaw)
+		for _, tt := range triggerTypes {
+			if !slices.Contains(validConversationTriggerTypes, tt) {
+				presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid trigger_type: "+tt))
+				return
+			}
+		}
+		filter.TriggerTypes = triggerTypes
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("created_after")); raw != "" {
+		t, ok := parseCreatedAfterBound(raw)
+		if !ok {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid created_after"))
+			return
+		}
+		filter.CreatedAfter = t
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("created_before")); raw != "" {
+		t, ok := parseCreatedBeforeBound(raw)
+		if !ok {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid created_before"))
+			return
+		}
+		filter.CreatedBefore = t
+	}
+	if search := strings.TrimSpace(r.URL.Query().Get("search")); search != "" {
+		filter.Search = &search
 	}
 	if cursorRaw := r.URL.Query().Get("cursor"); cursorRaw != "" {
 		filter.CursorAfter = &cursorRaw

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"slices"
 	"testing"
 	"time"
 
@@ -249,11 +251,11 @@ func TestListConversations_FiltersPassedToService(t *testing.T) {
 	if gotFilter.ProjectID == nil || *gotFilter.ProjectID != projectID {
 		t.Errorf("expected ProjectID filter %v, got %v", projectID, gotFilter.ProjectID)
 	}
-	if gotFilter.AgentID == nil || *gotFilter.AgentID != agentID {
-		t.Errorf("expected AgentID filter %v, got %v", agentID, gotFilter.AgentID)
+	if !slices.Equal(gotFilter.AgentIDs, []uuid.UUID{agentID}) {
+		t.Errorf("expected AgentIDs filter [%v], got %v", agentID, gotFilter.AgentIDs)
 	}
-	if gotFilter.Status == nil || *gotFilter.Status != "running" {
-		t.Errorf("expected Status filter %q, got %v", "running", gotFilter.Status)
+	if !slices.Equal(gotFilter.Statuses, []string{"running"}) {
+		t.Errorf("expected Statuses filter [%q], got %v", "running", gotFilter.Statuses)
 	}
 	if gotFilter.CursorAfter == nil || *gotFilter.CursorAfter != "some-opaque-cursor" {
 		t.Errorf("expected CursorAfter filter %q, got %v", "some-opaque-cursor", gotFilter.CursorAfter)
@@ -262,7 +264,7 @@ func TestListConversations_FiltersPassedToService(t *testing.T) {
 
 func TestListConversations_InvalidAgentIDIgnored(t *testing.T) {
 	// A malformed agent_id query param should be silently dropped rather than
-	// erroring the request — only a valid UUID sets the filter.
+	// erroring the request — only valid UUIDs are added to the filter.
 	var gotFilter agentdom.ListConversationsFilter
 	svc := &mockAgentSvc{
 		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
@@ -274,8 +276,170 @@ func TestListConversations_InvalidAgentIDIgnored(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if gotFilter.AgentID != nil {
-		t.Errorf("expected AgentID filter to remain nil for malformed input, got %v", *gotFilter.AgentID)
+	if len(gotFilter.AgentIDs) != 0 {
+		t.Errorf("expected AgentIDs filter to remain empty for malformed input, got %v", gotFilter.AgentIDs)
+	}
+}
+
+func TestListConversations_MultiValueAgentIDAndStatus(t *testing.T) {
+	agent1, agent2 := uuid.New(), uuid.New()
+	var gotFilter agentdom.ListConversationsFilter
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			gotFilter = filter
+			return nil, false, nil
+		},
+	}
+	_, _ = doListConversations(t, svc, uuid.New().String(),
+		"agent_id="+agent1.String()+","+agent2.String()+"&status=running,paused")
+
+	if !slices.Equal(gotFilter.AgentIDs, []uuid.UUID{agent1, agent2}) {
+		t.Errorf("expected AgentIDs filter [%v, %v], got %v", agent1, agent2, gotFilter.AgentIDs)
+	}
+	if !slices.Equal(gotFilter.Statuses, []string{"running", "paused"}) {
+		t.Errorf("expected Statuses filter [running paused], got %v", gotFilter.Statuses)
+	}
+}
+
+func TestListConversations_TriggerTypeFilterPassedToService(t *testing.T) {
+	var gotFilter agentdom.ListConversationsFilter
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			gotFilter = filter
+			return nil, false, nil
+		},
+	}
+	_, _ = doListConversations(t, svc, uuid.New().String(), "trigger_type=task_assigned,chat_message")
+
+	if !slices.Equal(gotFilter.TriggerTypes, []string{"task_assigned", "chat_message"}) {
+		t.Errorf("expected TriggerTypes filter [task_assigned chat_message], got %v", gotFilter.TriggerTypes)
+	}
+}
+
+func TestListConversations_SearchFilterPassedToService(t *testing.T) {
+	var gotFilter agentdom.ListConversationsFilter
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			gotFilter = filter
+			return nil, false, nil
+		},
+	}
+	_, _ = doListConversations(t, svc, uuid.New().String(), "search=%20fix+the+bug%20")
+
+	if gotFilter.Search == nil || *gotFilter.Search != "fix the bug" {
+		t.Errorf("expected trimmed Search filter %q, got %v", "fix the bug", gotFilter.Search)
+	}
+}
+
+func TestListConversations_SearchAbsentWhenBlank(t *testing.T) {
+	var gotFilter agentdom.ListConversationsFilter
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			gotFilter = filter
+			return nil, false, nil
+		},
+	}
+	_, _ = doListConversations(t, svc, uuid.New().String(), "search=%20%20")
+
+	if gotFilter.Search != nil {
+		t.Errorf("expected nil Search filter for blank input, got %q", *gotFilter.Search)
+	}
+}
+
+func TestListConversations_DateRangeFilterPassedToService(t *testing.T) {
+	// A bare "YYYY-MM-DD" date is treated as a whole UTC day, inclusive on
+	// both ends — so created_before=2026-01-31 becomes an exclusive bound of
+	// UTC midnight on 2026-02-01. See parseCreatedAfterBound/
+	// parseCreatedBeforeBound.
+	var gotFilter agentdom.ListConversationsFilter
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			gotFilter = filter
+			return nil, false, nil
+		},
+	}
+	_, _ = doListConversations(t, svc, uuid.New().String(), "created_after=2026-01-01&created_before=2026-01-31")
+
+	wantAfter := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	wantBefore := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	if gotFilter.CreatedAfter == nil || !gotFilter.CreatedAfter.Equal(wantAfter) {
+		t.Errorf("expected CreatedAfter filter %v, got %v", wantAfter, gotFilter.CreatedAfter)
+	}
+	if gotFilter.CreatedBefore == nil || !gotFilter.CreatedBefore.Equal(wantBefore) {
+		t.Errorf("expected CreatedBefore filter %v, got %v", wantBefore, gotFilter.CreatedBefore)
+	}
+}
+
+func TestListConversations_DateRangeFilterAcceptsRFC3339Timestamp(t *testing.T) {
+	// The frontend sends precise RFC3339 instants (computed from the user's
+	// local calendar day) rather than bare dates, to avoid the UTC-day
+	// mismatch a bare date would have for non-UTC users. Those must be used
+	// exactly as given, with no additional whole-day adjustment.
+	var gotFilter agentdom.ListConversationsFilter
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, filter agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			gotFilter = filter
+			return nil, false, nil
+		},
+	}
+	_, _ = doListConversations(t, svc, uuid.New().String(),
+		"created_after="+url.QueryEscape("2026-01-01T08:00:00Z")+"&created_before="+url.QueryEscape("2026-01-31T08:00:00Z"))
+
+	wantAfter := time.Date(2026, 1, 1, 8, 0, 0, 0, time.UTC)
+	wantBefore := time.Date(2026, 1, 31, 8, 0, 0, 0, time.UTC)
+	if gotFilter.CreatedAfter == nil || !gotFilter.CreatedAfter.Equal(wantAfter) {
+		t.Errorf("expected CreatedAfter filter %v, got %v", wantAfter, gotFilter.CreatedAfter)
+	}
+	if gotFilter.CreatedBefore == nil || !gotFilter.CreatedBefore.Equal(wantBefore) {
+		t.Errorf("expected CreatedBefore filter %v, got %v", wantBefore, gotFilter.CreatedBefore)
+	}
+}
+
+func TestListConversations_InvalidDateRangeRejected(t *testing.T) {
+	cases := []string{
+		"created_after=not-a-date",
+		"created_after=2026-13-40",
+		"created_before=not-a-date",
+	}
+	for _, query := range cases {
+		t.Run(query, func(t *testing.T) {
+			svc := &mockAgentSvc{
+				listConversations: func(_ context.Context, _ agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+					t.Fatal("service should not be called for an invalid date filter")
+					return nil, false, nil
+				},
+			}
+			rec, _ := doListConversations(t, svc, uuid.New().String(), query)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestListConversations_InvalidStatusRejected(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, _ agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			t.Fatal("service should not be called for an invalid status filter")
+			return nil, false, nil
+		},
+	}
+	rec, _ := doListConversations(t, svc, uuid.New().String(), "status=running,not-a-real-status")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestListConversations_InvalidTriggerTypeRejected(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversations: func(_ context.Context, _ agentdom.ListConversationsFilter, _ int) ([]*agentdom.AgentConversation, bool, error) {
+			t.Fatal("service should not be called for an invalid trigger_type filter")
+			return nil, false, nil
+		},
+	}
+	rec, _ := doListConversations(t, svc, uuid.New().String(), "trigger_type=not-a-real-type")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/services/api/internal/transport/http/handler/helpers.go
+++ b/services/api/internal/transport/http/handler/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/Paca-AI/api/internal/apierr"
 )
@@ -73,4 +74,16 @@ func parseOffsetLimit(r *http.Request) (offset, limit int, err error) {
 	}
 
 	return offset, limit, nil
+}
+
+// splitCommaList splits a comma-separated query param into its trimmed,
+// non-empty parts (e.g. "running, paused" -> ["running", "paused"]).
+func splitCommaList(raw string) []string {
+	var out []string
+	for _, s := range strings.Split(raw, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/services/api/migrations/000028_add_conversation_search_and_filters.sql
+++ b/services/api/migrations/000028_add_conversation_search_and_filters.sql
@@ -1,0 +1,58 @@
+-- 000028_add_conversation_search_and_filters.sql
+-- Supports the conversation list's new server-side filters (agent, status,
+-- type/trigger_type, date range) and free-text search.
+--
+-- 1. idx_agent_conversations_trigger_type: mirrors the existing
+--    idx_agent_conversations_agent_status composite index, but for
+--    trigger_type ("type") filtering.
+--
+-- 2. agent_conversation_event_search_text(): a best-effort extraction of
+--    human-readable text from a conversation event's JSONB payload, covering
+--    the known text-bearing paths across OpenHands SDK event types (approximates
+--    the per-event-type logic in the frontend's conversation-to-thread-messages.ts).
+--    It's used only to build a search index and to match search queries, not for
+--    display, so it doesn't need pixel-perfect fidelity with the UI rendering.
+--    Marked IMMUTABLE so it can back a GIN expression index below.
+--
+-- 3. idx_agent_conversation_events_search: a GIN index over
+--    to_tsvector('simple', agent_conversation_event_search_text(payload)),
+--    letting the conversation list's search filter match conversations whose
+--    events contain the search text without a full unindexed JSONB scan.
+--    CREATE INDEX CONCURRENTLY isn't usable here — this repo's migration
+--    runner (RunMigrationsFS/execInTx) wraps each file in its own
+--    transaction, and CONCURRENTLY cannot run inside one.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversations_trigger_type
+    ON agent_conversations (project_id, trigger_type);
+
+CREATE OR REPLACE FUNCTION agent_conversation_event_search_text(payload JSONB)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+    SELECT string_agg(v, ' ')
+    FROM (VALUES
+        (payload->>'content'),
+        (payload #>> '{llm_message,content}'),
+        (payload->>'thought'),
+        (payload #>> '{action,message}'),
+        (payload #>> '{observation,content}'),
+        (payload #>> '{observation,message}'),
+        (payload->>'message'),
+        (payload->>'error'),
+        (payload->>'rejection_reason'),
+        (payload->>'output'),
+        (payload->>'raw_output'),
+        (payload->>'title')
+    ) AS t(v)
+    WHERE v IS NOT NULL;
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_agent_conversation_events_search
+    ON agent_conversation_events
+    USING GIN (to_tsvector('simple', agent_conversation_event_search_text(payload)));
+
+COMMIT;

--- a/services/api/test/e2e/conversation_pagination_test.go
+++ b/services/api/test/e2e/conversation_pagination_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"testing"
 	"time"
 
@@ -64,11 +65,18 @@ func seedConversationFixture(t *testing.T, env *e2eEnv) (client *http.Client, to
 // deterministically instead of relying on wall-clock timing.
 func createConversationAt(t *testing.T, env *e2eEnv, projID string, agentID, memberID uuid.UUID, status string, createdAt time.Time) string {
 	t.Helper()
+	return createConversationWithTriggerAt(t, env, projID, agentID, memberID, status, "chat_message", createdAt)
+}
+
+// createConversationWithTriggerAt is createConversationAt with an explicit
+// trigger_type, for tests exercising the trigger_type ("type") filter.
+func createConversationWithTriggerAt(t *testing.T, env *e2eEnv, projID string, agentID, memberID uuid.UUID, status, triggerType string, createdAt time.Time) string {
+	t.Helper()
 	conv := &agentdom.AgentConversation{
 		ID:                  uuid.New(),
 		AgentID:             agentID,
 		ProjectID:           uuid.MustParse(projID),
-		TriggerType:         "chat_message",
+		TriggerType:         triggerType,
 		TriggeredByMemberID: &memberID,
 		Status:              status,
 		CreatedAt:           createdAt,
@@ -366,6 +374,284 @@ func TestE2EListConversationPagination_AgentIDFilter(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestE2EListConversationPagination_TriggerTypeFilter
+// Verifies cursor pagination works correctly when combined with the
+// trigger_type ("type") filter.
+// ---------------------------------------------------------------------------
+
+func TestE2EListConversationPagination_TriggerTypeFilter(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+
+	base := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	var taskAssignedIDs []string
+	for i := 0; i < 4; i++ {
+		id := createConversationWithTriggerAt(t, env, projID, agentID, memberID, "finished", "task_assigned", base.Add(time.Duration(i)*time.Minute))
+		taskAssignedIDs = append(taskAssignedIDs, id)
+	}
+	// Noise: conversations of a different type must not appear in filtered results.
+	for i := 0; i < 2; i++ {
+		createConversationWithTriggerAt(t, env, projID, agentID, memberID, "finished", "chat_message", base.Add(time.Duration(10+i)*time.Minute))
+	}
+
+	t.Run("first_page_has_cursor_when_more_exist", func(t *testing.T) {
+		data := listConversationsPage(t, env, client, token, projID, url.Values{
+			"trigger_type": {"task_assigned"},
+			"page_size":    {"2"},
+		})
+		items, _ := data["items"].([]any)
+		if len(items) != 2 {
+			t.Errorf("expected 2 task_assigned conversations on first page, got %d", len(items))
+		}
+		if nextCursorStr(data) == "" {
+			t.Error("expected next_cursor when more task_assigned conversations exist beyond first page")
+		}
+	})
+
+	t.Run("full_traversal_returns_only_matching_type_without_duplicates", func(t *testing.T) {
+		seen := make(map[string]int)
+		cursor := ""
+		for {
+			q := url.Values{"trigger_type": {"task_assigned"}, "page_size": {"2"}}
+			if cursor != "" {
+				q.Set("cursor", cursor)
+			}
+			data := listConversationsPage(t, env, client, token, projID, q)
+			for _, id := range itemIDs(data) {
+				seen[id]++
+			}
+			cursor = nextCursorStr(data)
+			if cursor == "" {
+				break
+			}
+		}
+		if len(seen) != 4 {
+			t.Errorf("expected 4 task_assigned conversations from full traversal, got %d", len(seen))
+		}
+		for _, id := range taskAssignedIDs {
+			if seen[id] != 1 {
+				t.Errorf("task_assigned conversation %q appeared %d times (expected exactly once)", id, seen[id])
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestE2EListConversationPagination_MultiValueFilters
+// Verifies agent_id and status accept comma-separated lists, combined via IN
+// clauses (agent IN (...) AND status IN (...)), and still page correctly.
+// ---------------------------------------------------------------------------
+
+func TestE2EListConversationPagination_MultiValueFilters(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, agentA, memberID := seedConversationFixture(t, env)
+
+	editorRoleID := projectRoleIDByName(t, env, client, token, projID, "Editor")
+	status, resp := createAgentRequest(t, env, client, token, projID,
+		llmAgentBody(editorRoleID, "conv-pag-agent-c-"+uuid.NewString(), nil))
+	if status != http.StatusCreated {
+		t.Fatalf("create second agent: expected 201, got %d: %+v", status, resp)
+	}
+	data, _ := resp.Data.(map[string]any)
+	agentBIDStr, _ := data["id"].(string)
+	agentB, err := uuid.Parse(agentBIDStr)
+	if err != nil {
+		t.Fatalf("parse second agent id: %v", err)
+	}
+
+	base := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	var wantIDs []string
+	wantIDs = append(wantIDs, createConversationAt(t, env, projID, agentA, memberID, "running", base))
+	wantIDs = append(wantIDs, createConversationAt(t, env, projID, agentB, memberID, "paused", base.Add(time.Minute)))
+	// Noise: right agents wrong status, right status wrong agent, and a third agent entirely.
+	createConversationAt(t, env, projID, agentA, memberID, "finished", base.Add(2*time.Minute))
+	createConversationAt(t, env, projID, agentB, memberID, "finished", base.Add(3*time.Minute))
+
+	q := url.Values{
+		"agent_id":  {agentA.String() + "," + agentB.String()},
+		"status":    {"running,paused"},
+		"page_size": {"10"},
+	}
+	got := itemIDs(listConversationsPage(t, env, client, token, projID, q))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 conversations matching agent IN (A,B) AND status IN (running,paused), got %d: %v", len(got), got)
+	}
+	for _, id := range wantIDs {
+		if !slices.Contains(got, id) {
+			t.Errorf("expected conversation %q in multi-value filtered results, got %v", id, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestE2EListConversationPagination_DateRangeFilter
+// Verifies created_after/created_before filter conversations by created_at,
+// with an inclusive whole-day upper bound (created_before=2026-03-15 must
+// include a conversation created at 23:59:59 that day but exclude one created
+// at 00:00:00 the next day) — see the ::date + INTERVAL '1 day' comparison in
+// ListConversations.
+// ---------------------------------------------------------------------------
+
+func TestE2EListConversationPagination_DateRangeFilter(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+
+	tooEarly := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC))
+	inRangeStart := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC))
+	inRangeEnd := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 15, 23, 59, 59, 0, time.UTC))
+	tooLate := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC))
+
+	got := itemIDs(listConversationsPage(t, env, client, token, projID, url.Values{
+		"created_after":  {"2026-03-11"},
+		"created_before": {"2026-03-15"},
+		"page_size":      {"10"},
+	}))
+
+	if !slices.Contains(got, inRangeStart) || !slices.Contains(got, inRangeEnd) {
+		t.Errorf("expected both boundary-inclusive conversations in range, got %v", got)
+	}
+	if slices.Contains(got, tooEarly) {
+		t.Errorf("expected conversation before created_after to be excluded, got %v", got)
+	}
+	if slices.Contains(got, tooLate) {
+		t.Errorf("expected conversation on the day after created_before to be excluded (whole-day inclusive upper bound), got %v", got)
+	}
+}
+
+// TestE2EListConversationPagination_DateRangeFilterRFC3339 verifies that a
+// full RFC3339 timestamp (as the frontend sends, computed from the user's
+// local calendar day) is used as the exact instant boundary rather than
+// being reinterpreted as a UTC calendar day — see parseCreatedAfterBound/
+// parseCreatedBeforeBound in the handler.
+func TestE2EListConversationPagination_DateRangeFilterRFC3339(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+
+	before := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 15, 7, 59, 59, 0, time.UTC))
+	atBound := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC))
+	after := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Date(2026, 3, 15, 8, 0, 1, 0, time.UTC))
+
+	got := itemIDs(listConversationsPage(t, env, client, token, projID, url.Values{
+		"created_after": {"2026-03-15T08:00:00Z"},
+		"page_size":     {"10"},
+	}))
+
+	if !slices.Contains(got, atBound) || !slices.Contains(got, after) {
+		t.Errorf("expected conversations at/after the exact instant boundary, got %v", got)
+	}
+	if slices.Contains(got, before) {
+		t.Errorf("expected conversation just before the exact instant boundary to be excluded, got %v", got)
+	}
+}
+
+func TestE2EListConversations_InvalidDateFilterRejected(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, _, _ := seedConversationFixture(t, env)
+
+	reqURL := fmt.Sprintf("%s/api/v1/projects/%s/conversations?created_after=not-a-date", env.base, projID)
+	req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusBadRequest)
+	assertErrorCode(t, resp, "BAD_REQUEST")
+}
+
+// ---------------------------------------------------------------------------
+// TestE2EListConversationPagination_SearchFilter
+// Verifies the search filter matches conversations by text extracted from
+// their events' JSONB payloads, and that it composes correctly with cursor
+// pagination (a search matching more than one page of conversations still
+// traverses cleanly with no duplicates/gaps).
+// ---------------------------------------------------------------------------
+
+func TestE2EListConversationPagination_SearchFilter(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+
+	base := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	var loginBugIDs []string
+	for i := 0; i < 3; i++ {
+		id := createConversationAt(t, env, projID, agentID, memberID, "finished", base.Add(time.Duration(i)*time.Minute))
+		createConversationEventWithPayload(t, env, id, 0, "MessageEvent", map[string]any{
+			"content": "please investigate the login bug on the auth page",
+		})
+		loginBugIDs = append(loginBugIDs, id)
+	}
+
+	// Noise: an unrelated conversation whose event text shouldn't match, and
+	// one with no events at all (must not false-positive via a NULL EXISTS).
+	unrelatedID := createConversationAt(t, env, projID, agentID, memberID, "finished", base.Add(10*time.Minute))
+	createConversationEventWithPayload(t, env, unrelatedID, 0, "MessageEvent", map[string]any{
+		"content": "please update the dependency versions in package.json",
+	})
+	createConversationAt(t, env, projID, agentID, memberID, "finished", base.Add(11*time.Minute))
+
+	t.Run("matches_conversations_by_event_text", func(t *testing.T) {
+		got := itemIDs(listConversationsPage(t, env, client, token, projID, url.Values{
+			"search":    {"login bug"},
+			"page_size": {"10"},
+		}))
+		if len(got) != 3 {
+			t.Fatalf("expected 3 conversations matching search, got %d: %v", len(got), got)
+		}
+		for _, id := range loginBugIDs {
+			if !slices.Contains(got, id) {
+				t.Errorf("expected conversation %q in search results", id)
+			}
+		}
+		if slices.Contains(got, unrelatedID) {
+			t.Errorf("expected unrelated conversation to be excluded from search results")
+		}
+	})
+
+	t.Run("full_traversal_with_search_active_has_no_duplicates", func(t *testing.T) {
+		seen := make(map[string]int)
+		cursor := ""
+		for {
+			q := url.Values{"search": {"login"}, "page_size": {"2"}}
+			if cursor != "" {
+				q.Set("cursor", cursor)
+			}
+			data := listConversationsPage(t, env, client, token, projID, q)
+			for _, id := range itemIDs(data) {
+				seen[id]++
+			}
+			cursor = nextCursorStr(data)
+			if cursor == "" {
+				break
+			}
+		}
+		if len(seen) != 3 {
+			t.Errorf("expected 3 unique conversations from full traversal with search active, got %d", len(seen))
+		}
+		for _, id := range loginBugIDs {
+			if seen[id] != 1 {
+				t.Errorf("conversation %q appeared %d times during search traversal (expected exactly once)", id, seen[id])
+			}
+		}
+	})
+
+	t.Run("no_matches_returns_empty_page_and_no_cursor", func(t *testing.T) {
+		data := listConversationsPage(t, env, client, token, projID, url.Values{"search": {"nonexistent-term-xyz"}})
+		items, _ := data["items"].([]any)
+		if len(items) != 0 {
+			t.Errorf("expected 0 items for a search term with no matches, got %d", len(items))
+		}
+		if nextCursorStr(data) != "" {
+			t.Error("expected no next_cursor when search matches nothing")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // TestE2EListConversationEvents_OffsetLimitValidation
 // Mirrors the page_size validation coverage above, applied to this sibling
 // endpoint's offset/limit pair: an explicitly supplied out-of-range or
@@ -448,13 +734,22 @@ func TestE2EListConversationPagination_EmptyProject(t *testing.T) {
 // repository, mirroring how the ai-agent service persists SDK events.
 func createConversationEvent(t *testing.T, env *e2eEnv, convID string, index int, eventType string) {
 	t.Helper()
+	createConversationEventWithPayload(t, env, convID, index, eventType, map[string]any{})
+}
+
+// createConversationEventWithPayload is createConversationEvent with an
+// explicit payload, for tests exercising the search filter (which matches
+// against text extracted from payload — see agent_conversation_event_search_text
+// in migration 000028).
+func createConversationEventWithPayload(t *testing.T, env *e2eEnv, convID string, index int, eventType string, payload map[string]any) {
+	t.Helper()
 	e := &agentdom.AgentConversationEvent{
 		ID:             uuid.New(),
 		ConversationID: uuid.MustParse(convID),
 		EventIndex:     index,
 		EventType:      eventType,
 		EventSource:    "agent",
-		Payload:        map[string]any{},
+		Payload:        payload,
 	}
 	if err := env.agentRepo.CreateConversationEvent(env.ctx, e); err != nil {
 		t.Fatalf("create conversation event: %v", err)


### PR DESCRIPTION
## Summary
- Adds server-side filtering (by agent, status, type/trigger_type, and created-date range) and free-text search to the conversation list, so all narrowing happens in the API and composes correctly with the existing keyset cursor pagination instead of filtering an already-fetched page client-side.
- **Search** matches against conversation *messages*, not just conversation-level fields — migration `000028_add_conversation_search_and_filters.sql` adds `agent_conversation_event_search_text()` (extracts human-readable text from the JSONB `payload` across the different OpenHands SDK event types) plus a GIN `tsvector` expression index on `agent_conversation_events`, and the list query does `EXISTS (... to_tsvector(...) @@ plainto_tsquery(...))` against it. Also adds an index on `(project_id, trigger_type)` for the type filter.
- `ListConversationsFilter` (`internal/domain/agent`) now takes `AgentIDs`/`Statuses`/`TriggerTypes` slices plus `CreatedAfter`/`CreatedBefore`/`Search`; the repository query was rewritten onto the existing `queryBuilder` helper (previously hand-rolled string concatenation) for `IN (...)` clauses, matching `task_repository.go`'s conventions.
- Handler accepts comma-separated `agent_id`/`status`/`trigger_type` (backward compatible with existing single-value callers), plus new `created_after`/`created_before` (validated `YYYY-MM-DD`, 400 on invalid) and `search` params.
- Date-range filtering compares against `created_at` (`TIMESTAMPTZ`) with `>= $1::date` / `< ($2::date + INTERVAL '1 day')` — deliberately not the tasks-style `<=` pattern, since that would silently truncate the upper bound to midnight against a timestamp column.
- Frontend: new `ConversationFilters` component (multi-select dropdowns for agent/status/type, a date-range picker, debounced search input) wired into the conversations page; `conversationsQueryOptions` now keys its infinite query on the full filter object so switching filters starts a fresh paginated fetch. i18n strings added across all 9 locales.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean in `services/api`
- [x] `PACA_E2E=1 go test ./test/e2e/...` — new e2e coverage for trigger-type/date-range/search/multi-value filters, including a full cursor-pagination traversal under an active filter (no duplicates/gaps)
- [x] `tsc -b` and `biome check` clean on `apps/web`
- [x] `vitest run` — 340/340 passing, including new `agent-api.test.ts` coverage for the query-param builder
- [x] Manually verified against a live dev stack with real seeded data: status/agent/type/date-range filters, message-content search, combined filters, and cursor pagination under an active filter all behaved correctly