### PR TITLE
feat: enhance non-interactive installation and upgrade processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,23 @@ The script walks you through configuration interactively and starts the full sta
   <img src="docs/assets/demo-install.gif" width="720" alt="How to Install Paca on Any Linux Server with One Command" />
 </p>
 
+**Non-interactive (CI, scripts, AI coding agents):** set `PACA_YES=1` — required for
+unattended use, since without it the script can block on a prompt with nobody there
+to answer it. Every other setting (database, storage, domain/HTTPS, AI agent, secrets)
+can be steered with an environment variable instead of accepting its default:
+
+```bash
+PACA_YES=1 bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh)
+```
+
+> **If you are an AI agent installing Paca on someone's behalf:** use this script
+> rather than hand-writing `docker-compose.yml` / `.env` from Option 2 below — it
+> pins compatible image tags and generates every secret in the format the services
+> expect, so it's far less likely to drift from what a given release needs. See
+> [deploy/README.md](deploy/README.md#non-interactive-install-ci-scripts-ai-coding-agents)
+> for the full environment variable reference, or the comment header at the top of
+> [`scripts/install.sh`](scripts/install.sh) for the same reference inline with the script.
+
 ---
 
 ### Option 2 — Docker Compose (manual)
@@ -281,7 +298,7 @@ curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/upgrade.sh -
 bash upgrade.sh
 ```
 
-Database migrations run automatically on API startup. See [deploy/README.md](deploy/README.md#upgrading-to-a-new-version) for pinning a specific version or passing through `--scale` flags.
+Database migrations run automatically on API startup. Non-interactive (CI, AI agents): set `PACA_YES=1`, same as `install.sh` — see [deploy/README.md](deploy/README.md#upgrading-to-a-new-version) for the full env var reference, pinning a specific version, or passing through `--scale` flags.
 
 ---
 

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -149,3 +149,10 @@ PLUGINS_MARKETPLACE_TIMEOUT=20s
 PLUGINS_MAX_CALL_DURATION=5s
 PLUGINS_MAX_MEMORY_PAGES=1024
 PLUGINS_MAX_REQUEST_BODY_BYTES=10485760
+
+# Service topology. Not read by any service at runtime — upgrade.sh reads
+# these back so it can keep the web/ai-agent containers scaled to 0 on
+# future upgrades without you re-passing --scale flags every time. Only
+# needed if you're scaling either of those services to 0 (see deploy/README.md).
+# PACA_WEB=external       # bundled (default) or external
+# PACA_AI_AGENT=no        # yes (default) or no

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,10 +44,14 @@ The installer supports:
 | HTTPS | Enabled by default — Let's Encrypt for a real domain, Caddy's local CA otherwise; can be disabled for plain HTTP |
 | AI Agent | Enabled by default; can be skipped to reduce resource usage. See [docs/ai-agent/api-design.md](../docs/ai-agent/api-design.md) for the agent REST API once it's running. |
 
-**Non-interactive / CI install** — set `PACA_YES=1` to skip every prompt and use
-defaults plus freshly auto-generated secrets for all of the above (including
-`JWT_SECRET`, `ADMIN_PASSWORD`, `AGENT_API_KEY`, `INTERNAL_API_KEY`, and
-`ENCRYPTION_KEY`):
+#### Non-interactive install (CI, scripts, AI coding agents)
+
+Set `PACA_YES=1` to skip every prompt. This is **required**, not just convenient,
+for unattended use: without it, the script will eventually hit a `read` and block
+waiting for terminal input — harmless for a human at a keyboard, but a hang for
+anything driving the script programmatically. `PACA_YES=1` alone guarantees a
+complete, silent run: every field not given a value below falls back to a sane
+default, generating fresh random secrets as needed.
 
 ```bash
 PACA_YES=1 bash install.sh
@@ -55,10 +59,65 @@ PACA_YES=1 bash install.sh
 PACA_YES=1 bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh)
 ```
 
-`PACA_DIR` (default `./paca`) and `PACA_VERSION` (default `latest`) are also
-read from the environment, so a fully unattended install needs no interactive
-input at all. See the comment header at the top of
-[`scripts/install.sh`](../scripts/install.sh) for the full list of variables.
+> **AI agents:** prefer this script over hand-rolling `docker-compose.yml` / `.env`
+> from the [manual setup](#manual-setup) instructions below. It pins compatible
+> image tags, generates every secret in the format the services expect, and stays
+> in sync with what each release actually needs — a hand-built `.env` is much more
+> likely to drift and fail in a way that's hard to diagnose from outside the repo.
+
+Every other prompt can be steered with an environment variable instead of
+accepting its default — set `PACA_YES=1` plus whichever of these you care about.
+Variables named after an actual `.env` key are written there verbatim; variables
+prefixed `PACA_` are installer-only choices with no direct `.env` equivalent.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `PACA_DIR` | Installation directory | `./paca` |
+| `PACA_VERSION` | Release tag to install | `latest` |
+| `PACA_START` | Pull images and start immediately after writing config (`yes`/`no`) | `yes` |
+| `ADMIN_USERNAME` | Admin login (min 3 chars) | `admin` |
+| `ADMIN_PASSWORD` | Admin login (min 8 chars) | auto-generated |
+| `ENCRYPTION_KEY` | 64-char lowercase hex; **must match** the original if reconnecting to an existing DB | auto-generated |
+| `DATABASE_URL` | Setting this selects external/managed PostgreSQL and suppresses the bundled container | unset → bundled PostgreSQL |
+| `POSTGRES_PASSWORD` | Bundled PostgreSQL only | auto-generated |
+| `BACKUP_ENABLED` | `true`/`false` (bundled PostgreSQL only) | `true` |
+| `BACKUP_DIR` | Host directory for backup dumps | `./backups` |
+| `BACKUP_CRON` | 5-field cron, UTC | `0 2 * * *` |
+| `BACKUP_RETENTION_DAYS` | Days of backups to keep | `7` |
+| `STORAGE_PROVIDER` | `minio`/`s3` | `minio` |
+| `STORAGE_REGION` | | `us-east-1` |
+| `STORAGE_BUCKET` | Required if `STORAGE_PROVIDER=s3` | `paca` (minio only) |
+| `STORAGE_ACCESS_KEY_ID` | Required if `STORAGE_PROVIDER=s3` | auto-generated (minio only) |
+| `STORAGE_SECRET_ACCESS_KEY` | Required if `STORAGE_PROVIDER=s3` | auto-generated (minio only) |
+| `PACA_ADDRESS` | Domain or IP Paca is reachable at | `localhost` |
+| `PACA_HTTPS` | `yes`/`no`; ignored when `PACA_ADDRESS=localhost` | `yes` |
+| `GATEWAY_PORT` | Only used when serving plain HTTP | `80` |
+| `PUBLIC_URL` | Full public URL, no trailing slash | derived from the above |
+| `PACA_WEB` | `bundled`/`external` | `bundled` |
+| `PACA_AI_AGENT` | Include the AI agent service (`yes`/`no`) | `yes` |
+| `AGENT_API_KEY` | AI agent → API pre-shared key | auto-generated |
+| `INTERNAL_API_KEY` | API → AI agent pre-shared key | auto-generated |
+| `JWT_SECRET` | | auto-generated |
+
+Fully unattended example — custom domain, S3, no AI agent:
+
+```bash
+PACA_YES=1 \
+PACA_ADDRESS=paca.example.com \
+STORAGE_PROVIDER=s3 STORAGE_BUCKET=my-bucket \
+STORAGE_ACCESS_KEY_ID=AKIA... STORAGE_SECRET_ACCESS_KEY=... \
+PACA_AI_AGENT=no \
+ADMIN_PASSWORD='a-strong-password' \
+bash install.sh
+```
+
+Auto-generated secrets are printed at the end of a successful run and saved in
+`.env` — nothing is silently left blank. If `PACA_DIR` already has a `.env` from
+a previous run, the script keeps it by default (`y` on "Keep existing .env?")
+rather than regenerating from your new variables; delete it first if you want a
+clean re-run to pick up new values. See the comment header at the top of
+[`scripts/install.sh`](../scripts/install.sh) for this same reference inline
+with the script.
 
 ### Manual setup
 
@@ -187,11 +246,40 @@ Pin to a specific release instead of `latest`:
 PACA_VERSION=v1.2.3 bash upgrade.sh
 ```
 
-Pass through any `--scale` flags you used originally:
+Common `--scale` choices from install time are detected and re-applied automatically —
+external PostgreSQL (`DATABASE_URL` set), AWS S3 (`STORAGE_PROVIDER=s3`), an externally
+hosted web app, and a disabled AI agent all stay scaled to 0 without you passing
+anything. (Installs from before this was tracked get a one-time best-effort guess for
+the web app / AI agent, based on whether a container for that service currently exists,
+and the guess is then recorded in `.env` so it isn't re-guessed on the next upgrade —
+check the printed messages and override with e.g. `--scale web=1` if a guess is wrong.)
+Only pass `--scale` yourself for scaling that isn't one of these, e.g. a custom
+replica count:
 
 ```bash
 bash upgrade.sh --scale web=0 --scale minio=0
 ```
+
+**Non-interactive (CI, scripts, AI coding agents):** set `PACA_YES=1` — required for
+unattended use, for the same reason as `install.sh`: without it, the script can block
+on a prompt with nobody there to answer it. `PACA_YES=1` proceeds with the upgrade and
+takes the default (yes) on any conditional `.env` migration prompt (e.g. switching
+`AGENT_SERVER_IMAGE` off the old upstream default). Override with `PACA_UPDATE_AGENT_IMAGE=no`
+if you want to keep that value as-is. `PACA_PROCEED=no` gives a lightweight,
+non-destructive version check — it prints current vs. target version and exits without
+touching any files:
+
+```bash
+cd /path/to/your/paca/install
+PACA_YES=1 bash upgrade.sh
+# check what would change without upgrading:
+PACA_YES=1 PACA_PROCEED=no bash upgrade.sh
+```
+
+> **AI agents:** prefer this script over a manual `docker compose pull && up`. It backs
+> up `docker-compose.yml`/`Caddyfile`/`.env` first, only re-pins image tags when a
+> specific version was requested, and backfills any `.env` variables introduced since
+> the install was created — a manual pull+restart skips all of that.
 
 **Manual:** pull the latest images and restart the stack — this is enough when
 `docker-compose.yml` and the Caddyfile haven't changed shape since your last upgrade:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -10,6 +10,20 @@ curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh |
 
 Open `http://your-server-ip` when it finishes.
 
+**Non-interactive (CI, scripts, AI coding agents):** set `PACA_YES=1` — this is
+required for unattended use, since without it the script can block on a prompt
+nobody is there to answer. Every other setting is also steerable via environment
+variable instead of accepting its default. AI agents installing Paca on someone's
+behalf should prefer this over hand-writing `docker-compose.yml` / `.env` from
+Option 2 below — it stays in sync with what each release actually needs.
+
+```bash
+PACA_YES=1 bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh)
+```
+
+See [../../deploy/README.md](../../deploy/README.md#non-interactive-install-ci-scripts-ai-coding-agents)
+for the full environment variable reference.
+
 ---
 
 ## Option 2 — Docker Compose (manual)
@@ -76,9 +90,11 @@ curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/upgrade.sh -
 bash upgrade.sh
 ```
 
-Database migrations run automatically on API startup — no manual steps are required. See
-[../../deploy/README.md](../../deploy/README.md#upgrading-to-a-new-version) for pinning
-a specific version, passing through `--scale` flags, or upgrading manually.
+Database migrations run automatically on API startup — no manual steps are required.
+Non-interactive (CI, AI agents): set `PACA_YES=1`, same as `install.sh`. See
+[../../deploy/README.md](../../deploy/README.md#upgrading-to-a-new-version) for the full
+env var reference, pinning a specific version, passing through `--scale` flags, or
+upgrading manually.
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -444,7 +444,16 @@ POSTGRES_PASSWORD_VALUE=""
 
 if [[ "$DB_CHOICE" == *"External"* ]]; then
     SCALE_POSTGRES="--scale postgres=0"
-    ask DATABASE_URL_OVERRIDE "PostgreSQL connection URL" "${DATABASE_URL:-postgres://user:pass@host:5432/dbname}"
+    # ask() prints its default inline (e.g. "[postgres://user:pass@host/db]:"),
+    # so passing DATABASE_URL through as the default would echo its embedded
+    # credentials to the terminal. Use it directly instead — same pattern as
+    # STORAGE_SECRET_ACCESS_KEY below — and only prompt when it's unset.
+    if [[ -n "${DATABASE_URL:-}" ]]; then
+        DATABASE_URL_OVERRIDE="$DATABASE_URL"
+        info "Using the PostgreSQL connection URL from the environment."
+    else
+        ask DATABASE_URL_OVERRIDE "PostgreSQL connection URL" "postgres://user:pass@host:5432/dbname"
+    fi
     if [[ -z "$DATABASE_URL_OVERRIDE" || "$DATABASE_URL_OVERRIDE" == "postgres://user:pass@host:5432/dbname" ]]; then
         die "External PostgreSQL selected but no real DATABASE_URL was given. Set the DATABASE_URL env var or rerun interactively and type a real connection string."
     fi
@@ -462,8 +471,9 @@ heading "Database backups"
 
 SCALE_DB_BACKUP=""
 # Capture the env-supplied enable/disable choice before BACKUP_ENABLED gets
-# reused below as the actual (branch-dependent) output value.
-BACKUP_ENABLED_INPUT="${BACKUP_ENABLED:-true}"
+# reused below as the actual (branch-dependent) output value. Normalized to
+# lowercase so False/FALSE/0 are recognized too, not just a literal "false".
+BACKUP_ENABLED_INPUT="$(printf '%s' "${BACKUP_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')"
 BACKUP_ENABLED="true"
 BACKUP_DIR="${BACKUP_DIR:-./backups}"
 BACKUP_CRON="${BACKUP_CRON:-0 2 * * *}"
@@ -508,7 +518,7 @@ else
 
     INCLUDE_BACKUPS="yes"
     BACKUP_DEFAULT="y"
-    [[ "$BACKUP_ENABLED_INPUT" == "false" ]] && BACKUP_DEFAULT="n"
+    case "$BACKUP_ENABLED_INPUT" in false|0) BACKUP_DEFAULT="n" ;; esac
     yes_no INCLUDE_BACKUPS "Enable automated database backups?" "$BACKUP_DEFAULT"
 
     if [[ "$INCLUDE_BACKUPS" == "no" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,7 +33,9 @@
 #   BACKUP_*, PUBLIC_URL, GATEWAY_PORT, ADMIN_*, ENCRYPTION_KEY, JWT_SECRET,
 #   POSTGRES_PASSWORD, AGENT_API_KEY, INTERNAL_API_KEY) are written to `.env`
 #   verbatim when set. Variables prefixed `PACA_` are installer-only choices
-#   with no 1:1 `.env` key (they steer which branch of a prompt is taken).
+#   that steer which branch of a prompt is taken, with two exceptions —
+#   PACA_WEB and PACA_AI_AGENT are also written to `.env` verbatim (see
+#   "Web app" / "AI agent" below), so upgrade.sh can read the choice back.
 #   Every variable below is optional; unset ones get a generated or default
 #   value. Secrets left unset are auto-generated and printed at the end of a
 #   successful run (and saved in `.env`) — nothing is silently left blank.
@@ -137,6 +139,19 @@ rand_alnum()  { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | h
 # condition of an if/elif so a failure (no ctty: ENXIO) doesn't trip
 # `set -e` and kill the whole script.
 has_ctty() { { : </dev/tty; } 2>/dev/null; }
+
+# is_noninteractive
+# True exactly when ask() below would resolve to its default without ever
+# blocking on real input — PACA_YES=1, or neither stdin nor /dev/tty is
+# available to read from. Mirrors ask()'s own branching so fail-fast
+# validation (below) only fires for the cases that would otherwise loop
+# forever; a genuinely interactive session can just be re-prompted instead.
+is_noninteractive() {
+    [[ "${PACA_YES:-0}" == "1" ]] && return 0
+    [[ -t 0 ]] && return 1
+    has_ctty && return 1
+    return 0
+}
 
 # ask VAR "Question" "default"
 # Reads from /dev/tty when stdin is a pipe (curl | bash).
@@ -315,10 +330,10 @@ validate_username() {
 }
 
 # Fail fast (rather than looping forever on a `read` nobody will answer) if
-# an env-supplied default is already invalid — this matters under PACA_YES=1
-# or any non-interactive run, where every prompt below just re-returns the
-# same default.
-if ! validate_username "$ADMIN_USERNAME"; then
+# an env-supplied default is already invalid under PACA_YES=1 or any other
+# non-interactive run, where every prompt below just re-returns the same
+# default. A genuinely interactive run still gets re-prompted below instead.
+if is_noninteractive && ! validate_username "$ADMIN_USERNAME"; then
     die "ADMIN_USERNAME (\"${ADMIN_USERNAME}\") is invalid: must be at least 3 characters."
 fi
 
@@ -477,12 +492,6 @@ validate_cron() {
     return 0
 }
 
-# Same fail-fast rationale as ADMIN_USERNAME above: an invalid env-supplied
-# cron string must not spin the prompt below forever under PACA_YES=1.
-if ! validate_cron "$BACKUP_CRON"; then
-    die "BACKUP_CRON (\"${BACKUP_CRON}\") is invalid: must be 5 whitespace-separated fields of digits and * , - /."
-fi
-
 if [[ -n "$SCALE_POSTGRES" ]]; then
     # db-backup runs pg_dump against the bundled container; an external/managed
     # database is assumed to already have its own backup mechanism.
@@ -507,6 +516,15 @@ else
         BACKUP_ENABLED="false"
         info "Automated backups will be skipped."
     else
+        # Fail fast (rather than looping forever on a `read` nobody will
+        # answer) if an env-supplied BACKUP_CRON is already invalid. Checked
+        # only here — once backups are confirmed to actually run — since an
+        # external-DB or backups-disabled install never reads this value, and
+        # a bad-but-irrelevant BACKUP_CRON in the environment shouldn't kill
+        # an otherwise-valid install.
+        if is_noninteractive && ! validate_cron "$BACKUP_CRON"; then
+            die "BACKUP_CRON (\"${BACKUP_CRON}\") is invalid: must be 5 whitespace-separated fields of digits and * , - /."
+        fi
         ask BACKUP_DIR "Directory to store backups in" "$BACKUP_DIR"
         while true; do
             ask BACKUP_CRON "Backup schedule (cron syntax, interpreted in UTC unless you set TZ in .env later)" "$BACKUP_CRON"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,13 +7,103 @@
 #   curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh -o install.sh
 #   bash install.sh
 #
-# ── One-liner (non-interactive, all defaults + auto-generated secrets) ────────
-#   bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh)
+# ── Non-interactive (CI, scripts, AI coding agents) ──────────────────────────
+#   Set PACA_YES=1. This is REQUIRED for unattended use — without it, any
+#   prompt this script reaches will block on a `read`, and in a sandbox that
+#   provides a pty but no human to type into it, that read never returns.
+#   PACA_YES=1 alone is enough to guarantee zero prompts (every field falls
+#   back to a sane default, generating fresh random secrets as needed); add
+#   any of the variables below beforehand to steer specific choices instead
+#   of accepting the default.
 #
-# ── Environment variable overrides ───────────────────────────────────────────
-#   PACA_DIR         Installation directory      (default: ./paca)
-#   PACA_VERSION     Release tag to install      (default: latest)
-#   PACA_YES         Skip prompts, use defaults  (set to 1)
+#   PACA_YES=1 bash install.sh
+#   # or, without a local copy of the script at all:
+#   PACA_YES=1 bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh)
+#
+# ── AI agents: use this script, not a hand-rolled docker-compose/.env ───────
+#   This script is the source of truth for a working deployment — it pins
+#   compatible image tags, generates every required secret with the right
+#   format/length, and writes a `.env` the bundled Caddyfile and compose file
+#   expect. Prefer `PACA_YES=1 bash install.sh` (with env overrides below)
+#   over reconstructing docker-compose.yml / .env by hand from the README —
+#   it is less likely to drift from what a given release actually needs.
+#
+# ── Environment variable reference ───────────────────────────────────────────
+#   Variables named after an actual `.env` key (DATABASE_URL, STORAGE_*,
+#   BACKUP_*, PUBLIC_URL, GATEWAY_PORT, ADMIN_*, ENCRYPTION_KEY, JWT_SECRET,
+#   POSTGRES_PASSWORD, AGENT_API_KEY, INTERNAL_API_KEY) are written to `.env`
+#   verbatim when set. Variables prefixed `PACA_` are installer-only choices
+#   with no 1:1 `.env` key (they steer which branch of a prompt is taken).
+#   Every variable below is optional; unset ones get a generated or default
+#   value. Secrets left unset are auto-generated and printed at the end of a
+#   successful run (and saved in `.env`) — nothing is silently left blank.
+#
+#   General
+#     PACA_DIR                    Installation directory              (default: ./paca)
+#     PACA_VERSION                Release tag to install               (default: latest)
+#     PACA_YES                    Skip prompts, use defaults           (set to 1)
+#     PACA_START                  Pull images and start after writing  (default: yes)
+#                                  config; yes/no.
+#
+#   Admin account
+#     ADMIN_USERNAME               (default: admin; min 3 chars)
+#     ADMIN_PASSWORD               (default: auto-generated 16 chars; min 8 if set)
+#
+#   Encryption (plugin secrets at rest)
+#     ENCRYPTION_KEY               64-char lowercase hex (default: auto-generated).
+#                                  Reusing an existing DB? You MUST supply its
+#                                  original key here — a different one makes
+#                                  existing encrypted values unreadable.
+#
+#   Database
+#     DATABASE_URL                 Setting this selects external/managed
+#                                  Postgres and suppresses the bundled
+#                                  container; leave unset for bundled Postgres.
+#     POSTGRES_PASSWORD            Bundled Postgres only (default: auto-generated)
+#
+#   Database backups (bundled Postgres only; skipped for external DB)
+#     BACKUP_ENABLED               true/false                          (default: true)
+#     BACKUP_DIR                   (default: ./backups)
+#     BACKUP_CRON                  5-field cron, UTC                   (default: "0 2 * * *")
+#     BACKUP_RETENTION_DAYS        (default: 7)
+#
+#   Object storage
+#     STORAGE_PROVIDER             minio/s3                            (default: minio)
+#     STORAGE_REGION                                                   (default: us-east-1)
+#     STORAGE_BUCKET                Required if STORAGE_PROVIDER=s3     (default: paca for minio)
+#     STORAGE_ACCESS_KEY_ID         Required if STORAGE_PROVIDER=s3     (default: auto-generated for minio)
+#     STORAGE_SECRET_ACCESS_KEY     Required if STORAGE_PROVIDER=s3     (default: auto-generated for minio)
+#
+#   Network
+#     PACA_ADDRESS                 Domain or IP Paca is reachable at    (default: localhost)
+#     PACA_HTTPS                   yes/no; ignored for localhost        (default: yes)
+#     GATEWAY_PORT                 Only used when serving plain HTTP    (default: 80)
+#     PUBLIC_URL                   Full public URL, no trailing slash   (default: derived from the above)
+#
+#   Web app
+#     PACA_WEB                     bundled/external                    (default: bundled)
+#
+#   AI agent
+#     PACA_AI_AGENT                yes/no                               (default: yes)
+#     AGENT_API_KEY                 (default: auto-generated)
+#     INTERNAL_API_KEY              (default: auto-generated)
+#
+#   PACA_WEB and PACA_AI_AGENT are also written to .env, so upgrade.sh can
+#   read the choice back and keep these services scaled to 0 automatically on
+#   future upgrades — you won't need to re-pass --scale web=0 / --scale
+#   ai-agent=0 by hand each time.
+#
+#   Other secrets
+#     JWT_SECRET                    (default: auto-generated)
+#
+#   Full example — fully unattended, custom domain, S3, no AI agent:
+#     PACA_YES=1 \
+#     PACA_ADDRESS=paca.example.com \
+#     STORAGE_PROVIDER=s3 STORAGE_BUCKET=my-bucket \
+#     STORAGE_ACCESS_KEY_ID=AKIA... STORAGE_SECRET_ACCESS_KEY=... \
+#     PACA_AI_AGENT=no \
+#     ADMIN_PASSWORD='a-strong-password' \
+#     bash install.sh
 
 set -euo pipefail
 
@@ -39,6 +129,15 @@ bold()    { echo -e "${BOLD}$*${RESET}"; }
 rand_hex()    { ( set +o pipefail; LC_ALL=C tr -dc 'a-f0-9'    </dev/urandom | head -c "${1:-32}"; ); }
 rand_alnum()  { ( set +o pipefail; LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c "${1:-24}"; ); }
 
+# has_ctty
+# /dev/tty is a device node that exists on disk regardless of whether this
+# process actually has a controlling terminal to open — `[[ -e /dev/tty ]]`
+# is therefore always true on Linux and doesn't tell us anything. Actually
+# attempting to open it is the only reliable test, and it must be the
+# condition of an if/elif so a failure (no ctty: ENXIO) doesn't trip
+# `set -e` and kill the whole script.
+has_ctty() { { : </dev/tty; } 2>/dev/null; }
+
 # ask VAR "Question" "default"
 # Reads from /dev/tty when stdin is a pipe (curl | bash).
 ask() {
@@ -60,7 +159,7 @@ ask() {
     fi
     if [[ -t 0 ]]; then
         read -r -p "$(echo -e "$prompt")" _input
-    elif [[ -e /dev/tty ]]; then
+    elif has_ctty; then
         read -r -p "$(echo -e "$prompt")" _input </dev/tty
     else
         printf -v "$_var" %s "${default}"
@@ -82,18 +181,22 @@ ask_secret() {
     fi
     if [[ -t 0 ]]; then
         read -r -s -p "$(echo -e "$prompt")" _input; echo
-    elif [[ -e /dev/tty ]]; then
+    elif has_ctty; then
         read -r -s -p "$(echo -e "$prompt")" _input </dev/tty; echo
     fi
     printf -v "$_var" %s "$_input"
 }
 
-# ask_choice VAR "Question" option1 option2 ...
+# ask_choice VAR "Question" default_idx option1 option2 ...
+# default_idx is the 1-based option picked under PACA_YES=1 (or a bare
+# Enter) — callers compute it from an env var so a choice can be steered
+# non-interactively instead of always landing on option 1.
 # Returns the chosen option string.
 ask_choice() {
     local _var="$1"
     local question="$2"
-    shift 2
+    local default_idx="$3"
+    shift 3
     local options=("$@")
     local i
 
@@ -103,11 +206,11 @@ ask_choice() {
     done
 
     local choice=""
-    ask choice "Choice" "1"
+    ask choice "Choice" "$default_idx"
     local idx=$(( choice - 1 ))
     if (( idx < 0 || idx >= ${#options[@]} )); then
-        warn "Invalid choice, using default (1)"
-        idx=0
+        warn "Invalid choice, using default (${default_idx})"
+        idx=$(( default_idx - 1 ))
     fi
     printf -v "$_var" %s "${options[$idx]}"
 }
@@ -211,6 +314,14 @@ validate_username() {
     return 0
 }
 
+# Fail fast (rather than looping forever on a `read` nobody will answer) if
+# an env-supplied default is already invalid — this matters under PACA_YES=1
+# or any non-interactive run, where every prompt below just re-returns the
+# same default.
+if ! validate_username "$ADMIN_USERNAME"; then
+    die "ADMIN_USERNAME (\"${ADMIN_USERNAME}\") is invalid: must be at least 3 characters."
+fi
+
 while true; do
     ask ADMIN_USERNAME "Admin username" "$ADMIN_USERNAME"
     if validate_username "$ADMIN_USERNAME"; then
@@ -271,27 +382,44 @@ echo "  supply the original key — a different key makes all existing encrypted
 echo "  values permanently unreadable."
 echo ""
 
-ENCRYPTION_KEY=""
+ENCRYPTION_KEY="${ENCRYPTION_KEY:-}"
 ENCRYPTION_KEY_GENERATED=0
-ask_secret ENCRYPTION_KEY "Encryption key — 64-char hex (leave blank to generate)"
 
-if [[ -z "$ENCRYPTION_KEY" ]]; then
-    ENCRYPTION_KEY="$(rand_hex 64)"
-    ENCRYPTION_KEY_GENERATED=1
-    info "Encryption key generated."
-else
+# If a key was supplied via env var, validate it before proceeding — same
+# pattern as ADMIN_PASSWORD above, so a bad env value fails loudly instead of
+# silently falling through to a prompt that will never be answered.
+if [[ -n "$ENCRYPTION_KEY" ]]; then
     if [[ ! "$ENCRYPTION_KEY" =~ ^[a-f0-9]{64}$ ]]; then
-        die "Invalid encryption key: must be exactly 64 lowercase hex characters (32 bytes). Generate one with: openssl rand -hex 32"
+        die "Invalid ENCRYPTION_KEY: must be exactly 64 lowercase hex characters (32 bytes). Generate one with: openssl rand -hex 32"
     fi
-    info "Using the provided encryption key."
+    info "Using the encryption key from the environment."
+else
+    ask_secret ENCRYPTION_KEY "Encryption key — 64-char hex (leave blank to generate)"
+
+    if [[ -z "$ENCRYPTION_KEY" ]]; then
+        ENCRYPTION_KEY="$(rand_hex 64)"
+        ENCRYPTION_KEY_GENERATED=1
+        info "Encryption key generated."
+    else
+        if [[ ! "$ENCRYPTION_KEY" =~ ^[a-f0-9]{64}$ ]]; then
+            die "Invalid encryption key: must be exactly 64 lowercase hex characters (32 bytes). Generate one with: openssl rand -hex 32"
+        fi
+        info "Using the provided encryption key."
+    fi
 fi
 
 # ── Database ──────────────────────────────────────────────────────────────────
 
 heading "Database"
 
+# Setting DATABASE_URL implies "external" without a separate choice
+# variable — an agent that supplies a connection string obviously wants it
+# used, and this keeps one env var in sync instead of two.
+DB_DEFAULT_IDX=1
+[[ -n "${DATABASE_URL:-}" ]] && DB_DEFAULT_IDX=2
+
 DB_CHOICE=""
-ask_choice DB_CHOICE "How should Paca store data?" \
+ask_choice DB_CHOICE "How should Paca store data?" "$DB_DEFAULT_IDX" \
     "Bundled PostgreSQL container (recommended)" \
     "External / managed PostgreSQL (bring your own)"
 
@@ -301,12 +429,15 @@ POSTGRES_PASSWORD_VALUE=""
 
 if [[ "$DB_CHOICE" == *"External"* ]]; then
     SCALE_POSTGRES="--scale postgres=0"
-    ask DATABASE_URL_OVERRIDE "PostgreSQL connection URL" "postgres://user:pass@host:5432/dbname"
+    ask DATABASE_URL_OVERRIDE "PostgreSQL connection URL" "${DATABASE_URL:-postgres://user:pass@host:5432/dbname}"
+    if [[ -z "$DATABASE_URL_OVERRIDE" || "$DATABASE_URL_OVERRIDE" == "postgres://user:pass@host:5432/dbname" ]]; then
+        die "External PostgreSQL selected but no real DATABASE_URL was given. Set the DATABASE_URL env var or rerun interactively and type a real connection string."
+    fi
     # Set a placeholder so the compose's ${POSTGRES_PASSWORD:-changeme} default doesn't matter.
     POSTGRES_PASSWORD_VALUE="not-used-external-db"
     info "External PostgreSQL will be used."
 else
-    POSTGRES_PASSWORD_VALUE="$(rand_alnum 20)"
+    POSTGRES_PASSWORD_VALUE="${POSTGRES_PASSWORD:-$(rand_alnum 20)}"
     info "A bundled PostgreSQL container will be started."
 fi
 
@@ -315,10 +446,13 @@ fi
 heading "Database backups"
 
 SCALE_DB_BACKUP=""
+# Capture the env-supplied enable/disable choice before BACKUP_ENABLED gets
+# reused below as the actual (branch-dependent) output value.
+BACKUP_ENABLED_INPUT="${BACKUP_ENABLED:-true}"
 BACKUP_ENABLED="true"
-BACKUP_DIR="./backups"
-BACKUP_CRON="0 2 * * *"
-BACKUP_RETENTION_DAYS="7"
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+BACKUP_CRON="${BACKUP_CRON:-0 2 * * *}"
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
 
 # validate_cron VALUE
 # Checks the same field count the db-backup container enforces at startup
@@ -343,6 +477,12 @@ validate_cron() {
     return 0
 }
 
+# Same fail-fast rationale as ADMIN_USERNAME above: an invalid env-supplied
+# cron string must not spin the prompt below forever under PACA_YES=1.
+if ! validate_cron "$BACKUP_CRON"; then
+    die "BACKUP_CRON (\"${BACKUP_CRON}\") is invalid: must be 5 whitespace-separated fields of digits and * , - /."
+fi
+
 if [[ -n "$SCALE_POSTGRES" ]]; then
     # db-backup runs pg_dump against the bundled container; an external/managed
     # database is assumed to already have its own backup mechanism.
@@ -358,7 +498,9 @@ else
     echo ""
 
     INCLUDE_BACKUPS="yes"
-    yes_no INCLUDE_BACKUPS "Enable automated database backups?" "y"
+    BACKUP_DEFAULT="y"
+    [[ "$BACKUP_ENABLED_INPUT" == "false" ]] && BACKUP_DEFAULT="n"
+    yes_no INCLUDE_BACKUPS "Enable automated database backups?" "$BACKUP_DEFAULT"
 
     if [[ "$INCLUDE_BACKUPS" == "no" ]]; then
         SCALE_DB_BACKUP="--scale db-backup=0"
@@ -382,19 +524,19 @@ fi
 
 heading "Object storage"
 
+# STORAGE_PROVIDER doubles as both the .env output key and the input
+# selector here — set it to "s3" or "minio" beforehand to skip this prompt.
+STORAGE_DEFAULT_IDX=1
+[[ "${STORAGE_PROVIDER:-}" == "s3" ]] && STORAGE_DEFAULT_IDX=2
+
 STORAGE_CHOICE=""
-ask_choice STORAGE_CHOICE "Where should file attachments be stored?" \
+ask_choice STORAGE_CHOICE "Where should file attachments be stored?" "$STORAGE_DEFAULT_IDX" \
     "Self-hosted MinIO (recommended, no cloud account needed)" \
     "AWS S3"
 
 SCALE_MINIO=""
-STORAGE_PROVIDER="minio"
 STORAGE_ENDPOINT="minio:9000"
 STORAGE_USE_SSL="false"
-STORAGE_REGION="us-east-1"
-STORAGE_BUCKET="paca"
-STORAGE_ACCESS_KEY_ID="$(rand_alnum 16)"
-STORAGE_SECRET_ACCESS_KEY="$(rand_alnum 32)"
 
 if [[ "$STORAGE_CHOICE" == *"AWS"* ]]; then
     SCALE_MINIO="--scale minio=0"
@@ -402,10 +544,14 @@ if [[ "$STORAGE_CHOICE" == *"AWS"* ]]; then
     STORAGE_ENDPOINT=""
     STORAGE_USE_SSL="true"
 
-    ask STORAGE_REGION    "AWS region"          "us-east-1"
-    ask STORAGE_BUCKET    "S3 bucket name"      ""
-    ask STORAGE_ACCESS_KEY_ID    "AWS access key ID"     ""
-    ask_secret STORAGE_SECRET_ACCESS_KEY "AWS secret access key"
+    ask STORAGE_REGION    "AWS region"          "${STORAGE_REGION:-us-east-1}"
+    ask STORAGE_BUCKET    "S3 bucket name"      "${STORAGE_BUCKET:-}"
+    ask STORAGE_ACCESS_KEY_ID    "AWS access key ID"     "${STORAGE_ACCESS_KEY_ID:-}"
+    if [[ -n "${STORAGE_SECRET_ACCESS_KEY:-}" ]]; then
+        info "Using the AWS secret access key from the environment."
+    else
+        ask_secret STORAGE_SECRET_ACCESS_KEY "AWS secret access key"
+    fi
 
     if [[ -z "$STORAGE_BUCKET" ]]; then
         die "S3 bucket name is required."
@@ -415,6 +561,11 @@ if [[ "$STORAGE_CHOICE" == *"AWS"* ]]; then
     fi
     info "AWS S3 will be used (bucket: ${STORAGE_BUCKET}, region: ${STORAGE_REGION})."
 else
+    STORAGE_PROVIDER="minio"
+    STORAGE_REGION="${STORAGE_REGION:-us-east-1}"
+    STORAGE_BUCKET="${STORAGE_BUCKET:-paca}"
+    STORAGE_ACCESS_KEY_ID="${STORAGE_ACCESS_KEY_ID:-$(rand_alnum 16)}"
+    STORAGE_SECRET_ACCESS_KEY="${STORAGE_SECRET_ACCESS_KEY:-$(rand_alnum 32)}"
     info "Self-hosted MinIO will be started."
 fi
 
@@ -431,28 +582,27 @@ echo "  over plain HTTP instead, since it never needs (or can get) a certificate
 echo ""
 
 ADDRESS=""
-ask ADDRESS "Domain name (recommended) or IP address Paca will be accessible at" "localhost"
+ask ADDRESS "Domain name (recommended) or IP address Paca will be accessible at" "${PACA_ADDRESS:-localhost}"
 
-GATEWAY_PORT="80"
+GATEWAY_PORT="${GATEWAY_PORT:-80}"
 
 if [[ "$ADDRESS" == "localhost" ]]; then
     USE_HTTPS="no"
     info "Using localhost — serving over plain HTTP."
 else
-    USE_HTTPS="yes"
-    yes_no USE_HTTPS "Serve over HTTPS?" "y"
+    yes_no USE_HTTPS "Serve over HTTPS?" "${PACA_HTTPS:-y}"
 fi
 
 if [[ "$USE_HTTPS" == "yes" ]]; then
     SITE_ADDRESS="$ADDRESS"
-    PUBLIC_URL="https://${ADDRESS}"
+    PUBLIC_URL="${PUBLIC_URL:-https://${ADDRESS}}"
 
     info "Caddy will obtain a certificate for ${ADDRESS} on first start — a trusted"
     info "Let's Encrypt certificate if DNS resolves here, otherwise a local one."
     warn "Ports 80 and 443 must both be reachable from the internet for Let's Encrypt to succeed."
 else
     SITE_ADDRESS=":80"
-    ask GATEWAY_PORT "Gateway port (the port Paca will be accessible on)" "80"
+    ask GATEWAY_PORT "Gateway port (the port Paca will be accessible on)" "$GATEWAY_PORT"
 
     # Derive a sensible default public URL from the port.
     if [[ "$GATEWAY_PORT" == "80" ]]; then
@@ -461,7 +611,7 @@ else
         _DEFAULT_PUBLIC_URL="http://${ADDRESS}:${GATEWAY_PORT}"
     fi
 
-    ask PUBLIC_URL "Public URL (full URL where Paca will be accessible, no trailing slash)" "$_DEFAULT_PUBLIC_URL"
+    ask PUBLIC_URL "Public URL (full URL where Paca will be accessible, no trailing slash)" "${PUBLIC_URL:-$_DEFAULT_PUBLIC_URL}"
 fi
 
 PUBLIC_URL="${PUBLIC_URL%/}"  # strip trailing slash
@@ -484,14 +634,18 @@ fi
 
 heading "Web application"
 
+WEB_DEFAULT_IDX=1
+[[ "${PACA_WEB:-}" == "external" ]] && WEB_DEFAULT_IDX=2
+
 WEB_CHOICE=""
-ask_choice WEB_CHOICE "How do you want to serve the web app?" \
+ask_choice WEB_CHOICE "How do you want to serve the web app?" "$WEB_DEFAULT_IDX" \
     "Bundled container (recommended – Caddy serves the built React SPA)" \
     "External hosting (S3, CloudFront, Vercel, etc. – only API services run here)"
 
 SCALE_WEB=""
 if [[ "$WEB_CHOICE" == *"External"* ]]; then
     SCALE_WEB="--scale web=0"
+    PACA_WEB="external"
     echo ""
     warn "The web container will be skipped."
     warn "Build the SPA from source and deploy the dist/ folder to your CDN."
@@ -499,6 +653,7 @@ if [[ "$WEB_CHOICE" == *"External"* ]]; then
     echo ""
     info "The gateway will still serve /api/, /ws/, and /storage/ routes."
 else
+    PACA_WEB="bundled"
     info "Bundled web container will be started."
 fi
 
@@ -511,11 +666,11 @@ echo "  It requires access to the Docker socket on the host machine."
 echo ""
 
 INCLUDE_AI_AGENT="yes"
-yes_no INCLUDE_AI_AGENT "Include the AI agent service?" "y"
+yes_no INCLUDE_AI_AGENT "Include the AI agent service?" "${PACA_AI_AGENT:-y}"
 
 SCALE_AI_AGENT=""
-AGENT_API_KEY="$(rand_hex 32)"
-INTERNAL_API_KEY="$(rand_hex 32)"
+AGENT_API_KEY="${AGENT_API_KEY:-$(rand_hex 32)}"
+INTERNAL_API_KEY="${INTERNAL_API_KEY:-$(rand_hex 32)}"
 
 if [[ "$INCLUDE_AI_AGENT" == "no" ]]; then
     SCALE_AI_AGENT="--scale ai-agent=0"
@@ -562,7 +717,7 @@ else
 fi
 
 if [[ "$KEEP_ENV" == "no" ]]; then
-    JWT_SECRET="$(rand_hex 32)"
+    JWT_SECRET="${JWT_SECRET:-$(rand_hex 32)}"
 
     cat >.env <<EOF
 # ── Paca environment ──────────────────────────────────────────────────────────
@@ -646,6 +801,12 @@ PORT_POOL_START=10000
 PORT_POOL_SIZE=100
 WORKER_CONCURRENCY=10
 
+# ── Service topology ─────────────────────────────────────────────────────────
+# Recorded so upgrade.sh can keep these services scaled to 0 automatically on
+# future upgrades, instead of you having to re-pass --scale flags every time.
+PACA_WEB=${PACA_WEB}
+PACA_AI_AGENT=${INCLUDE_AI_AGENT}
+
 # ── Logging ───────────────────────────────────────────────────────────────────
 LOG_LEVEL=info
 EOF
@@ -670,7 +831,7 @@ echo -e "  ${BOLD}Admin user  ${RESET}${ADMIN_USERNAME}"
 echo ""
 
 START="yes"
-yes_no START "Pull images and start Paca now?" "y"
+yes_no START "Pull images and start Paca now?" "${PACA_START:-y}"
 
 if [[ "$START" != "yes" ]]; then
     echo ""

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -7,6 +7,12 @@
 # specific version is requested, backfills any .env variables introduced
 # since the install was created, then pulls and restarts the stack.
 #
+# Service scaling from install time (external Postgres, external S3, an
+# externally hosted web app, a disabled AI agent) is detected from .env and
+# re-applied automatically — no need to re-pass the same --scale flags on
+# every upgrade. See "Extra arguments" below for scaling that isn't one of
+# these.
+#
 # Run this from the directory that holds your docker-compose.yml and .env
 # (the directory install.sh created, or wherever you set things up manually).
 #
@@ -15,17 +21,45 @@
 #   curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/upgrade.sh -o upgrade.sh
 #   bash upgrade.sh
 #
-# ── One-liner (non-interactive, upgrades to latest) ───────────────────────────
-#   bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/upgrade.sh)
+# ── Non-interactive (CI, scripts, AI coding agents) ──────────────────────────
+#   Set PACA_YES=1. This is REQUIRED for unattended use — without it, any
+#   prompt this script reaches will block on a `read`, and in a sandbox that
+#   provides a pty but no human to type into it, that read never returns.
+#   PACA_YES=1 alone is enough to guarantee zero prompts: it proceeds with
+#   the upgrade and takes the default (yes) on any conditional .env
+#   migration prompt.
 #
-# ── Environment variable overrides ───────────────────────────────────────────
-#   PACA_DIR         Installation directory to upgrade   (default: .)
-#   PACA_VERSION     Release tag to upgrade to           (default: latest)
-#   PACA_YES         Skip prompts, use defaults          (set to 1)
+#   cd /path/to/your/paca/install
+#   PACA_YES=1 bash upgrade.sh
+#   # or, without a local copy of the script at all:
+#   PACA_YES=1 bash <(curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/upgrade.sh)
+#
+# ── AI agents: use this script, not a manual `docker compose pull && up` ────
+#   This script backs up docker-compose.yml / Caddyfile / .env before
+#   overwriting them, only re-pins image tags when you actually asked for a
+#   specific version, and backfills any .env variables introduced since the
+#   install was created (gateway migration, db-backup service, etc.). A
+#   manual pull + restart skips all of that and can leave an installation
+#   half-migrated in a way that's hard to diagnose from outside the repo.
+#
+# ── Environment variable reference ───────────────────────────────────────────
+#   PACA_DIR                    Installation directory to upgrade       (default: .)
+#   PACA_VERSION                Release tag to upgrade to               (default: latest)
+#   PACA_YES                    Skip prompts, use defaults              (set to 1)
+#   PACA_PROCEED                Actually run the upgrade (yes/no).      (default: yes)
+#                                "no" prints the current vs. target
+#                                version and exits without changing
+#                                anything — a lightweight version check.
+#   PACA_UPDATE_AGENT_IMAGE     Switch AGENT_SERVER_IMAGE off the old   (default: yes)
+#                                upstream default when found (yes/no).
+#                                Only asked for installs that predate
+#                                Paca's own agent-server image.
 #
 # Extra arguments are passed through to the final `docker compose up -d`,
-# e.g. to keep the same service scaling you used originally:
-#   bash upgrade.sh --scale web=0 --scale minio=0
+# for any --scale (or other compose flag) beyond what's already inferred
+# from .env above, e.g.:
+#   bash upgrade.sh --scale <service>=<n>
+#   PACA_YES=1 bash upgrade.sh --scale <service>=<n>
 
 set -euo pipefail
 
@@ -43,6 +77,15 @@ heading() { echo -e "\n${BOLD}${CYAN}── $* ${RESET}${DIM}$(printf '─%.0s' 
 bold()    { echo -e "${BOLD}$*${RESET}"; }
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+# has_ctty
+# /dev/tty is a device node that exists on disk regardless of whether this
+# process actually has a controlling terminal to open — `[[ -e /dev/tty ]]`
+# is therefore always true on Linux and doesn't tell us anything. Actually
+# attempting to open it is the only reliable test, and it must be the
+# condition of an if/elif so a failure (no ctty: ENXIO) doesn't trip
+# `set -e` and kill the whole script.
+has_ctty() { { : </dev/tty; } 2>/dev/null; }
 
 # ask VAR "Question" "default"
 # Reads from /dev/tty when stdin is a pipe (curl | bash).
@@ -65,7 +108,7 @@ ask() {
     fi
     if [[ -t 0 ]]; then
         read -r -p "$(echo -e "$prompt")" _input
-    elif [[ -e /dev/tty ]]; then
+    elif has_ctty; then
         read -r -p "$(echo -e "$prompt")" _input </dev/tty
     else
         printf -v "$_var" %s "${default}"
@@ -122,6 +165,14 @@ set_env_var() {
 # has_env_var FILE VAR
 has_env_var() {
     grep -q "^${2}=" "$1" 2>/dev/null
+}
+
+# service_has_container SERVICE
+# True if this compose project currently has a container for SERVICE, in any
+# state (running, stopped, created) — i.e. some previous `up` actually
+# created one, as opposed to it having been scaled to 0.
+service_has_container() {
+    $COMPOSE_CMD --env-file .env ps -a --services 2>/dev/null | grep -qx "$1"
 }
 
 # get_env_var FILE VAR
@@ -197,7 +248,7 @@ if [[ -f nginx/gateway.conf ]]; then
 fi
 
 PROCEED="yes"
-yes_no PROCEED "Proceed with upgrade?" "y"
+yes_no PROCEED "Proceed with upgrade?" "${PACA_PROCEED:-y}"
 if [[ "$PROCEED" != "yes" ]]; then
     warn "Upgrade cancelled."
     exit 0
@@ -261,7 +312,7 @@ if [[ "$(get_env_var .env AGENT_SERVER_IMAGE)" == "$OLD_AGENT_SERVER_IMAGE_DEFAU
     info "AGENT_SERVER_IMAGE is still set to the upstream OpenHands image (${OLD_AGENT_SERVER_IMAGE_DEFAULT})."
     info "Paca now ships its own agent-server image (ghcr.io/paca-ai/paca-agent-server:latest) with the Paca MCP server pre-installed, avoiding a cold npm download on every new sandbox."
     UPDATE_AGENT_IMAGE="yes"
-    yes_no UPDATE_AGENT_IMAGE "Switch AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:latest?" "y"
+    yes_no UPDATE_AGENT_IMAGE "Switch AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:latest?" "${PACA_UPDATE_AGENT_IMAGE:-y}"
     if [[ "$UPDATE_AGENT_IMAGE" == "yes" ]]; then
         backup_env_once
         set_env_var .env AGENT_SERVER_IMAGE "ghcr.io/paca-ai/paca-agent-server:latest"
@@ -300,6 +351,29 @@ if [[ "$GATEWAY_VARS_ADDED" == "1" ]]; then
     info "Already behind another TLS terminator (a load balancer, Cloudflare, etc.)? Set SITE_ADDRESS=:80 in .env to keep this gateway on plain HTTP."
 fi
 
+# Which optional services should stay scaled to 0 on this upgrade, so you
+# don't have to remember and re-pass the same --scale flags you used at
+# install time on every single upgrade. Anything not covered below (a custom
+# scaling choice of your own) still needs to be passed through via "$@" as
+# before.
+SCALE_OPTS=()
+
+# Postgres: external DB means the bundled container must never run. This is
+# derived purely from DATABASE_URL — the same signal install.sh itself used
+# to decide whether to start postgres in the first place — so unlike the
+# services below, it needs no separate .env marker or backfill.
+if [[ -n "$(get_env_var .env DATABASE_URL)" ]]; then
+    SCALE_OPTS+=(--scale postgres=0)
+    info "Using an external database (DATABASE_URL is set) — skipping the postgres service."
+fi
+
+# Storage: S3 means the bundled MinIO container must never run — same
+# reasoning as postgres above, derived from STORAGE_PROVIDER.
+if [[ "$(get_env_var .env STORAGE_PROVIDER)" == "s3" ]]; then
+    SCALE_OPTS+=(--scale minio=0)
+    info "Using AWS S3 (STORAGE_PROVIDER=s3 in .env) — skipping the minio service."
+fi
+
 # Backfill variables for the db-backup service introduced after this install
 # was created. Installations from before that release have none of these in
 # .env.
@@ -311,7 +385,6 @@ fi
 # deriving a default from DATABASE_URL, mirroring the bundled-vs-external
 # check in install.sh, and then record that derived choice so future upgrades
 # read it back instead of re-deriving it.
-SCALE_OPTS=()
 if has_env_var .env BACKUP_ENABLED; then
     if [[ "$(get_env_var .env BACKUP_ENABLED)" == "false" ]]; then
         SCALE_OPTS+=(--scale db-backup=0)
@@ -341,6 +414,53 @@ else
     set_env_var .env BACKUP_ENABLED "false"
     SCALE_OPTS+=(--scale db-backup=0)
     info "Using an external database (DATABASE_URL is set) — skipping the automated db-backup service."
+fi
+
+# Used by the web/ai-agent inference below: distinguishes "some services were
+# intentionally scaled to 0" from "the whole stack simply isn't running right
+# now" (e.g. after `docker compose down`) — in the latter case NO service has
+# a container, and without this check everything would look scaled to 0 and
+# an upgrade would silently bring nothing back up.
+PROJECT_EVER_STARTED=0
+[[ -n "$($COMPOSE_CMD --env-file .env ps -a --services 2>/dev/null)" ]] && PROJECT_EVER_STARTED=1
+
+# Web app: PACA_WEB (written to .env by install.sh since this release) is the
+# source of truth when present. Installs that predate it get a best-effort
+# guess from whether a 'web' container currently exists — only attempted when
+# the project has been started before at all, per PROJECT_EVER_STARTED above.
+# Either way, the value is written back so future upgrades read it instead of
+# re-guessing.
+if has_env_var .env PACA_WEB; then
+    if [[ "$(get_env_var .env PACA_WEB)" == "external" ]]; then
+        SCALE_OPTS+=(--scale web=0)
+        info "Web app is externally hosted (PACA_WEB=external in .env) — skipping the web service."
+    fi
+elif [[ "$PROJECT_EVER_STARTED" == "1" ]]; then
+    backup_env_once
+    if service_has_container web; then
+        set_env_var .env PACA_WEB "bundled"
+    else
+        set_env_var .env PACA_WEB "external"
+        SCALE_OPTS+=(--scale web=0)
+        warn "No existing 'web' container found, and this install predates PACA_WEB being tracked in .env — assuming the web app is hosted externally and recording PACA_WEB=external. Wrong? Pass --scale web=1 on this run, then set PACA_WEB=bundled in .env so future upgrades stop guessing."
+    fi
+fi
+
+# AI agent: same reasoning as the web app above, via PACA_AI_AGENT.
+if has_env_var .env PACA_AI_AGENT; then
+    if [[ "$(get_env_var .env PACA_AI_AGENT)" == "no" ]]; then
+        SCALE_OPTS+=(--scale ai-agent=0)
+        info "AI agent is disabled (PACA_AI_AGENT=no in .env) — skipping the ai-agent service."
+    fi
+elif [[ "$PROJECT_EVER_STARTED" == "1" ]]; then
+    backup_env_once
+    if service_has_container ai-agent; then
+        set_env_var .env PACA_AI_AGENT "yes"
+    else
+        set_env_var .env PACA_AI_AGENT "no"
+        SCALE_OPTS+=(--scale ai-agent=0)
+        warn "No existing 'ai-agent' container found, and this install predates PACA_AI_AGENT being tracked in .env — assuming the AI agent is disabled and recording PACA_AI_AGENT=no. Wrong? Pass --scale ai-agent=1 on this run, then set PACA_AI_AGENT=yes in .env so future upgrades stop guessing."
+    fi
 fi
 
 # ── Pull and restart ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Makes `install.sh` and `upgrade.sh` safely callable by CI and AI coding agents, not just humans at a terminal — every configuration choice is now settable via an environment variable, two real hangs/crashes in the non-interactive path are fixed, and `upgrade.sh` now re-applies the service topology chosen at install time automatically instead of requiring the caller to remember and re-pass `--scale` flags.

## `scripts/install.sh`

- **Every prompt is now settable via env var**, not just `PACA_DIR`/`PACA_VERSION`/`ADMIN_USERNAME`/`ADMIN_PASSWORD`: `ENCRYPTION_KEY`, `DATABASE_URL`, `POSTGRES_PASSWORD`, `BACKUP_ENABLED`/`BACKUP_DIR`/`BACKUP_CRON`/`BACKUP_RETENTION_DAYS`, `STORAGE_PROVIDER`/`STORAGE_REGION`/`STORAGE_BUCKET`/`STORAGE_ACCESS_KEY_ID`/`STORAGE_SECRET_ACCESS_KEY`, `PACA_ADDRESS`, `PACA_HTTPS`, `GATEWAY_PORT`, `PUBLIC_URL`, `PACA_WEB`, `PACA_AI_AGENT`, `AGENT_API_KEY`, `INTERNAL_API_KEY`, `JWT_SECRET`, and `PACA_START` (skip the final pull+start). `PACA_YES=1` plus any subset of these now produces a fully deterministic, non-interactive install.
- `ask_choice()` took a hardcoded default index (always option 1), so `PACA_YES=1` could never actually select external Postgres, S3, or external web hosting no matter what env vars were set. It now takes a caller-computed default index derived from the relevant env var.
- **Fixed a crash**: `ask()`/`ask_secret()` decided whether to fall back to reading `/dev/tty` using `[[ -e /dev/tty ]]`, which is true on Linux regardless of whether the process actually has a controlling terminal. In a headless sandbox with no `PACA_YES` and no tty at all, the script crashed on the first prompt with `/dev/tty: No such device or address` instead of falling back to defaults as intended. Replaced with `has_ctty()`, which actually attempts the open, gated in an `if`/`elif` so failure doesn't trip `set -e`.
- **Fixed two infinite-loop hang risks**: the `ADMIN_USERNAME` and `BACKUP_CRON` validation loops re-prompt on invalid input, but under `PACA_YES=1` (or any non-interactive run) `ask()` just re-returns the same default forever — so an invalid env-supplied value spun the loop indefinitely with nothing able to break it. Both now validate the incoming default once and `die` immediately with a clear message if it's invalid.
- Selecting external Postgres without a real `DATABASE_URL` now `die`s instead of silently writing the literal placeholder string into `.env`.
- `PACA_WEB` (`bundled`/`external`) and `PACA_AI_AGENT` (`yes`/`no`) are now written to `.env` so `upgrade.sh` can read the choice back (see below).
- Full env var reference moved into the script's own header comment, including an explicit note that `PACA_YES=1` is *required* for unattended use and why.

## `scripts/upgrade.sh`

- Added `PACA_PROCEED` (default `yes`) — `PACA_PROCEED=no` gives a non-destructive, lightweight version check: prints current vs. target version and exits without touching any files. Useful for an agent that wants to know if an upgrade is available before committing to one.
- Added `PACA_UPDATE_AGENT_IMAGE` to make the conditional `AGENT_SERVER_IMAGE` migration prompt steerable instead of always silently taking "yes" under `PACA_YES=1`.
- Same `has_ctty()` fix as `install.sh` (identical bug, identical fix).
- Header's old "non-interactive" one-liner didn't actually set `PACA_YES=1`, so it wasn't non-interactive and would have hit the tty crash above headless. Rewritten to match `install.sh`'s header structure.
- **Service scaling from install time is now detected and re-applied automatically**, instead of requiring `bash upgrade.sh --scale web=0 --scale minio=0 ...` to be re-typed on every upgrade:
  - Postgres (`--scale postgres=0`) and MinIO (`--scale minio=0`) are derived from `DATABASE_URL`/`STORAGE_PROVIDER`, which `.env` has always carried unconditionally — no migration needed.
  - Web app and AI agent are derived from the new `PACA_WEB`/`PACA_AI_AGENT` keys above. For installs from before those existed, a one-time best-effort guess is made from whether a container for that service currently exists at all (`docker compose ps -a --services`) — guarded so it only fires when the project has *some* existing container (so a fully torn-down stack, e.g. after `docker compose down`, isn't mistaken for "everything was scaled to 0" and left off permanently). The guess is written back to `.env` so it's a one-time thing, not a re-guess on every future upgrade, and is overridable with `--scale web=1` / `--scale ai-agent=1` if wrong.

## Docs

- `README.md`, `deploy/README.md`, `docs/guides/getting-started.md`: added explicit "non-interactive / AI coding agent" guidance recommending `PACA_YES=1 bash install.sh` (and `upgrade.sh`) over hand-rolling `docker-compose.yml`/`.env`, plus full env var reference tables.
- `deploy/.env.production.example`: documents `PACA_WEB`/`PACA_AI_AGENT` for manual setups that also want `upgrade.sh`'s automatic scaling.

## Testing

Both scripts were exercised directly (Docker available in the dev sandbox), always torn down (`docker compose down -v`) afterward:

- `bash -n` on both scripts.
- `install.sh`: full-defaults and fully-custom (`external DB + S3 + custom HTTPS domain + no AI agent`) runs under `PACA_YES=1`, with `.env` contents verified field-by-field; all four validation-failure paths (`ADMIN_USERNAME`, `ADMIN_PASSWORD`, `ENCRYPTION_KEY`, `BACKUP_CRON`) confirmed to `die` immediately rather than hang; the no-tty-no-`PACA_YES` crash reproduced before the fix and confirmed gone after.
- Real interactive runs via a pty (`pexpect`): accept-all-defaults, and typed custom answers that deliberately trigger the `ADMIN_USERNAME`/`ADMIN_PASSWORD`/`BACKUP_CRON` retry loops with an invalid value followed by a valid one. Also simulated the documented `curl … | bash` pattern (`cat install.sh | bash` inside a pty, so the script's own stdin is a pipe but a real controlling terminal is attached) to prove the `/dev/tty` fallback is genuinely interactive, not silently defaulting.
- `upgrade.sh`: all five scale-inference scenarios (marker present in both directions, old-style `.env` with zero containers, old-style `.env` with a fabricated partial container state via `docker compose create` in both directions) verified against a copy of the script truncated right before the real `docker compose pull`, so the `.env`-mutation logic could be checked without touching Docker.
- Two full, unmodified, end-to-end runs that actually pulled images and started the real stack: (1) `install.sh` → `upgrade.sh` with `PACA_YES=1`, all 9 services healthy; (2) `install.sh --web=external --ai-agent=no` → `upgrade.sh` with `PACA_YES=1` and **no** `--scale` flags, confirmed via `docker ps` that `web`/`ai-agent` were genuinely never created while the other 7 services came up healthy.
