### PR TITLE
feat: implement ACP conversation handling to allow resuming from terminal states

### DIFF
--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -29,6 +29,7 @@ import {
 	heartbeatConversation,
 	pauseConversation,
 	sendChatMessage,
+	sendConversationMessage,
 	stopConversation,
 } from "@/lib/agent-api";
 import { cn } from "@/lib/utils";
@@ -42,9 +43,11 @@ import {
 function ConversationControls({
 	projectId,
 	conversation,
+	isACP,
 }: {
 	projectId: string;
 	conversation: AgentConversation;
+	isACP: boolean;
 }) {
 	const { t } = useTranslation("projects");
 	const qc = useQueryClient();
@@ -69,11 +72,16 @@ function ConversationControls({
 	// otherwise have no way to stop a running conversation at all. Show this
 	// control for every non-terminal status (queued, running, paused) so a
 	// stop action is always available, regardless of trigger type.
+	//
+	// ACP is the exception: its composer is now shown for every trigger type
+	// (see canReply below), so the composer's own Cancel/pause button is
+	// always reachable there — this header Stop button (a full teardown,
+	// distinct from pause) would just be redundant.
 	const isTerminal =
 		conversation.status === "finished" ||
 		conversation.status === "failed" ||
 		conversation.status === "stopped";
-	if (isTerminal) return null;
+	if (isTerminal || isACP) return null;
 
 	return (
 		<div className="flex items-center gap-2">
@@ -139,16 +147,18 @@ export function ConversationView({
 		conversation?.status === "finished" ||
 		conversation?.status === "failed" ||
 		conversation?.status === "stopped";
-	// ACP conversations never really end server-side — the user's local
-	// bridge daemon keeps the underlying conversation alive in memory (see
-	// SendChatMessage's ACP resume path in services/api), so a reply can
-	// always continue the same conversation_id regardless of status. LLM
-	// conversations still need a fresh conversation once terminal (handled
+	const isChatMessage = conversation?.trigger_type === "chat_message";
+	// ACP conversations stay replyable for every trigger type (task_assigned,
+	// comment_mention, etc.), not just chat_message ones — the user's local
+	// bridge daemon keeps a conversation alive by conversation_id regardless
+	// of why it started, and regardless of status (see
+	// SendConversationMessage's ACP branch in services/api), so a reply can
+	// always continue it. LLM conversations are unchanged: only chat_message
+	// ones with a live session, and never once terminal (handled
 	// transparently by onNew below via the returned conversation id).
-	const canReply =
-		conversation?.trigger_type === "chat_message" &&
-		!!conversation.chat_session_id &&
-		(!isTerminal || isACP);
+	const canReply = isACP
+		? !isChatMessage || !!conversation?.chat_session_id
+		: isChatMessage && !!conversation?.chat_session_id && !isTerminal;
 
 	const messages = useMemo(
 		() => eventsToThreadMessages(events, isRunning),
@@ -165,13 +175,23 @@ export function ConversationView({
 	};
 
 	const onNew = async (message: AppendMessage) => {
-		if (!conversation?.chat_session_id) {
+		if (!conversation) {
 			throw new Error(t("agents.conversationView.conversationEnded"));
 		}
 		const text = extractTextOnlyContent(message);
 		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
+
+		if (!conversation.chat_session_id) {
+			// ACP conversation of a non-chat trigger type (task_assigned,
+			// comment_mention, etc.) — reply in place on the same
+			// conversation_id rather than through a chat session.
+			await sendConversationMessage(projectId, conversation.id, text);
+			invalidate();
+			return;
+		}
+
 		const result = await sendChatMessage(
 			projectId,
 			conversation.agent_id,
@@ -259,9 +279,9 @@ export function ConversationView({
 	// no visible messages. When messages exist, render the Thread normally so
 	// the user can trace what happened before the failure — the header's
 	// status badge and the bottom error footer already convey the failure.
-	// Skipped when canReply is true (an ACP chat conversation, which stays
-	// replyable straight through a failure) so the user can retry instead of
-	// hitting a dead end.
+	// Skipped when canReply is true (an ACP conversation, which stays
+	// replyable straight through a failure regardless of trigger type) so
+	// the user can retry instead of hitting a dead end.
 	if (
 		isError ||
 		(conversation.status === "failed" && messages.length === 0 && !canReply)
@@ -327,6 +347,7 @@ export function ConversationView({
 					<ConversationControls
 						projectId={projectId}
 						conversation={conversation}
+						isACP={isACP}
 					/>
 				</div>
 			</div>

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
 	type AgentConversation,
+	agentQueryOptions,
 	CONVERSATION_HEARTBEAT_INTERVAL_MS,
 	CONVERSATION_STATUS_COLORS,
 	CONVERSATION_STATUS_LABELS,
@@ -126,6 +127,11 @@ export function ConversationView({
 	const { data: events = [], isLoading: eventsLoading } = useQuery(
 		conversationEventsQueryOptions(projectId, conversationId),
 	);
+	const { data: agent } = useQuery({
+		...agentQueryOptions(projectId, conversation?.agent_id ?? ""),
+		enabled: !!conversation?.agent_id,
+	});
+	const isACP = agent?.agent_type === "acp";
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";
@@ -133,9 +139,16 @@ export function ConversationView({
 		conversation?.status === "finished" ||
 		conversation?.status === "failed" ||
 		conversation?.status === "stopped";
+	// ACP conversations never really end server-side — the user's local
+	// bridge daemon keeps the underlying conversation alive in memory (see
+	// SendChatMessage's ACP resume path in services/api), so a reply can
+	// always continue the same conversation_id regardless of status. LLM
+	// conversations still need a fresh conversation once terminal (handled
+	// transparently by onNew below via the returned conversation id).
 	const canReply =
 		conversation?.trigger_type === "chat_message" &&
-		!!conversation.chat_session_id;
+		!!conversation.chat_session_id &&
+		(!isTerminal || isACP);
 
 	const messages = useMemo(
 		() => eventsToThreadMessages(events, isRunning),
@@ -192,22 +205,32 @@ export function ConversationView({
 		convertMessage: (m) => m,
 		onNew,
 		onCancel,
-		isDisabled: !canReply || isTerminal,
+		isDisabled: !canReply,
 	});
 
 	// Pings the ai-agent service every ~30s while this chat conversation is
 	// loaded, so its sandbox's idle timer never trips as long as this view
 	// stays open — mirrors the heartbeat in ai-chat-float.tsx. Only chat
 	// conversations have a sandbox that pauses between turns; task/comment
-	// triggered ones would just be a pointless no-op server-side.
+	// triggered ones would just be a pointless no-op server-side. ACP
+	// conversations have no cloud sandbox to keep alive either (the user's
+	// local bridge daemon owns their lifecycle instead), so heartbeating one
+	// would just be a wasted round trip.
 	useEffect(() => {
-		if (conversation?.trigger_type !== "chat_message" || isTerminal) return;
+		if (conversation?.trigger_type !== "chat_message" || isTerminal || isACP)
+			return;
 		void heartbeatConversation(projectId, conversationId).catch(() => {});
 		const interval = setInterval(() => {
 			void heartbeatConversation(projectId, conversationId).catch(() => {});
 		}, CONVERSATION_HEARTBEAT_INTERVAL_MS);
 		return () => clearInterval(interval);
-	}, [conversation?.trigger_type, isTerminal, projectId, conversationId]);
+	}, [
+		conversation?.trigger_type,
+		isTerminal,
+		isACP,
+		projectId,
+		conversationId,
+	]);
 
 	if (convLoading || eventsLoading) {
 		return (
@@ -236,7 +259,13 @@ export function ConversationView({
 	// no visible messages. When messages exist, render the Thread normally so
 	// the user can trace what happened before the failure — the header's
 	// status badge and the bottom error footer already convey the failure.
-	if (isError || (conversation.status === "failed" && messages.length === 0)) {
+	// Skipped when canReply is true (an ACP chat conversation, which stays
+	// replyable straight through a failure) so the user can retry instead of
+	// hitting a dead end.
+	if (
+		isError ||
+		(conversation.status === "failed" && messages.length === 0 && !canReply)
+	) {
 		return (
 			<div className="flex flex-col h-full items-center justify-center gap-4 p-6">
 				<div className="flex size-12 items-center justify-center rounded-full bg-destructive/10">

--- a/apps/web/src/components/projects/ai-chat-float.tsx
+++ b/apps/web/src/components/projects/ai-chat-float.tsx
@@ -16,6 +16,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
 	type AgentConversation,
+	agentQueryOptions,
 	CONVERSATION_HEARTBEAT_INTERVAL_MS,
 	conversationEventsQueryOptions,
 	conversationQueryOptions,
@@ -96,6 +97,11 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		...conversationEventsQueryOptions(projectId, conversationId ?? ""),
 		enabled: !!conversationId,
 	});
+	const { data: agent } = useQuery({
+		...agentQueryOptions(projectId, conversation?.agent_id ?? ""),
+		enabled: !!conversation?.agent_id,
+	});
+	const isACP = agent?.agent_type === "acp";
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";
@@ -181,10 +187,16 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		invalidate();
 	};
 
+	// ACP conversations stay replyable straight through a terminal status —
+	// the user's local bridge daemon keeps the underlying conversation alive
+	// independent of Paca's own status bookkeeping (see SendChatMessage's ACP
+	// resume path in services/api), so "finished"/"failed"/"stopped" doesn't
+	// mean dead-ended the way it does for an LLM chat conversation.
 	const canReply =
 		!conversationId ||
 		(conversation?.trigger_type === "chat_message" &&
-			!!conversation.chat_session_id);
+			!!conversation.chat_session_id &&
+			(!isTerminal || isACP));
 
 	const runtime = useExternalStoreRuntime({
 		messages,
@@ -192,7 +204,7 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		convertMessage: (m) => m,
 		onNew,
 		onCancel,
-		isDisabled: !canReply || isTerminal,
+		isDisabled: !canReply,
 		isSendDisabled: (!conversationId && !agentId) || isSubmitting,
 	});
 
@@ -232,15 +244,18 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 	// the tab closes (or the network drops), heartbeats simply stop and the
 	// ai-agent idle reaper reclaims the sandbox once ~3 minutes pass with no
 	// heartbeat — this replaces the old pagehide-triggered immediate stop.
+	// ACP conversations skip this entirely: there's no cloud sandbox to keep
+	// alive (the user's local bridge daemon owns that lifecycle instead), so
+	// heartbeating one would just be a wasted round trip.
 	useEffect(() => {
-		if (!conversationId || isTerminal) return;
+		if (!conversationId || isTerminal || isACP) return;
 		const id = conversationId;
 		void heartbeatConversation(projectId, id).catch(() => {});
 		const interval = setInterval(() => {
 			void heartbeatConversation(projectId, id).catch(() => {});
 		}, CONVERSATION_HEARTBEAT_INTERVAL_MS);
 		return () => clearInterval(interval);
-	}, [conversationId, isTerminal, projectId]);
+	}, [conversationId, isTerminal, isACP, projectId]);
 
 	return (
 		<>
@@ -292,7 +307,8 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 						{conversationId &&
 						isTerminal &&
 						conversation?.status === "failed" &&
-						messages.length === 0 ? (
+						messages.length === 0 &&
+						!canReply ? (
 							<FloatingChatFailedBanner message={conversation?.error_message} />
 						) : (
 							<AgentPickerContext.Provider value={pickerState}>

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -599,6 +599,24 @@ export async function pauseConversation(
 	return data.data;
 }
 
+// sendConversationMessage replies to a conversation directly by id, rather
+// than through a chat session — used for ACP conversations of any trigger
+// type (task_assigned, comment_mention, etc.), which stay resumable straight
+// through a terminal status since the user's local bridge daemon keeps them
+// alive regardless of why they were started. LLM conversations don't use
+// this path today; that flow is still the chat-session-based sendChatMessage
+// above.
+export async function sendConversationMessage(
+	projectId: string,
+	conversationId: string,
+	message: string,
+): Promise<void> {
+	await apiClient.instance.post(
+		`/projects/${projectId}/conversations/${conversationId}/messages`,
+		{ message },
+	);
+}
+
 // heartbeatConversation refreshes a chat conversation's idle timer on the
 // ai-agent service — pinged periodically while a conversation is loaded in a
 // browser tab so its sandbox isn't reclaimed as long as the tab stays open.

--- a/services/api/internal/domain/agent/conversation_status.go
+++ b/services/api/internal/domain/agent/conversation_status.go
@@ -21,9 +21,13 @@ const (
 )
 
 // IsTerminal reports whether this status ends the conversation's lifecycle.
-// Terminal conversations cannot be resumed — a new conversation must be
-// created instead (see SendChatMessage, which only reuses a conversation
-// when its status is ConversationStatusPaused).
+// For an LLM agent, a terminal conversation cannot be resumed — a new
+// conversation must be created instead (see SendChatMessage, which normally
+// only reuses a conversation when its status is ConversationStatusPaused).
+// ACP-type agents are the exception: SendChatMessage resumes the same
+// conversation_id even from a terminal status, since the local bridge
+// daemon keeps the underlying conversation alive independent of Paca's own
+// status bookkeeping.
 func (s ConversationStatus) IsTerminal() bool {
 	return s == ConversationStatusFinished || s == ConversationStatusFailed || s == ConversationStatusStopped
 }

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -774,6 +774,14 @@ func (s *Service) StartChatSession(ctx context.Context, projectID, agentID, memb
 // finish is left with status "paused" rather than "finished". A reply while
 // paused resumes that same conversation (same conversation_id, so the agent
 // keeps the sandbox/history) instead of cold-starting a new one.
+//
+// ACP-type agents get the same treatment even once a conversation goes
+// terminal (finished/failed/stopped): unlike an LLM agent's cloud sandbox,
+// which is gone for good once its chat conversation ends, an ACP agent's
+// local bridge daemon (apps/acp-bridge) keeps the underlying Conversation
+// object alive in memory for as long as the daemon keeps running. So a reply
+// can always continue the *same* conversation_id, no matter how long ago it
+// went terminal — see runner.ConversationRunner.start_turn's resume branch.
 func (s *Service) SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string) (*agentdom.AgentConversation, error) {
 	session, err := s.repo.FindChatSessionByID(ctx, sessionID)
 	if err != nil {
@@ -810,8 +818,27 @@ func (s *Service) SendChatMessage(ctx context.Context, projectID, sessionID, mem
 				return nil, agentdom.ErrConversationBusy
 			}
 		case agentdom.ConversationStatusFinished, agentdom.ConversationStatusFailed, agentdom.ConversationStatusStopped:
-			// Terminal status — fall through to create a new conversation.
-			conv = nil
+			agent, err := s.repo.FindAgentByID(ctx, session.AgentID)
+			if err != nil {
+				return nil, err
+			}
+			if agent.AgentType == agentdom.AgentTypeACP {
+				// Resume — same atomic-claim treatment as the paused case
+				// above, just starting from a terminal status instead of
+				// "paused" (ACP conversations never reach "paused" — see the
+				// doc comment above).
+				claimed, err := s.repo.ClaimConversationStatus(ctx, latest.ID,
+					latest.Status, string(agentdom.ConversationStatusRunning))
+				if err != nil {
+					return nil, err
+				}
+				if !claimed {
+					return nil, agentdom.ErrConversationBusy
+				}
+			} else {
+				// Terminal status — fall through to create a new conversation.
+				conv = nil
+			}
 		}
 	}
 

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -709,11 +709,28 @@ func (s *Service) Heartbeat(ctx context.Context, projectID, conversationID uuid.
 }
 
 // SendConversationMessage publishes a chat message to an active conversation.
+//
+// ACP-type agents route through sendACPConversationMessage instead: unlike an
+// LLM agent (where a follow-up message only ever makes sense while a turn is
+// actually running), an ACP agent's local bridge daemon keeps a conversation
+// alive by conversation_id regardless of which trigger type started it
+// (task_assigned, comment_mention, description_write, automation_message —
+// not just chat_message), so it can always be resumed here too — mirroring
+// SendChatMessage's terminal-status resume for chat sessions.
 func (s *Service) SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID) error {
 	c, err := s.GetConversation(ctx, projectID, conversationID)
 	if err != nil {
 		return err
 	}
+
+	agent, err := s.repo.FindAgentByID(ctx, c.AgentID)
+	if err != nil {
+		return err
+	}
+	if agent.AgentType == agentdom.AgentTypeACP {
+		return s.sendACPConversationMessage(ctx, c, message, memberID)
+	}
+
 	if agentdom.ConversationStatus(c.Status) != agentdom.ConversationStatusRunning {
 		return agentdom.ErrConversationNotRunning
 	}
@@ -722,6 +739,39 @@ func (s *Service) SendConversationMessage(ctx context.Context, projectID, conver
 		"project_id":      projectID.String(),
 		"message":         message,
 		"member_id":       memberID.String(),
+	})
+}
+
+// sendACPConversationMessage resumes an ACP conversation of any trigger type
+// so it can be continued from the chat box, not just chat_message ones.
+func (s *Service) sendACPConversationMessage(ctx context.Context, c *agentdom.AgentConversation, message string, memberID uuid.UUID) error {
+	status := agentdom.ConversationStatus(c.Status)
+	if status == agentdom.ConversationStatusRunning || status == agentdom.ConversationStatusQueued {
+		// Still mid-turn (or not yet picked up by the worker) — reject
+		// instead of dispatching a second start_turn on top of one the
+		// bridge hasn't finished: ConversationRunner.start_turn's own
+		// "still running" guard would report the *in-flight* turn as
+		// failed, not queue this message behind it.
+		return agentdom.ErrConversationBusy
+	}
+	// Claim atomically so two concurrent replies can't both win and
+	// double-publish a resume trigger for the same conversation_id — same
+	// race guard as SendChatMessage's resume paths.
+	claimed, err := s.repo.ClaimConversationStatus(ctx, c.ID, string(status), string(agentdom.ConversationStatusRunning))
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return agentdom.ErrConversationBusy
+	}
+	return s.publishTrigger(ctx, events.TopicAgentChatMessage, map[string]any{
+		"conversation_id": c.ID.String(),
+		"project_id":      c.ProjectID.String(),
+		"agent_id":        c.AgentID.String(),
+		"trigger_type":    c.TriggerType,
+		"actor_member_id": memberID.String(),
+		"message":         message,
+		"repo_plugin_ids": strings.Join(s.gatherRepoPluginIDs(ctx), ","),
 	})
 }
 

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -990,6 +990,7 @@ func TestSendConversationMessage_Success(t *testing.T) {
 	}
 
 	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeLLM),
 		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return conversation, nil
 		},
@@ -1013,6 +1014,7 @@ func TestSendConversationMessage_NotRunning(t *testing.T) {
 	}
 
 	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeLLM),
 		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return conversation, nil
 		},
@@ -1025,6 +1027,135 @@ func TestSendConversationMessage_NotRunning(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotRunning)
+}
+
+// TestSendConversationMessage_ACPResumesAnyTriggerType covers ACP agents'
+// exception: a message can resume a conversation of *any* trigger type
+// (task_assigned, comment_mention, etc.), not just chat_message, once it's
+// no longer actively running — the local bridge daemon keeps it alive by
+// conversation_id regardless of what started it.
+func TestSendConversationMessage_ACPResumesAnyTriggerType(t *testing.T) {
+	for _, status := range []string{"paused", "finished", "failed", "stopped"} {
+		t.Run(status, func(t *testing.T) {
+			projectID := uuid.New()
+			conversationID := uuid.New()
+			conversation := &agentdom.AgentConversation{
+				ID:          conversationID,
+				ProjectID:   projectID,
+				TriggerType: "task_assigned",
+				Status:      status,
+			}
+
+			var claimedFrom, claimedTo string
+			repo := &mockAgentRepo{
+				findAgentByID: findAgentByIDReturning(agentdom.AgentTypeACP),
+				findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+					return conversation, nil
+				},
+				claimConversationStatus: func(_ context.Context, id uuid.UUID, from, to string) (bool, error) {
+					if id != conversationID {
+						t.Fatalf("unexpected conversation id claimed: %s", id)
+					}
+					claimedFrom, claimedTo = from, to
+					return true, nil
+				},
+			}
+			projRepo := &mockProjectRepo{}
+			pluginRepo := &mockPluginRepo{}
+			svc := New(repo, projRepo, nil, pluginRepo)
+
+			err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "keep going", uuid.New())
+
+			assert.NoError(t, err)
+			assert.Equal(t, status, claimedFrom)
+			assert.Equal(t, "running", claimedTo)
+		})
+	}
+}
+
+func TestSendConversationMessage_ACPBusyWhenRunning(t *testing.T) {
+	projectID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:          conversationID,
+		ProjectID:   projectID,
+		TriggerType: "comment_mention",
+		Status:      "running",
+	}
+
+	claimCalled := false
+	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeACP),
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+		claimConversationStatus: func(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+			claimCalled = true
+			return true, nil
+		},
+	}
+	projRepo := &mockProjectRepo{}
+	pluginRepo := &mockPluginRepo{}
+	svc := New(repo, projRepo, nil, pluginRepo)
+
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "are you there?", uuid.New())
+
+	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
+	assert.False(t, claimCalled, "must not attempt to claim/dispatch on top of an in-flight turn")
+}
+
+func TestSendConversationMessage_ACPBusyWhenQueued(t *testing.T) {
+	projectID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:          conversationID,
+		ProjectID:   projectID,
+		TriggerType: "task_assigned",
+		Status:      "queued",
+	}
+
+	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeACP),
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+	}
+	projRepo := &mockProjectRepo{}
+	pluginRepo := &mockPluginRepo{}
+	svc := New(repo, projRepo, nil, pluginRepo)
+
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "are you there?", uuid.New())
+
+	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
+}
+
+func TestSendConversationMessage_ACPResumeRaceLoses(t *testing.T) {
+	projectID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:          conversationID,
+		ProjectID:   projectID,
+		TriggerType: "task_assigned",
+		Status:      "finished",
+	}
+
+	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeACP),
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+		claimConversationStatus: func(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+			// Another concurrent request already claimed the resume.
+			return false, nil
+		},
+	}
+	projRepo := &mockProjectRepo{}
+	pluginRepo := &mockPluginRepo{}
+	svc := New(repo, projRepo, nil, pluginRepo)
+
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "keep going", uuid.New())
+
+	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
 
 func TestStopConversation_Success(t *testing.T) {

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -1352,6 +1352,174 @@ func TestSendChatMessage_ResumesPausedConversation(t *testing.T) {
 	assert.Equal(t, "running", claimedTo)
 }
 
+// TestSendChatMessage_ACPResumesTerminalConversation covers the ACP-specific
+// exception to IsTerminal: replying to a finished/failed/stopped
+// conversation must resume the same conversation_id (the local bridge daemon
+// keeps it alive indefinitely) instead of creating a new one.
+func TestSendChatMessage_ACPResumesTerminalConversation(t *testing.T) {
+	for _, status := range []string{"finished", "failed", "stopped"} {
+		t.Run(status, func(t *testing.T) {
+			projectID := uuid.New()
+			agentID := uuid.New()
+			memberID := uuid.New()
+			sessionID := uuid.New()
+			terminalConvID := uuid.New()
+			session := &agentdom.AgentChatSession{
+				ID:        sessionID,
+				AgentID:   agentID,
+				ProjectID: projectID,
+			}
+			terminal := &agentdom.AgentConversation{
+				ID:            terminalConvID,
+				AgentID:       agentID,
+				ProjectID:     projectID,
+				ChatSessionID: &sessionID,
+				Status:        status,
+			}
+
+			createCalled := false
+			var claimedFrom, claimedTo string
+			repo := &mockAgentRepo{
+				findAgentByID: findAgentByIDReturning(agentdom.AgentTypeACP),
+				findChatSessionByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentChatSession, error) {
+					return session, nil
+				},
+				findLatestConversationBySession: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+					return terminal, nil
+				},
+				claimConversationStatus: func(_ context.Context, id uuid.UUID, from, to string) (bool, error) {
+					if id != terminalConvID {
+						t.Fatalf("unexpected conversation id claimed: %s", id)
+					}
+					claimedFrom, claimedTo = from, to
+					return true, nil
+				},
+				createConversation: func(_ context.Context, _ *agentdom.AgentConversation) error {
+					createCalled = true
+					return nil
+				},
+				updateChatSession: func(_ context.Context, _ *agentdom.AgentChatSession) error {
+					return nil
+				},
+			}
+			projRepo := &mockProjectRepo{}
+			pluginRepo := &mockPluginRepo{}
+			svc := New(repo, projRepo, nil, pluginRepo)
+
+			resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+
+			assert.NoError(t, err)
+			assert.False(t, createCalled, "resuming a terminal ACP conversation must not create a new one")
+			assert.Equal(t, terminalConvID, resultConv.ID)
+			assert.Equal(t, status, claimedFrom)
+			assert.Equal(t, "running", claimedTo)
+		})
+	}
+}
+
+// TestSendChatMessage_ACPResumeRaceLoses mirrors
+// TestSendChatMessage_ResumeRaceLoses for the terminal-ACP resume path: two
+// concurrent replies to the same terminal conversation must not both win.
+func TestSendChatMessage_ACPResumeRaceLoses(t *testing.T) {
+	projectID := uuid.New()
+	agentID := uuid.New()
+	memberID := uuid.New()
+	sessionID := uuid.New()
+	terminalConvID := uuid.New()
+	session := &agentdom.AgentChatSession{
+		ID:        sessionID,
+		AgentID:   agentID,
+		ProjectID: projectID,
+	}
+	terminal := &agentdom.AgentConversation{
+		ID:            terminalConvID,
+		AgentID:       agentID,
+		ProjectID:     projectID,
+		ChatSessionID: &sessionID,
+		Status:        "finished",
+	}
+
+	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeACP),
+		findChatSessionByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentChatSession, error) {
+			return session, nil
+		},
+		findLatestConversationBySession: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return terminal, nil
+		},
+		claimConversationStatus: func(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+			// Another concurrent request already claimed the resume.
+			return false, nil
+		},
+	}
+	projRepo := &mockProjectRepo{}
+	pluginRepo := &mockPluginRepo{}
+	svc := New(repo, projRepo, nil, pluginRepo)
+
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+
+	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
+}
+
+// TestSendChatMessage_LLMTerminalCreatesNewConversation is a regression guard
+// for the non-ACP path: an LLM agent's terminal conversation must still
+// create a brand new conversation, unlike the ACP resume behavior above.
+func TestSendChatMessage_LLMTerminalCreatesNewConversation(t *testing.T) {
+	projectID := uuid.New()
+	agentID := uuid.New()
+	memberID := uuid.New()
+	sessionID := uuid.New()
+	oldConvID := uuid.New()
+	session := &agentdom.AgentChatSession{
+		ID:        sessionID,
+		AgentID:   agentID,
+		ProjectID: projectID,
+	}
+	finished := &agentdom.AgentConversation{
+		ID:            oldConvID,
+		AgentID:       agentID,
+		ProjectID:     projectID,
+		ChatSessionID: &sessionID,
+		Status:        "finished",
+	}
+
+	createCalled := false
+	claimCalled := false
+	repo := &mockAgentRepo{
+		findAgentByID: findAgentByIDReturning(agentdom.AgentTypeLLM),
+		findChatSessionByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentChatSession, error) {
+			return session, nil
+		},
+		findLatestConversationBySession: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return finished, nil
+		},
+		claimConversationStatus: func(_ context.Context, _ uuid.UUID, _, _ string) (bool, error) {
+			claimCalled = true
+			return true, nil
+		},
+		createConversation: func(_ context.Context, conv *agentdom.AgentConversation) error {
+			createCalled = true
+			if conv.ID == oldConvID {
+				t.Fatalf("expected a freshly generated conversation id, got the old one")
+			}
+			return nil
+		},
+		updateChatSession: func(_ context.Context, _ *agentdom.AgentChatSession) error {
+			return nil
+		},
+	}
+	projRepo := &mockProjectRepo{}
+	pluginRepo := &mockPluginRepo{}
+	svc := New(repo, projRepo, nil, pluginRepo)
+
+	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello again")
+
+	assert.NoError(t, err)
+	assert.True(t, createCalled, "a terminal LLM conversation must create a new conversation")
+	assert.False(t, claimCalled, "must not attempt to claim/resume a terminal LLM conversation")
+	assert.NotEqual(t, oldConvID, resultConv.ID)
+}
+
 func TestSendChatMessage_ResumeRaceLoses(t *testing.T) {
 	projectID := uuid.New()
 	agentID := uuid.New()


### PR DESCRIPTION
## Problem

ACP conversations dead-end once a turn ends. `IsTerminal()` (finished/failed/stopped) forces `SendChatMessage` to spin up a brand-new conversation for any reply — but an ACP agent's local bridge daemon (`apps/acp-bridge`) keeps the real `Conversation` object alive in memory for as long as it keeps running, independent of Paca's own status bookkeeping. A fresh conversation throws away context the daemon still has.

## Change

- `SendChatMessage` now resumes the *same* `conversation_id` for ACP-type agents even from a terminal status (finished/failed/stopped), via the same atomic-claim resume path (`ClaimConversationStatus` → `running`) #341 introduced for the `paused` case.
- `ConversationStatus.IsTerminal()`'s doc comment now calls out the ACP exception.
- `ConversationView` / `AIChatFloat` (web): an ACP conversation stays replyable straight through a terminal status — `canReply` no longer gates on `!isTerminal` when the agent is ACP-type — skips the failed-conversation dead-end screen, and skips the chat heartbeat (ACP has no cloud sandbox to keep alive; the local bridge daemon owns that lifecycle instead).

## Related

Builds directly on #341, which introduced the atomic-claim resume-on-`paused` pattern in `SendChatMessage` — this PR extends that same mechanism to cover ACP conversations that have gone terminal, not just `paused`.

## Tests

`TestSendChatMessage_ACPResumesTerminalConversation` covers resume from finished/failed/stopped for ACP agents.
