### PR TITLE
feat: hide system prompt and git committer identity for ACP agents

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
@@ -170,16 +170,16 @@ function OverviewTab({
 
 	const isDirty =
 		name !== agent.name ||
-		systemPrompt !== agent.system_prompt ||
-		committerName !== agent.git_committer_name ||
-		committerEmail !== agent.git_committer_email ||
 		(isAcp
 			? acpProviderSelect !== (agent.acp_provider ?? "claude-code") ||
 				acpCommandParts.join(" ") !== (agent.acp_command ?? []).join(" ")
 			: llmProvider !== agent.llm_provider ||
 				llmModel !== agent.llm_model ||
 				llmApiKey !== "" ||
-				llmBaseUrl !== (agent.llm_base_url ?? ""));
+				llmBaseUrl !== (agent.llm_base_url ?? "") ||
+				systemPrompt !== agent.system_prompt ||
+				committerName !== agent.git_committer_name ||
+				committerEmail !== agent.git_committer_email);
 
 	const saveMutation = useMutation({
 		mutationFn: () =>
@@ -197,10 +197,10 @@ function OverviewTab({
 							llm_model: llmModel,
 							...(llmApiKey ? { llm_api_key: llmApiKey } : {}),
 							llm_base_url: llmBaseUrl,
+							system_prompt: systemPrompt,
+							git_committer_name: committerName.trim(),
+							git_committer_email: committerEmail.trim(),
 						}),
-				system_prompt: systemPrompt,
-				git_committer_name: committerName.trim(),
-				git_committer_email: committerEmail.trim(),
 			}),
 		onSuccess: (updated) => {
 			qc.setQueryData(["projects", projectId, "agents", agent.id], updated);
@@ -413,48 +413,54 @@ function OverviewTab({
 				</>
 			)}
 
-			<div className="space-y-1.5">
-				<Label>{t("agents.detail.overview.systemPromptLabel")}</Label>
-				<Textarea
-					value={systemPrompt}
-					onChange={(e) => setSystemPrompt(e.target.value)}
-					rows={5}
-					disabled={!canWrite}
-					className="font-mono text-xs"
-				/>
-			</div>
-
-			<Separator />
-
-			<div>
-				<p className="text-sm font-medium mb-1">
-					{t("agents.detail.overview.gitCommitterIdentity")}
-				</p>
-				<p className="text-xs text-muted-foreground mb-3">
-					{t("agents.detail.overview.gitCommitterHint")}
-				</p>
-				<div className="grid grid-cols-2 gap-3">
+			{/* System prompt and git committer identity are LLM-only — an ACP
+			    agent's local CLI owns its own prompt and git identity. */}
+			{!isAcp && (
+				<>
 					<div className="space-y-1.5">
-						<Label>{t("agents.detail.overview.committerNameLabel")}</Label>
-						<Input
-							value={committerName}
-							onChange={(e) => setCommitterName(e.target.value)}
+						<Label>{t("agents.detail.overview.systemPromptLabel")}</Label>
+						<Textarea
+							value={systemPrompt}
+							onChange={(e) => setSystemPrompt(e.target.value)}
+							rows={5}
 							disabled={!canWrite}
-							placeholder="paca-agent"
+							className="font-mono text-xs"
 						/>
 					</div>
-					<div className="space-y-1.5">
-						<Label>{t("agents.detail.overview.committerEmailLabel")}</Label>
-						<Input
-							type="email"
-							value={committerEmail}
-							onChange={(e) => setCommitterEmail(e.target.value)}
-							disabled={!canWrite}
-							placeholder="paca-agent@users.noreply.github.com"
-						/>
+
+					<Separator />
+
+					<div>
+						<p className="text-sm font-medium mb-1">
+							{t("agents.detail.overview.gitCommitterIdentity")}
+						</p>
+						<p className="text-xs text-muted-foreground mb-3">
+							{t("agents.detail.overview.gitCommitterHint")}
+						</p>
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label>{t("agents.detail.overview.committerNameLabel")}</Label>
+								<Input
+									value={committerName}
+									onChange={(e) => setCommitterName(e.target.value)}
+									disabled={!canWrite}
+									placeholder="paca-agent"
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label>{t("agents.detail.overview.committerEmailLabel")}</Label>
+								<Input
+									type="email"
+									value={committerEmail}
+									onChange={(e) => setCommitterEmail(e.target.value)}
+									disabled={!canWrite}
+									placeholder="paca-agent@users.noreply.github.com"
+								/>
+							</div>
+						</div>
 					</div>
-				</div>
-			</div>
+				</>
+			)}
 
 			{canWrite && (
 				<div className="flex items-center gap-3 pt-2">

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/index.tsx
@@ -217,6 +217,7 @@ function CreateAgentDialog({
 							llm_model: llmModel,
 							llm_api_key: llmApiKey,
 							llm_base_url: llmBaseUrl,
+							system_prompt: systemPrompt,
 						}
 					: {
 							acp_provider: acpProvider,
@@ -224,7 +225,6 @@ function CreateAgentDialog({
 								? { acp_command: acpCommandParts }
 								: {}),
 						}),
-				system_prompt: systemPrompt,
 			});
 			if (agent.agent_type !== "acp") {
 				return { agent, token: null };
@@ -328,50 +328,90 @@ function CreateAgentDialog({
 				{/* ── Step 1: Identity ─────────────────────────────────────────── */}
 				{step === 1 && (
 					<div className="overflow-y-auto max-h-[62vh] px-6 py-5 space-y-5">
-						{/* Preset grid */}
-						<div className="space-y-2">
-							<Label className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-								{t("agents.createDialog.startFromPreset")}
-							</Label>
+						{/* Agent Type */}
+						<div className="space-y-1.5">
+							<Label>{t("agents.createDialog.agentTypeLabel")}</Label>
 							<div className="grid grid-cols-2 gap-2">
-								{AGENT_PRESETS.map((preset) => {
-									const Icon = PRESET_ICON_MAP[preset.id] ?? Bot;
-									const isSelected = presetId === preset.id;
+								{(["llm", "acp"] as const).map((type) => {
+									const isSelected = agentType === type;
 									return (
 										<button
-											key={preset.id}
+											key={type}
 											type="button"
-											onClick={() => onPresetChange(preset.id)}
+											onClick={() => setAgentType(type)}
 											className={cn(
-												"flex items-start gap-2.5 rounded-lg border p-3 text-left transition-all",
+												"rounded-lg border p-3 text-left transition-all",
 												isSelected
 													? "border-primary/40 bg-primary/5 ring-1 ring-primary/20 shadow-sm"
 													: "border-border/60 hover:border-border hover:bg-muted/30",
 											)}
 										>
-											<div
-												className={cn(
-													"flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
-													isSelected
-														? "bg-primary/15 text-primary"
-														: "bg-muted text-muted-foreground",
+											<p className="text-xs font-semibold leading-tight">
+												{t(
+													type === "llm"
+														? "agents.createDialog.agentTypeLLM"
+														: "agents.createDialog.agentTypeACP",
 												)}
-											>
-												<Icon className="size-3.5" />
-											</div>
-											<div className="min-w-0">
-												<p className="text-xs font-semibold leading-tight">
-													{preset.label}
-												</p>
-												<p className="mt-0.5 line-clamp-2 text-xs leading-tight text-muted-foreground">
-													{preset.description}
-												</p>
-											</div>
+											</p>
+											<p className="mt-0.5 text-xs leading-tight text-muted-foreground">
+												{t(
+													type === "llm"
+														? "agents.createDialog.agentTypeLLMHint"
+														: "agents.createDialog.agentTypeACPHint",
+												)}
+											</p>
 										</button>
 									);
 								})}
 							</div>
 						</div>
+
+						{/* Preset grid — LLM-only; an ACP agent has no model/prompt to preset */}
+						{agentType === "llm" && (
+							<div className="space-y-2">
+								<Label className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+									{t("agents.createDialog.startFromPreset")}
+								</Label>
+								<div className="grid grid-cols-2 gap-2">
+									{AGENT_PRESETS.map((preset) => {
+										const Icon = PRESET_ICON_MAP[preset.id] ?? Bot;
+										const isSelected = presetId === preset.id;
+										return (
+											<button
+												key={preset.id}
+												type="button"
+												onClick={() => onPresetChange(preset.id)}
+												className={cn(
+													"flex items-start gap-2.5 rounded-lg border p-3 text-left transition-all",
+													isSelected
+														? "border-primary/40 bg-primary/5 ring-1 ring-primary/20 shadow-sm"
+														: "border-border/60 hover:border-border hover:bg-muted/30",
+												)}
+											>
+												<div
+													className={cn(
+														"flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
+														isSelected
+															? "bg-primary/15 text-primary"
+															: "bg-muted text-muted-foreground",
+													)}
+												>
+													<Icon className="size-3.5" />
+												</div>
+												<div className="min-w-0">
+													<p className="text-xs font-semibold leading-tight">
+														{preset.label}
+													</p>
+													<p className="mt-0.5 line-clamp-2 text-xs leading-tight text-muted-foreground">
+														{preset.description}
+													</p>
+												</div>
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						)}
 
 						{/* Name + Handle */}
 						<div className="space-y-3">
@@ -445,44 +485,6 @@ function CreateAgentDialog({
 				{/* ── Step 2: AI Configuration ─────────────────────────────────── */}
 				{step === 2 && (
 					<div className="overflow-y-auto max-h-[62vh] px-6 py-5 space-y-5">
-						{/* Agent Type */}
-						<div className="space-y-1.5">
-							<Label>{t("agents.createDialog.agentTypeLabel")}</Label>
-							<div className="grid grid-cols-2 gap-2">
-								{(["llm", "acp"] as const).map((type) => {
-									const isSelected = agentType === type;
-									return (
-										<button
-											key={type}
-											type="button"
-											onClick={() => setAgentType(type)}
-											className={cn(
-												"rounded-lg border p-3 text-left transition-all",
-												isSelected
-													? "border-primary/40 bg-primary/5 ring-1 ring-primary/20 shadow-sm"
-													: "border-border/60 hover:border-border hover:bg-muted/30",
-											)}
-										>
-											<p className="text-xs font-semibold leading-tight">
-												{t(
-													type === "llm"
-														? "agents.createDialog.agentTypeLLM"
-														: "agents.createDialog.agentTypeACP",
-												)}
-											</p>
-											<p className="mt-0.5 text-xs leading-tight text-muted-foreground">
-												{t(
-													type === "llm"
-														? "agents.createDialog.agentTypeLLMHint"
-														: "agents.createDialog.agentTypeACPHint",
-												)}
-											</p>
-										</button>
-									);
-								})}
-							</div>
-						</div>
-
 						{agentType === "acp" && (
 							<div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-3">
 								<div className="flex items-center gap-1.5">
@@ -682,32 +684,34 @@ function CreateAgentDialog({
 							</>
 						)}
 
-						{/* System Prompt */}
-						<div className="space-y-1.5">
-							<div className="flex items-center justify-between">
-								<Label htmlFor="agent-system-prompt">
-									{t("agents.createDialog.systemPromptLabel")}{" "}
-									<span className="text-muted-foreground font-normal text-xs">
-										{t("agents.createDialog.optional")}
-									</span>
-								</Label>
-								{systemPrompt.length > 0 && (
-									<span className="text-xs text-muted-foreground">
-										{t("agents.createDialog.charsCount", {
-											count: systemPrompt.length,
-										})}
-									</span>
-								)}
+						{/* System Prompt — LLM-only; an ACP agent's local CLI owns its own prompt */}
+						{agentType === "llm" && (
+							<div className="space-y-1.5">
+								<div className="flex items-center justify-between">
+									<Label htmlFor="agent-system-prompt">
+										{t("agents.createDialog.systemPromptLabel")}{" "}
+										<span className="text-muted-foreground font-normal text-xs">
+											{t("agents.createDialog.optional")}
+										</span>
+									</Label>
+									{systemPrompt.length > 0 && (
+										<span className="text-xs text-muted-foreground">
+											{t("agents.createDialog.charsCount", {
+												count: systemPrompt.length,
+											})}
+										</span>
+									)}
+								</div>
+								<Textarea
+									id="agent-system-prompt"
+									placeholder={t("agents.createDialog.systemPromptPlaceholder")}
+									value={systemPrompt}
+									onChange={(e) => setSystemPrompt(e.target.value)}
+									rows={4}
+									className="resize-none text-sm"
+								/>
 							</div>
-							<Textarea
-								id="agent-system-prompt"
-								placeholder={t("agents.createDialog.systemPromptPlaceholder")}
-								value={systemPrompt}
-								onChange={(e) => setSystemPrompt(e.target.value)}
-								rows={4}
-								className="resize-none text-sm"
-							/>
-						</div>
+						)}
 
 						{createMutation.isError && (
 							<p className="text-sm text-destructive rounded-md bg-destructive/10 px-3 py-2">

--- a/docs/ai-agent/api-design.md
+++ b/docs/ai-agent/api-design.md
@@ -75,12 +75,11 @@ Create a new agent. This also creates the corresponding `project_members` row wi
   "handle": "local-claude",
   "agent_type": "acp",
   "acp_provider": "claude-code",
-  "system_prompt": "You are a senior software engineer...",
   "project_role_id": "uuid"
 }
 ```
 
-`acp_provider` (one of `claude-code`, `codex`, `gemini-cli`, `custom`) is required when `agent_type` is `acp`. `acp_command` is required only when `acp_provider` is `custom` — built-in providers resolve a default launch command via the OpenHands SDK's own provider registry. None of the `llm_*` fields apply to `acp` agents.
+`acp_provider` (one of `claude-code`, `codex`, `gemini-cli`, `custom`) is required when `agent_type` is `acp`. `acp_command` is required only when `acp_provider` is `custom` — built-in providers resolve a default launch command via the OpenHands SDK's own provider registry. None of the `llm_*` fields apply to `acp` agents, nor do `system_prompt`, `git_committer_name`, or `git_committer_email` — the local ACP client owns its own system prompt and git identity, so Paca silently ignores those fields for `acp` agents rather than persisting them.
 
 **Response:** `201 Created` with the created agent object.
 

--- a/docs/ai-agent/overview.md
+++ b/docs/ai-agent/overview.md
@@ -247,12 +247,13 @@ Each template also carries a set of trigger keywords (e.g. `developer` triggers 
 
 ## Customization
 
-`llm` agents expose four customization axes; `acp` agents only the latter two, since MCP servers/skills for `acp` live in the user's own local CLI config rather than Paca (see [Execution Models](#execution-models)):
+`llm` agents expose the customization axes below; none of them apply to `acp` agents, since the system prompt, git committer identity, MCP servers, and skills for `acp` all live in the user's own local CLI config rather than Paca (see [Execution Models](#execution-models)):
 
 | Axis | Applies to | Description |
 |---|---|---|
 | **LLM Provider** | `llm` only | Any LiteLLM-supported provider: Anthropic, OpenAI, Azure, AWS Bedrock, Gemini, Groq, OpenRouter, local LLMs, etc. |
-| **System Prompt** | both | Free-form Jinja2 template or plain text, optionally pre-filled from a skill template. |
+| **System Prompt** | `llm` only | Free-form Jinja2 template or plain text, optionally pre-filled from a skill template. |
+| **Git Committer Identity** | `llm` only | Name/email used for `GIT_AUTHOR_*`/`GIT_COMMITTER_*` in the sandbox container. |
 | **Skills** | `llm` only | AgentSkills-standard `SKILL.md` directories or inline text skills. Stored in the DB, mounted into the container at runtime. |
 | **MCP Servers** | `llm` only | JSON MCP config following the standard `mcpServers` format. Evaluated inside the container at conversation start. |
 

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -33,15 +33,20 @@ type Agent struct {
 	// ACPBridgeTokenHash is the SHA-256 hex digest of the current bridge
 	// token, used only for verification — never serialized to API responses.
 	ACPBridgeTokenHash string
-	SystemPrompt       string
-	MaxIterations      int
-	TimeoutMinutes     int
-	GitCommitterName   string
-	GitCommitterEmail  string
-	CreatedBy          *uuid.UUID
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
-	DeletedAt          *time.Time
+	// SystemPrompt, GitCommitterName, and GitCommitterEmail are LLM-only —
+	// an ACP agent runs via the user's own local ACP client (see
+	// ACPProvider), which owns its own system prompt and git identity, so
+	// Paca never forwards these; they stay zero-valued on acp-type agents
+	// (see CreateAgent/UpdateAgent in service/agent).
+	SystemPrompt      string
+	MaxIterations     int
+	TimeoutMinutes    int
+	GitCommitterName  string
+	GitCommitterEmail string
+	CreatedBy         *uuid.UUID
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         *time.Time
 	// Member ID in project_members (populated on create / list)
 	MemberID   *uuid.UUID
 	MCPServers []*AgentMCPServer

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -106,19 +106,16 @@ func (s *Service) CreateAgent(ctx context.Context, projectID uuid.UUID, in agent
 
 	now := time.Now()
 	a := &agentdom.Agent{
-		ID:                uuid.New(),
-		ProjectID:         projectID,
-		Name:              name,
-		Handle:            handle,
-		AgentType:         agentType,
-		SystemPrompt:      in.SystemPrompt,
-		MaxIterations:     in.MaxIterations,
-		TimeoutMinutes:    in.TimeoutMinutes,
-		GitCommitterName:  in.GitCommitterName,
-		GitCommitterEmail: in.GitCommitterEmail,
-		CreatedBy:         in.CreatedBy,
-		CreatedAt:         now,
-		UpdatedAt:         now,
+		ID:             uuid.New(),
+		ProjectID:      projectID,
+		Name:           name,
+		Handle:         handle,
+		AgentType:      agentType,
+		MaxIterations:  in.MaxIterations,
+		TimeoutMinutes: in.TimeoutMinutes,
+		CreatedBy:      in.CreatedBy,
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 
 	if agentType == agentdom.AgentTypeACP {
@@ -140,6 +137,19 @@ func (s *Service) CreateAgent(ctx context.Context, projectID uuid.UUID, in agent
 		a.LLMModel = in.LLMModel
 		a.LLMAPIKeySecret = encryptedKey
 		a.LLMBaseURL = in.LLMBaseURL
+		// System prompt and git committer identity are LLM-only (see the
+		// doc comment on Agent.SystemPrompt) — an ACP agent's local CLI
+		// owns both of these itself, so they're left unset for ACP agents
+		// rather than accepting values that would never take effect.
+		a.SystemPrompt = in.SystemPrompt
+		a.GitCommitterName = in.GitCommitterName
+		a.GitCommitterEmail = in.GitCommitterEmail
+		if a.GitCommitterName == "" {
+			a.GitCommitterName = "paca-agent"
+		}
+		if a.GitCommitterEmail == "" {
+			a.GitCommitterEmail = "280579135+paca-agent@users.noreply.github.com"
+		}
 	}
 	const maxIterationsLimit = 500
 	const defaultMaxIterations = 500
@@ -154,12 +164,6 @@ func (s *Service) CreateAgent(ctx context.Context, projectID uuid.UUID, in agent
 		a.TimeoutMinutes = 30
 	} else if a.TimeoutMinutes > timeoutMinutesLimit {
 		a.TimeoutMinutes = timeoutMinutesLimit
-	}
-	if a.GitCommitterName == "" {
-		a.GitCommitterName = "paca-agent"
-	}
-	if a.GitCommitterEmail == "" {
-		a.GitCommitterEmail = "280579135+paca-agent@users.noreply.github.com"
 	}
 
 	// Atomically create the agent and its project membership in one transaction.
@@ -203,7 +207,11 @@ func (s *Service) UpdateAgent(ctx context.Context, projectID, agentID uuid.UUID,
 	// erroring, matching CreateAgent's per-type field selection. Anything
 	// other than the explicit ACP type is treated as LLM (its default, as
 	// in CreateAgent) so an agent loaded with an unset AgentType isn't
-	// silently locked out of updating its LLM fields.
+	// silently locked out of updating its LLM fields. SystemPrompt and the
+	// git committer identity fields ride along in this same block — like
+	// the LLM fields, they're meaningless on an ACP agent (see the doc
+	// comment on Agent.SystemPrompt), so a request that sets them on one is
+	// silently ignored too.
 	if a.AgentType != agentdom.AgentTypeACP {
 		if in.LLMProvider != nil {
 			a.LLMProvider = *in.LLMProvider
@@ -221,6 +229,15 @@ func (s *Service) UpdateAgent(ctx context.Context, projectID, agentID uuid.UUID,
 		if in.LLMBaseURL != nil {
 			a.LLMBaseURL = *in.LLMBaseURL
 		}
+		if in.SystemPrompt != nil {
+			a.SystemPrompt = *in.SystemPrompt
+		}
+		if in.GitCommitterName != nil {
+			a.GitCommitterName = *in.GitCommitterName
+		}
+		if in.GitCommitterEmail != nil {
+			a.GitCommitterEmail = *in.GitCommitterEmail
+		}
 	}
 	if a.AgentType == agentdom.AgentTypeACP {
 		if in.ACPProvider != nil {
@@ -235,9 +252,6 @@ func (s *Service) UpdateAgent(ctx context.Context, projectID, agentID uuid.UUID,
 		if a.ACPProvider != nil && *a.ACPProvider == agentdom.ACPProviderCustom && len(a.ACPCommand) == 0 {
 			return nil, agentdom.ErrACPCommandRequired
 		}
-	}
-	if in.SystemPrompt != nil {
-		a.SystemPrompt = *in.SystemPrompt
 	}
 	const maxIterationsLimit = 500
 	const defaultMaxIterations = 500
@@ -260,12 +274,6 @@ func (s *Service) UpdateAgent(ctx context.Context, projectID, agentID uuid.UUID,
 			v = timeoutMinutesLimit
 		}
 		a.TimeoutMinutes = v
-	}
-	if in.GitCommitterName != nil {
-		a.GitCommitterName = *in.GitCommitterName
-	}
-	if in.GitCommitterEmail != nil {
-		a.GitCommitterEmail = *in.GitCommitterEmail
 	}
 	a.UpdatedAt = time.Now()
 

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -630,17 +630,26 @@ func TestUpdateAgent_ACPAgentIgnoresLLMFields(t *testing.T) {
 	newModel := "gpt-4"
 	newAPIKey := "sk-leaked-onto-acp-agent"
 	newBaseURL := "https://api.openai.com/v1"
+	newSystemPrompt := "you are a helpful assistant"
+	newCommitterName := "someone"
+	newCommitterEmail := "someone@example.com"
 
 	result, err := svc.UpdateAgent(context.Background(), projectID, agentID, agentdom.UpdateAgentInput{
-		LLMModel:   &newModel,
-		LLMAPIKey:  &newAPIKey,
-		LLMBaseURL: &newBaseURL,
+		LLMModel:          &newModel,
+		LLMAPIKey:         &newAPIKey,
+		LLMBaseURL:        &newBaseURL,
+		SystemPrompt:      &newSystemPrompt,
+		GitCommitterName:  &newCommitterName,
+		GitCommitterEmail: &newCommitterEmail,
 	})
 
 	assert.NoError(t, err)
 	assert.Empty(t, result.LLMModel)
 	assert.Empty(t, result.LLMAPIKeySecret)
 	assert.Empty(t, result.LLMBaseURL)
+	assert.Empty(t, result.SystemPrompt)
+	assert.Empty(t, result.GitCommitterName)
+	assert.Empty(t, result.GitCommitterEmail)
 }
 
 func TestUpdateAgent_LLMAgentIgnoresACPFields(t *testing.T) {
@@ -2012,6 +2021,37 @@ func TestCreateAgent_ACPCustomProviderSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, agentdom.AgentTypeACP, result.AgentType)
 	assert.Equal(t, []string{"npx", "-y", "my-acp-server"}, result.ACPCommand)
+}
+
+func TestCreateAgent_ACPIgnoresSystemPromptAndGitCommitterFields(t *testing.T) {
+	projectID := uuid.New()
+	projectRoleID := uuid.New()
+
+	repo := &mockAgentRepo{
+		findAgentByHandle: func(_ context.Context, _ uuid.UUID, _ string) (*agentdom.Agent, error) {
+			return nil, agentdom.ErrAgentNotFound
+		},
+		createAgentWithMembership: func(_ context.Context, _ *agentdom.Agent, _ uuid.UUID, _, _ uuid.UUID) error {
+			return nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	result, err := svc.CreateAgent(context.Background(), projectID, agentdom.CreateAgentInput{
+		Name:              "ACP Agent",
+		Handle:            "acp-agent",
+		AgentType:         agentdom.AgentTypeACP,
+		ACPProvider:       agentdom.ACPProviderClaudeCode,
+		ProjectRoleID:     projectRoleID,
+		SystemPrompt:      "you are a helpful assistant",
+		GitCommitterName:  "someone",
+		GitCommitterEmail: "someone@example.com",
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, result.SystemPrompt)
+	assert.Empty(t, result.GitCommitterName)
+	assert.Empty(t, result.GitCommitterEmail)
 }
 
 func TestGenerateACPBridgeToken_Success(t *testing.T) {

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -45,6 +45,8 @@ type AgentResponse struct {
 // LLM fields are required when agent_type is "llm" (the default when
 // omitted); ACP fields are required when agent_type is "acp" — validated in
 // the handler since it depends on the value of AgentType itself.
+// SystemPrompt, GitCommitterName, and GitCommitterEmail are LLM-only too —
+// the service silently drops them for "acp" agents (see agent.CreateAgent).
 type CreateAgentRequest struct {
 	Name              string    `json:"name" binding:"required"`
 	Handle            string    `json:"handle" binding:"required"`


### PR DESCRIPTION
## Summary
- ACP-type agents no longer support a custom system prompt or git committer identity — `CreateAgent`/`UpdateAgent` now treat `system_prompt`, `git_committer_name`, and `git_committer_email` as LLM-only fields, silently ignored for `acp` agents (same pattern already used for MCP servers/skills/env vars).
- Create-agent dialog: the "Agent Type" choice now happens in step 1, before the preset picker, and the preset grid (which only sets LLM provider/model/system prompt) is hidden entirely when creating an ACP agent.
- Agent detail page: the System Prompt and Git Committer Identity sections are hidden for ACP agents and excluded from the update payload.
- Updated `docs/ai-agent/overview.md` and `docs/ai-agent/api-design.md` to reflect that these fields are LLM-only.

## Test plan
- [x] `go test ./...` in `services/api`
- [x] `go vet ./...` in `services/api`
- [x] `npx tsc -b` in `apps/web`
- [x] `npx biome check` on the changed frontend files
- [x] Manual smoke test: create/edit an ACP agent in the UI and confirm the preset picker, system prompt, and git committer fields are hidden
