### PR TITLE
feat: speed up API build and gate "latest" on a complete release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,15 @@ name: cd
 #     docker-compose.yml — standalone compose (no source tree required)
 #     Caddyfile          — Caddy gateway configuration
 #     .env.production.example — environment variable template
+#
+# "Latest" label sequencing (hold-release-label / promote-release below):
+# no image is pushed with a :latest Docker tag, and the GitHub release itself
+# is held off the "Latest" release marker, until every job in this workflow
+# has succeeded. This keeps /releases/latest and every :latest image tag
+# pointing at the previous, fully-shipped release for the whole ~20-30 minute
+# build window instead of a half-published one. install.sh/upgrade.sh are
+# also stamped with this exact release's tag as their default target, so a
+# plain `bash install.sh` never depends on the :latest tag being current.
 
 on:
   release:
@@ -37,10 +46,33 @@ permissions:
 env:
   REGISTRY: ghcr.io
 
-# ─────────────────────────────────────────────────────────────────────────────
-# API service image
-# ─────────────────────────────────────────────────────────────────────────────
 jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Hold the "Latest" release label until every artefact has actually shipped
+  # ─────────────────────────────────────────────────────────────────────────────
+  # GitHub marks a newly published release "Latest" (and /releases/latest
+  # resolves to it) immediately on publish by default. This workflow takes
+  # 20-30 minutes, so during that window /releases/latest/download/* would
+  # 404 (release-assets hasn't run yet) and any :latest Docker pull would
+  # still be fine (see below) but the release page itself would look "live"
+  # before it is. Demote it back to no label here — promote-release (the
+  # last job in this file) re-marks it "Latest" only once everything below
+  # has succeeded.
+  hold-release-label:
+    name: Hold "Latest" label until release is complete
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Unmark this release as "Latest"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.event.release.tag_name }}" --repo "${{ github.repository }}" --latest=false
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # API service image
+  # ─────────────────────────────────────────────────────────────────────────────
   api-image:
     name: Build and push API image
     runs-on: ubuntu-latest
@@ -76,7 +108,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -132,7 +163,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -186,7 +216,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -237,7 +266,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -289,7 +317,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -428,10 +455,26 @@ jobs:
   # End-users download and run:
   #   curl -fsSL https://github.com/Paca-AI/paca/releases/latest/download/install.sh -o install.sh
   #   bash install.sh
+  #
+  # Waits for every image/package job so these assets — and the exact version
+  # they're stamped with below — are never uploaded for a release that isn't
+  # fully shippable. If any of those jobs fail, this job is skipped and the
+  # previous release (still the "Latest" one; see hold-release-label /
+  # promote-release) keeps serving installs/upgrades until it's fixed.
   # ─────────────────────────────────────────────────────────────────────────────
   release-assets:
     name: Upload deployment assets to release
     runs-on: ubuntu-latest
+    needs:
+      [
+        api-image,
+        realtime-image,
+        web-image,
+        ai-agent-image,
+        agent-server-image,
+        publish-mcp,
+        publish-acp-bridge,
+      ]
     permissions:
       contents: write
 
@@ -449,6 +492,17 @@ jobs:
           cp scripts/upgrade.sh                    upgrade.sh
           chmod +x install.sh upgrade.sh
 
+          # Stamp this release's own tag as the scripts' default version. A
+          # plain `bash install.sh` / `bash upgrade.sh` downloaded from this
+          # release then pins to a version that's guaranteed to exist,
+          # instead of the floating :latest Docker tag, which promote-release
+          # only updates once this job has already succeeded. Targets the
+          # single `PACA_DEFAULT_VERSION="latest"` line each script keeps for
+          # exactly this purpose — see the comment above it in install.sh /
+          # upgrade.sh before changing this pattern.
+          VERSION="${{ github.event.release.tag_name }}"
+          sed -i "s/^PACA_DEFAULT_VERSION=\"latest\"$/PACA_DEFAULT_VERSION=\"${VERSION}\"/" install.sh upgrade.sh
+
       - name: Upload assets to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -460,3 +514,72 @@ jobs:
             Caddyfile \
             .env.production.example \
             --clobber
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Promote release to "Latest"
+  #
+  # Runs only once every image/package job AND release-assets have succeeded,
+  # so this never fires for a partially-shipped release. Skipped entirely for
+  # pre-releases, which should never become the default install/upgrade
+  # target. Two things happen together here, deliberately in the same job:
+  #   1. Every image gets a :latest tag pointing at this version's manifest,
+  #      via `imagetools create` (a registry-side copy, no rebuild needed).
+  #   2. The GitHub release is marked "Latest" (undoing hold-release-label),
+  #      so /releases/latest/download/* starts serving this release's assets.
+  # Reversing the order (label first, tags second) would let /releases/latest
+  # briefly resolve to a release whose :latest images aren't there yet.
+  # ─────────────────────────────────────────────────────────────────────────────
+  promote-release:
+    name: Promote release to "Latest"
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
+    needs:
+      [
+        api-image,
+        realtime-image,
+        web-image,
+        ai-agent-image,
+        agent-server-image,
+        publish-mcp,
+        publish-acp-bridge,
+        release-assets,
+      ]
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag images as :latest
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.release.tag_name }}"
+          TAG="${VERSION#v}"
+          for image in paca-api paca-realtime paca-web paca-ai-agent paca-agent-server; do
+            docker buildx imagetools create \
+              -t "${{ env.REGISTRY }}/${{ github.repository_owner }}/${image}:latest" \
+              "${{ env.REGISTRY }}/${{ github.repository_owner }}/${image}:${TAG}"
+            docker buildx imagetools create \
+              -t "${{ secrets.DOCKERHUB_USERNAME }}/${image}:latest" \
+              "${{ secrets.DOCKERHUB_USERNAME }}/${image}:${TAG}"
+          done
+
+      - name: Mark release as "Latest"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.event.release.tag_name }}" --repo "${{ github.repository }}" --latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,6 +86,9 @@ jobs:
           push: true
           build-args: |
             PACA_VERSION=${{ github.event.release.tag_name }}
+            GOMAXPROCS=4
+            GOMEMLIMIT=6GiB
+            GOBUILD_P=4
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -429,16 +432,6 @@ jobs:
   release-assets:
     name: Upload deployment assets to release
     runs-on: ubuntu-latest
-    needs:
-      [
-        api-image,
-        realtime-image,
-        web-image,
-        ai-agent-image,
-        agent-server-image,
-        publish-mcp,
-        publish-acp-bridge,
-      ]
     permissions:
       contents: write
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,8 @@ jobs:
       - name: Unmark this release as "Latest"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.event.release.tag_name }}" --repo "${{ github.repository }}" --latest=false
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --latest=false
 
   # ─────────────────────────────────────────────────────────────────────────────
   # API service image
@@ -535,6 +536,7 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     needs:
       [
+        hold-release-label,
         api-image,
         realtime-image,
         web-image,
@@ -582,4 +584,5 @@ jobs:
       - name: Mark release as "Latest"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.event.release.tag_name }}" --repo "${{ github.repository }}" --latest
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --latest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,7 +42,8 @@
 #
 #   General
 #     PACA_DIR                    Installation directory              (default: ./paca)
-#     PACA_VERSION                Release tag to install               (default: latest)
+#     PACA_VERSION                Release tag to install               (default: the release this
+#                                  script shipped with, or latest when run from a checkout)
 #     PACA_YES                    Skip prompts, use defaults           (set to 1)
 #     PACA_START                  Pull images and start after writing  (default: yes)
 #                                  config; yes/no.
@@ -259,7 +260,15 @@ download() {
 
 # ── Version / URL resolution ──────────────────────────────────────────────────
 
-PACA_VERSION="${PACA_VERSION:-latest}"
+# CD stamps this to the exact tag of the release install.sh ships with (see
+# the "Prepare assets" step in .github/workflows/cd.yml), so a plain
+# `bash install.sh` installs a version that's guaranteed to exist instead of
+# whatever :latest happens to resolve to. The source tree keeps "latest" so a
+# checkout run directly still behaves sensibly. Keep this a standalone
+# `NAME="value"` assignment — CD's sed matches on that exact shape.
+PACA_DEFAULT_VERSION="latest"
+
+PACA_VERSION="${PACA_VERSION:-$PACA_DEFAULT_VERSION}"
 
 if [[ "$PACA_VERSION" == "latest" ]]; then
     RELEASE_BASE="https://github.com/Paca-AI/paca/releases/latest/download"
@@ -824,7 +833,7 @@ ENCRYPTION_KEY=${ENCRYPTION_KEY}
 AGENT_API_KEY=${AGENT_API_KEY}
 INTERNAL_API_KEY=${INTERNAL_API_KEY}
 AI_AGENT_PORT=8082
-AGENT_SERVER_IMAGE=ghcr.io/paca-ai/paca-agent-server:latest
+AGENT_SERVER_IMAGE=ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}
 PORT_POOL_START=10000
 PORT_POOL_SIZE=100
 WORKER_CONCURRENCY=10

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -44,7 +44,8 @@
 #
 # ── Environment variable reference ───────────────────────────────────────────
 #   PACA_DIR                    Installation directory to upgrade       (default: .)
-#   PACA_VERSION                Release tag to upgrade to               (default: latest)
+#   PACA_VERSION                Release tag to upgrade to               (default: the release this
+#                                script shipped with, or latest when run from a checkout)
 #   PACA_YES                    Skip prompts, use defaults              (set to 1)
 #   PACA_PROCEED                Actually run the upgrade (yes/no).      (default: yes)
 #                                "no" prints the current vs. target
@@ -182,7 +183,15 @@ get_env_var() {
 
 # ── Version / URL resolution ──────────────────────────────────────────────────
 
-PACA_VERSION="${PACA_VERSION:-latest}"
+# CD stamps this to the exact tag of the release upgrade.sh ships with (see
+# the "Prepare assets" step in .github/workflows/cd.yml), so a plain
+# `bash upgrade.sh` upgrades to a version that's guaranteed to exist instead
+# of whatever :latest happens to resolve to. The source tree keeps "latest"
+# so a checkout run directly still behaves sensibly. Keep this a standalone
+# `NAME="value"` assignment — CD's sed matches on that exact shape.
+PACA_DEFAULT_VERSION="latest"
+
+PACA_VERSION="${PACA_VERSION:-$PACA_DEFAULT_VERSION}"
 
 if [[ "$PACA_VERSION" == "latest" ]]; then
     RELEASE_BASE="https://github.com/Paca-AI/paca/releases/latest/download"
@@ -293,6 +302,12 @@ if [[ "$PACA_VERSION" != "latest" ]]; then
         image_name="$(echo "$var" | sed -e 's/^PACA_//' -e 's/_IMAGE$//' | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')"
         set_env_var .env "$var" "pacaai/paca-${image_name}:${IMAGE_TAG}"
     done
+    # Only re-pin AGENT_SERVER_IMAGE if it's already on Paca's own image —
+    # never overwrite a custom value. The old-upstream-image migration below
+    # handles the one other known default separately.
+    if [[ "$(get_env_var .env AGENT_SERVER_IMAGE)" == ghcr.io/paca-ai/paca-agent-server:* ]]; then
+        set_env_var .env AGENT_SERVER_IMAGE "ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}"
+    fi
     info "Pinned image versions in .env to ${IMAGE_TAG}."
 else
     info "Using floating :latest images — no image version changes needed."
@@ -310,13 +325,13 @@ OLD_AGENT_SERVER_IMAGE_DEFAULT="ghcr.io/openhands/agent-server:latest-python"
 if [[ "$(get_env_var .env AGENT_SERVER_IMAGE)" == "$OLD_AGENT_SERVER_IMAGE_DEFAULT" ]]; then
     heading "Agent-server image"
     info "AGENT_SERVER_IMAGE is still set to the upstream OpenHands image (${OLD_AGENT_SERVER_IMAGE_DEFAULT})."
-    info "Paca now ships its own agent-server image (ghcr.io/paca-ai/paca-agent-server:latest) with the Paca MCP server pre-installed, avoiding a cold npm download on every new sandbox."
+    info "Paca now ships its own agent-server image (ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}) with the Paca MCP server pre-installed, avoiding a cold npm download on every new sandbox."
     UPDATE_AGENT_IMAGE="yes"
-    yes_no UPDATE_AGENT_IMAGE "Switch AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:latest?" "${PACA_UPDATE_AGENT_IMAGE:-y}"
+    yes_no UPDATE_AGENT_IMAGE "Switch AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}?" "${PACA_UPDATE_AGENT_IMAGE:-y}"
     if [[ "$UPDATE_AGENT_IMAGE" == "yes" ]]; then
         backup_env_once
-        set_env_var .env AGENT_SERVER_IMAGE "ghcr.io/paca-ai/paca-agent-server:latest"
-        info "Updated AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:latest."
+        set_env_var .env AGENT_SERVER_IMAGE "ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}"
+        info "Updated AGENT_SERVER_IMAGE to ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}."
     else
         info "Keeping AGENT_SERVER_IMAGE unchanged."
     fi

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.26-alpine AS builder
+# --platform=$BUILDPLATFORM pins this stage to the host arch (e.g. amd64)
+# regardless of TARGETPLATFORM, so multi-arch builds cross-compile natively
+# via GOOS/GOARCH instead of running the Go compiler under QEMU emulation for
+# arm64 — that emulation was the dominant cost in multi-platform CI builds.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 WORKDIR /build
 
@@ -10,9 +14,19 @@ RUN go mod download
 
 COPY . .
 
-# Keep compile-time memory usage low for small Docker Desktop allocations.
-RUN CGO_ENABLED=0 GOOS=linux GOMAXPROCS=1 GOMEMLIMIT=768MiB \
-	go build -p=1 -ldflags="-s -w" -o api ./cmd/api
+ARG TARGETOS
+ARG TARGETARCH
+
+# GOMAXPROCS/GOMEMLIMIT/-p default to single-core/low-memory for small Docker
+# Desktop allocations (local builds, e2e CI). CD overrides these via
+# --build-arg since GitHub Actions runners have more headroom and native
+# cross-compilation removes the memory pressure that motivated the low
+# defaults in the first place.
+ARG GOMAXPROCS=1
+ARG GOMEMLIMIT=768MiB
+ARG GOBUILD_P=1
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOMAXPROCS=$GOMAXPROCS GOMEMLIMIT=$GOMEMLIMIT \
+	go build -p=$GOBUILD_P -ldflags="-s -w" -o api ./cmd/api
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM alpine:3.21


### PR DESCRIPTION
## Summary

**CD: speed up the API image build.** The `services/api` builder stage now cross-compiles natively (`--platform=$BUILDPLATFORM` + `GOOS=$TARGETOS GOARCH=$TARGETARCH`) instead of running the Go compiler under QEMU emulation for `linux/arm64`, which was the dominant cost of the ~20 minute build. `GOMAXPROCS` / `GOMEMLIMIT` / `-p` are now build-args (defaulting to the original single-core/768MiB values for local and e2e builds) that `cd.yml` overrides to `4` cores / `6GiB` for CI.

**CD: never expose a half-shipped release.** Previously `release-assets` (which uploads `install.sh`, `upgrade.sh`, `docker-compose.yml`, etc.) depended on every image/package job, so those files simply didn't exist for the ~20-30 minutes a release was building, and GitHub already marks a release "Latest" the instant it's published — so `/releases/latest/download/*` 404'd, and any Docker `:latest` pull could land on a stale mix of old/new images depending on which per-service job happened to finish first. Fixed with three coordinated pieces:
- `hold-release-label` (new, runs first) immediately demotes the release off GitHub's "Latest" marker, so `/releases/latest` keeps resolving to the previous, fully-shipped release for the whole build window.
- Per-service jobs no longer push a `:latest` Docker tag at all — only version-pinned tags (`{{version}}`, `{{major}}.{{minor}}`).
- `promote-release` (new, final job, depends on every other job, skipped for pre-releases) retags every image `:latest` via `docker buildx imagetools create` (registry-side copy, no rebuild) and only then marks the GitHub release "Latest" — tags first, label second, so `/releases/latest` never points at a release whose `:latest` images aren't there yet.

`release-assets` keeps its original `needs` on every image/package job, so it (and the version it stamps into the scripts below) never runs for a release that isn't fully shippable.

**install.sh / upgrade.sh: pin to a specific version instead of floating `:latest`.** Both scripts now default to `PACA_DEFAULT_VERSION="latest"`, a single dedicated, comment-flagged line that CD's `release-assets` job stamps to the release's own tag before upload (`sed -i 's/^PACA_DEFAULT_VERSION="latest"$/PACA_DEFAULT_VERSION="<tag>"/'`). A plain `bash install.sh` / `bash upgrade.sh` downloaded from a release therefore always targets a version guaranteed to exist, rather than depending on the `:latest` Docker tag being current. `AGENT_SERVER_IMAGE` (previously hardcoded to `:latest` in both scripts) now pins to the same version tag as everything else, including in `upgrade.sh`'s re-pin and old-upstream-image migration logic. The source-tree copies of both scripts keep `PACA_DEFAULT_VERSION="latest"` so a plain checkout still behaves sensibly, and the header doc comments were reworded to be evergreen instead of needing their own sed pass.

## Test plan

- [ ] Publish a release and confirm `/releases/latest` keeps pointing at the previous release until `promote-release` runs, then flips over
- [ ] Confirm every image (`paca-api`, `paca-realtime`, `paca-web`, `paca-ai-agent`, `paca-agent-server`) gets a `:latest` tag on both GHCR and DockerHub only after `promote-release` succeeds
- [ ] Confirm `install.sh` / `upgrade.sh` downloaded from that release have `PACA_DEFAULT_VERSION` stamped to the release tag, and that a plain run pins `PACA_API_IMAGE`, `PACA_WEB_IMAGE`, `PACA_REALTIME_IMAGE`, `PACA_AI_AGENT_IMAGE`, and `AGENT_SERVER_IMAGE` to that version
- [ ] Confirm the API image build time drops from ~20 min and both `linux/amd64`/`linux/arm64` images still run correctly
- [ ] Confirm local `docker compose` / e2e builds of `services/api` are unaffected (still single-core defaults), and `scripts/install.sh`/`scripts/upgrade.sh` run directly from a checkout still default to `latest`
