### PR TITLE
feat: add agent activity feed functionality

### DIFF
--- a/apps/web/src/components/projects/agents/agent-activity-filters.test.tsx
+++ b/apps/web/src/components/projects/agents/agent-activity-filters.test.tsx
@@ -1,0 +1,58 @@
+// Tests for agent-activity-filters.tsx
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentActivityFilters as AgentActivityFiltersState } from "@/lib/agent-api";
+import { AgentActivityFilters } from "./agent-activity-filters";
+
+describe("AgentActivityFilters", () => {
+	it("debounces search input before calling onFiltersChange", async () => {
+		const onFiltersChange = vi.fn();
+		render(
+			<AgentActivityFilters filters={{}} onFiltersChange={onFiltersChange} />,
+		);
+
+		fireEvent.change(screen.getByPlaceholderText(/search activity/i), {
+			target: { value: "renamed" },
+		});
+
+		expect(onFiltersChange).not.toHaveBeenCalled();
+
+		await waitFor(() => {
+			expect(onFiltersChange).toHaveBeenCalledWith({ search: "renamed" });
+		});
+	});
+
+	it("toggling a source type checkbox adds it to the filters", async () => {
+		const onFiltersChange = vi.fn();
+		render(
+			<AgentActivityFilters filters={{}} onFiltersChange={onFiltersChange} />,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /filters/i }));
+		fireEvent.click(await screen.findByText("Task"));
+
+		expect(onFiltersChange).toHaveBeenCalledWith({ sourceTypes: ["task"] });
+	});
+
+	it("clear-all resets the search input and calls onFiltersChange with no filters", async () => {
+		const onFiltersChange = vi.fn();
+		const filters: AgentActivityFiltersState = { search: "renamed" };
+		render(
+			<AgentActivityFilters
+				filters={filters}
+				onFiltersChange={onFiltersChange}
+			/>,
+		);
+
+		const searchInput = screen.getByPlaceholderText(
+			/search activity/i,
+		) as HTMLInputElement;
+		expect(searchInput.value).toBe("renamed");
+
+		fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+
+		expect(onFiltersChange).toHaveBeenCalledWith({});
+		expect(searchInput.value).toBe("");
+	});
+});

--- a/apps/web/src/components/projects/agents/agent-activity-filters.tsx
+++ b/apps/web/src/components/projects/agents/agent-activity-filters.tsx
@@ -1,0 +1,260 @@
+import { Search, SlidersHorizontal, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Calendar } from "@/components/ui/calendar";
+import { Input } from "@/components/ui/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
+import type {
+	AgentActivityFilters as AgentActivityFiltersState,
+	AgentActivitySourceType,
+} from "@/lib/agent-api";
+import { cn } from "@/lib/utils";
+
+const ALL_SOURCE_TYPES: AgentActivitySourceType[] = ["task", "doc"];
+
+function parseDateOnly(s?: string): Date | undefined {
+	if (!s) return undefined;
+	const [y, m, d] = s.split("-").map(Number);
+	if (!y || !m || !d) return undefined;
+	return new Date(y, m - 1, d);
+}
+
+function toDateOnlyString(date: Date): string {
+	const y = date.getFullYear();
+	const m = String(date.getMonth() + 1).padStart(2, "0");
+	const d = String(date.getDate()).padStart(2, "0");
+	return `${y}-${m}-${d}`;
+}
+
+const dateTriggerClassName = (active: boolean) =>
+	cn(
+		"inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-all duration-150",
+		active
+			? "border-primary/40 bg-primary/8 text-primary"
+			: "border-border/25 bg-muted/25 text-muted-foreground hover:border-border/50 hover:bg-muted/40",
+	);
+
+// ── Popover section building blocks ──────────────────────────────────────────
+
+function FilterSectionLabel({ children }: { children: React.ReactNode }) {
+	return (
+		<p className="px-0.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60">
+			{children}
+		</p>
+	);
+}
+
+function CheckListRow({
+	label,
+	checked,
+	onChange,
+}: {
+	label: string;
+	checked: boolean;
+	onChange: () => void;
+}) {
+	return (
+		<label className="flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-muted/40">
+			<input
+				type="checkbox"
+				checked={checked}
+				onChange={onChange}
+				className="size-3.5 shrink-0 cursor-pointer rounded accent-primary"
+			/>
+			<span className="flex-1 truncate">{label}</span>
+		</label>
+	);
+}
+
+// ── Date range ────────────────────────────────────────────────────────────────
+
+function DateRangeFilter({
+	createdAfter,
+	createdBefore,
+	onChange,
+}: {
+	createdAfter?: string;
+	createdBefore?: string;
+	onChange: (next: { createdAfter?: string; createdBefore?: string }) => void;
+}) {
+	const { t } = useTranslation("projects");
+	return (
+		<div className="flex items-center gap-1.5">
+			<Popover>
+				<PopoverTrigger
+					type="button"
+					className={dateTriggerClassName(!!createdAfter)}
+				>
+					{createdAfter ?? t("agents.detail.activity.filters.dateFrom")}
+				</PopoverTrigger>
+				<PopoverContent className="w-auto p-2" align="start">
+					<Calendar
+						mode="single"
+						selected={parseDateOnly(createdAfter)}
+						onSelect={(d) =>
+							onChange({ createdAfter: d ? toDateOnlyString(d) : undefined })
+						}
+					/>
+				</PopoverContent>
+			</Popover>
+			<Popover>
+				<PopoverTrigger
+					type="button"
+					className={dateTriggerClassName(!!createdBefore)}
+				>
+					{createdBefore ?? t("agents.detail.activity.filters.dateTo")}
+				</PopoverTrigger>
+				<PopoverContent className="w-auto p-2" align="start">
+					<Calendar
+						mode="single"
+						selected={parseDateOnly(createdBefore)}
+						onSelect={(d) =>
+							onChange({ createdBefore: d ? toDateOnlyString(d) : undefined })
+						}
+					/>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}
+
+// ── Filter bar ────────────────────────────────────────────────────────────────
+
+export interface AgentActivityFiltersProps {
+	filters: AgentActivityFiltersState;
+	onFiltersChange: (next: AgentActivityFiltersState) => void;
+}
+
+export function AgentActivityFilters({
+	filters,
+	onFiltersChange,
+}: AgentActivityFiltersProps) {
+	const { t } = useTranslation("projects");
+	const [searchInput, setSearchInput] = useState(filters.search ?? "");
+	const [filtersOpen, setFiltersOpen] = useState(false);
+
+	const debouncedSetSearch = useDebouncedCallback((value: string) => {
+		onFiltersChange({ ...filters, search: value || undefined });
+	}, 300);
+
+	// Keeps the visible input in sync when search is cleared/changed from
+	// outside this component (e.g. the "clear all" button below).
+	useEffect(() => {
+		setSearchInput(filters.search ?? "");
+	}, [filters.search]);
+
+	const activeFilterCount =
+		((filters.sourceTypes?.length ?? 0) ? 1 : 0) +
+		(filters.createdAfter || filters.createdBefore ? 1 : 0);
+	const hasAnyActive = activeFilterCount > 0 || !!filters.search;
+
+	const toggleSourceType = (value: AgentActivitySourceType) => {
+		const current = filters.sourceTypes;
+		const next = current?.includes(value)
+			? current.filter((v) => v !== value)
+			: [...(current ?? []), value];
+		onFiltersChange({
+			...filters,
+			sourceTypes: next.length > 0 ? next : undefined,
+		});
+	};
+
+	return (
+		<div className="flex items-center gap-1.5 border-b border-border/50 px-2 py-2">
+			<div className="relative min-w-0 flex-1">
+				<Search className="absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground/60" />
+				<Input
+					value={searchInput}
+					onChange={(e) => {
+						setSearchInput(e.target.value);
+						debouncedSetSearch(e.target.value);
+					}}
+					placeholder={t("agents.detail.activity.filters.searchPlaceholder")}
+					className="h-7 pl-6 text-xs"
+				/>
+			</div>
+
+			<Popover open={filtersOpen} onOpenChange={setFiltersOpen}>
+				<PopoverTrigger
+					type="button"
+					aria-label={t("agents.detail.activity.filters.title")}
+					className={cn(
+						"relative flex size-7 shrink-0 items-center justify-center rounded-md transition-all duration-150",
+						filtersOpen || activeFilterCount > 0
+							? "bg-primary/8 text-primary/80"
+							: "text-muted-foreground/60 hover:text-foreground hover:bg-muted/60",
+					)}
+				>
+					<SlidersHorizontal className="size-3.5" />
+					{activeFilterCount > 0 && (
+						<span className="absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground">
+							{activeFilterCount}
+						</span>
+					)}
+				</PopoverTrigger>
+				<PopoverContent
+					side="bottom"
+					align="end"
+					sideOffset={6}
+					className="w-72 rounded-xl border border-border/40 p-0 shadow-xl"
+				>
+					<div className="border-b border-border/30 bg-muted/20 px-3 py-2">
+						<p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+							{t("agents.detail.activity.filters.title")}
+						</p>
+					</div>
+					<div className="max-h-[60vh] space-y-3 overflow-y-auto p-3">
+						<section>
+							<FilterSectionLabel>
+								{t("agents.detail.activity.filters.type")}
+							</FilterSectionLabel>
+							<div className="flex flex-col gap-0.5">
+								{ALL_SOURCE_TYPES.map((st) => (
+									<CheckListRow
+										key={st}
+										label={t(`agents.detail.activity.sourceType.${st}`)}
+										checked={filters.sourceTypes?.includes(st) ?? false}
+										onChange={() => toggleSourceType(st)}
+									/>
+								))}
+							</div>
+						</section>
+
+						<div className="border-t border-border/20" />
+
+						<section>
+							<FilterSectionLabel>
+								{t("agents.detail.activity.filters.dateRange")}
+							</FilterSectionLabel>
+							<DateRangeFilter
+								createdAfter={filters.createdAfter}
+								createdBefore={filters.createdBefore}
+								onChange={(range) => onFiltersChange({ ...filters, ...range })}
+							/>
+						</section>
+					</div>
+				</PopoverContent>
+			</Popover>
+
+			{hasAnyActive && (
+				<button
+					type="button"
+					onClick={() => {
+						setSearchInput("");
+						onFiltersChange({});
+					}}
+					aria-label={t("agents.detail.activity.filters.clearAll")}
+					title={t("agents.detail.activity.filters.clearAll")}
+					className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-all duration-150 hover:bg-muted/60 hover:text-foreground"
+				>
+					<X className="size-3.5" />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/agents/agent-activity-tab.test.tsx
+++ b/apps/web/src/components/projects/agents/agent-activity-tab.test.tsx
@@ -1,0 +1,213 @@
+// Tests for agent-activity-tab.tsx
+// Key regression: task activity descriptions (assignee/reporter/sprint changes)
+// must resolve project member/sprint names, not fall back to raw member ids.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// ActivityRow always renders a router <Link>, which needs a RouterProvider
+// ancestor to resolve href/isServer — replace it with a plain anchor so the
+// component can render standalone in this test.
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+		"@tanstack/react-router",
+	);
+	return {
+		...actual,
+		Link: ({
+			children,
+			to,
+			params,
+		}: ComponentProps<"a"> & Record<string, unknown>) => (
+			<a
+				href={typeof to === "string" ? to : undefined}
+				data-params={JSON.stringify(params)}
+			>
+				{children}
+			</a>
+		),
+	};
+});
+
+// agentActivitiesQueryOptions/projectMembersQueryOptions/sprintsQueryOptions
+// all call their fetcher (listAgentActivities/listProjectMembers/listSprints)
+// from within the *same* module, so mocking just the fetcher export doesn't
+// intercept that internal call (ESM same-module bindings aren't affected by
+// vi.mock's export override). Mock the *QueryOptions functions directly instead.
+const { mockListAgentActivities, mockListProjectMembers, mockListSprints } =
+	vi.hoisted(() => ({
+		mockListAgentActivities: vi.fn(),
+		mockListProjectMembers: vi.fn(),
+		mockListSprints: vi.fn(),
+	}));
+
+vi.mock("@/lib/agent-api", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/agent-api")>("@/lib/agent-api");
+	return {
+		...actual,
+		agentActivitiesQueryOptions: () => ({
+			queryKey: ["test", "agentActivities"],
+			queryFn: mockListAgentActivities,
+			initialPageParam: undefined,
+			getNextPageParam: (lastPage: { next_cursor: string | null }) =>
+				lastPage.next_cursor ?? undefined,
+		}),
+	};
+});
+
+vi.mock("@/lib/project-api", async () => {
+	const actual =
+		await vi.importActual<typeof import("@/lib/project-api")>(
+			"@/lib/project-api",
+		);
+	return {
+		...actual,
+		projectMembersQueryOptions: () => ({
+			queryKey: ["test", "members"],
+			queryFn: mockListProjectMembers,
+		}),
+	};
+});
+
+vi.mock("@/lib/interaction-api", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/interaction-api")>(
+		"@/lib/interaction-api",
+	);
+	return {
+		...actual,
+		sprintsQueryOptions: () => ({
+			queryKey: ["test", "sprints"],
+			queryFn: mockListSprints,
+		}),
+	};
+});
+
+import { AgentActivityTab } from "./agent-activity-tab";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const PROJECT_ID = "proj-1";
+const AGENT_ID = "agent-1";
+const MEMBER_ID = "3f7c2b10-aaaa-bbbb-cccc-1234567890ab";
+
+describe("AgentActivityTab", () => {
+	it("resolves the assignee's display name instead of a truncated member id", async () => {
+		mockListAgentActivities.mockResolvedValue({
+			items: [
+				{
+					id: "activity-1",
+					source_type: "task",
+					source_id: "task-1",
+					source_title: "Fix the login bug",
+					source_deleted: false,
+					activity_type: "task.updated",
+					content: {
+						changes: [{ field: "assignee", old: [], new: [MEMBER_ID] }],
+					},
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+			],
+			page_size: 20,
+			next_cursor: null,
+		});
+		mockListProjectMembers.mockResolvedValue([
+			{
+				id: MEMBER_ID,
+				project_id: PROJECT_ID,
+				user_id: "user-1",
+				project_role_id: "role-1",
+				username: "jdoe",
+				full_name: "Jane Doe",
+				role_name: "Member",
+			},
+		]);
+		mockListSprints.mockResolvedValue([]);
+
+		render(<AgentActivityTab projectId={PROJECT_ID} agentId={AGENT_ID} />, {
+			wrapper,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
+		});
+		expect(
+			screen.queryByText(new RegExp(MEMBER_ID.slice(0, 8))),
+		).not.toBeInTheDocument();
+	});
+
+	it("falls back to a truncated id while member names haven't loaded yet", async () => {
+		mockListAgentActivities.mockResolvedValue({
+			items: [
+				{
+					id: "activity-1",
+					source_type: "task",
+					source_id: "task-1",
+					source_title: "Fix the login bug",
+					source_deleted: false,
+					activity_type: "task.updated",
+					content: {
+						changes: [{ field: "assignee", old: [], new: [MEMBER_ID] }],
+					},
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+			],
+			page_size: 20,
+			next_cursor: null,
+		});
+		mockListProjectMembers.mockResolvedValue([]);
+		mockListSprints.mockResolvedValue([]);
+
+		render(<AgentActivityTab projectId={PROJECT_ID} agentId={AGENT_ID} />, {
+			wrapper,
+		});
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(new RegExp(MEMBER_ID.slice(0, 8))),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("renders a deleted source's title as plain text instead of a link", async () => {
+		mockListAgentActivities.mockResolvedValue({
+			items: [
+				{
+					id: "activity-1",
+					source_type: "task",
+					source_id: "task-1",
+					source_title: "Fix the login bug",
+					source_deleted: true,
+					activity_type: "task.deleted",
+					content: {},
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+			],
+			page_size: 20,
+			next_cursor: null,
+		});
+		mockListProjectMembers.mockResolvedValue([]);
+		mockListSprints.mockResolvedValue([]);
+
+		render(<AgentActivityTab projectId={PROJECT_ID} agentId={AGENT_ID} />, {
+			wrapper,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText("Fix the login bug")).toBeInTheDocument();
+		});
+		expect(
+			screen.queryByRole("link", { name: /Fix the login bug/ }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/components/projects/agents/agent-activity-tab.tsx
+++ b/apps/web/src/components/projects/agents/agent-activity-tab.tsx
@@ -1,0 +1,179 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Activity, CheckSquare, FileText } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AgentActivityFilters } from "@/components/projects/agents/agent-activity-filters";
+import { activityDescription } from "@/components/projects/interactions/task-detail/activity-item";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+	type AgentActivity,
+	type AgentActivityFilters as AgentActivityFiltersState,
+	agentActivitiesQueryOptions,
+} from "@/lib/agent-api";
+import type { DocActivityContent, DocActivityType } from "@/lib/doc-api";
+import { timeAgo } from "@/lib/time-ago";
+import { describeDocActivity } from "../docs/doc-activity-pane";
+
+const EMPTY_NAME_MAPS = { members: {}, sprints: {} };
+
+function describeItem(
+	item: AgentActivity,
+	t: ReturnType<typeof useTranslation<"projects">>["t"],
+): string {
+	if (item.activity_type === "comment") {
+		return t("agents.detail.activity.commented");
+	}
+	if (item.source_type === "task") {
+		return activityDescription(
+			{
+				activity_type: item.activity_type,
+				content: item.content as Record<string, unknown> | unknown[],
+			},
+			EMPTY_NAME_MAPS,
+			t,
+		);
+	}
+	return describeDocActivity(
+		{
+			activity_type: item.activity_type as DocActivityType,
+			content: item.content as string | DocActivityContent | null,
+		},
+		t,
+	);
+}
+
+function ActivityRow({
+	projectId,
+	item,
+}: {
+	projectId: string;
+	item: AgentActivity;
+}) {
+	const { t } = useTranslation("projects");
+	const { t: tCommon } = useTranslation("common");
+	const Icon = item.source_type === "task" ? CheckSquare : FileText;
+	const description = describeItem(item, t);
+
+	return (
+		<div className="flex items-start gap-3 border-b border-border/10 px-1 py-2.5 last:border-0">
+			<div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-muted/40 text-muted-foreground/80">
+				<Icon className="size-3.5" />
+			</div>
+			<div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+				<Badge variant="outline" className="shrink-0 text-[10px] font-semibold">
+					{t(`agents.detail.activity.sourceType.${item.source_type}`)}
+				</Badge>
+				{description && (
+					<span className="text-sm text-foreground/80">{description}</span>
+				)}
+				{item.source_type === "task" ? (
+					<Link
+						to="/projects/$projectId/tasks/$taskId"
+						params={{ projectId, taskId: item.source_id }}
+						className="truncate text-sm font-medium text-primary hover:underline"
+					>
+						{item.source_title}
+					</Link>
+				) : (
+					<Link
+						to="/projects/$projectId/docs/$docId"
+						params={{ projectId, docId: item.source_id }}
+						className="truncate text-sm font-medium text-primary hover:underline"
+					>
+						{item.source_title}
+					</Link>
+				)}
+				<span className="ml-auto shrink-0 text-xs text-muted-foreground/45">
+					{timeAgo(item.created_at, tCommon)}
+				</span>
+			</div>
+		</div>
+	);
+}
+
+export interface AgentActivityTabProps {
+	projectId: string;
+	agentId: string;
+}
+
+export function AgentActivityTab({
+	projectId,
+	agentId,
+}: AgentActivityTabProps) {
+	const { t } = useTranslation("projects");
+	const [filters, setFilters] = useState<AgentActivityFiltersState>({});
+
+	const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+		useInfiniteQuery(agentActivitiesQueryOptions(projectId, agentId, filters));
+
+	const items = data?.pages.flatMap((page) => page.items) ?? [];
+	const hasActiveFilters = Object.values(filters).some((v) =>
+		Array.isArray(v) ? v.length > 0 : !!v,
+	);
+
+	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const container = scrollContainerRef.current;
+		const target = loadMoreRef.current;
+		if (!container || !target) return;
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+					void fetchNextPage();
+				}
+			},
+			{ root: container, rootMargin: "150px" },
+		);
+		observer.observe(target);
+		return () => observer.disconnect();
+	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col rounded-xl border border-border/50">
+			<AgentActivityFilters filters={filters} onFiltersChange={setFilters} />
+			<div
+				ref={scrollContainerRef}
+				className="min-h-0 flex-1 overflow-y-auto px-3 py-1"
+			>
+				{isLoading ? (
+					<div className="space-y-2 py-2">
+						{Array.from({ length: 5 }).map((_, i) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: skeleton
+							<Skeleton key={i} className="h-10 rounded-lg" />
+						))}
+					</div>
+				) : items.length === 0 ? (
+					<div className="flex flex-col items-center justify-center gap-3 py-14 text-center">
+						<Activity className="size-8 text-muted-foreground/40" />
+						<p className="text-sm text-muted-foreground">
+							{hasActiveFilters
+								? t("agents.detail.activity.emptyFiltered.title")
+								: t("agents.detail.activity.empty.title")}
+						</p>
+						<p className="max-w-xs text-xs text-muted-foreground">
+							{hasActiveFilters
+								? t("agents.detail.activity.emptyFiltered.description")
+								: t("agents.detail.activity.empty.description")}
+						</p>
+					</div>
+				) : (
+					<>
+						{items.map((item) => (
+							<ActivityRow key={item.id} projectId={projectId} item={item} />
+						))}
+						{hasNextPage && (
+							<div ref={loadMoreRef} className="py-2">
+								{isFetchingNextPage && <Skeleton className="h-10 rounded-lg" />}
+							</div>
+						)}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/projects/agents/agent-activity-tab.tsx
+++ b/apps/web/src/components/projects/agents/agent-activity-tab.tsx
@@ -1,10 +1,13 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Activity, CheckSquare, FileText } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AgentActivityFilters } from "@/components/projects/agents/agent-activity-filters";
-import { activityDescription } from "@/components/projects/interactions/task-detail/activity-item";
+import {
+	type ActivityNameMaps,
+	activityDescription,
+} from "@/components/projects/interactions/task-detail/activity-item";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -13,13 +16,14 @@ import {
 	agentActivitiesQueryOptions,
 } from "@/lib/agent-api";
 import type { DocActivityContent, DocActivityType } from "@/lib/doc-api";
+import { sprintsQueryOptions } from "@/lib/interaction-api";
+import { projectMembersQueryOptions } from "@/lib/project-api";
 import { timeAgo } from "@/lib/time-ago";
 import { describeDocActivity } from "../docs/doc-activity-pane";
 
-const EMPTY_NAME_MAPS = { members: {}, sprints: {} };
-
 function describeItem(
 	item: AgentActivity,
+	names: ActivityNameMaps,
 	t: ReturnType<typeof useTranslation<"projects">>["t"],
 ): string {
 	if (item.activity_type === "comment") {
@@ -31,7 +35,7 @@ function describeItem(
 				activity_type: item.activity_type,
 				content: item.content as Record<string, unknown> | unknown[],
 			},
-			EMPTY_NAME_MAPS,
+			names,
 			t,
 		);
 	}
@@ -47,14 +51,16 @@ function describeItem(
 function ActivityRow({
 	projectId,
 	item,
+	names,
 }: {
 	projectId: string;
 	item: AgentActivity;
+	names: ActivityNameMaps;
 }) {
 	const { t } = useTranslation("projects");
 	const { t: tCommon } = useTranslation("common");
 	const Icon = item.source_type === "task" ? CheckSquare : FileText;
-	const description = describeItem(item, t);
+	const description = describeItem(item, names, t);
 
 	return (
 		<div className="flex items-start gap-3 border-b border-border/10 px-1 py-2.5 last:border-0">
@@ -68,7 +74,11 @@ function ActivityRow({
 				{description && (
 					<span className="text-sm text-foreground/80">{description}</span>
 				)}
-				{item.source_type === "task" ? (
+				{item.source_deleted ? (
+					<span className="truncate text-sm font-medium text-muted-foreground/70">
+						{item.source_title}
+					</span>
+				) : item.source_type === "task" ? (
 					<Link
 						to="/projects/$projectId/tasks/$taskId"
 						params={{ projectId, taskId: item.source_id }}
@@ -107,6 +117,20 @@ export function AgentActivityTab({
 
 	const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
 		useInfiniteQuery(agentActivitiesQueryOptions(projectId, agentId, filters));
+
+	const { data: membersData } = useQuery(projectMembersQueryOptions(projectId));
+	const { data: sprintsData } = useQuery(sprintsQueryOptions(projectId));
+	const names = useMemo<ActivityNameMaps>(() => {
+		const members: Record<string, string> = {};
+		for (const m of membersData ?? []) {
+			members[m.id] = m.full_name || m.username;
+		}
+		const sprints: Record<string, string> = {};
+		for (const s of sprintsData ?? []) {
+			sprints[s.id] = s.name;
+		}
+		return { members, sprints };
+	}, [membersData, sprintsData]);
 
 	const items = data?.pages.flatMap((page) => page.items) ?? [];
 	const hasActiveFilters = Object.values(filters).some((v) =>
@@ -164,7 +188,12 @@ export function AgentActivityTab({
 				) : (
 					<>
 						{items.map((item) => (
-							<ActivityRow key={item.id} projectId={projectId} item={item} />
+							<ActivityRow
+								key={item.id}
+								projectId={projectId}
+								item={item}
+								names={names}
+							/>
 						))}
 						{hasNextPage && (
 							<div ref={loadMoreRef} className="py-2">

--- a/apps/web/src/components/projects/docs/doc-activity-pane.tsx
+++ b/apps/web/src/components/projects/docs/doc-activity-pane.tsx
@@ -2,10 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { TFunction } from "i18next";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	type ActivityEntry,
-	ActivityPane,
-} from "@/components/shared/activity-pane";
+import { ActivityPane } from "@/components/shared/activity-pane";
 import { textToBlocks } from "@/components/shared/comment-blocknote";
 import { currentUserQueryOptions } from "@/lib/auth-api";
 import {
@@ -45,16 +42,18 @@ function getDocActivityChanges(content: unknown): DocActivityChange[] {
 	);
 }
 
-function describeDocActivity(
-	entry: ActivityEntry,
+// Exported (and narrowed to just the fields it needs) so the agent activity
+// feed tab can reuse the same doc-activity copy without duplicating it — see
+// apps/web/src/components/projects/agents/agent-activity-tab.tsx.
+export function describeDocActivity(
+	entry: Pick<DocActivity, "activity_type" | "content">,
 	t: TFunction<"projects">,
 ): string {
-	const activity = entry as DocActivity;
-	switch (activity.activity_type) {
+	switch (entry.activity_type) {
 		case "doc.created":
 			return t("docs.activity.created");
 		case "doc.updated": {
-			const changes = getDocActivityChanges(activity.content);
+			const changes = getDocActivityChanges(entry.content);
 			if (changes.length > 0) {
 				const fields = changes.map((c) => c.field).join(", ");
 				return t("docs.activity.updatedFields", { fields });
@@ -68,7 +67,7 @@ function describeDocActivity(
 		case "comment":
 			return "";
 		default:
-			return activity.activity_type;
+			return entry.activity_type;
 	}
 }
 

--- a/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/activity-item.tsx
@@ -132,8 +132,11 @@ export function describeTaskChange(
 	}
 }
 
-function activityDescription(
-	entry: ActivityEntry,
+// Exported (and narrowed to just the fields it needs) so the agent activity
+// feed tab can reuse the same task-activity copy without duplicating it —
+// see apps/web/src/components/projects/agents/agent-activity-tab.tsx.
+export function activityDescription(
+	entry: Pick<ActivityEntry, "activity_type" | "content">,
 	names: ActivityNameMaps,
 	t: TFunction<"projects">,
 ): string {

--- a/apps/web/src/hooks/use-project-realtime.ts
+++ b/apps/web/src/hooks/use-project-realtime.ts
@@ -23,9 +23,16 @@
 // task.* events  → invalidate ["projects", projectId, "tasks"]
 //                  This covers allTasksQueryOptions, taskQueryOptions,
 //                  sprintTasksQueryOptions, epicTasksQueryOptions, etc.
+//                  Also invalidates ["projects", projectId, "agentActivities"]
+//                  (agentActivitiesQueryOptions) — task activity changes can
+//                  belong to any agent, so every agent's activity feed cache
+//                  is invalidated rather than trying to parse which agent
+//                  from the payload.
 // doc.* events   → invalidate ["projects", projectId, "docs"]
 //                  This covers docFoldersQueryOptions, docListQueryOptions,
-//                  docQueryOptions, etc.
+//                  docQueryOptions, etc. Also invalidates
+//                  ["projects", projectId, "agentActivities"], same reasoning
+//                  as task.* above.
 // sprint.* events → invalidate ["projects", projectId, "sprints"]
 //                  This covers sprintsQueryOptions and sprintQueryOptions —
 //                  replaces the sidebar's old refetchInterval polling.
@@ -72,12 +79,18 @@ export function useProjectRealtime(projectId: string): void {
 				void queryClient.invalidateQueries({
 					queryKey: ["projects", projectId, "tasks"],
 				});
+				void queryClient.invalidateQueries({
+					queryKey: ["projects", projectId, "agentActivities"],
+				});
 				return;
 			}
 
 			if (type.startsWith("doc.")) {
 				void queryClient.invalidateQueries({
 					queryKey: ["projects", projectId, "docs"],
+				});
+				void queryClient.invalidateQueries({
+					queryKey: ["projects", projectId, "agentActivities"],
 				});
 				return;
 			}

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -121,7 +121,8 @@
 				"overview": "Overview",
 				"mcpServers": "MCP Servers",
 				"skills": "Skills",
-				"envVars": "Environment"
+				"envVars": "Environment",
+				"activity": "Activity"
 			},
 			"overview": {
 				"nameLabel": "Name",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "Cancel",
 					"addSkill": "Add skill"
+				}
+			},
+			"activity": {
+				"commented": "commented",
+				"sourceType": {
+					"task": "Task",
+					"doc": "Doc"
+				},
+				"empty": {
+					"title": "No activity yet",
+					"description": "Task and document activity performed by this agent will show up here."
+				},
+				"emptyFiltered": {
+					"title": "No matching activity",
+					"description": "Try adjusting your filters or search."
+				},
+				"filters": {
+					"title": "Filters",
+					"type": "Type",
+					"dateRange": "Date range",
+					"searchPlaceholder": "Search activity…",
+					"dateFrom": "From",
+					"dateTo": "To",
+					"clearAll": "Clear filters"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -121,7 +121,8 @@
 				"overview": "Resumen",
 				"mcpServers": "Servidores MCP",
 				"skills": "Skills",
-				"envVars": "Entorno"
+				"envVars": "Entorno",
+				"activity": "Actividad"
 			},
 			"overview": {
 				"nameLabel": "Nombre",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "Cancelar",
 					"addSkill": "Añadir skill"
+				}
+			},
+			"activity": {
+				"commented": "comentó",
+				"sourceType": {
+					"task": "Tarea",
+					"doc": "Documento"
+				},
+				"empty": {
+					"title": "Sin actividad todavía",
+					"description": "La actividad en tareas y documentos realizada por este agente aparecerá aquí."
+				},
+				"emptyFiltered": {
+					"title": "Sin actividad coincidente",
+					"description": "Intenta ajustar los filtros o la búsqueda."
+				},
+				"filters": {
+					"title": "Filtros",
+					"type": "Tipo",
+					"dateRange": "Rango de fechas",
+					"searchPlaceholder": "Buscar actividad…",
+					"dateFrom": "Desde",
+					"dateTo": "Hasta",
+					"clearAll": "Borrar filtros"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -121,7 +121,8 @@
 				"overview": "Aperçu",
 				"mcpServers": "Serveurs MCP",
 				"skills": "Compétences",
-				"envVars": "Environnement"
+				"envVars": "Environnement",
+				"activity": "Activité"
 			},
 			"overview": {
 				"nameLabel": "Nom",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "Annuler",
 					"addSkill": "Ajouter la compétence"
+				}
+			},
+			"activity": {
+				"commented": "a commenté",
+				"sourceType": {
+					"task": "Tâche",
+					"doc": "Document"
+				},
+				"empty": {
+					"title": "Aucune activité pour le moment",
+					"description": "L'activité sur les tâches et documents effectuée par cet agent apparaîtra ici."
+				},
+				"emptyFiltered": {
+					"title": "Aucune activité correspondante",
+					"description": "Essayez d'ajuster vos filtres ou votre recherche."
+				},
+				"filters": {
+					"title": "Filtres",
+					"type": "Type",
+					"dateRange": "Plage de dates",
+					"searchPlaceholder": "Rechercher une activité…",
+					"dateFrom": "Du",
+					"dateTo": "Au",
+					"clearAll": "Effacer les filtres"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -121,7 +121,8 @@
 				"overview": "概要",
 				"mcpServers": "MCPサーバー",
 				"skills": "スキル",
-				"envVars": "環境変数"
+				"envVars": "環境変数",
+				"activity": "アクティビティ"
 			},
 			"overview": {
 				"nameLabel": "名前",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "キャンセル",
 					"addSkill": "スキルを追加"
+				}
+			},
+			"activity": {
+				"commented": "コメントしました",
+				"sourceType": {
+					"task": "タスク",
+					"doc": "ドキュメント"
+				},
+				"empty": {
+					"title": "まだアクティビティはありません",
+					"description": "このエージェントによるタスクおよびドキュメントのアクティビティがここに表示されます。"
+				},
+				"emptyFiltered": {
+					"title": "該当するアクティビティがありません",
+					"description": "フィルターや検索条件を調整してみてください。"
+				},
+				"filters": {
+					"title": "フィルター",
+					"type": "タイプ",
+					"dateRange": "日付範囲",
+					"searchPlaceholder": "アクティビティを検索…",
+					"dateFrom": "開始日",
+					"dateTo": "終了日",
+					"clearAll": "フィルターをクリア"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -121,7 +121,8 @@
 				"overview": "개요",
 				"mcpServers": "MCP 서버",
 				"skills": "스킬",
-				"envVars": "환경 변수"
+				"envVars": "환경 변수",
+				"activity": "활동"
 			},
 			"overview": {
 				"nameLabel": "이름",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "취소",
 					"addSkill": "스킬 추가"
+				}
+			},
+			"activity": {
+				"commented": "댓글을 남겼습니다",
+				"sourceType": {
+					"task": "작업",
+					"doc": "문서"
+				},
+				"empty": {
+					"title": "아직 활동이 없습니다",
+					"description": "이 에이전트가 수행한 작업 및 문서 활동이 여기에 표시됩니다."
+				},
+				"emptyFiltered": {
+					"title": "일치하는 활동이 없습니다",
+					"description": "필터나 검색어를 조정해 보세요."
+				},
+				"filters": {
+					"title": "필터",
+					"type": "유형",
+					"dateRange": "날짜 범위",
+					"searchPlaceholder": "활동 검색…",
+					"dateFrom": "시작일",
+					"dateTo": "종료일",
+					"clearAll": "필터 초기화"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -121,7 +121,8 @@
 				"overview": "Visão geral",
 				"mcpServers": "Servidores MCP",
 				"skills": "Skills",
-				"envVars": "Ambiente"
+				"envVars": "Ambiente",
+				"activity": "Atividade"
 			},
 			"overview": {
 				"nameLabel": "Nome",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "Cancelar",
 					"addSkill": "Adicionar skill"
+				}
+			},
+			"activity": {
+				"commented": "comentou",
+				"sourceType": {
+					"task": "Tarefa",
+					"doc": "Documento"
+				},
+				"empty": {
+					"title": "Nenhuma atividade ainda",
+					"description": "A atividade em tarefas e documentos realizada por este agente aparecerá aqui."
+				},
+				"emptyFiltered": {
+					"title": "Nenhuma atividade correspondente",
+					"description": "Tente ajustar seus filtros ou busca."
+				},
+				"filters": {
+					"title": "Filtros",
+					"type": "Tipo",
+					"dateRange": "Intervalo de datas",
+					"searchPlaceholder": "Pesquisar atividade…",
+					"dateFrom": "De",
+					"dateTo": "Até",
+					"clearAll": "Limpar filtros"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -121,7 +121,8 @@
 				"overview": "Обзор",
 				"mcpServers": "MCP-серверы",
 				"skills": "Навыки",
-				"envVars": "Окружение"
+				"envVars": "Окружение",
+				"activity": "Активность"
 			},
 			"overview": {
 				"nameLabel": "Имя",
@@ -216,6 +217,30 @@
 					"urlLabel": "URL",
 					"cancel": "Отмена",
 					"addSkill": "Добавить навык"
+				}
+			},
+			"activity": {
+				"commented": "оставил комментарий",
+				"sourceType": {
+					"task": "Задача",
+					"doc": "Документ"
+				},
+				"empty": {
+					"title": "Пока нет активности",
+					"description": "Здесь будет отображаться активность этого агента по задачам и документам."
+				},
+				"emptyFiltered": {
+					"title": "Нет подходящей активности",
+					"description": "Попробуйте изменить фильтры или запрос поиска."
+				},
+				"filters": {
+					"title": "Фильтры",
+					"type": "Тип",
+					"dateRange": "Диапазон дат",
+					"searchPlaceholder": "Поиск по активности…",
+					"dateFrom": "С",
+					"dateTo": "По",
+					"clearAll": "Сбросить фильтры"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -121,7 +121,8 @@
 				"overview": "Tổng quan",
 				"mcpServers": "Máy chủ MCP",
 				"skills": "Skill",
-				"envVars": "Môi trường"
+				"envVars": "Môi trường",
+				"activity": "Hoạt động"
 			},
 			"overview": {
 				"nameLabel": "Tên",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "Hủy",
 					"addSkill": "Thêm skill"
+				}
+			},
+			"activity": {
+				"commented": "đã bình luận",
+				"sourceType": {
+					"task": "Công việc",
+					"doc": "Tài liệu"
+				},
+				"empty": {
+					"title": "Chưa có hoạt động nào",
+					"description": "Hoạt động trên công việc và tài liệu do tác nhân này thực hiện sẽ hiển thị ở đây."
+				},
+				"emptyFiltered": {
+					"title": "Không có hoạt động phù hợp",
+					"description": "Hãy thử điều chỉnh bộ lọc hoặc tìm kiếm."
+				},
+				"filters": {
+					"title": "Bộ lọc",
+					"type": "Loại",
+					"dateRange": "Khoảng thời gian",
+					"searchPlaceholder": "Tìm kiếm hoạt động…",
+					"dateFrom": "Từ ngày",
+					"dateTo": "Đến ngày",
+					"clearAll": "Xóa bộ lọc"
 				}
 			}
 		},

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -121,7 +121,8 @@
 				"overview": "概览",
 				"mcpServers": "MCP 服务器",
 				"skills": "技能",
-				"envVars": "环境变量"
+				"envVars": "环境变量",
+				"activity": "动态"
 			},
 			"overview": {
 				"nameLabel": "名称",
@@ -210,6 +211,30 @@
 					"urlLabel": "URL",
 					"cancel": "取消",
 					"addSkill": "添加技能"
+				}
+			},
+			"activity": {
+				"commented": "发表了评论",
+				"sourceType": {
+					"task": "任务",
+					"doc": "文档"
+				},
+				"empty": {
+					"title": "暂无动态",
+					"description": "该代理执行的任务和文档动态将显示在此处。"
+				},
+				"emptyFiltered": {
+					"title": "没有匹配的动态",
+					"description": "请尝试调整筛选条件或搜索内容。"
+				},
+				"filters": {
+					"title": "筛选",
+					"type": "类型",
+					"dateRange": "日期范围",
+					"searchPlaceholder": "搜索动态…",
+					"dateFrom": "起始日期",
+					"dateTo": "结束日期",
+					"clearAll": "清除筛选"
 				}
 			}
 		},

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -779,6 +779,97 @@ export const chatSessionsQueryOptions = (projectId: string, agentId: string) =>
 		queryFn: () => listChatSessions(projectId, agentId),
 	});
 
+// ── Activity Feed ────────────────────────────────────────────────────────────
+
+export type AgentActivitySourceType = "task" | "doc";
+
+export interface AgentActivity {
+	id: string;
+	source_type: AgentActivitySourceType;
+	source_id: string;
+	source_title: string;
+	activity_type: string;
+	// Heterogeneous by source_type (task activity content vs doc activity
+	// content have different shapes) — callers narrow it per-row using
+	// source_type before passing to activityDescription/describeDocActivity.
+	content: unknown;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface AgentActivityListResult {
+	items: AgentActivity[];
+	page_size: number;
+	next_cursor: string | null;
+}
+
+export const AGENT_ACTIVITIES_PAGE_SIZE = 20;
+
+export interface ListAgentActivitiesOptions {
+	sourceTypes?: AgentActivitySourceType[];
+	/** Local calendar dates ("YYYY-MM-DD") — see ListConversationsOptions above. */
+	createdAfter?: string;
+	createdBefore?: string;
+	/** Free-text search matched server-side against the linked task/doc title and activity content. */
+	search?: string;
+	cursor?: string;
+	pageSize?: number;
+}
+
+function buildAgentActivityQueryParams(opts: ListAgentActivitiesOptions = {}) {
+	const params: Record<string, string | number> = {};
+	params.page_size = opts.pageSize ?? AGENT_ACTIVITIES_PAGE_SIZE;
+	if (opts.cursor) params.cursor = opts.cursor;
+	if (opts.sourceTypes && opts.sourceTypes.length > 0)
+		params.type = opts.sourceTypes.join(",");
+	if (opts.createdAfter)
+		params.created_after = localDateStartISO(opts.createdAfter);
+	if (opts.createdBefore)
+		params.created_before = localDateExclusiveEndISO(opts.createdBefore);
+	if (opts.search?.trim()) params.search = opts.search.trim();
+	return params;
+}
+
+export async function listAgentActivities(
+	projectId: string,
+	agentId: string,
+	options?: ListAgentActivitiesOptions,
+): Promise<AgentActivityListResult> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<AgentActivityListResult>
+	>(`/projects/${projectId}/agents/${agentId}/activities`, {
+		params: buildAgentActivityQueryParams(options),
+	});
+	return data.data;
+}
+
+// Cursor-paginated the same way conversationsQueryOptions is (see above) —
+// not nested under the ["projects", projectId, "agents", ...] prefix so that
+// task.*/doc.* realtime invalidation (use-project-realtime.ts) can target
+// every agent's activity feed at once without also invalidating agent
+// detail/mcp-servers/skills/env-vars caches.
+export type AgentActivityFilters = Omit<
+	ListAgentActivitiesOptions,
+	"cursor" | "pageSize"
+>;
+
+export const agentActivitiesQueryOptions = (
+	projectId: string,
+	agentId: string,
+	filters: AgentActivityFilters = {},
+) =>
+	infiniteQueryOptions({
+		queryKey: ["projects", projectId, "agentActivities", agentId, filters],
+		queryFn: ({ pageParam }: { pageParam: string | undefined }) =>
+			listAgentActivities(projectId, agentId, {
+				...filters,
+				cursor: pageParam,
+				pageSize: AGENT_ACTIVITIES_PAGE_SIZE,
+			}),
+		initialPageParam: undefined as string | undefined,
+		getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+	});
+
 // ── LLM Models ────────────────────────────────────────────────────────────────
 
 export interface LLMProviderInfo {

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -788,6 +788,10 @@ export interface AgentActivity {
 	source_type: AgentActivitySourceType;
 	source_id: string;
 	source_title: string;
+	// True when the linked task/doc has since been deleted — the activity
+	// (including the delete action itself) stays in the feed, but the UI
+	// shouldn't link to a source that no longer resolves.
+	source_deleted: boolean;
 	activity_type: string;
 	// Heterogeneous by source_type (task activity content vs doc activity
 	// content have different shapes) — callers narrow it per-row using

--- a/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/agents/$agentId/index.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
+	Activity as ActivityIcon,
 	Bot,
 	Check,
 	Code2,
@@ -15,6 +16,7 @@ import {
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AcpBridgeSetup } from "@/components/projects/agents/acp-bridge-setup";
+import { AgentActivityTab } from "@/components/projects/agents/agent-activity-tab";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -83,7 +85,7 @@ export const Route = createFileRoute(
 	component: AgentDetailPage,
 });
 
-type Tab = "overview" | "mcp-servers" | "skills" | "env-vars";
+type Tab = "overview" | "mcp-servers" | "skills" | "env-vars" | "activity";
 
 const CUSTOM = "__custom__";
 
@@ -1241,6 +1243,11 @@ const TABS = [
 		labelKey: "agents.detail.tabs.envVars",
 		icon: KeyRound,
 	},
+	{
+		id: "activity",
+		labelKey: "agents.detail.tabs.activity",
+		icon: ActivityIcon,
+	},
 ] as const satisfies {
 	id: Tab;
 	labelKey: string;
@@ -1359,7 +1366,13 @@ function AgentDetailPage() {
 			</div>
 
 			{/* Tab content */}
-			<div className="flex-1 overflow-auto p-6">
+			<div
+				className={
+					activeTab === "activity"
+						? "flex flex-1 min-h-0 flex-col p-6"
+						: "flex-1 overflow-auto p-6"
+				}
+			>
 				{activeTab === "overview" && (
 					<OverviewTab
 						agent={agent}
@@ -1387,6 +1400,9 @@ function AgentDetailPage() {
 						agentId={agentId}
 						canWrite={canWrite}
 					/>
+				)}
+				{activeTab === "activity" && (
+					<AgentActivityTab projectId={projectId} agentId={agentId} />
 				)}
 			</div>
 		</div>

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -297,6 +297,8 @@ const (
 	CodeAgentConversationBusy Code = "AGENT_CONVERSATION_BUSY"
 	// CodeAgentConversationInvalidCursor indicates a client-supplied pagination cursor failed to decode.
 	CodeAgentConversationInvalidCursor Code = "AGENT_CONVERSATION_INVALID_CURSOR"
+	// CodeAgentActivityInvalidCursor indicates a client-supplied activity feed pagination cursor failed to decode.
+	CodeAgentActivityInvalidCursor Code = "AGENT_ACTIVITY_INVALID_CURSOR"
 	// CodeAgentChatSessionNotFound indicates the requested chat session does not exist.
 	CodeAgentChatSessionNotFound Code = "AGENT_CHAT_SESSION_NOT_FOUND"
 	// CodeAgentEnvVarNotFound indicates the requested environment variable does not exist.

--- a/services/api/internal/domain/agent/activity_feed.go
+++ b/services/api/internal/domain/agent/activity_feed.go
@@ -22,15 +22,19 @@ const (
 // ActivityFeedItem is one row of an agent's unified task+doc activity feed.
 // SourceTitle is the joined task/document title at query time, so the UI can
 // render and link to "commented on <title>" without a second round trip.
+// Deleted tasks/docs are intentionally still included (an agent deleting a
+// task is itself an activity worth keeping in the feed) — SourceDeleted lets
+// the UI skip linking to a source that no longer resolves.
 type ActivityFeedItem struct {
-	ID           uuid.UUID
-	SourceType   ActivitySourceType
-	SourceID     uuid.UUID
-	SourceTitle  string
-	ActivityType string
-	Content      json.RawMessage
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID            uuid.UUID
+	SourceType    ActivitySourceType
+	SourceID      uuid.UUID
+	SourceTitle   string
+	SourceDeleted bool
+	ActivityType  string
+	Content       json.RawMessage
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 // ListAgentActivitiesFilter carries optional filters for listing an agent's

--- a/services/api/internal/domain/agent/activity_feed.go
+++ b/services/api/internal/domain/agent/activity_feed.go
@@ -1,0 +1,55 @@
+package agentdom
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ActivitySourceType identifies which activity table an ActivityFeedItem
+// came from — an agent's activity feed unions task_activities and
+// doc_activities, which have no common parent table.
+type ActivitySourceType string
+
+const (
+	ActivitySourceTask ActivitySourceType = "task"
+	ActivitySourceDoc  ActivitySourceType = "doc"
+)
+
+// ActivityFeedItem is one row of an agent's unified task+doc activity feed.
+// SourceTitle is the joined task/document title at query time, so the UI can
+// render and link to "commented on <title>" without a second round trip.
+type ActivityFeedItem struct {
+	ID           uuid.UUID
+	SourceType   ActivitySourceType
+	SourceID     uuid.UUID
+	SourceTitle  string
+	ActivityType string
+	Content      json.RawMessage
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// ListAgentActivitiesFilter carries optional filters for listing an agent's
+// activity feed. ActorMemberID is required — it's the project_members.id
+// that task_activities.actor_id/doc_activities.actor_id are resolved
+// against (see FindMemberByAgent), not the agents.id itself.
+type ListAgentActivitiesFilter struct {
+	ActorMemberID uuid.UUID
+	SourceTypes   []ActivitySourceType
+	CreatedAfter  *time.Time
+	CreatedBefore *time.Time
+	// Search matches activities whose linked task/document title or raw
+	// content contains this text (case-insensitive substring match).
+	Search      *string
+	CursorAfter *string
+}
+
+// ActivityFeedRepository defines storage for an agent's unified activity feed.
+type ActivityFeedRepository interface {
+	// ListAgentActivities returns up to limit activities matching the
+	// filter, ordered newest-first, plus whether more pages remain.
+	ListAgentActivities(ctx context.Context, in ListAgentActivitiesFilter, limit int) ([]*ActivityFeedItem, bool, error)
+}

--- a/services/api/internal/domain/agent/activity_feed.go
+++ b/services/api/internal/domain/agent/activity_feed.go
@@ -13,6 +13,7 @@ import (
 // doc_activities, which have no common parent table.
 type ActivitySourceType string
 
+// The two ActivitySourceType values, one per unioned activity table.
 const (
 	ActivitySourceTask ActivitySourceType = "task"
 	ActivitySourceDoc  ActivitySourceType = "doc"

--- a/services/api/internal/domain/agent/cursor.go
+++ b/services/api/internal/domain/agent/cursor.go
@@ -36,3 +36,33 @@ func DecodeConversationCursor(s string) (*ConversationCursor, error) {
 	c.CreatedAt = c.CreatedAt.UTC()
 	return &c, nil
 }
+
+// ActivityFeedCursor holds the stable ordering fields for keyset-based
+// pagination over an agent's activity feed, which is always ordered by
+// created_at DESC, id DESC.
+type ActivityFeedCursor struct {
+	CreatedAt time.Time `json:"ca"`
+	ID        string    `json:"id"`
+}
+
+// EncodeActivityFeedCursor builds an opaque base64 cursor from the last
+// activity item on a page.
+func EncodeActivityFeedCursor(item *ActivityFeedItem) string {
+	cur := ActivityFeedCursor{CreatedAt: item.CreatedAt.UTC(), ID: item.ID.String()}
+	b, _ := json.Marshal(cur)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// DecodeActivityFeedCursor parses a cursor token produced by EncodeActivityFeedCursor.
+func DecodeActivityFeedCursor(s string) (*ActivityFeedCursor, error) {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decode cursor base64: %w", err)
+	}
+	var c ActivityFeedCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("decode cursor json: %w", err)
+	}
+	c.CreatedAt = c.CreatedAt.UTC()
+	return &c, nil
+}

--- a/services/api/internal/domain/agent/errors.go
+++ b/services/api/internal/domain/agent/errors.go
@@ -61,3 +61,10 @@ var (
 var (
 	ErrChatSessionNotFound = errors.New("chat session not found")
 )
+
+// Activity feed errors
+var (
+	// ErrActivityFeedInvalidCursor is returned when a client-supplied
+	// activity feed pagination cursor fails to decode.
+	ErrActivityFeedInvalidCursor = errors.New("invalid pagination cursor")
+)

--- a/services/api/internal/domain/agent/repository.go
+++ b/services/api/internal/domain/agent/repository.go
@@ -15,6 +15,7 @@ type Repository interface {
 	EnvVarRepository
 	ConversationRepository
 	ChatSessionRepository
+	ActivityFeedRepository
 }
 
 // AgentRepository defines storage operations for agents.

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -14,6 +14,7 @@ type Service interface {
 	EnvVarService
 	ConversationService
 	ChatSessionService
+	ActivityFeedService
 }
 
 // AgentService defines agent CRUD use cases.
@@ -77,6 +78,11 @@ type ChatSessionService interface {
 	StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*AgentChatSession, *AgentConversation, error)
 	SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string) (*AgentConversation, error)
 	ListChatMessages(ctx context.Context, sessionID uuid.UUID, offset, limit int) ([]*AgentConversationEvent, int64, error)
+}
+
+// ActivityFeedService defines the agent activity feed use case.
+type ActivityFeedService interface {
+	ListAgentActivities(ctx context.Context, in ListAgentActivitiesFilter, limit int) (items []*ActivityFeedItem, hasMore bool, err error)
 }
 
 // --- Input types ---

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -1189,3 +1189,133 @@ func chatSessionToRecord(s *agentdom.AgentChatSession) agentChatSessionRecord {
 		UpdatedAt:     s.UpdatedAt,
 	}
 }
+
+// -------------------------------------------------------------------------
+// Activity Feed
+// -------------------------------------------------------------------------
+
+type agentActivityFeedRecord struct {
+	ID           string          `db:"id"`
+	SourceType   string          `db:"source_type"`
+	SourceID     string          `db:"source_id"`
+	SourceTitle  string          `db:"source_title"`
+	ActivityType string          `db:"activity_type"`
+	Content      json.RawMessage `db:"content"`
+	CreatedAt    time.Time       `db:"created_at"`
+	UpdatedAt    time.Time       `db:"updated_at"`
+}
+
+// ListAgentActivities returns a keyset-paginated page of an agent's unified
+// task+doc activity feed, ordered newest-first. task_activities and
+// doc_activities are combined via UNION ALL into a common column shape
+// (agentActivityFeedRecord) up front, filtered by actor_id — both branches
+// reference the same $1 placeholder since it's one value used twice, not
+// two separate args. The dynamic filters (source type, date range, search,
+// cursor) are then applied to the combined result exactly like
+// ListConversations applies its filters to agent_conversations, fetching
+// one row beyond limit to detect whether more pages remain.
+func (r *AgentRepository) ListAgentActivities(ctx context.Context, in agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error) {
+	b := newQueryBuilder()
+	b.idx = 2 // $1 is reserved for the actor member id, shared by both UNION branches
+
+	if len(in.SourceTypes) > 0 {
+		types := make([]string, len(in.SourceTypes))
+		for i, t := range in.SourceTypes {
+			types[i] = string(t)
+		}
+		b.addInClause("source_type", types)
+	}
+	if in.CreatedAfter != nil {
+		p := b.placeholder()
+		b.args = append(b.args, *in.CreatedAfter)
+		b.whereClauses = append(b.whereClauses, "created_at >= "+p)
+	}
+	if in.CreatedBefore != nil {
+		p := b.placeholder()
+		b.args = append(b.args, *in.CreatedBefore)
+		b.whereClauses = append(b.whereClauses, "created_at < "+p)
+	}
+	if in.Search != nil {
+		if q := strings.TrimSpace(*in.Search); q != "" {
+			p := b.placeholder()
+			b.args = append(b.args, "%"+q+"%")
+			// Matches either the linked task/document title or the raw
+			// activity content (field diffs, comment text, etc.) — a plain
+			// case-insensitive substring match, not full-text search, since
+			// activity content is small compared to conversation event
+			// payloads (which do warrant the tsvector/GIN approach used by
+			// listConversations' search).
+			b.whereClauses = append(b.whereClauses,
+				fmt.Sprintf("(source_title ILIKE %s OR content::text ILIKE %s)", p, p))
+		}
+	}
+	if in.CursorAfter != nil {
+		cur, err := agentdom.DecodeActivityFeedCursor(*in.CursorAfter)
+		if err != nil {
+			return nil, false, fmt.Errorf("%w: %s", agentdom.ErrActivityFeedInvalidCursor, err)
+		}
+		p1 := b.placeholder()
+		p2 := b.placeholder()
+		b.args = append(b.args, cur.CreatedAt, cur.ID)
+		b.whereClauses = append(b.whereClauses, fmt.Sprintf("(created_at, id) < (%s, %s)", p1, p2))
+	}
+
+	limitP := b.placeholder()
+	b.args = append(b.args, limit+1)
+
+	whereSQL := "1=1"
+	if len(b.whereClauses) > 0 {
+		whereSQL += " AND " + strings.Join(b.whereClauses, " AND ")
+	}
+
+	query := `WITH agent_activities AS (
+		SELECT ta.id, 'task' AS source_type, ta.task_id AS source_id, t.title AS source_title,
+		       ta.activity_type, ta.content, ta.created_at, ta.updated_at
+		FROM task_activities ta
+		JOIN tasks t ON t.id = ta.task_id
+		WHERE ta.actor_id = $1 AND ta.deleted_at IS NULL
+		UNION ALL
+		SELECT da.id, 'doc' AS source_type, da.document_id AS source_id, d.title AS source_title,
+		       da.activity_type, da.content, da.created_at, da.updated_at
+		FROM doc_activities da
+		JOIN documents d ON d.id = da.document_id
+		WHERE da.actor_id = $1 AND da.deleted_at IS NULL
+	)
+	SELECT id, source_type, source_id, source_title, activity_type, content, created_at, updated_at
+	FROM agent_activities WHERE ` + whereSQL + fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %s`, limitP)
+
+	args := append([]interface{}{in.ActorMemberID.String()}, b.args...)
+
+	var recs []agentActivityFeedRecord
+	if err := r.db.SelectContext(ctx, &recs, query, args...); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := len(recs) > limit
+	if hasMore {
+		recs = recs[:limit]
+	}
+
+	result := make([]*agentdom.ActivityFeedItem, 0, len(recs))
+	for _, rec := range recs {
+		result = append(result, activityFeedItemFromRecord(rec))
+	}
+	return result, hasMore, nil
+}
+
+func activityFeedItemFromRecord(rec agentActivityFeedRecord) *agentdom.ActivityFeedItem {
+	content := rec.Content
+	if len(content) == 0 {
+		content = json.RawMessage("{}")
+	}
+	return &agentdom.ActivityFeedItem{
+		ID:           mustParseUUID(rec.ID),
+		SourceType:   agentdom.ActivitySourceType(rec.SourceType),
+		SourceID:     mustParseUUID(rec.SourceID),
+		SourceTitle:  rec.SourceTitle,
+		ActivityType: rec.ActivityType,
+		Content:      content,
+		CreatedAt:    rec.CreatedAt,
+		UpdatedAt:    rec.UpdatedAt,
+	}
+}

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -1195,14 +1195,15 @@ func chatSessionToRecord(s *agentdom.AgentChatSession) agentChatSessionRecord {
 // -------------------------------------------------------------------------
 
 type agentActivityFeedRecord struct {
-	ID           string          `db:"id"`
-	SourceType   string          `db:"source_type"`
-	SourceID     string          `db:"source_id"`
-	SourceTitle  string          `db:"source_title"`
-	ActivityType string          `db:"activity_type"`
-	Content      json.RawMessage `db:"content"`
-	CreatedAt    time.Time       `db:"created_at"`
-	UpdatedAt    time.Time       `db:"updated_at"`
+	ID            string          `db:"id"`
+	SourceType    string          `db:"source_type"`
+	SourceID      string          `db:"source_id"`
+	SourceTitle   string          `db:"source_title"`
+	SourceDeleted bool            `db:"source_deleted"`
+	ActivityType  string          `db:"activity_type"`
+	Content       json.RawMessage `db:"content"`
+	CreatedAt     time.Time       `db:"created_at"`
+	UpdatedAt     time.Time       `db:"updated_at"`
 }
 
 // ListAgentActivities returns a keyset-paginated page of an agent's unified
@@ -1270,18 +1271,20 @@ func (r *AgentRepository) ListAgentActivities(ctx context.Context, in agentdom.L
 
 	query := `WITH agent_activities AS (
 		SELECT ta.id, 'task' AS source_type, ta.task_id AS source_id, t.title AS source_title,
+		       (t.deleted_at IS NOT NULL) AS source_deleted,
 		       ta.activity_type, ta.content, ta.created_at, ta.updated_at
 		FROM task_activities ta
 		JOIN tasks t ON t.id = ta.task_id
 		WHERE ta.actor_id = $1 AND ta.deleted_at IS NULL
 		UNION ALL
 		SELECT da.id, 'doc' AS source_type, da.document_id AS source_id, d.title AS source_title,
+		       (d.deleted_at IS NOT NULL) AS source_deleted,
 		       da.activity_type, da.content, da.created_at, da.updated_at
 		FROM doc_activities da
 		JOIN documents d ON d.id = da.document_id
 		WHERE da.actor_id = $1 AND da.deleted_at IS NULL
 	)
-	SELECT id, source_type, source_id, source_title, activity_type, content, created_at, updated_at
+	SELECT id, source_type, source_id, source_title, source_deleted, activity_type, content, created_at, updated_at
 	FROM agent_activities WHERE ` + whereSQL + fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %s`, limitP)
 
 	args := append([]interface{}{in.ActorMemberID.String()}, b.args...)
@@ -1309,13 +1312,14 @@ func activityFeedItemFromRecord(rec agentActivityFeedRecord) *agentdom.ActivityF
 		content = json.RawMessage("{}")
 	}
 	return &agentdom.ActivityFeedItem{
-		ID:           mustParseUUID(rec.ID),
-		SourceType:   agentdom.ActivitySourceType(rec.SourceType),
-		SourceID:     mustParseUUID(rec.SourceID),
-		SourceTitle:  rec.SourceTitle,
-		ActivityType: rec.ActivityType,
-		Content:      content,
-		CreatedAt:    rec.CreatedAt,
-		UpdatedAt:    rec.UpdatedAt,
+		ID:            mustParseUUID(rec.ID),
+		SourceType:    agentdom.ActivitySourceType(rec.SourceType),
+		SourceID:      mustParseUUID(rec.SourceID),
+		SourceTitle:   rec.SourceTitle,
+		SourceDeleted: rec.SourceDeleted,
+		ActivityType:  rec.ActivityType,
+		Content:       content,
+		CreatedAt:     rec.CreatedAt,
+		UpdatedAt:     rec.UpdatedAt,
 	}
 }

--- a/services/api/internal/repository/postgres/agent_repository_test.go
+++ b/services/api/internal/repository/postgres/agent_repository_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	agentdom "github.com/Paca-AI/api/internal/domain/agent"
 )
 
 // TestAgentFromReadRow_ValidACPCommand verifies the happy path still maps
@@ -44,4 +46,49 @@ func TestAgentFromReadRow_MalformedACPCommand(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, a)
+}
+
+// TestActivityFeedItemFromRecord_MapsFields verifies the UNION row mapping
+// preserves source type/id and title needed to render and link each row.
+func TestActivityFeedItemFromRecord_MapsFields(t *testing.T) {
+	id := uuid.New()
+	sourceID := uuid.New()
+	rec := agentActivityFeedRecord{
+		ID:           id.String(),
+		SourceType:   "task",
+		SourceID:     sourceID.String(),
+		SourceTitle:  "Fix the bug",
+		ActivityType: "task.created",
+		Content:      []byte(`{"foo":"bar"}`),
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	item := activityFeedItemFromRecord(rec)
+
+	assert.Equal(t, id, item.ID)
+	assert.Equal(t, agentdom.ActivitySourceTask, item.SourceType)
+	assert.Equal(t, sourceID, item.SourceID)
+	assert.Equal(t, "Fix the bug", item.SourceTitle)
+	assert.Equal(t, "task.created", item.ActivityType)
+	assert.JSONEq(t, `{"foo":"bar"}`, string(item.Content))
+}
+
+// TestActivityFeedItemFromRecord_EmptyContentDefaultsToEmptyObject mirrors
+// ActivityFromEntity's task-activity behavior: a nil/empty content column
+// (the JSONB default is '{}', but defensively handle a genuinely empty
+// value too) surfaces as "{}" rather than an invalid empty json.RawMessage.
+func TestActivityFeedItemFromRecord_EmptyContentDefaultsToEmptyObject(t *testing.T) {
+	rec := agentActivityFeedRecord{
+		ID:         uuid.New().String(),
+		SourceType: "doc",
+		SourceID:   uuid.New().String(),
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+	}
+
+	item := activityFeedItemFromRecord(rec)
+
+	assert.Equal(t, agentdom.ActivitySourceDoc, item.SourceType)
+	assert.JSONEq(t, `{}`, string(item.Content))
 }

--- a/services/api/internal/repository/postgres/agent_repository_test.go
+++ b/services/api/internal/repository/postgres/agent_repository_test.go
@@ -70,6 +70,7 @@ func TestActivityFeedItemFromRecord_MapsFields(t *testing.T) {
 	assert.Equal(t, agentdom.ActivitySourceTask, item.SourceType)
 	assert.Equal(t, sourceID, item.SourceID)
 	assert.Equal(t, "Fix the bug", item.SourceTitle)
+	assert.False(t, item.SourceDeleted)
 	assert.Equal(t, "task.created", item.ActivityType)
 	assert.JSONEq(t, `{"foo":"bar"}`, string(item.Content))
 }
@@ -91,4 +92,27 @@ func TestActivityFeedItemFromRecord_EmptyContentDefaultsToEmptyObject(t *testing
 
 	assert.Equal(t, agentdom.ActivitySourceDoc, item.SourceType)
 	assert.JSONEq(t, `{}`, string(item.Content))
+}
+
+// TestActivityFeedItemFromRecord_PreservesSourceDeleted verifies that an
+// activity whose task/doc has since been (soft-)deleted still maps through
+// with SourceDeleted set — the feed keeps the activity (e.g. the delete
+// action itself is history worth showing) but flags it so the UI can skip
+// linking to a source that no longer resolves.
+func TestActivityFeedItemFromRecord_PreservesSourceDeleted(t *testing.T) {
+	rec := agentActivityFeedRecord{
+		ID:            uuid.New().String(),
+		SourceType:    "task",
+		SourceID:      uuid.New().String(),
+		SourceTitle:   "Fix the bug",
+		SourceDeleted: true,
+		ActivityType:  "task.deleted",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+
+	item := activityFeedItemFromRecord(rec)
+
+	assert.True(t, item.SourceDeleted)
+	assert.Equal(t, "Fix the bug", item.SourceTitle)
 }

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -646,6 +646,11 @@ func (s *Service) ListConversations(ctx context.Context, in agentdom.ListConvers
 	return s.repo.ListConversations(ctx, in, limit)
 }
 
+// ListAgentActivities returns a page of an agent's unified task+doc activity feed.
+func (s *Service) ListAgentActivities(ctx context.Context, in agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error) {
+	return s.repo.ListAgentActivities(ctx, in, limit)
+}
+
 // GetConversation returns a single conversation after verifying project ownership.
 func (s *Service) GetConversation(ctx context.Context, projectID, conversationID uuid.UUID) (*agentdom.AgentConversation, error) {
 	c, err := s.repo.FindConversationByID(ctx, conversationID)

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -61,6 +61,7 @@ type mockAgentRepo struct {
 	findChatSessionByID             func(ctx context.Context, id uuid.UUID) (*agentdom.AgentChatSession, error)
 	createChatSession               func(ctx context.Context, session *agentdom.AgentChatSession) error
 	updateChatSession               func(ctx context.Context, session *agentdom.AgentChatSession) error
+	listAgentActivities             func(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error)
 }
 
 func (m *mockAgentRepo) ListAgents(ctx context.Context, projectID uuid.UUID) ([]*agentdom.Agent, error) {
@@ -248,6 +249,13 @@ func (m *mockAgentRepo) DeleteEnvVar(ctx context.Context, id uuid.UUID) error {
 func (m *mockAgentRepo) ListConversations(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error) {
 	if m.listConversations != nil {
 		return m.listConversations(ctx, filter, limit)
+	}
+	return nil, false, nil
+}
+
+func (m *mockAgentRepo) ListAgentActivities(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error) {
+	if m.listAgentActivities != nil {
+		return m.listAgentActivities(ctx, filter, limit)
 	}
 	return nil, false, nil
 }
@@ -986,6 +994,48 @@ func TestListConversations_PropagatesRepoError(t *testing.T) {
 	_, hasMore, err := svc.ListConversations(context.Background(), agentdom.ListConversationsFilter{}, 20)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationInvalidCursor)
+	assert.False(t, hasMore)
+}
+
+func TestListAgentActivities_Success(t *testing.T) {
+	memberID := uuid.New()
+	items := []*agentdom.ActivityFeedItem{
+		{ID: uuid.New(), SourceType: agentdom.ActivitySourceTask, ActivityType: "task.created"},
+		{ID: uuid.New(), SourceType: agentdom.ActivitySourceDoc, ActivityType: "doc.updated"},
+	}
+
+	var gotFilter agentdom.ListAgentActivitiesFilter
+	var gotLimit int
+	repo := &mockAgentRepo{
+		listAgentActivities: func(_ context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error) {
+			gotFilter = filter
+			gotLimit = limit
+			return items, true, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	filter := agentdom.ListAgentActivitiesFilter{ActorMemberID: memberID}
+	result, hasMore, err := svc.ListAgentActivities(context.Background(), filter, 20)
+
+	assert.NoError(t, err)
+	assert.True(t, hasMore)
+	assert.Equal(t, items, result)
+	assert.Equal(t, 20, gotLimit)
+	assert.Equal(t, memberID, gotFilter.ActorMemberID)
+}
+
+func TestListAgentActivities_PropagatesRepoError(t *testing.T) {
+	repo := &mockAgentRepo{
+		listAgentActivities: func(_ context.Context, _ agentdom.ListAgentActivitiesFilter, _ int) ([]*agentdom.ActivityFeedItem, bool, error) {
+			return nil, false, agentdom.ErrActivityFeedInvalidCursor
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, hasMore, err := svc.ListAgentActivities(context.Background(), agentdom.ListAgentActivitiesFilter{}, 20)
+
+	assert.ErrorIs(t, err, agentdom.ErrActivityFeedInvalidCursor)
 	assert.False(t, hasMore)
 }
 

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -381,14 +381,15 @@ func ConversationFromEntity(c *agentdom.AgentConversation) AgentConversationResp
 // AgentActivityResponse is the public view of one item in an agent's unified
 // task+doc activity feed.
 type AgentActivityResponse struct {
-	ID           uuid.UUID       `json:"id"`
-	SourceType   string          `json:"source_type"`
-	SourceID     uuid.UUID       `json:"source_id"`
-	SourceTitle  string          `json:"source_title"`
-	ActivityType string          `json:"activity_type"`
-	Content      json.RawMessage `json:"content"`
-	CreatedAt    time.Time       `json:"created_at"`
-	UpdatedAt    time.Time       `json:"updated_at"`
+	ID            uuid.UUID       `json:"id"`
+	SourceType    string          `json:"source_type"`
+	SourceID      uuid.UUID       `json:"source_id"`
+	SourceTitle   string          `json:"source_title"`
+	SourceDeleted bool            `json:"source_deleted"`
+	ActivityType  string          `json:"activity_type"`
+	Content       json.RawMessage `json:"content"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
 }
 
 // AgentActivityFromEntity maps a domain ActivityFeedItem to an AgentActivityResponse DTO.
@@ -398,14 +399,15 @@ func AgentActivityFromEntity(a *agentdom.ActivityFeedItem) AgentActivityResponse
 		content = json.RawMessage("{}")
 	}
 	return AgentActivityResponse{
-		ID:           a.ID,
-		SourceType:   string(a.SourceType),
-		SourceID:     a.SourceID,
-		SourceTitle:  a.SourceTitle,
-		ActivityType: a.ActivityType,
-		Content:      content,
-		CreatedAt:    a.CreatedAt,
-		UpdatedAt:    a.UpdatedAt,
+		ID:            a.ID,
+		SourceType:    string(a.SourceType),
+		SourceID:      a.SourceID,
+		SourceTitle:   a.SourceTitle,
+		SourceDeleted: a.SourceDeleted,
+		ActivityType:  a.ActivityType,
+		Content:       content,
+		CreatedAt:     a.CreatedAt,
+		UpdatedAt:     a.UpdatedAt,
 	}
 }
 

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -374,6 +375,37 @@ func ConversationFromEntity(c *agentdom.AgentConversation) AgentConversationResp
 		CreatedAt:           c.CreatedAt,
 		AgentName:           c.AgentName,
 		AgentHandle:         c.AgentHandle,
+	}
+}
+
+// AgentActivityResponse is the public view of one item in an agent's unified
+// task+doc activity feed.
+type AgentActivityResponse struct {
+	ID           uuid.UUID       `json:"id"`
+	SourceType   string          `json:"source_type"`
+	SourceID     uuid.UUID       `json:"source_id"`
+	SourceTitle  string          `json:"source_title"`
+	ActivityType string          `json:"activity_type"`
+	Content      json.RawMessage `json:"content"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+// AgentActivityFromEntity maps a domain ActivityFeedItem to an AgentActivityResponse DTO.
+func AgentActivityFromEntity(a *agentdom.ActivityFeedItem) AgentActivityResponse {
+	content := a.Content
+	if len(content) == 0 {
+		content = json.RawMessage("{}")
+	}
+	return AgentActivityResponse{
+		ID:           a.ID,
+		SourceType:   string(a.SourceType),
+		SourceID:     a.SourceID,
+		SourceTitle:  a.SourceTitle,
+		ActivityType: a.ActivityType,
+		Content:      content,
+		CreatedAt:    a.CreatedAt,
+		UpdatedAt:    a.UpdatedAt,
 	}
 }
 

--- a/services/api/internal/transport/http/handler/agent_handler.go
+++ b/services/api/internal/transport/http/handler/agent_handler.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -957,4 +959,93 @@ func (h *AgentHandler) GetACPBridgeStatus(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
+}
+
+// --- Activity Feed ------------------------------------------------------------
+
+var validActivitySourceTypes = []string{"task", "doc"}
+
+// ListAgentActivities handles GET /projects/:projectId/agents/:agentId/activities.
+//
+// Supported query params (all optional, combine with AND):
+//   - type=<task|doc>|<task,doc>            filter by one or more source types
+//   - created_after=<YYYY-MM-DD|RFC3339>    activities created on/after this date/instant
+//   - created_before=<YYYY-MM-DD|RFC3339>   activities created before this date/instant
+//   - search=<text>                         matches the linked task/doc title or activity content
+//   - cursor=<opaque>, page_size=<1-200>    keyset pagination (see next_cursor in response)
+func (h *AgentHandler) ListAgentActivities(w http.ResponseWriter, r *http.Request) {
+	projectID, agentID, err := h.parseAgentForProject(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if h.memberRepo == nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "member resolver not available"))
+		return
+	}
+	member, err := h.memberRepo.FindMemberByAgent(r.Context(), projectID, agentID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	pageSize, err := parsePageSize(r, 20, 200)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	filter := agentdom.ListAgentActivitiesFilter{ActorMemberID: member.ID}
+	if typesRaw := r.URL.Query().Get("type"); typesRaw != "" {
+		for _, t := range splitCommaList(typesRaw) {
+			if !slices.Contains(validActivitySourceTypes, t) {
+				presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid type: "+t))
+				return
+			}
+			filter.SourceTypes = append(filter.SourceTypes, agentdom.ActivitySourceType(t))
+		}
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("created_after")); raw != "" {
+		t, ok := parseCreatedAfterBound(raw)
+		if !ok {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid created_after"))
+			return
+		}
+		filter.CreatedAfter = t
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("created_before")); raw != "" {
+		t, ok := parseCreatedBeforeBound(raw)
+		if !ok {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "invalid created_before"))
+			return
+		}
+		filter.CreatedBefore = t
+	}
+	if search := strings.TrimSpace(r.URL.Query().Get("search")); search != "" {
+		filter.Search = &search
+	}
+	if cursorRaw := r.URL.Query().Get("cursor"); cursorRaw != "" {
+		filter.CursorAfter = &cursorRaw
+	}
+
+	items, hasMore, err := h.svc.ListAgentActivities(r.Context(), filter, pageSize)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	resp := make([]dto.AgentActivityResponse, 0, len(items))
+	for _, item := range items {
+		resp = append(resp, dto.AgentActivityFromEntity(item))
+	}
+
+	var nextCursor *string
+	if hasMore && len(items) > 0 {
+		s := agentdom.EncodeActivityFeedCursor(items[len(items)-1])
+		nextCursor = &s
+	}
+	presenter.OK(w, r, map[string]any{
+		"items":       resp,
+		"page_size":   pageSize,
+		"next_cursor": nextCursor,
+	})
 }

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -30,6 +30,7 @@ type mockAgentSvc struct {
 	startChatSession       func(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error)
 	listConversations      func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
 	listConversationEvents func(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error)
+	listAgentActivities    func(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error)
 }
 
 func (m *mockAgentSvc) ListAgents(_ context.Context, _ uuid.UUID) ([]*agentdom.Agent, error) {
@@ -95,6 +96,12 @@ func (m *mockAgentSvc) ListConversations(ctx context.Context, filter agentdom.Li
 	}
 	return nil, false, nil
 }
+func (m *mockAgentSvc) ListAgentActivities(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error) {
+	if m.listAgentActivities != nil {
+		return m.listAgentActivities(ctx, filter, limit)
+	}
+	return nil, false, nil
+}
 func (m *mockAgentSvc) GetConversation(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 	return nil, errors.New("not found")
 }
@@ -152,11 +159,12 @@ func newAgentRouter(svc agentdom.Service) chi.Router {
 }
 
 // fakeMemberRepo implements projectdom.MemberRepository, letting tests
-// control FindMemberByUserProject — the only method resolveMemberID calls.
-// Every other method panics if invoked, since resolveMemberID tests should
-// never reach them.
+// control FindMemberByUserProject (used by resolveMemberID) and
+// FindMemberByAgent (used by ListAgentActivities). Every other method
+// panics if invoked, since those tests should never reach them.
 type fakeMemberRepo struct {
 	findByUserProject func(ctx context.Context, userID, projectID uuid.UUID) (*projectdom.ProjectMember, error)
+	findByAgent       func(ctx context.Context, projectID, agentID uuid.UUID) (*projectdom.ProjectMember, error)
 }
 
 func (f *fakeMemberRepo) ListMembers(context.Context, uuid.UUID) ([]*projectdom.ProjectMember, error) {
@@ -165,8 +173,11 @@ func (f *fakeMemberRepo) ListMembers(context.Context, uuid.UUID) ([]*projectdom.
 func (f *fakeMemberRepo) FindMember(context.Context, uuid.UUID, uuid.UUID) (*projectdom.ProjectMember, error) {
 	panic("fakeMemberRepo: FindMember not used by resolveMemberID tests")
 }
-func (f *fakeMemberRepo) FindMemberByAgent(context.Context, uuid.UUID, uuid.UUID) (*projectdom.ProjectMember, error) {
-	panic("fakeMemberRepo: FindMemberByAgent not used by resolveMemberID tests")
+func (f *fakeMemberRepo) FindMemberByAgent(ctx context.Context, projectID, agentID uuid.UUID) (*projectdom.ProjectMember, error) {
+	if f.findByAgent != nil {
+		return f.findByAgent(ctx, projectID, agentID)
+	}
+	panic("fakeMemberRepo: FindMemberByAgent not configured")
 }
 func (f *fakeMemberRepo) FindMemberByUserProject(ctx context.Context, userID, projectID uuid.UUID) (*projectdom.ProjectMember, error) {
 	return f.findByUserProject(ctx, userID, projectID)
@@ -229,6 +240,7 @@ func newAgentRouterWithMemberRepo(svc agentdom.Service, memberRepo projectdom.Me
 	r.Use(claimsMiddleware(subject))
 	r.Route("/projects/{projectId}/agents/{agentId}", func(r chi.Router) {
 		r.Post("/chat-sessions", h.StartChatSession)
+		r.Get("/activities", h.ListAgentActivities)
 	})
 	return r
 }
@@ -602,5 +614,122 @@ func TestResolveMemberID_Resolved_PassesMemberIDToService(t *testing.T) {
 	}
 	if gotMemberID != resolvedMemberID {
 		t.Fatalf("expected resolved member ID %v to reach the service, got %v", resolvedMemberID, gotMemberID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListAgentActivities tests
+// ---------------------------------------------------------------------------
+
+func TestListAgentActivities_NoMemberRepoConfigured_Returns500(t *testing.T) {
+	r := newAgentRouterWithMemberRepo(validAgentSvc(), nil, uuid.New().String())
+	projectID := uuid.New()
+	agentID := uuid.New()
+
+	w := doAgentRequest(t, r, http.MethodGet,
+		"/projects/"+projectID.String()+"/agents/"+agentID.String()+"/activities", nil)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when no member repo is configured, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAgentActivities_WrongProject_Returns404(t *testing.T) {
+	svc := &mockAgentSvc{
+		getAgent: func(_ context.Context, _, _ uuid.UUID) (*agentdom.Agent, error) {
+			return nil, agentdom.ErrAgentNotFound
+		},
+	}
+	memberRepo := &fakeMemberRepo{}
+	r := newAgentRouterWithMemberRepo(svc, memberRepo, uuid.New().String())
+	projectID := uuid.New()
+	agentID := uuid.New()
+
+	w := doAgentRequest(t, r, http.MethodGet,
+		"/projects/"+projectID.String()+"/agents/"+agentID.String()+"/activities", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for wrong-project agent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAgentActivities_MemberNotFound_Returns404(t *testing.T) {
+	memberRepo := &fakeMemberRepo{
+		findByAgent: func(context.Context, uuid.UUID, uuid.UUID) (*projectdom.ProjectMember, error) {
+			return nil, projectdom.ErrMemberNotFound
+		},
+	}
+	r := newAgentRouterWithMemberRepo(validAgentSvc(), memberRepo, uuid.New().String())
+	projectID := uuid.New()
+	agentID := uuid.New()
+
+	w := doAgentRequest(t, r, http.MethodGet,
+		"/projects/"+projectID.String()+"/agents/"+agentID.String()+"/activities", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when the agent has no project membership, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAgentActivities_InvalidType_Returns400(t *testing.T) {
+	memberID := uuid.New()
+	memberRepo := &fakeMemberRepo{
+		findByAgent: func(context.Context, uuid.UUID, uuid.UUID) (*projectdom.ProjectMember, error) {
+			return &projectdom.ProjectMember{ID: memberID}, nil
+		},
+	}
+	r := newAgentRouterWithMemberRepo(validAgentSvc(), memberRepo, uuid.New().String())
+	projectID := uuid.New()
+	agentID := uuid.New()
+
+	w := doAgentRequest(t, r, http.MethodGet,
+		"/projects/"+projectID.String()+"/agents/"+agentID.String()+"/activities?type=bogus", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an invalid type filter, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListAgentActivities_Success_ResolvesMemberAndForwardsFilters(t *testing.T) {
+	memberID := uuid.New()
+	memberRepo := &fakeMemberRepo{
+		findByAgent: func(context.Context, uuid.UUID, uuid.UUID) (*projectdom.ProjectMember, error) {
+			return &projectdom.ProjectMember{ID: memberID}, nil
+		},
+	}
+	var gotFilter agentdom.ListAgentActivitiesFilter
+	svc := validAgentSvc()
+	svc.listAgentActivities = func(_ context.Context, filter agentdom.ListAgentActivitiesFilter, _ int) ([]*agentdom.ActivityFeedItem, bool, error) {
+		gotFilter = filter
+		return []*agentdom.ActivityFeedItem{
+			{ID: uuid.New(), SourceType: agentdom.ActivitySourceTask, ActivityType: "task.created"},
+		}, false, nil
+	}
+	r := newAgentRouterWithMemberRepo(svc, memberRepo, uuid.New().String())
+	projectID := uuid.New()
+	agentID := uuid.New()
+
+	w := doAgentRequest(t, r, http.MethodGet,
+		"/projects/"+projectID.String()+"/agents/"+agentID.String()+"/activities?type=task,doc&search=hello", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if gotFilter.ActorMemberID != memberID {
+		t.Fatalf("expected the resolved member ID %v to reach the service, got %v", memberID, gotFilter.ActorMemberID)
+	}
+	wantTypes := []agentdom.ActivitySourceType{agentdom.ActivitySourceTask, agentdom.ActivitySourceDoc}
+	if len(gotFilter.SourceTypes) != len(wantTypes) || gotFilter.SourceTypes[0] != wantTypes[0] || gotFilter.SourceTypes[1] != wantTypes[1] {
+		t.Fatalf("expected source types %v, got %v", wantTypes, gotFilter.SourceTypes)
+	}
+	if gotFilter.Search == nil || *gotFilter.Search != "hello" {
+		t.Fatalf("expected search %q, got %v", "hello", gotFilter.Search)
+	}
+
+	var body struct {
+		Data struct {
+			Items []any `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if len(body.Data.Items) != 1 {
+		t.Fatalf("expected 1 item in response, got %d", len(body.Data.Items))
 	}
 }

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -335,6 +335,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusConflict, apierr.CodeAgentConversationBusy
 	case errors.Is(err, agentdom.ErrConversationInvalidCursor):
 		return http.StatusBadRequest, apierr.CodeAgentConversationInvalidCursor
+	case errors.Is(err, agentdom.ErrActivityFeedInvalidCursor):
+		return http.StatusBadRequest, apierr.CodeAgentActivityInvalidCursor
 	case errors.Is(err, agentdom.ErrChatSessionNotFound):
 		return http.StatusNotFound, apierr.CodeAgentChatSessionNotFound
 	case errors.Is(err, agentdom.ErrEnvVarNotFound):

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -531,6 +531,10 @@ func New(deps Deps) http.Handler {
 						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsRead)).
 							Get("/{agentId}/acp-bridge-status", deps.Agent.GetACPBridgeStatus)
 
+						// Activity feed
+						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsRead)).
+							Get("/{agentId}/activities", deps.Agent.ListAgentActivities)
+
 						// MCP servers
 						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAgentsRead)).
 							Get("/{agentId}/mcp-servers", deps.Agent.ListMCPServers)

--- a/services/api/migrations/000030_add_activity_actor_cursor_indexes.sql
+++ b/services/api/migrations/000030_add_activity_actor_cursor_indexes.sql
@@ -1,0 +1,17 @@
+-- Composite indexes for keyset-paginated "activities by actor" queries (the
+-- agent activity feed), mirroring idx_agent_conversations_cursor_pagination
+-- (migration 000025). Query pattern per table:
+--   WHERE actor_id = ? AND deleted_at IS NULL AND (created_at, id) < (?, ?)
+--   ORDER BY created_at DESC, id DESC
+-- The old single-column actor index on task_activities is superseded by the
+-- composite one below (a composite index's leading column still serves
+-- plain actor_id lookups). doc_activities had no actor index at all.
+DROP INDEX IF EXISTS idx_task_activities_actor_id;
+
+CREATE INDEX IF NOT EXISTS idx_task_activities_actor_cursor
+    ON task_activities (actor_id, created_at DESC, id DESC)
+    WHERE actor_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_doc_activities_actor_cursor
+    ON doc_activities (actor_id, created_at DESC, id DESC)
+    WHERE actor_id IS NOT NULL AND deleted_at IS NULL;


### PR DESCRIPTION
## Summary
Adds an "Activity" tab to the agent detail page: a unified, cursor-paginated, filterable feed of every task and doc activity a given agent has performed across the project, styled like a log viewer with infinite scroll.

## Backend
- New `GET /projects/:projectId/agents/:agentId/activities` endpoint (`services/api/internal/transport/http/handler/agent_handler.go`) resolves the agent's `project_members.id` via `memberRepo.FindMemberByAgent`, then lists a keyset-paginated (`created_at`, `id`) page combining `task_activities` and `doc_activities`, filterable by `type` (task/doc), `created_after`/`created_before`, and free-text `search` (matches the linked task/doc title or activity content).
- `AgentRepository.ListAgentActivities` (`services/api/internal/repository/postgres/agent_repository.go`) implements this with a single `UNION ALL` CTE over both tables joined to `tasks`/`documents` for the display title, mirroring the existing conversations cursor-pagination pattern.
- New domain types/cursor in `domain/agent/activity_feed.go` and `cursor.go`; new `AgentActivityResponse` DTO; new `AGENT_ACTIVITY_INVALID_CURSOR` error code.
- Migration `000030_add_activity_actor_cursor_indexes.sql` adds composite `(actor_id, created_at DESC, id DESC)` indexes on both activity tables (`doc_activities` previously had no actor index at all).

## Frontend
- New `AgentActivityTab` / `AgentActivityFilters` components, modeled on the existing Conversations page's `IntersectionObserver`-driven infinite scroll and filter popover.
- New `agentActivitiesQueryOptions` cursor-paginated query in `agent-api.ts`, keyed separately from the `"agents"` prefix so realtime invalidation can target every agent's feed without over-invalidating other agent caches.
- Exported and lightly narrowed the existing `activityDescription`/`describeDocActivity` renderers so the new tab reuses the same activity copy instead of duplicating it.
- Wired a new "Activity" tab into the agent detail page; wired `task.*`/`doc.*` realtime events to invalidate the activity feed.
- Translated into all 9 locales (en, es, fr, ja, ko, pt-BR, ru, vi, zh-CN).

## Test plan
- [x] `go build ./...`, `go vet ./...`, and `go test ./...` in `services/api` — new coverage for the query mapping, service passthrough, and every handler branch (missing member repo, wrong project, member not found, invalid type filter, success).
- [x] `golangci-lint run ./...` in `services/api` — clean.
- [x] `tsc -b`, `biome check .`, and `vitest run` in `apps/web` — all clean (345 tests passing).
- [x] Manually verified against the running dev stack: confirmed the new indexes applied to the live DB, and exercised the live endpoint end-to-end (base fetch, type filter, invalid type → 400, search hit/miss, date filter, malformed cursor → 400).
