### PR TITLE
feat: enhance chat functionality

### DIFF
--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -69,6 +69,9 @@ export type ThreadGroupPart = MessagePrimitive.GroupedParts.GroupPart;
 export type ThreadComponents = {
 	AssistantMessage?: ComponentType | undefined;
 	Welcome?: ComponentType | undefined;
+	/** Rendered at the start of the composer's action row (left of the mic/send
+	 * controls) — e.g. an agent picker shown inline while starting a new chat. */
+	ComposerStart?: ComponentType | undefined;
 	ToolFallback?: ToolCallMessagePartComponent | undefined;
 	ToolGroup?:
 		| ComponentType<PropsWithChildren<{ group: ThreadGroupPart }>>
@@ -124,7 +127,7 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
 			>
 				<div
 					className={cn(
-						"mx-auto flex w-full max-w-(--thread-max-width) flex-1 flex-col px-4 pt-4",
+						"mx-auto flex w-full max-w-(--thread-max-width) flex-1 flex-col pl-4 pr-1 pt-4",
 						isEmpty && "justify-center",
 					)}
 				>
@@ -143,7 +146,7 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
 
 					<ThreadPrimitive.ViewportFooter
 						className={cn(
-							"aui-thread-viewport-footer bg-background flex flex-col gap-4 overflow-visible pb-4 md:pb-6",
+							"aui-thread-viewport-footer bg-background flex flex-col overflow-visible pb-4",
 							!isEmpty &&
 								"sticky bottom-0 mt-auto rounded-t-(--composer-radius)",
 						)}
@@ -260,8 +263,10 @@ const Composer: FC = () => {
 
 const ComposerAction: FC = () => {
 	const { t } = useTranslation("projects");
+	const { ComposerStart } = useContext(ThreadComponentsContext);
 	return (
-		<div className="aui-composer-action-wrapper relative flex items-center justify-end">
+		<div className="aui-composer-action-wrapper relative flex items-center justify-between gap-2">
+			{ComposerStart ? <ComposerStart /> : <div />}
 			<div className="flex items-center gap-1.5">
 				<AuiIf condition={(s) => s.thread.capabilities.dictation}>
 					<AuiIf condition={(s) => s.composer.dictation == null}>

--- a/apps/web/src/components/projects/agents/agent-picker.tsx
+++ b/apps/web/src/components/projects/agents/agent-picker.tsx
@@ -1,0 +1,89 @@
+import { Link } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
+import { createContext, useContext } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+// ── Agent picker ──────────────────────────────────────────────────────────────
+//
+// Rendered inline in the composer's action row (`ThreadComponents.ComposerStart`)
+// so picking an agent lives in the same box as the message input and send
+// button — no separate "pick an agent first" step before the composer shows
+// up. `ComposerStart` takes no props, so the picker's data is passed down via
+// this context instead. Shared between the floating chat widget and the
+// Conversations page's inline "new conversation" thread — same UX, same code.
+
+export interface AgentPickerState {
+	agents: { id: string; name: string }[];
+	agentsLoading: boolean;
+	agentId: string;
+	onAgentChange: (id: string) => void;
+	/** Once a conversation has started, the agent is fixed for its lifetime —
+	 * lock the picker instead of implying a switch would do anything. */
+	disabled?: boolean;
+	/** Needed to link to the Agents page when the project has none yet. */
+	projectId: string;
+}
+
+export const AgentPickerContext = createContext<AgentPickerState | null>(null);
+
+export function AgentPickerInline() {
+	const { t } = useTranslation("projects");
+	const picker = useContext(AgentPickerContext);
+	if (!picker) return null;
+	const { agents, agentsLoading, agentId, onAgentChange, disabled, projectId } =
+		picker;
+
+	if (agentsLoading) {
+		return <div className="h-7 w-32 animate-pulse rounded-full bg-muted" />;
+	}
+	if (agents.length === 0) {
+		return (
+			<Button
+				size="sm"
+				variant="outline"
+				className="h-7 gap-1.5 rounded-full text-xs"
+				render={
+					<Link
+						to="/projects/$projectId/agents"
+						params={{ projectId }}
+						search={{ create: true }}
+					/>
+				}
+			>
+				<Plus className="size-3.5" />
+				{t("agents.page.newAgent")}
+			</Button>
+		);
+	}
+
+	return (
+		<Select
+			value={agentId}
+			onValueChange={(v) => v && onAgentChange(v)}
+			items={agents.map((a) => ({ value: a.id, label: a.name }))}
+			disabled={disabled}
+		>
+			<SelectTrigger
+				size="sm"
+				className="h-7 rounded-full border-none bg-transparent pl-2.5 text-xs font-medium text-muted-foreground hover:bg-accent disabled:opacity-100"
+			>
+				<SelectValue placeholder={t("aiChat.selectAgentPlaceholder")} />
+			</SelectTrigger>
+			<SelectContent align="start">
+				{agents.map((agent) => (
+					<SelectItem key={agent.id} value={agent.id}>
+						{agent.name}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/apps/web/src/components/projects/agents/agent-picker.tsx
+++ b/apps/web/src/components/projects/agents/agent-picker.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,6 +11,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { agentsQueryOptions } from "@/lib/agent-api";
 
 // ── Agent picker ──────────────────────────────────────────────────────────────
 //
@@ -34,6 +36,44 @@ export interface AgentPickerState {
 
 export const AgentPickerContext = createContext<AgentPickerState | null>(null);
 
+// Fetches the project's agents and owns the selected-agent state that feeds
+// `AgentPickerState` — shared by the floating chat widget and the
+// Conversations page's inline "new conversation" thread so neither duplicates
+// the query + selection wiring (or the single-agent auto-select behavior
+// below) on its own.
+export function useAgentPicker(
+	projectId: string,
+	options?: { disabled?: boolean },
+) {
+	const { data: agents = [], isLoading: agentsLoading } = useQuery(
+		agentsQueryOptions(projectId),
+	);
+	const [agentId, setAgentId] = useState("");
+
+	// Nothing to actually pick between — auto-select the project's only agent
+	// instead of forcing an explicit choice before the composer will send.
+	useEffect(() => {
+		if (!agentId && agents.length === 1 && agents[0]) {
+			setAgentId(agents[0].id);
+		}
+	}, [agents, agentId]);
+
+	const disabled = options?.disabled;
+	const pickerState = useMemo<AgentPickerState>(
+		() => ({
+			agents,
+			agentsLoading,
+			agentId,
+			onAgentChange: setAgentId,
+			disabled,
+			projectId,
+		}),
+		[agents, agentsLoading, agentId, disabled, projectId],
+	);
+
+	return { agentId, setAgentId, agents, agentsLoading, pickerState };
+}
+
 export function AgentPickerInline() {
 	const { t } = useTranslation("projects");
 	const picker = useContext(AgentPickerContext);
@@ -50,6 +90,7 @@ export function AgentPickerInline() {
 				size="sm"
 				variant="outline"
 				className="h-7 gap-1.5 rounded-full text-xs"
+				nativeButton={false}
 				render={
 					<Link
 						to="/projects/$projectId/agents"

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
@@ -1,5 +1,18 @@
-import type { ThreadMessageLike } from "@assistant-ui/react";
+import type { AppendMessage, ThreadMessageLike } from "@assistant-ui/react";
 import type { AgentConversationEvent } from "@/lib/agent-api";
+
+// Our chat runtimes (conversation-view.tsx / ai-chat-float.tsx / the
+// Conversations page's new-conversation composer) only ever send a single
+// text part — there's no attachment UI wired up to any of them (see
+// thread.tsx's Composer comment) — so reject anything else instead of
+// silently dropping it. Returns null rather than throwing so each call site
+// can raise its own translated error message.
+export function extractTextOnlyContent(message: AppendMessage): string | null {
+	if (message.content.length !== 1 || message.content[0]?.type !== "text") {
+		return null;
+	}
+	return message.content[0].text;
+}
 
 // Extract plain text from a content block array [{type:"text", text:"..."}] or a bare string.
 export function extractContentText(content: unknown): string | null {

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -31,7 +31,10 @@ import {
 	stopConversation,
 } from "@/lib/agent-api";
 import { cn } from "@/lib/utils";
-import { eventsToThreadMessages } from "./conversation-to-thread-messages";
+import {
+	eventsToThreadMessages,
+	extractTextOnlyContent,
+} from "./conversation-to-thread-messages";
 
 // ── Controls ──────────────────────────────────────────────────────────────────
 
@@ -152,14 +155,15 @@ export function ConversationView({
 		if (!conversation?.chat_session_id) {
 			throw new Error(t("agents.conversationView.conversationEnded"));
 		}
-		if (message.content.length !== 1 || message.content[0]?.type !== "text") {
+		const text = extractTextOnlyContent(message);
+		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
 		const result = await sendChatMessage(
 			projectId,
 			conversation.agent_id,
 			conversation.chat_session_id,
-			{ message: message.content[0].text },
+			{ message: text },
 		);
 		// The previous conversation may have already ended (explicitly
 		// stopped, or reaped after 3 minutes with no heartbeat) — replying

--- a/apps/web/src/components/projects/ai-chat-float.tsx
+++ b/apps/web/src/components/projects/ai-chat-float.tsx
@@ -11,12 +11,11 @@ import { Thread } from "@/components/assistant-ui/thread";
 import {
 	AgentPickerContext,
 	AgentPickerInline,
-	type AgentPickerState,
+	useAgentPicker,
 } from "@/components/projects/agents/agent-picker";
 import { Button } from "@/components/ui/button";
 import {
 	type AgentConversation,
-	agentsQueryOptions,
 	CONVERSATION_HEARTBEAT_INTERVAL_MS,
 	conversationEventsQueryOptions,
 	conversationQueryOptions,
@@ -27,7 +26,10 @@ import {
 	stopConversation,
 } from "@/lib/agent-api";
 import { cn } from "@/lib/utils";
-import { eventsToThreadMessages } from "./agents/conversation-to-thread-messages";
+import {
+	eventsToThreadMessages,
+	extractTextOnlyContent,
+} from "./agents/conversation-to-thread-messages";
 
 interface AIChatFloatProps {
 	projectId: string;
@@ -76,13 +78,15 @@ function FloatingChatFailedBanner({
 export function AIChatFloat({ projectId }: AIChatFloatProps) {
 	const { t } = useTranslation("projects");
 	const [open, setOpen] = useState(false);
-	const [agentId, setAgentId] = useState("");
 	const [conversationId, setConversationId] = useState<string | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const qc = useQueryClient();
 
-	const { data: agents = [], isLoading: agentsLoading } = useQuery(
-		agentsQueryOptions(projectId),
-	);
+	// Locked once a conversation exists — the agent is fixed for its
+	// lifetime; switching it here would silently do nothing useful.
+	const { agentId, pickerState } = useAgentPicker(projectId, {
+		disabled: !!conversationId,
+	});
 
 	const { data: conversation } = useQuery({
 		...conversationQueryOptions(projectId, conversationId ?? ""),
@@ -117,51 +121,58 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 	};
 
 	const onNew = async (message: AppendMessage) => {
-		if (message.content.length !== 1 || message.content[0]?.type !== "text") {
+		const text = extractTextOnlyContent(message);
+		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
-		const text = message.content[0].text;
 
-		if (!conversationId) {
-			if (!agentId) throw new Error(t("aiChat.selectAgentFirst"));
-			const result = await startChatSession(projectId, agentId, {
-				message: text,
-			});
-			// Seed the cache before flipping conversationId so the Thread
-			// doesn't flash a "can't reply" state while the query resolves.
-			qc.setQueryData(
-				conversationQueryOptions(projectId, result.conversation.id).queryKey,
-				result.conversation,
-			);
-			setConversationId(result.conversation.id);
-			void qc.invalidateQueries({
-				queryKey: ["projects", projectId, "conversations"],
-			});
-			return;
-		}
+		// Guards against a fast double-Enter firing two requests (e.g. two
+		// chat sessions) before the first one resolves and flips isRunning.
+		setIsSubmitting(true);
+		try {
+			if (!conversationId) {
+				if (!agentId) throw new Error(t("aiChat.selectAgentFirst"));
+				const result = await startChatSession(projectId, agentId, {
+					message: text,
+				});
+				// Seed the cache before flipping conversationId so the Thread
+				// doesn't flash a "can't reply" state while the query resolves.
+				qc.setQueryData(
+					conversationQueryOptions(projectId, result.conversation.id).queryKey,
+					result.conversation,
+				);
+				setConversationId(result.conversation.id);
+				void qc.invalidateQueries({
+					queryKey: ["projects", projectId, "conversations"],
+				});
+				return;
+			}
 
-		if (!conversation?.chat_session_id) {
-			throw new Error(t("agents.conversationView.conversationEnded"));
-		}
-		const result = await sendChatMessage(
-			projectId,
-			conversation.agent_id,
-			conversation.chat_session_id,
-			{ message: text },
-		);
-		// The previous conversation may have already ended (explicitly
-		// stopped, or reaped after 3 minutes with no heartbeat) — replying
-		// then silently starts a fresh conversation server-side. Follow it,
-		// otherwise the UI keeps polling the old (now terminal) conversation
-		// and the reply appears to vanish.
-		if (result.id !== conversationId) {
-			qc.setQueryData(
-				conversationQueryOptions(projectId, result.id).queryKey,
-				result,
+			if (!conversation?.chat_session_id) {
+				throw new Error(t("agents.conversationView.conversationEnded"));
+			}
+			const result = await sendChatMessage(
+				projectId,
+				conversation.agent_id,
+				conversation.chat_session_id,
+				{ message: text },
 			);
-			setConversationId(result.id);
+			// The previous conversation may have already ended (explicitly
+			// stopped, or reaped after 3 minutes with no heartbeat) — replying
+			// then silently starts a fresh conversation server-side. Follow it,
+			// otherwise the UI keeps polling the old (now terminal) conversation
+			// and the reply appears to vanish.
+			if (result.id !== conversationId) {
+				qc.setQueryData(
+					conversationQueryOptions(projectId, result.id).queryKey,
+					result,
+				);
+				setConversationId(result.id);
+			}
+			invalidate(result.id);
+		} finally {
+			setIsSubmitting(false);
 		}
-		invalidate(result.id);
 	};
 
 	const onCancel = async () => {
@@ -182,7 +193,7 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		onNew,
 		onCancel,
 		isDisabled: !canReply || isTerminal,
-		isSendDisabled: !conversationId && !agentId,
+		isSendDisabled: (!conversationId && !agentId) || isSubmitting,
 	});
 
 	// Chat sandboxes are kept alive between replies (see conversation-view's
@@ -230,20 +241,6 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		}, CONVERSATION_HEARTBEAT_INTERVAL_MS);
 		return () => clearInterval(interval);
 	}, [conversationId, isTerminal, projectId]);
-
-	const pickerState = useMemo<AgentPickerState>(
-		() => ({
-			agents,
-			agentsLoading,
-			agentId,
-			onAgentChange: setAgentId,
-			// Locked once a conversation exists — the agent is fixed for its
-			// lifetime; switching it here would silently do nothing useful.
-			disabled: !!conversationId,
-			projectId,
-		}),
-		[agents, agentsLoading, agentId, conversationId, projectId],
-	);
 
 	return (
 		<>

--- a/apps/web/src/components/projects/ai-chat-float.tsx
+++ b/apps/web/src/components/projects/ai-chat-float.tsx
@@ -5,17 +5,15 @@ import {
 } from "@assistant-ui/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Bot, Plus, X } from "lucide-react";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Thread } from "@/components/assistant-ui/thread";
-import { Button } from "@/components/ui/button";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
+	AgentPickerContext,
+	AgentPickerInline,
+	type AgentPickerState,
+} from "@/components/projects/agents/agent-picker";
+import { Button } from "@/components/ui/button";
 import {
 	type AgentConversation,
 	agentsQueryOptions,
@@ -35,63 +33,13 @@ interface AIChatFloatProps {
 	projectId: string;
 }
 
-// ── Agent picker ──────────────────────────────────────────────────────────────
-//
-// Shown in Thread's empty-state Welcome slot so picking an agent is the first
-// thing the user sees. `ThreadComponents.Welcome` takes no props, so the
-// picker's data is passed down via this small context instead.
-
-interface AgentPickerState {
-	agents: { id: string; name: string }[];
-	agentsLoading: boolean;
-	agentId: string;
-	onAgentChange: (id: string) => void;
-}
-
-const AgentPickerContext = createContext<AgentPickerState | null>(null);
-
-function FloatingChatWelcome() {
-	const { t } = useTranslation("projects");
-	const picker = useContext(AgentPickerContext);
-	if (!picker) return null;
-	const { agents, agentsLoading, agentId, onAgentChange } = picker;
-
-	return (
-		<div className="mb-4 flex flex-col items-center gap-3">
-			<div className="w-full space-y-1.5 text-left">
-				<p className="text-xs font-medium text-muted-foreground">
-					{t("aiChat.agentLabel")}
-				</p>
-				{agentsLoading ? (
-					<div className="h-9 animate-pulse rounded-md bg-muted" />
-				) : agents.length === 0 ? (
-					<p className="text-xs text-muted-foreground">
-						{t("aiChat.noAgentsConfigured")}
-					</p>
-				) : (
-					<Select
-						value={agentId}
-						onValueChange={(v) => v && onAgentChange(v)}
-						items={agents.map((a) => ({ value: a.id, label: a.name }))}
-					>
-						<SelectTrigger className="h-9 text-sm">
-							<SelectValue placeholder={t("aiChat.selectAgentPlaceholder")} />
-						</SelectTrigger>
-						<SelectContent>
-							{agents.map((agent) => (
-								<SelectItem key={agent.id} value={agent.id}>
-									{agent.name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				)}
-			</div>
-		</div>
-	);
-}
-
-const THREAD_COMPONENTS = { Welcome: FloatingChatWelcome };
+// Floating chatbox is a compact overlay — no room for (and no need for) the
+// full-page welcome heading, so suppress it here; the conversation page's
+// blank composer still shows it via Thread's default.
+const THREAD_COMPONENTS = {
+	ComposerStart: AgentPickerInline,
+	Welcome: () => null,
+};
 
 // ── Failed conversation banner ────────────────────────────────────────────────
 
@@ -284,8 +232,17 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 	}, [conversationId, isTerminal, projectId]);
 
 	const pickerState = useMemo<AgentPickerState>(
-		() => ({ agents, agentsLoading, agentId, onAgentChange: setAgentId }),
-		[agents, agentsLoading, agentId],
+		() => ({
+			agents,
+			agentsLoading,
+			agentId,
+			onAgentChange: setAgentId,
+			// Locked once a conversation exists — the agent is fixed for its
+			// lifetime; switching it here would silently do nothing useful.
+			disabled: !!conversationId,
+			projectId,
+		}),
+		[agents, agentsLoading, agentId, conversationId, projectId],
 	);
 
 	return (

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "Chat with AI Agent",
 		"newConversation": "New conversation",
 		"agentLabel": "Agent",
-		"noAgentsConfigured": "No agents configured for this project.",
 		"selectAgentPlaceholder": "Select an agent…",
 		"selectAgentFirst": "Please select an agent first."
 	},

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "Chatear con agente de IA",
 		"newConversation": "Nueva conversación",
 		"agentLabel": "Agente",
-		"noAgentsConfigured": "No hay agentes configurados para este proyecto.",
 		"selectAgentPlaceholder": "Selecciona un agente…",
 		"selectAgentFirst": "Selecciona primero un agente."
 	},

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "Discuter avec l'agent IA",
 		"newConversation": "Nouvelle conversation",
 		"agentLabel": "Agent",
-		"noAgentsConfigured": "Aucun agent configuré pour ce projet.",
 		"selectAgentPlaceholder": "Sélectionner un agent…",
 		"selectAgentFirst": "Veuillez d'abord sélectionner un agent."
 	},

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "AIエージェントとチャット",
 		"newConversation": "新しい会話",
 		"agentLabel": "エージェント",
-		"noAgentsConfigured": "このプロジェクトにはエージェントが設定されていません。",
 		"selectAgentPlaceholder": "エージェントを選択…",
 		"selectAgentFirst": "まずエージェントを選択してください。"
 	},

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "AI 에이전트와 채팅",
 		"newConversation": "새 대화",
 		"agentLabel": "에이전트",
-		"noAgentsConfigured": "이 프로젝트에 구성된 에이전트가 없습니다.",
 		"selectAgentPlaceholder": "에이전트를 선택하세요…",
 		"selectAgentFirst": "먼저 에이전트를 선택해 주세요."
 	},

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "Conversar com o agente de IA",
 		"newConversation": "Nova conversa",
 		"agentLabel": "Agente",
-		"noAgentsConfigured": "Nenhum agente configurado para este projeto.",
 		"selectAgentPlaceholder": "Selecione um agente…",
 		"selectAgentFirst": "Selecione um agente primeiro."
 	},

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -675,7 +675,6 @@
 		"chatWithAgent": "Чат с AI-агентом",
 		"newConversation": "Новый диалог",
 		"agentLabel": "Агент",
-		"noAgentsConfigured": "Для этого проекта агенты не настроены.",
 		"selectAgentPlaceholder": "Выберите агента…",
 		"selectAgentFirst": "Сначала выберите агента."
 	},

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "Trò chuyện với AI Agent",
 		"newConversation": "Hội thoại mới",
 		"agentLabel": "Agent",
-		"noAgentsConfigured": "Chưa có agent nào được cấu hình cho dự án này.",
 		"selectAgentPlaceholder": "Chọn một agent…",
 		"selectAgentFirst": "Vui lòng chọn một agent trước."
 	},

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -661,7 +661,6 @@
 		"chatWithAgent": "与 AI 智能体聊天",
 		"newConversation": "新建对话",
 		"agentLabel": "智能体",
-		"noAgentsConfigured": "此项目尚未配置智能体。",
 		"selectAgentPlaceholder": "选择一个智能体…",
 		"selectAgentFirst": "请先选择一个智能体。"
 	},

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -257,26 +257,6 @@ body::after {
 	content: none; /* dot grid removed — pure surfaces only */
 }
 
-a {
-	color: var(--lagoon);
-	text-decoration-color: rgba(94, 143, 24, 0.35);
-	text-decoration-thickness: 1px;
-	text-underline-offset: 2px;
-}
-
-a:hover {
-	color: var(--lagoon-deep);
-}
-
-.dark a {
-	color: var(--lagoon);
-	text-decoration-color: rgba(158, 217, 87, 0.35);
-}
-
-.dark a:hover {
-	color: var(--lagoon-deep);
-}
-
 code {
 	font-size: 0.9em;
 	border: 1px solid var(--line);
@@ -437,6 +417,26 @@ a {
 	body {
 		background-color: var(--background);
 		color: var(--foreground);
+	}
+	/* Default anchor color — scoped to this layer so Tailwind utility classes
+	 * (e.g. `text-primary-foreground` on a Button rendered as a Link) still
+	 * win per cascade-layer order, instead of this unconditionally
+	 * overriding them. */
+	a {
+		color: var(--lagoon);
+		text-decoration-color: rgba(94, 143, 24, 0.35);
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+	a:hover {
+		color: var(--lagoon-deep);
+	}
+	.dark a {
+		color: var(--lagoon);
+		text-decoration-color: rgba(158, 217, 87, 0.35);
+	}
+	.dark a:hover {
+		color: var(--lagoon-deep);
 	}
 	/* BlockNote shadcn integration — required border styles */
 	.bn-shadcn * {

--- a/apps/web/src/routes/_authenticated/projects/$projectId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId.tsx
@@ -1,5 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import {
+	createFileRoute,
+	Outlet,
+	redirect,
+	useMatches,
+} from "@tanstack/react-router";
 import { AlertCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -28,6 +33,16 @@ function ProjectLayout() {
 	// leaves / cleans up on unmount (i.e. when navigating away from the project).
 	useProjectRealtime(projectId);
 
+	// The Conversations page has its own dedicated "New conversation" entry
+	// point in its header, so the floating chat launcher would just be a
+	// redundant second way to start a chat there — hide it on that page (and
+	// its nested conversation routes) while keeping it available everywhere
+	// else in the project.
+	const matches = useMatches();
+	const onConversationsPage = matches.some((m) =>
+		m.routeId.startsWith("/_authenticated/projects/$projectId/conversations"),
+	);
+
 	if (isError || !project) {
 		return (
 			<div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-muted-foreground">
@@ -40,7 +55,7 @@ function ProjectLayout() {
 	return (
 		<>
 			<Outlet />
-			<AIChatFloat projectId={projectId} />
+			{!onConversationsPage && <AIChatFloat projectId={projectId} />}
 		</>
 	);
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
@@ -81,6 +81,9 @@ const CUSTOM = "__custom__";
 export const Route = createFileRoute(
 	"/_authenticated/projects/$projectId/agents/",
 )({
+	validateSearch: (search: Record<string, unknown>) => ({
+		create: search.create === true || search.create === "true",
+	}),
 	loader: async ({ context: { queryClient }, params: { projectId } }) => {
 		await Promise.all([
 			queryClient.ensureQueryData(agentsQueryOptions(projectId)),
@@ -1014,6 +1017,7 @@ function AgentCard({
 function AgentsPage() {
 	const { t } = useTranslation("projects");
 	const { projectId } = Route.useParams();
+	const { create } = Route.useSearch();
 	const { hasProjectPermission } = useProjectPermissions(projectId);
 	const canWrite = hasProjectPermission("agents.write");
 
@@ -1021,7 +1025,7 @@ function AgentsPage() {
 	const { data: agents = [], isLoading } = useQuery(
 		agentsQueryOptions(projectId),
 	);
-	const [createOpen, setCreateOpen] = useState(false);
+	const [createOpen, setCreateOpen] = useState(create);
 	const [acpSetupAgent, setAcpSetupAgent] = useState<Agent | null>(null);
 	const [acpSetupToken, setAcpSetupToken] = useState<AcpBridgeToken | null>(
 		null,

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
@@ -1018,6 +1018,7 @@ function AgentsPage() {
 	const { t } = useTranslation("projects");
 	const { projectId } = Route.useParams();
 	const { create } = Route.useSearch();
+	const navigate = Route.useNavigate();
 	const { hasProjectPermission } = useProjectPermissions(projectId);
 	const canWrite = hasProjectPermission("agents.write");
 
@@ -1030,6 +1031,20 @@ function AgentsPage() {
 	const [acpSetupToken, setAcpSetupToken] = useState<AcpBridgeToken | null>(
 		null,
 	);
+
+	// `?create=true` (from the agent picker's "no agents yet" empty state)
+	// only needs to open the dialog once — leaving it in the URL would
+	// reopen the dialog on every refresh/back-navigation after the user
+	// closes it, so strip it once the dialog's opened state is consumed.
+	function handleCreateOpenChange(nextOpen: boolean) {
+		setCreateOpen(nextOpen);
+		if (!nextOpen && create) {
+			navigate({
+				search: (prev) => ({ ...prev, create: false }),
+				replace: true,
+			});
+		}
+	}
 
 	return (
 		<div className="flex flex-col">
@@ -1113,7 +1128,7 @@ function AgentsPage() {
 			<CreateAgentDialog
 				projectId={projectId}
 				open={createOpen}
-				onOpenChange={setCreateOpen}
+				onOpenChange={handleCreateOpenChange}
 				onAcpAgentCreated={(agent, token) => {
 					setAcpSetupAgent(agent);
 					setAcpSetupToken(token);

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
@@ -5,12 +5,13 @@ import {
 	Outlet,
 	useParams,
 } from "@tanstack/react-router";
-import { Clock, MessageSquare, Zap } from "lucide-react";
+import { Clock, MessageSquare, Plus, Zap } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConversationFilters } from "@/components/projects/agents/conversation-filters";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useProjectRealtime } from "@/hooks/use-project-realtime";
 import {
@@ -166,10 +167,23 @@ function ConversationsLayout() {
 	return (
 		<div className="flex flex-1 min-h-0">
 			<div className="w-80 shrink-0 border-r border-border/50 flex flex-col min-h-0">
-				<div className="shrink-0 border-b border-border/50 px-4 py-3">
+				<div className="shrink-0 border-b border-border/50 px-4 py-3 flex items-center justify-between gap-2">
 					<h2 className="text-sm font-semibold">
 						{t("conversationsPage.title")}
 					</h2>
+					<Button
+						size="sm"
+						className="gap-1.5"
+						render={
+							<Link
+								to="/projects/$projectId/conversations"
+								params={{ projectId }}
+							/>
+						}
+					>
+						<Plus className="size-3.5" />
+						{t("aiChat.newConversation")}
+					</Button>
 				</div>
 				<ConversationFilters
 					agents={agents}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations.tsx
@@ -174,6 +174,7 @@ function ConversationsLayout() {
 					<Button
 						size="sm"
 						className="gap-1.5"
+						nativeButton={false}
 						render={
 							<Link
 								to="/projects/$projectId/conversations"

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
@@ -1,58 +1,97 @@
-import type { InfiniteData } from "@tanstack/react-query";
-import { createFileRoute, redirect } from "@tanstack/react-router";
-import { MessageSquare } from "lucide-react";
-import { useTranslation } from "react-i18next";
+import type { ThreadMessageLike } from "@assistant-ui/react";
 import {
-	type ConversationListResult,
-	conversationsQueryOptions,
+	type AppendMessage,
+	AssistantRuntimeProvider,
+	useExternalStoreRuntime,
+} from "@assistant-ui/react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Thread } from "@/components/assistant-ui/thread";
+import {
+	AgentPickerContext,
+	AgentPickerInline,
+	type AgentPickerState,
+} from "@/components/projects/agents/agent-picker";
+import {
+	agentsQueryOptions,
+	conversationQueryOptions,
+	startChatSession,
 } from "@/lib/agent-api";
 
 export const Route = createFileRoute(
 	"/_authenticated/projects/$projectId/conversations/",
 )({
-	// The parent `conversations` layout route's loader already populated the
-	// conversations list in the query cache, so this can read it synchronously
-	// instead of refetching — landing directly on the most recently created
-	// conversation instead of showing a bare "pick one" screen. The list's
-	// first page is ordered newest-first, so its first item is the latest
-	// conversation without needing to scan every loaded page.
-	//
-	// `preload` is true when this loader runs speculatively (e.g. the sidebar
-	// nav Link's hover-intent preload, since the router defaults to
-	// `defaultPreload: "intent"`) rather than for a real navigation — must not
-	// redirect in that case, or merely hovering the nav item silently
-	// navigates the page away from wherever the user actually is.
-	loader: ({ context: { queryClient }, params: { projectId }, preload }) => {
-		if (preload) return;
-
-		const data = queryClient.getQueryData<InfiniteData<ConversationListResult>>(
-			conversationsQueryOptions(projectId).queryKey,
-		);
-		const latest = data?.pages[0]?.items[0];
-		if (!latest) return;
-
-		throw redirect({
-			to: "/projects/$projectId/conversations/$conversationId",
-			params: { projectId, conversationId: latest.id },
-			replace: true,
-		});
-	},
-	component: EmptyConversationState,
+	component: NewConversationThread,
 });
 
-function EmptyConversationState() {
+// No conversation is selected — landing on `/conversations` directly (via the
+// sidebar nav item or the "New conversation" button) always shows this blank
+// composer, never an existing conversation. Render a live assistant-ui
+// Thread with the agent picker docked in the composer itself
+// (`ComposerStart`) — same box as the message input, no separate step
+// before you can type. Same component used by the floating chat widget.
+function NewConversationThread() {
 	const { t } = useTranslation("projects");
+	const { projectId } = Route.useParams();
+	const qc = useQueryClient();
+	const navigate = useNavigate();
+
+	const [agentId, setAgentId] = useState("");
+	const { data: agents = [], isLoading: agentsLoading } = useQuery(
+		agentsQueryOptions(projectId),
+	);
+
+	const onNew = async (message: AppendMessage) => {
+		if (!agentId) throw new Error(t("aiChat.selectAgentFirst"));
+		if (message.content.length !== 1 || message.content[0]?.type !== "text") {
+			throw new Error(t("agents.conversationView.textOnlyMessage"));
+		}
+		const text = message.content[0].text;
+
+		const result = await startChatSession(projectId, agentId, {
+			message: text,
+		});
+		qc.setQueryData(
+			conversationQueryOptions(projectId, result.conversation.id).queryKey,
+			result.conversation,
+		);
+		void qc.invalidateQueries({
+			queryKey: ["projects", projectId, "conversations"],
+		});
+		navigate({
+			to: "/projects/$projectId/conversations/$conversationId",
+			params: { projectId, conversationId: result.conversation.id },
+		});
+	};
+
+	const messages: ThreadMessageLike[] = [];
+
+	const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+		messages,
+		isRunning: false,
+		convertMessage: (m) => m,
+		onNew,
+		isSendDisabled: !agentId,
+	});
+
+	const pickerState = useMemo<AgentPickerState>(
+		() => ({
+			agents,
+			agentsLoading,
+			agentId,
+			onAgentChange: setAgentId,
+			projectId,
+		}),
+		[agents, agentsLoading, agentId, projectId],
+	);
+
 	return (
-		<div className="flex flex-col h-full items-center justify-center gap-3 text-center px-6">
-			<MessageSquare className="size-10 text-muted-foreground/40" />
-			<div>
-				<p className="text-sm font-medium">
-					{t("conversationsPage.detail.empty.title")}
-				</p>
-				<p className="text-xs text-muted-foreground mt-1 max-w-xs">
-					{t("conversationsPage.detail.empty.description")}
-				</p>
-			</div>
-		</div>
+		<AgentPickerContext.Provider value={pickerState}>
+			<AssistantRuntimeProvider runtime={runtime}>
+				<Thread components={{ ComposerStart: AgentPickerInline }} />
+			</AssistantRuntimeProvider>
+		</AgentPickerContext.Provider>
 	);
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/index.tsx
@@ -4,21 +4,18 @@ import {
 	AssistantRuntimeProvider,
 	useExternalStoreRuntime,
 } from "@assistant-ui/react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Thread } from "@/components/assistant-ui/thread";
 import {
 	AgentPickerContext,
 	AgentPickerInline,
-	type AgentPickerState,
+	useAgentPicker,
 } from "@/components/projects/agents/agent-picker";
-import {
-	agentsQueryOptions,
-	conversationQueryOptions,
-	startChatSession,
-} from "@/lib/agent-api";
+import { extractTextOnlyContent } from "@/components/projects/agents/conversation-to-thread-messages";
+import { conversationQueryOptions, startChatSession } from "@/lib/agent-api";
 
 export const Route = createFileRoute(
 	"/_authenticated/projects/$projectId/conversations/",
@@ -38,32 +35,37 @@ function NewConversationThread() {
 	const qc = useQueryClient();
 	const navigate = useNavigate();
 
-	const [agentId, setAgentId] = useState("");
-	const { data: agents = [], isLoading: agentsLoading } = useQuery(
-		agentsQueryOptions(projectId),
-	);
+	const { agentId, pickerState } = useAgentPicker(projectId);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const onNew = async (message: AppendMessage) => {
 		if (!agentId) throw new Error(t("aiChat.selectAgentFirst"));
-		if (message.content.length !== 1 || message.content[0]?.type !== "text") {
+		const text = extractTextOnlyContent(message);
+		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
-		const text = message.content[0].text;
 
-		const result = await startChatSession(projectId, agentId, {
-			message: text,
-		});
-		qc.setQueryData(
-			conversationQueryOptions(projectId, result.conversation.id).queryKey,
-			result.conversation,
-		);
-		void qc.invalidateQueries({
-			queryKey: ["projects", projectId, "conversations"],
-		});
-		navigate({
-			to: "/projects/$projectId/conversations/$conversationId",
-			params: { projectId, conversationId: result.conversation.id },
-		});
+		// Guards against a fast double-Enter firing two chat sessions before
+		// the first request resolves and this component navigates away.
+		setIsSubmitting(true);
+		try {
+			const result = await startChatSession(projectId, agentId, {
+				message: text,
+			});
+			qc.setQueryData(
+				conversationQueryOptions(projectId, result.conversation.id).queryKey,
+				result.conversation,
+			);
+			void qc.invalidateQueries({
+				queryKey: ["projects", projectId, "conversations"],
+			});
+			navigate({
+				to: "/projects/$projectId/conversations/$conversationId",
+				params: { projectId, conversationId: result.conversation.id },
+			});
+		} finally {
+			setIsSubmitting(false);
+		}
 	};
 
 	const messages: ThreadMessageLike[] = [];
@@ -73,19 +75,8 @@ function NewConversationThread() {
 		isRunning: false,
 		convertMessage: (m) => m,
 		onNew,
-		isSendDisabled: !agentId,
+		isSendDisabled: !agentId || isSubmitting,
 	});
-
-	const pickerState = useMemo<AgentPickerState>(
-		() => ({
-			agents,
-			agentsLoading,
-			agentId,
-			onAgentChange: setAgentId,
-			projectId,
-		}),
-		[agents, agentsLoading, agentId, projectId],
-	);
 
 	return (
 		<AgentPickerContext.Provider value={pickerState}>


### PR DESCRIPTION
## Summary

Reworks how users start a chat with an agent, moving agent selection into the composer itself instead of a separate step, and adds a dedicated "new conversation" thread on the Conversations page.

- Adds a shared `AgentPickerInline` component (`agent-picker.tsx`) rendered via a new `ComposerStart` slot in the assistant-ui `Thread`, docking the agent picker into the composer's action row next to the send/mic controls.
- Reworks the Conversations page: `/conversations` (no id selected) now renders a live, empty `Thread` with the agent picker inline, so a message can be sent directly to start a new conversation — replacing the old behavior of auto-redirecting to the most recent conversation or showing a static empty state.
- Adds a "New conversation" button to the Conversations sidebar header, and hides the floating chat launcher (`AIChatFloat`) on the Conversations page/routes since it now has its own entry point.
- Locks the agent picker once a conversation has started (`disabled` state), since switching agents mid-conversation has no effect.
- Supports deep-linking into agent creation via `?create=true` on the Agents page (used by the picker's "no agents yet" empty state).
- Removes the now-unused `noAgentsConfigured` i18n string across all locales.
- Minor CSS fix: scopes the default anchor color rule into a layer so Tailwind utility classes on `Link`-rendered buttons still take precedence.

## Test plan

- [ ] Open a project, use the floating chat launcher, verify agent picker works inline and locks once a conversation starts
- [ ] Navigate to the Conversations page, verify the floating launcher is hidden and "New conversation" starts a fresh composer
- [ ] Send a message from the new empty composer, verify it creates a conversation and navigates to it
- [ ] From the Agents page empty state in the picker, verify "New agent" link opens the create dialog via `?create=true`
- [ ] Spot-check translated locale files still parse correctly
