### PR TITLE
feat(web): infinite-scroll conversation events

### DIFF
--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -34,6 +34,7 @@ import {
 	createContext,
 	type FC,
 	type PropsWithChildren,
+	type ReactNode,
 	useContext,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -83,6 +84,22 @@ export type ThreadComponents = {
 
 export type ThreadProps = {
 	components?: ThreadComponents | undefined;
+	/** Rendered inside the viewport, above the messages. */
+	viewportHeader?: ReactNode | undefined;
+	/** Rendered inside the viewport, below the messages. */
+	viewportOverlay?: ReactNode | undefined;
+	/**
+	 * "bottom" gives classic chat behaviour: opens on the newest message and
+	 * stays pinned there while the reader is at the bottom. "top" anchors each
+	 * new user message at the top of the viewport and disables auto-scroll.
+	 */
+	turnAnchor?: "top" | "bottom" | undefined;
+	/**
+	 * Whether a starting run scrolls to the newest message. Queues a scroll the
+	 * viewport re-applies on every content resize until it is cleared, which
+	 * overrides a caller that is positioning the scroll itself.
+	 */
+	scrollToBottomOnRunStart?: boolean | undefined;
 };
 
 const EMPTY_COMPONENTS: ThreadComponents = {};
@@ -96,17 +113,41 @@ const isNewChatView = (s: AssistantState) =>
 	s.thread.messages.length === 0 &&
 	(!s.thread.isLoading || s.threads.isLoading);
 
-export const Thread: FC<ThreadProps> = ({ components = EMPTY_COMPONENTS }) => {
+export const Thread: FC<ThreadProps> = ({
+	components = EMPTY_COMPONENTS,
+	viewportHeader,
+	viewportOverlay,
+	turnAnchor = "top",
+	scrollToBottomOnRunStart = true,
+}) => {
 	const isEmpty = useAuiState(isNewChatView);
 
 	return (
 		<ThreadComponentsContext.Provider value={components}>
-			<ThreadRoot isEmpty={isEmpty} />
+			<ThreadRoot
+				isEmpty={isEmpty}
+				viewportHeader={viewportHeader}
+				viewportOverlay={viewportOverlay}
+				turnAnchor={turnAnchor}
+				scrollToBottomOnRunStart={scrollToBottomOnRunStart}
+			/>
 		</ThreadComponentsContext.Provider>
 	);
 };
 
-const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
+const ThreadRoot: FC<{
+	isEmpty: boolean;
+	viewportHeader?: ReactNode | undefined;
+	viewportOverlay?: ReactNode | undefined;
+	turnAnchor: "top" | "bottom";
+	scrollToBottomOnRunStart: boolean;
+}> = ({
+	isEmpty,
+	viewportHeader,
+	viewportOverlay,
+	turnAnchor,
+	scrollToBottomOnRunStart,
+}) => {
 	const { Welcome = ThreadWelcome } = useContext(ThreadComponentsContext);
 
 	return (
@@ -121,7 +162,8 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
 			}}
 		>
 			<ThreadPrimitive.Viewport
-				turnAnchor="top"
+				turnAnchor={turnAnchor}
+				scrollToBottomOnRunStart={scrollToBottomOnRunStart}
 				data-slot="aui_thread-viewport"
 				className="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth [scrollbar-gutter:stable]"
 			>
@@ -135,6 +177,8 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
 						<Welcome />
 					</AuiIf>
 
+					{viewportHeader}
+
 					<div
 						data-slot="aui_message-group"
 						className="mb-14 flex flex-col gap-y-6 empty:hidden"
@@ -143,6 +187,8 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
 							{() => <ThreadMessage />}
 						</ThreadPrimitive.Messages>
 					</div>
+
+					{viewportOverlay}
 
 					<ThreadPrimitive.ViewportFooter
 						className={cn(

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -172,7 +172,6 @@ export function ConversationView({
 	} = useConversationEventWindow({
 		projectId,
 		conversationId,
-		eventCount: conversation?.event_count,
 		ready: !convLoading,
 	});
 	// Project scope: GET /projects/:id/agents/:agentId (project members may

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -25,9 +25,7 @@ import {
 	CONVERSATION_STATUS_COLORS,
 	CONVERSATION_STATUS_LABELS,
 	chattableAgentsQueryOptions,
-	conversationEventsQueryOptions,
 	conversationQueryOptions,
-	globalConversationEventsQueryOptions,
 	globalConversationQueryOptions,
 	heartbeatConversation,
 	heartbeatGlobalConversation,
@@ -45,6 +43,8 @@ import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
 } from "./conversation-to-thread-messages";
+import { LoadOlderEvents, TailFollowIndicator } from "./event-window-controls";
+import { useConversationEventWindow } from "./use-conversation-event-window";
 
 // ── Controls ──────────────────────────────────────────────────────────────────
 
@@ -159,11 +159,22 @@ export function ConversationView({
 			? conversationQueryOptions(projectId, conversationId)
 			: globalConversationQueryOptions(conversationId),
 	);
-	const { data: events = [], isLoading: eventsLoading } = useQuery(
-		projectId
-			? conversationEventsQueryOptions(projectId, conversationId)
-			: globalConversationEventsQueryOptions(conversationId),
-	);
+	const {
+		events,
+		isLoading: eventsLoading,
+		hasOlder,
+		isLoadingOlder,
+		loadOlder,
+		newBelow,
+		following,
+		setFollowing,
+		jumpToLatest,
+	} = useConversationEventWindow({
+		projectId,
+		conversationId,
+		eventCount: conversation?.event_count,
+		ready: !convLoading,
+	});
 	// Project scope: GET /projects/:id/agents/:agentId (project members may
 	// always read their own project's agents). Global scope: the caller may
 	// not have agents.read (admin-gated), so this uses the unrestricted
@@ -423,7 +434,27 @@ export function ConversationView({
 			{/* Thread */}
 			<div className="flex-1 min-h-0">
 				<AssistantRuntimeProvider runtime={runtime}>
-					<Thread />
+					<Thread
+						turnAnchor="bottom"
+						// A run starting must not pull a reader who is paging back
+						// through history.
+						scrollToBottomOnRunStart={false}
+						viewportHeader={
+							<LoadOlderEvents
+								hasOlder={hasOlder}
+								isLoadingOlder={isLoadingOlder}
+								loadOlder={loadOlder}
+							/>
+						}
+						viewportOverlay={
+							<TailFollowIndicator
+								newBelow={newBelow}
+								following={following}
+								setFollowing={setFollowing}
+								jumpToLatest={jumpToLatest}
+							/>
+						}
+					/>
 				</AssistantRuntimeProvider>
 			</div>
 

--- a/apps/web/src/components/projects/agents/event-window-controls.tsx
+++ b/apps/web/src/components/projects/agents/event-window-controls.tsx
@@ -1,0 +1,151 @@
+import { useThreadViewport } from "@assistant-ui/react";
+import { ArrowDown, Loader2 } from "lucide-react";
+import { type FC, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+
+/**
+ * "Load older" control, with the scroll anchoring it requires: prepending grows
+ * the content above the viewport, and the browser keeps `scrollTop`, so the
+ * message the reader was looking at has to be put back where it was.
+ *
+ * Must render inside `ThreadPrimitive.Viewport`, which provides the viewport
+ * store this reads the scroll element from.
+ */
+export const LoadOlderEvents: FC<{
+	hasOlder: boolean;
+	isLoadingOlder: boolean;
+	loadOlder: () => void;
+}> = ({ hasOlder, isLoadingOlder, loadOlder }) => {
+	const { t } = useTranslation("projects");
+	const viewport = useThreadViewport((s) => s.element.viewport);
+	// Distance from the end of the content, which older events do not change.
+	// Message ids cannot be used: a message's id is the id of the first event in
+	// its group, so prepending renames the group it extends.
+	const anchorRef = useRef<number | null>(null);
+	const isLoadingOlderRef = useRef(isLoadingOlder);
+	isLoadingOlderRef.current = isLoadingOlder;
+
+	const onLoadOlder = () => {
+		if (viewport)
+			anchorRef.current = viewport.scrollHeight - viewport.scrollTop;
+		loadOlder();
+	};
+
+	// Prepended markdown and tool cards keep resizing for several frames after
+	// they commit, so the correction has to survive more than one pass.
+	useEffect(() => {
+		const content = viewport?.firstElementChild;
+		if (!viewport || !content) return;
+
+		let deferred = 0;
+		const apply = () => {
+			const fromEnd = anchorRef.current;
+			if (fromEnd === null) return;
+			const target = viewport.scrollHeight - fromEnd;
+			if (Math.abs(viewport.scrollTop - target) < 0.5) {
+				if (!isLoadingOlderRef.current) anchorRef.current = null;
+				return;
+			}
+			// The viewport sets `scroll-smooth`, which would animate this.
+			const previous = viewport.style.scrollBehavior;
+			viewport.style.scrollBehavior = "auto";
+			viewport.scrollTop = target;
+			viewport.style.scrollBehavior = previous;
+		};
+		const restore = () => {
+			apply();
+			// This observer belongs to a child of the viewport, so it runs before
+			// the viewport's own resize handling. Re-apply after it.
+			if (deferred) cancelAnimationFrame(deferred);
+			deferred = requestAnimationFrame(() => {
+				deferred = 0;
+				apply();
+			});
+		};
+		// A deliberate scroll means the reader, not us, decides the position.
+		const release = () => {
+			anchorRef.current = null;
+		};
+
+		const observer = new ResizeObserver(restore);
+		observer.observe(content);
+		viewport.addEventListener("pointerdown", release);
+		viewport.addEventListener("wheel", release, { passive: true });
+		viewport.addEventListener("keydown", release);
+		return () => {
+			observer.disconnect();
+			if (deferred) cancelAnimationFrame(deferred);
+			viewport.removeEventListener("pointerdown", release);
+			viewport.removeEventListener("wheel", release);
+			viewport.removeEventListener("keydown", release);
+		};
+	}, [viewport]);
+
+	if (!hasOlder) return null;
+
+	return (
+		<div className="flex justify-center pb-2">
+			<Button
+				variant="ghost"
+				size="sm"
+				onClick={onLoadOlder}
+				disabled={isLoadingOlder}
+				className="text-muted-foreground text-xs"
+			>
+				{isLoadingOlder ? (
+					<>
+						<Loader2 className="size-3 animate-spin" />
+						{t("agents.conversationView.loadingOlder")}
+					</>
+				) : (
+					t("agents.conversationView.loadOlder")
+				)}
+			</Button>
+		</div>
+	);
+};
+
+/**
+ * Tracks whether the reader is at the newest event, and offers a way back when
+ * events have arrived while they were reading history.
+ *
+ * Must render inside `ThreadPrimitive.Viewport`.
+ */
+export const TailFollowIndicator: FC<{
+	newBelow: number;
+	following: boolean;
+	setFollowing: (following: boolean) => void;
+	jumpToLatest: () => void;
+}> = ({ newBelow, following, setFollowing, jumpToLatest }) => {
+	const { t } = useTranslation("projects");
+	const isAtBottom = useThreadViewport((s) => s.isAtBottom);
+	const scrollToBottom = useThreadViewport((s) => s.scrollToBottom);
+
+	useEffect(() => {
+		if (isAtBottom !== following) setFollowing(isAtBottom);
+	}, [isAtBottom, following, setFollowing]);
+
+	const show = newBelow > 0 && !isAtBottom;
+	if (!show) return null;
+
+	return (
+		<div
+			className="sticky bottom-2 z-10 flex justify-center"
+			aria-live="polite"
+		>
+			<Button
+				size="sm"
+				variant="secondary"
+				className="gap-1.5 rounded-full text-xs shadow-md"
+				onClick={() => {
+					jumpToLatest();
+					scrollToBottom({ behavior: "auto" });
+				}}
+			>
+				<ArrowDown className="size-3" />
+				{t("agents.conversationView.newBelow", { count: newBelow })}
+			</Button>
+		</div>
+	);
+};

--- a/apps/web/src/components/projects/agents/event-window-controls.tsx
+++ b/apps/web/src/components/projects/agents/event-window-controls.tsx
@@ -1,13 +1,14 @@
 import { useThreadViewport } from "@assistant-ui/react";
 import { ArrowDown, Loader2 } from "lucide-react";
-import { type FC, useEffect, useRef } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 
 /**
- * "Load older" control, with the scroll anchoring it requires: prepending grows
- * the content above the viewport, and the browser keeps `scrollTop`, so the
- * message the reader was looking at has to be put back where it was.
+ * Loads older events as the reader scrolls near the top of what is loaded,
+ * with the scroll anchoring that requires: prepending grows the content
+ * above the viewport, and the browser keeps `scrollTop`, so the message the
+ * reader was looking at has to be put back where it was.
  *
  * Must render inside `ThreadPrimitive.Viewport`, which provides the viewport
  * store this reads the scroll element from.
@@ -19,6 +20,7 @@ export const LoadOlderEvents: FC<{
 }> = ({ hasOlder, isLoadingOlder, loadOlder }) => {
 	const { t } = useTranslation("projects");
 	const viewport = useThreadViewport((s) => s.element.viewport);
+	const sentinelRef = useRef<HTMLDivElement | null>(null);
 	// Distance from the end of the content, which older events do not change.
 	// Message ids cannot be used: a message's id is the id of the first event in
 	// its group, so prepending renames the group it extends.
@@ -26,7 +28,7 @@ export const LoadOlderEvents: FC<{
 	const isLoadingOlderRef = useRef(isLoadingOlder);
 	isLoadingOlderRef.current = isLoadingOlder;
 
-	const onLoadOlder = () => {
+	const triggerLoadOlder = () => {
 		if (viewport)
 			anchorRef.current = viewport.scrollHeight - viewport.scrollTop;
 		loadOlder();
@@ -63,9 +65,13 @@ export const LoadOlderEvents: FC<{
 				apply();
 			});
 		};
-		// A deliberate scroll means the reader, not us, decides the position.
+		// A deliberate scroll means the reader, not us, decides the position —
+		// but only once a fetch is no longer in flight. The load itself is now
+		// triggered by scrolling near the top, so the same gesture's momentum
+		// would otherwise cancel the anchor it just set before the response
+		// even lands.
 		const release = () => {
-			anchorRef.current = null;
+			if (!isLoadingOlderRef.current) anchorRef.current = null;
 		};
 
 		const observer = new ResizeObserver(restore);
@@ -82,26 +88,40 @@ export const LoadOlderEvents: FC<{
 		};
 	}, [viewport]);
 
+	// Tracks whether the sentinel above the oldest loaded message is on
+	// screen — rootMargin fires it a little before the reader hits the
+	// literal top, so the next page is already loading by the time they get
+	// there instead of hitting a dead stop.
+	const [sentinelVisible, setSentinelVisible] = useState(false);
+	useEffect(() => {
+		const sentinel = sentinelRef.current;
+		if (!viewport || !sentinel || !hasOlder) return;
+		const observer = new IntersectionObserver(
+			([entry]) => setSentinelVisible(entry.isIntersecting),
+			{ root: viewport, rootMargin: "150px 0px 0px 0px" },
+		);
+		observer.observe(sentinel);
+		return () => observer.disconnect();
+	}, [viewport, hasOlder]);
+
+	// Fires on becoming visible, and again each time a fetch completes while
+	// still visible — covers both "scrolled to the top" and "stayed at the
+	// top through several consecutive pages".
+	// biome-ignore lint/correctness/useExhaustiveDependencies: triggerLoadOlder is a new closure every render (it reads viewport) — depending on it would refire this effect on every render instead of only on the visibility/hasOlder/isLoadingOlder transitions it actually cares about.
+	useEffect(() => {
+		if (sentinelVisible && hasOlder && !isLoadingOlder) triggerLoadOlder();
+	}, [sentinelVisible, hasOlder, isLoadingOlder]);
+
 	if (!hasOlder) return null;
 
 	return (
-		<div className="flex justify-center pb-2">
-			<Button
-				variant="ghost"
-				size="sm"
-				onClick={onLoadOlder}
-				disabled={isLoadingOlder}
-				className="text-muted-foreground text-xs"
-			>
-				{isLoadingOlder ? (
-					<>
-						<Loader2 className="size-3 animate-spin" />
-						{t("agents.conversationView.loadingOlder")}
-					</>
-				) : (
-					t("agents.conversationView.loadOlder")
-				)}
-			</Button>
+		<div ref={sentinelRef} className="flex justify-center py-2">
+			{isLoadingOlder && (
+				<div className="flex items-center gap-1.5 text-muted-foreground text-xs">
+					<Loader2 className="size-3 animate-spin" />
+					{t("agents.conversationView.loadingOlder")}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/web/src/components/projects/agents/event-window-controls.tsx
+++ b/apps/web/src/components/projects/agents/event-window-controls.tsx
@@ -44,6 +44,15 @@ export const LoadOlderEvents: FC<{
 		const apply = () => {
 			const fromEnd = anchorRef.current;
 			if (fromEnd === null) return;
+			// The observed element also contains the composer/footer and the
+			// live message list, so a resize can land here before the older
+			// page's request even resolves — the reader typing, or the agent
+			// streaming new tokens at the bottom while they read history.
+			// `fromEnd` only accounts for the prepend; correcting against a
+			// resize that isn't the prepend yet would yank the reader's
+			// position for no reason. Nothing relevant can have landed before
+			// the fetch itself resolves.
+			if (isLoadingOlderRef.current) return;
 			const target = viewport.scrollHeight - fromEnd;
 			if (Math.abs(viewport.scrollTop - target) < 0.5) {
 				if (!isLoadingOlderRef.current) anchorRef.current = null;

--- a/apps/web/src/components/projects/agents/use-conversation-event-window.test.tsx
+++ b/apps/web/src/components/projects/agents/use-conversation-event-window.test.tsx
@@ -37,25 +37,60 @@ const range = (from: number, to: number) =>
 const PROJECT_PATH = `/projects/${PROJECT_ID}/conversations/${CONVERSATION_ID}/events`;
 const GLOBAL_PATH = `/agents/conversations/${CONVERSATION_ID}/events`;
 
-/** Serves `[offset, offset+limit)` plus the current total, as the API does. */
+// Opaque only in the sense the hook never parses it — this fake mirrors the
+// real API's cursor as "the event_index it was encoded from" so the fake
+// server below can decode it straight back.
+const cursorOf = (index: number) => `cur:${index}`;
+const indexOfCursor = (cursor: string) => Number(cursor.slice(4));
+
+/**
+ * Serves the same {items, total, next_cursor, prev_cursor} shape the real
+ * API does: no cursor returns the newest `limit` events; `after`/`before`
+ * seek by event_index in either direction. next_cursor is always present
+ * for a non-empty page (a live stream can never definitively rule out more
+ * arriving); prev_cursor is null only once event_index 0 is included.
+ */
 function fakeStream(initialCount: number) {
 	let count = initialCount;
 	mockGet.mockImplementation(
 		async (
 			_path: string,
-			{ params }: { params: { offset: number; limit: number } },
-		) => ({
-			data: {
-				success: true,
+			{
+				params,
+			}: { params: { after?: string; before?: string; limit: number } },
+		) => {
+			const { after, before, limit } = params;
+			let items: AgentConversationEvent[];
+			if (after !== undefined) {
+				const from = indexOfCursor(after) + 1;
+				const to = Math.min(from + limit - 1, count - 1);
+				items = from <= to ? range(from, to) : [];
+			} else if (before !== undefined) {
+				const to = indexOfCursor(before) - 1;
+				const from = Math.max(0, to - limit + 1);
+				items = to >= 0 ? range(from, to) : [];
+			} else {
+				const to = count - 1;
+				const from = Math.max(0, to - limit + 1);
+				items = to >= 0 ? range(from, to) : [];
+			}
+			const first = items[0];
+			const last = items.at(-1);
+			return {
 				data: {
-					items: range(
-						params.offset,
-						Math.min(params.offset + params.limit, count) - 1,
-					).filter((e) => e.event_index < count),
-					total: count,
+					success: true,
+					data: {
+						items,
+						total: count,
+						next_cursor: last ? cursorOf(last.event_index) : null,
+						prev_cursor:
+							first && first.event_index > 0
+								? cursorOf(first.event_index)
+								: null,
+					},
 				},
-			},
-		}),
+			};
+		},
 	);
 	return {
 		grow(by: number) {
@@ -113,7 +148,6 @@ function open(
 			useConversationEventWindow({
 				projectId: PROJECT_ID,
 				conversationId: CONVERSATION_ID,
-				eventCount: 275,
 				pageSize: 200,
 				...props,
 			}),
@@ -137,6 +171,9 @@ describe("useConversationEventWindow", () => {
 		expect(lastIndex(result.current.events)).toBe(274);
 		expect(result.current.hasOlder).toBe(true);
 		expect(requests(PROJECT_PATH)).toHaveLength(1);
+		// No cursor on the opening request — it doesn't need to already know
+		// how many events the conversation holds.
+		expect(paramsOf(PROJECT_PATH, 0)).toEqual({ limit: 200 });
 	});
 
 	it("pages older events in without refetching what it holds", async () => {
@@ -155,7 +192,7 @@ describe("useConversationEventWindow", () => {
 
 	it("stops offering older events at the start of the stream", async () => {
 		fakeStream(10);
-		const { result } = open({ eventCount: 10 });
+		const { result } = open();
 
 		await waitFor(() => expect(result.current.events).toHaveLength(10));
 		expect(result.current.hasOlder).toBe(false);
@@ -191,7 +228,7 @@ describe("useConversationEventWindow", () => {
 
 	it("takes events for a conversation that was empty when opened", async () => {
 		const stream = fakeStream(0);
-		const { result, signal } = open({ eventCount: 0 });
+		const { result, signal } = open();
 		await waitFor(() => expect(result.current.isLoading).toBe(false));
 		expect(result.current.events).toHaveLength(0);
 
@@ -202,7 +239,7 @@ describe("useConversationEventWindow", () => {
 
 	it("catches up across a burst that outruns one page", async () => {
 		const stream = fakeStream(10);
-		const { result, signal } = open({ eventCount: 10, pageSize: 5 });
+		const { result, signal } = open({ pageSize: 5 });
 		await waitFor(() => expect(lastIndex(result.current.events)).toBe(9));
 
 		// 12 new events with a 5-event page: needs three round trips.
@@ -212,28 +249,18 @@ describe("useConversationEventWindow", () => {
 		});
 	});
 
-	it("probes for the count when the API does not report one", async () => {
-		fakeStream(50);
-		const { result } = open({ eventCount: undefined });
-
-		await waitFor(() => expect(result.current.events).toHaveLength(50));
-		// First call is the one-row probe, then the window itself.
-		expect(paramsOf(PROJECT_PATH, 0)).toEqual({ offset: 0, limit: 1 });
-	});
-
-	it("holds the first fetch until the event count is settled", async () => {
+	it("holds the first fetch until ready", async () => {
 		fakeStream(275);
 		const { wrapper } = harness();
 
-		type Props = { ready: boolean; eventCount: number | undefined };
-		const initialProps: Props = { ready: false, eventCount: undefined };
+		type Props = { ready: boolean };
+		const initialProps: Props = { ready: false };
 
 		const { result, rerender } = renderHook(
-			({ ready, eventCount }: Props) =>
+			({ ready }: Props) =>
 				useConversationEventWindow({
 					projectId: PROJECT_ID,
 					conversationId: CONVERSATION_ID,
-					eventCount,
 					ready,
 					pageSize: 200,
 				}),
@@ -242,15 +269,14 @@ describe("useConversationEventWindow", () => {
 
 		expect(requests(PROJECT_PATH)).toHaveLength(0);
 
-		rerender({ ready: true, eventCount: 275 });
+		rerender({ ready: true });
 		await waitFor(() => expect(result.current.events).toHaveLength(200));
-		// Went straight to the tail: no probe was needed.
-		expect(paramsOf(PROJECT_PATH, 0)).toEqual({ offset: 75, limit: 200 });
+		expect(paramsOf(PROJECT_PATH, 0)).toEqual({ limit: 200 });
 	});
 
 	it("reads the global route when there is no project", async () => {
 		fakeStream(30);
-		const { result } = open({ projectId: undefined, eventCount: 30 });
+		const { result } = open({ projectId: undefined });
 
 		await waitFor(() => expect(result.current.events).toHaveLength(30));
 		expect(requests(GLOBAL_PATH)).toHaveLength(1);
@@ -270,14 +296,16 @@ describe("useConversationEventWindow", () => {
 	});
 	it("keeps paging back to the start without overlapping what is held", async () => {
 		fakeStream(250);
-		const { result } = open({ eventCount: 250, pageSize: 100 });
+		const { result } = open({ pageSize: 100 });
 		await waitFor(() => expect(result.current.events).toHaveLength(100));
 
 		act(() => result.current.loadOlder());
 		await waitFor(() => expect(result.current.events).toHaveLength(200));
 
-		// The last hop back covers 50 events, not a full page: asking for a full
-		// one would refetch events 50..99, which are already loaded.
+		// The last hop back covers 50 events, not a full page — keyset
+		// pagination on event_index can't overlap what's already loaded, unlike
+		// an offset scheme where a naive full-page request here would have
+		// refetched events 50..99.
 		act(() => result.current.loadOlder());
 		await waitFor(() => expect(result.current.events).toHaveLength(250));
 

--- a/apps/web/src/components/projects/agents/use-conversation-event-window.test.tsx
+++ b/apps/web/src/components/projects/agents/use-conversation-event-window.test.tsx
@@ -1,0 +1,291 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+vi.mock("@/lib/api-client", () => ({
+	apiClient: { instance: { get: mockGet } },
+}));
+
+import {
+	type AgentConversationEvent,
+	conversationEventsTailKey,
+	conversationEventWindowKey,
+} from "@/lib/agent-api";
+import { useConversationEventWindow } from "./use-conversation-event-window";
+
+const PROJECT_ID = "proj-1";
+const CONVERSATION_ID = "conv-1";
+
+function ev(index: number): AgentConversationEvent {
+	return {
+		id: `event-${index}`,
+		conversation_id: CONVERSATION_ID,
+		event_index: index,
+		event_type: "ACPToolCallEvent",
+		event_source: "agent",
+		payload: {},
+		created_at: "2026-01-01T00:00:00Z",
+	};
+}
+
+const range = (from: number, to: number) =>
+	Array.from({ length: to - from + 1 }, (_, i) => ev(from + i));
+
+const PROJECT_PATH = `/projects/${PROJECT_ID}/conversations/${CONVERSATION_ID}/events`;
+const GLOBAL_PATH = `/agents/conversations/${CONVERSATION_ID}/events`;
+
+/** Serves `[offset, offset+limit)` plus the current total, as the API does. */
+function fakeStream(initialCount: number) {
+	let count = initialCount;
+	mockGet.mockImplementation(
+		async (
+			_path: string,
+			{ params }: { params: { offset: number; limit: number } },
+		) => ({
+			data: {
+				success: true,
+				data: {
+					items: range(
+						params.offset,
+						Math.min(params.offset + params.limit, count) - 1,
+					).filter((e) => e.event_index < count),
+					total: count,
+				},
+			},
+		}),
+	);
+	return {
+		grow(by: number) {
+			count += by;
+			return count - 1; // highest index now present
+		},
+	};
+}
+
+const requests = (path: string) =>
+	mockGet.mock.calls.filter(([p]) => p === path);
+const paramsOf = (path: string, index = 0) =>
+	requests(path)[index]?.[1]?.params;
+
+function harness() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	const wrapper = ({ children }: PropsWithChildren) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	/**
+	 * What the realtime hooks do per agent event: invalidate the conversation
+	 * prefixes *and* write the tail signal. A window or signal keyed under either
+	 * prefix would be refetched or reset by the event meant to report it.
+	 */
+	const signal = (index: number | null) =>
+		act(() => {
+			void queryClient.invalidateQueries({
+				queryKey: ["projects", PROJECT_ID, "conversations"],
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["global-chat", "conversations"],
+			});
+			queryClient.setQueryData(
+				conversationEventsTailKey(CONVERSATION_ID),
+				(prev: { tick: number; index: number | null } | undefined) => ({
+					tick: (prev?.tick ?? 0) + 1,
+					index,
+				}),
+			);
+		});
+	return { queryClient, wrapper, signal };
+}
+
+const lastIndex = (events: AgentConversationEvent[]) =>
+	events.at(-1)?.event_index;
+
+function open(
+	props: Partial<Parameters<typeof useConversationEventWindow>[0]> = {},
+) {
+	const { wrapper, signal, queryClient } = harness();
+	const rendered = renderHook(
+		() =>
+			useConversationEventWindow({
+				projectId: PROJECT_ID,
+				conversationId: CONVERSATION_ID,
+				eventCount: 275,
+				pageSize: 200,
+				...props,
+			}),
+		{ wrapper },
+	);
+	return { ...rendered, signal, queryClient };
+}
+
+describe("useConversationEventWindow", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("opens on the newest page rather than the whole stream", async () => {
+		fakeStream(275);
+		const { result } = open();
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.events).toHaveLength(200);
+		expect(result.current.events[0].event_index).toBe(75);
+		expect(lastIndex(result.current.events)).toBe(274);
+		expect(result.current.hasOlder).toBe(true);
+		expect(requests(PROJECT_PATH)).toHaveLength(1);
+	});
+
+	it("pages older events in without refetching what it holds", async () => {
+		fakeStream(275);
+		const { result } = open({ pageSize: 100 });
+		await waitFor(() => expect(result.current.events).toHaveLength(100));
+
+		act(() => result.current.loadOlder());
+		await waitFor(() => expect(result.current.events).toHaveLength(200));
+
+		// One request per page, and still one unbroken ascending run.
+		expect(requests(PROJECT_PATH)).toHaveLength(2);
+		expect(result.current.events[0].event_index).toBe(75);
+		expect(lastIndex(result.current.events)).toBe(274);
+	});
+
+	it("stops offering older events at the start of the stream", async () => {
+		fakeStream(10);
+		const { result } = open({ eventCount: 10 });
+
+		await waitFor(() => expect(result.current.events).toHaveLength(10));
+		expect(result.current.hasOlder).toBe(false);
+	});
+
+	it("appends events as realtime reports them", async () => {
+		const stream = fakeStream(275);
+		const { result, signal } = open();
+		await waitFor(() => expect(result.current.events).toHaveLength(200));
+
+		await signal(stream.grow(1));
+		await waitFor(() => expect(lastIndex(result.current.events)).toBe(275));
+	});
+
+	it("counts rather than fetches while the reader is scrolled away", async () => {
+		const stream = fakeStream(275);
+		const { result, signal } = open();
+		await waitFor(() => expect(result.current.events).toHaveLength(200));
+		const callsAfterOpen = requests(PROJECT_PATH).length;
+
+		act(() => result.current.setFollowing(false));
+		await signal(stream.grow(3));
+
+		// Reported, not downloaded.
+		await waitFor(() => expect(result.current.newBelow).toBe(3));
+		expect(lastIndex(result.current.events)).toBe(274);
+		expect(requests(PROJECT_PATH)).toHaveLength(callsAfterOpen);
+
+		act(() => result.current.jumpToLatest());
+		await waitFor(() => expect(lastIndex(result.current.events)).toBe(277));
+		expect(result.current.newBelow).toBe(0);
+	});
+
+	it("takes events for a conversation that was empty when opened", async () => {
+		const stream = fakeStream(0);
+		const { result, signal } = open({ eventCount: 0 });
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.events).toHaveLength(0);
+
+		await signal(stream.grow(1));
+		await waitFor(() => expect(result.current.events).toHaveLength(1));
+		expect(lastIndex(result.current.events)).toBe(0);
+	});
+
+	it("catches up across a burst that outruns one page", async () => {
+		const stream = fakeStream(10);
+		const { result, signal } = open({ eventCount: 10, pageSize: 5 });
+		await waitFor(() => expect(lastIndex(result.current.events)).toBe(9));
+
+		// 12 new events with a 5-event page: needs three round trips.
+		await signal(stream.grow(12));
+		await waitFor(() => expect(lastIndex(result.current.events)).toBe(21), {
+			timeout: 3000,
+		});
+	});
+
+	it("probes for the count when the API does not report one", async () => {
+		fakeStream(50);
+		const { result } = open({ eventCount: undefined });
+
+		await waitFor(() => expect(result.current.events).toHaveLength(50));
+		// First call is the one-row probe, then the window itself.
+		expect(paramsOf(PROJECT_PATH, 0)).toEqual({ offset: 0, limit: 1 });
+	});
+
+	it("holds the first fetch until the event count is settled", async () => {
+		fakeStream(275);
+		const { wrapper } = harness();
+
+		type Props = { ready: boolean; eventCount: number | undefined };
+		const initialProps: Props = { ready: false, eventCount: undefined };
+
+		const { result, rerender } = renderHook(
+			({ ready, eventCount }: Props) =>
+				useConversationEventWindow({
+					projectId: PROJECT_ID,
+					conversationId: CONVERSATION_ID,
+					eventCount,
+					ready,
+					pageSize: 200,
+				}),
+			{ wrapper, initialProps },
+		);
+
+		expect(requests(PROJECT_PATH)).toHaveLength(0);
+
+		rerender({ ready: true, eventCount: 275 });
+		await waitFor(() => expect(result.current.events).toHaveLength(200));
+		// Went straight to the tail: no probe was needed.
+		expect(paramsOf(PROJECT_PATH, 0)).toEqual({ offset: 75, limit: 200 });
+	});
+
+	it("reads the global route when there is no project", async () => {
+		fakeStream(30);
+		const { result } = open({ projectId: undefined, eventCount: 30 });
+
+		await waitFor(() => expect(result.current.events).toHaveLength(30));
+		expect(requests(GLOBAL_PATH)).toHaveLength(1);
+		expect(requests(PROJECT_PATH)).toHaveLength(0);
+	});
+
+	it("keys the window and the signal outside the invalidated prefixes", () => {
+		// An infinite query refetches every page it holds, so an incidental prefix
+		// invalidation would re-read the whole stream.
+		for (const key of [
+			conversationEventWindowKey(CONVERSATION_ID),
+			conversationEventsTailKey(CONVERSATION_ID),
+		]) {
+			expect(key[0]).not.toBe("projects");
+			expect(key[0]).not.toBe("global-chat");
+		}
+	});
+	it("keeps paging back to the start without overlapping what is held", async () => {
+		fakeStream(250);
+		const { result } = open({ eventCount: 250, pageSize: 100 });
+		await waitFor(() => expect(result.current.events).toHaveLength(100));
+
+		act(() => result.current.loadOlder());
+		await waitFor(() => expect(result.current.events).toHaveLength(200));
+
+		// The last hop back covers 50 events, not a full page: asking for a full
+		// one would refetch events 50..99, which are already loaded.
+		act(() => result.current.loadOlder());
+		await waitFor(() => expect(result.current.events).toHaveLength(250));
+
+		expect(result.current.events[0].event_index).toBe(0);
+		expect(result.current.hasOlder).toBe(false);
+		// One unbroken ascending run, no duplicates.
+		expect(result.current.events.map((e) => e.event_index)).toEqual(
+			Array.from({ length: 250 }, (_, i) => i),
+		);
+	});
+});

--- a/apps/web/src/components/projects/agents/use-conversation-event-window.ts
+++ b/apps/web/src/components/projects/agents/use-conversation-event-window.ts
@@ -1,0 +1,126 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import {
+	type AgentConversationEvent,
+	CONVERSATION_EVENTS_PAGE_SIZE,
+	conversationEventCountQueryOptions,
+	conversationEventsTailQueryOptions,
+	conversationEventWindowInfiniteOptions,
+} from "@/lib/agent-api";
+
+export type UseConversationEventWindow = {
+	/** The loaded events, oldest first and contiguous. */
+	events: AgentConversationEvent[];
+	isLoading: boolean;
+	hasOlder: boolean;
+	isLoadingOlder: boolean;
+	loadOlder: () => void;
+	/** Events waiting past the window while not following. */
+	newBelow: number;
+	following: boolean;
+	setFollowing: (following: boolean) => void;
+	jumpToLatest: () => void;
+};
+
+/**
+ * Reads a conversation's events as a window anchored at the newest page,
+ * extending upwards on demand and forwards as events arrive.
+ *
+ * Paging by offset is safe on a live stream because `event_index` is gapless: an
+ * index is an offset, so a page addresses the same events however many arrive
+ * later. Pages therefore stay contiguous, which `eventsToThreadMessages`
+ * requires — it carries state across the array it is given (open tool calls keyed
+ * by id, the assistant message being accumulated) and is only correct over an
+ * unbroken run.
+ */
+export function useConversationEventWindow({
+	projectId,
+	conversationId,
+	eventCount,
+	/** Holds the first fetch until `eventCount` is settled, avoiding a probe. */
+	ready = true,
+	pageSize = CONVERSATION_EVENTS_PAGE_SIZE,
+}: {
+	/** Absent for a global-chat conversation. */
+	projectId?: string | undefined;
+	conversationId: string;
+	eventCount: number | undefined;
+	ready?: boolean;
+	pageSize?: number;
+}): UseConversationEventWindow {
+	// Whether the reader is at the newest event. Gates fetching forwards, so a
+	// reader looking at history does not pull events they cannot see.
+	const [following, setFollowing] = useState(true);
+
+	const { data: tail } = useQuery(
+		conversationEventsTailQueryOptions(conversationId),
+	);
+	const tailIndex = tail?.index ?? null;
+
+	const needsCount = typeof eventCount !== "number";
+	const { data: probedCount } = useQuery({
+		...conversationEventCountQueryOptions({ projectId, conversationId }),
+		enabled: ready && needsCount,
+	});
+	const count = eventCount ?? probedCount;
+	// Realtime can know about events before a count fetched earlier does.
+	const known = Math.max(count ?? 0, (tailIndex ?? -1) + 1);
+
+	const {
+		data,
+		isPending,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+		hasPreviousPage,
+		isFetchingPreviousPage,
+		fetchPreviousPage,
+	} = useInfiniteQuery({
+		...conversationEventWindowInfiniteOptions({
+			projectId,
+			conversationId,
+			count: known,
+			tailIndex,
+			pageSize,
+		}),
+		// Nothing to window until at least one event exists; a conversation that
+		// is empty when opened starts fetching when realtime reports its first.
+		enabled: ready && count !== undefined && known > 0,
+	});
+
+	const events = useMemo(
+		() => data?.pages.flatMap((page) => page.items) ?? [],
+		[data],
+	);
+
+	// Catch up to the tail a page at a time. Depends on `data` so an append that
+	// still leaves more to fetch re-runs this: the other values are unchanged
+	// across it, and a burst larger than one page would otherwise stall.
+	useEffect(() => {
+		if (!data || !following || !hasNextPage || isFetchingNextPage) return;
+		void fetchNextPage();
+	}, [data, following, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+	const loaded =
+		events.length === 0 ? 0 : (events.at(-1)?.event_index ?? -1) + 1;
+	const serverKnown = Math.max(
+		data?.pages.at(-1)?.total ?? 0,
+		(tailIndex ?? -1) + 1,
+		loaded,
+	);
+
+	return {
+		events,
+		// A conversation with no events is loaded, not loading.
+		isLoading: count === undefined || (known > 0 && isPending),
+		hasOlder: hasPreviousPage,
+		isLoadingOlder: isFetchingPreviousPage,
+		loadOlder: () => {
+			void fetchPreviousPage();
+		},
+		newBelow: following ? 0 : Math.max(0, serverKnown - loaded),
+		following,
+		setFollowing,
+		jumpToLatest: () => setFollowing(true),
+	};
+}

--- a/apps/web/src/components/projects/agents/use-conversation-event-window.ts
+++ b/apps/web/src/components/projects/agents/use-conversation-event-window.ts
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from "react";
 import {
 	type AgentConversationEvent,
 	CONVERSATION_EVENTS_PAGE_SIZE,
-	conversationEventCountQueryOptions,
 	conversationEventsTailQueryOptions,
 	conversationEventWindowInfiniteOptions,
 } from "@/lib/agent-api";
@@ -26,25 +25,23 @@ export type UseConversationEventWindow = {
  * Reads a conversation's events as a window anchored at the newest page,
  * extending upwards on demand and forwards as events arrive.
  *
- * Paging by offset is safe on a live stream because `event_index` is gapless: an
- * index is an offset, so a page addresses the same events however many arrive
- * later. Pages therefore stay contiguous, which `eventsToThreadMessages`
- * requires — it carries state across the array it is given (open tool calls keyed
- * by id, the assistant message being accumulated) and is only correct over an
- * unbroken run.
+ * Cursor-paginated on `event_index` (see conversationEventWindowInfiniteOptions):
+ * the window opens on the newest page with no cursor at all, so unlike an
+ * offset scheme it never needs to learn the conversation's length first.
+ * Pages stay contiguous, which `eventsToThreadMessages` requires — it carries
+ * state across the array it is given (open tool calls keyed by id, the
+ * assistant message being accumulated) and is only correct over an unbroken
+ * run.
  */
 export function useConversationEventWindow({
 	projectId,
 	conversationId,
-	eventCount,
-	/** Holds the first fetch until `eventCount` is settled, avoiding a probe. */
 	ready = true,
 	pageSize = CONVERSATION_EVENTS_PAGE_SIZE,
 }: {
 	/** Absent for a global-chat conversation. */
 	projectId?: string | undefined;
 	conversationId: string;
-	eventCount: number | undefined;
 	ready?: boolean;
 	pageSize?: number;
 }): UseConversationEventWindow {
@@ -57,15 +54,6 @@ export function useConversationEventWindow({
 	);
 	const tailIndex = tail?.index ?? null;
 
-	const needsCount = typeof eventCount !== "number";
-	const { data: probedCount } = useQuery({
-		...conversationEventCountQueryOptions({ projectId, conversationId }),
-		enabled: ready && needsCount,
-	});
-	const count = eventCount ?? probedCount;
-	// Realtime can know about events before a count fetched earlier does.
-	const known = Math.max(count ?? 0, (tailIndex ?? -1) + 1);
-
 	const {
 		data,
 		isPending,
@@ -75,17 +63,15 @@ export function useConversationEventWindow({
 		hasPreviousPage,
 		isFetchingPreviousPage,
 		fetchPreviousPage,
+		refetch,
 	} = useInfiniteQuery({
 		...conversationEventWindowInfiniteOptions({
 			projectId,
 			conversationId,
-			count: known,
 			tailIndex,
 			pageSize,
 		}),
-		// Nothing to window until at least one event exists; a conversation that
-		// is empty when opened starts fetching when realtime reports its first.
-		enabled: ready && count !== undefined && known > 0,
+		enabled: ready,
 	});
 
 	const events = useMemo(
@@ -96,10 +82,31 @@ export function useConversationEventWindow({
 	// Catch up to the tail a page at a time. Depends on `data` so an append that
 	// still leaves more to fetch re-runs this: the other values are unchanged
 	// across it, and a burst larger than one page would otherwise stall.
+	//
+	// A conversation with no events yet is the one case fetchNextPage can't
+	// drive this: its sole (empty) page carries no next_cursor to resume
+	// from, since there is no last event to encode one from. Re-opening on
+	// the tail via a plain refetch once realtime reports the first event
+	// replaces that empty page in place, rather than appending a second
+	// (still cursor-less) one that fetchNextPage would otherwise produce.
 	useEffect(() => {
-		if (!data || !following || !hasNextPage || isFetchingNextPage) return;
+		if (!data || !following || isFetchingNextPage) return;
+		if (events.length === 0) {
+			if ((tailIndex ?? -1) >= 0) void refetch();
+			return;
+		}
+		if (!hasNextPage) return;
 		void fetchNextPage();
-	}, [data, following, hasNextPage, isFetchingNextPage, fetchNextPage]);
+	}, [
+		data,
+		following,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+		events.length,
+		tailIndex,
+		refetch,
+	]);
 
 	const loaded =
 		events.length === 0 ? 0 : (events.at(-1)?.event_index ?? -1) + 1;
@@ -111,8 +118,7 @@ export function useConversationEventWindow({
 
 	return {
 		events,
-		// A conversation with no events is loaded, not loading.
-		isLoading: count === undefined || (known > 0 && isPending),
+		isLoading: isPending,
 		hasOlder: hasPreviousPage,
 		isLoadingOlder: isFetchingPreviousPage,
 		loadOlder: () => {

--- a/apps/web/src/hooks/use-global-agent-realtime.ts
+++ b/apps/web/src/hooks/use-global-agent-realtime.ts
@@ -19,6 +19,10 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import {
+	type ConversationEventsTail,
+	conversationEventsTailKey,
+} from "@/lib/agent-api";
 import { connectSocket, type RealtimeEvent } from "@/lib/socket-client";
 
 export function useGlobalAgentRealtime(enabled = true): void {
@@ -36,9 +40,39 @@ export function useGlobalAgentRealtime(enabled = true): void {
 			// useProjectRealtime's agent.* handling; prefix-matches both the
 			// single conversation and its events sub-key since TanStack Query
 			// invalidates by key prefix.
-			void queryClient.invalidateQueries({
-				queryKey: ["global-chat", "conversations"],
-			});
+			const conversationId =
+				typeof event.payload.conversation_id === "string"
+					? event.payload.conversation_id
+					: null;
+			// A persisted event carries its index and changes only the event stream;
+			// the conversation's own fields change on lifecycle messages.
+			const eventIndex = Number.parseInt(
+				String(event.payload.event_index ?? ""),
+				10,
+			);
+			const isPersistedEvent = Number.isFinite(eventIndex);
+
+			if (conversationId) {
+				queryClient.setQueryData(
+					conversationEventsTailKey(conversationId),
+					(prev: ConversationEventsTail | undefined) => ({
+						tick: (prev?.tick ?? 0) + 1,
+						index: isPersistedEvent
+							? Math.max(prev?.index ?? -1, eventIndex)
+							: (prev?.index ?? null),
+					}),
+				);
+				// For views that read the whole event list.
+				void queryClient.invalidateQueries({
+					queryKey: ["global-chat", "conversations", conversationId, "events"],
+				});
+			}
+
+			if (!isPersistedEvent) {
+				void queryClient.invalidateQueries({
+					queryKey: ["global-chat", "conversations"],
+				});
+			}
 		}
 
 		socket.on("event", handleEvent);

--- a/apps/web/src/hooks/use-project-realtime.test.tsx
+++ b/apps/web/src/hooks/use-project-realtime.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
 		leaveProject: vi.fn(),
 		rejoinProject: vi.fn(),
 		invalidateQueries: vi.fn(),
+		setQueryData: vi.fn(),
 	};
 });
 
@@ -34,6 +35,7 @@ vi.mock("@tanstack/react-query", async () => {
 		...actual,
 		useQueryClient: () => ({
 			invalidateQueries: mocks.invalidateQueries,
+			setQueryData: mocks.setQueryData,
 		}),
 	};
 });
@@ -273,5 +275,43 @@ describe("useProjectRealtime", () => {
 		expect(mocks.leaveProject).toHaveBeenCalledWith("proj-1");
 		// New project joined.
 		expect(mocks.joinProject).toHaveBeenCalledWith("proj-2");
+	});
+	it("does not refetch the conversation list or detail for a persisted event", () => {
+		renderHook(() => useProjectRealtime("proj-abc"));
+		const [, listener] = mocks.socket.on.mock.calls[0] as [
+			string,
+			(event: { type: string; payload: Record<string, unknown> }) => void,
+		];
+
+		listener({
+			type: "agent.acptoolcallevent",
+			payload: { conversation_id: "conv-1", event_index: "42" },
+		});
+
+		// The stream grew; the conversation's own fields did not.
+		expect(mocks.setQueryData).toHaveBeenCalled();
+		expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["projects", "proj-abc", "conversations", "conv-1", "events"],
+		});
+		expect(mocks.invalidateQueries).not.toHaveBeenCalledWith({
+			queryKey: ["projects", "proj-abc", "conversations"],
+		});
+	});
+
+	it("refetches the conversations prefix for a lifecycle event", () => {
+		renderHook(() => useProjectRealtime("proj-abc"));
+		const [, listener] = mocks.socket.on.mock.calls[0] as [
+			string,
+			(event: { type: string; payload: Record<string, unknown> }) => void,
+		];
+
+		listener({
+			type: "agent.conversation.finished",
+			payload: { conversation_id: "conv-1" },
+		});
+
+		expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["projects", "proj-abc", "conversations"],
+		});
 	});
 });

--- a/apps/web/src/hooks/use-project-realtime.ts
+++ b/apps/web/src/hooks/use-project-realtime.ts
@@ -56,6 +56,10 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import {
+	type ConversationEventsTail,
+	conversationEventsTailKey,
+} from "@/lib/agent-api";
+import {
 	connectSocket,
 	joinProject,
 	leaveProject,
@@ -173,23 +177,37 @@ export function useProjectRealtime(projectId: string | undefined): void {
 				return;
 			}
 
-			// agent.* events: invalidate conversation list/events and task activities
+			// agent.* events: conversation caches and task activities
 			// (agent.session.started is recorded as a task activity).
 			if (type.startsWith("agent.")) {
-				void queryClient.invalidateQueries({
-					queryKey: ["projects", currentProjectId, "conversations"],
-				});
-				// agent.session.started shows up in task activity feeds
-				if (type === "agent.session.started" || type.startsWith("task.")) {
-					void queryClient.invalidateQueries({
-						queryKey: ["projects", currentProjectId, "tasks"],
-					});
-				}
 				const conversationId =
 					typeof event.payload.conversation_id === "string"
 						? event.payload.conversation_id
 						: null;
+				// A persisted event carries its index. Such an event changes only the
+				// conversation's event stream — its own fields change on the lifecycle
+				// messages, which arrive separately — so the list and the detail are
+				// left alone. A run of a few hundred events would otherwise refetch
+				// both a few hundred times.
+				const eventIndex = Number.parseInt(
+					String(event.payload.event_index ?? ""),
+					10,
+				);
+				const isPersistedEvent = Number.isFinite(eventIndex);
+
 				if (conversationId) {
+					// How far the stream has grown, for views holding a window of
+					// events.
+					queryClient.setQueryData(
+						conversationEventsTailKey(conversationId),
+						(prev: ConversationEventsTail | undefined) => ({
+							tick: (prev?.tick ?? 0) + 1,
+							index: isPersistedEvent
+								? Math.max(prev?.index ?? -1, eventIndex)
+								: (prev?.index ?? null),
+						}),
+					);
+					// For views that read the whole event list.
 					void queryClient.invalidateQueries({
 						queryKey: [
 							"projects",
@@ -199,6 +217,18 @@ export function useProjectRealtime(projectId: string | undefined): void {
 							"events",
 						],
 					});
+				}
+
+				if (!isPersistedEvent) {
+					void queryClient.invalidateQueries({
+						queryKey: ["projects", currentProjectId, "conversations"],
+					});
+					// agent.session.started shows up in task activity feeds
+					if (type === "agent.session.started" || type.startsWith("task.")) {
+						void queryClient.invalidateQueries({
+							queryKey: ["projects", currentProjectId, "tasks"],
+						});
+					}
 				}
 				return;
 			}

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -262,7 +262,6 @@
 			"textOnlyMessage": "Only text messages are supported.",
 			"failed": "Conversation failed",
 			"noOutput": "The agent did not produce any output.",
-			"loadOlder": "Load earlier messages",
 			"loadingOlder": "Loading…",
 			"newBelow_one": "{{count}} new message",
 			"newBelow_other": "{{count}} new messages"

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -261,7 +261,11 @@
 			"conversationEnded": "This conversation has ended.",
 			"textOnlyMessage": "Only text messages are supported.",
 			"failed": "Conversation failed",
-			"noOutput": "The agent did not produce any output."
+			"noOutput": "The agent did not produce any output.",
+			"loadOlder": "Load earlier messages",
+			"loadingOlder": "Loading…",
+			"newBelow_one": "{{count}} new message",
+			"newBelow_other": "{{count}} new messages"
 		},
 		"thread": {
 			"composerPlaceholder": "Message agent…",

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "Esta conversación ha finalizado.",
 			"textOnlyMessage": "Solo se admiten mensajes de texto.",
 			"failed": "La conversación falló",
-			"noOutput": "El agente no produjo ninguna salida."
+			"noOutput": "El agente no produjo ninguna salida.",
+			"loadingOlder": "Cargando…",
+			"newBelow_one": "{{count}} mensaje nuevo",
+			"newBelow_other": "{{count}} mensajes nuevos"
 		},
 		"thread": {
 			"composerPlaceholder": "Enviar mensaje al agente…",

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "Cette conversation est terminée.",
 			"textOnlyMessage": "Seuls les messages texte sont pris en charge.",
 			"failed": "La conversation a échoué",
-			"noOutput": "L'agent n'a produit aucun résultat."
+			"noOutput": "L'agent n'a produit aucun résultat.",
+			"loadingOlder": "Chargement…",
+			"newBelow_one": "{{count}} nouveau message",
+			"newBelow_other": "{{count}} nouveaux messages"
 		},
 		"thread": {
 			"composerPlaceholder": "Message à l'agent…",

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "この会話は終了しました。",
 			"textOnlyMessage": "テキストメッセージのみサポートされています。",
 			"failed": "会話が失敗しました",
-			"noOutput": "エージェントは出力を生成しませんでした。"
+			"noOutput": "エージェントは出力を生成しませんでした。",
+			"loadingOlder": "読み込み中…",
+			"newBelow_one": "新着メッセージ{{count}}件",
+			"newBelow_other": "新着メッセージ{{count}}件"
 		},
 		"thread": {
 			"composerPlaceholder": "エージェントにメッセージ…",

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "이 대화가 종료되었습니다.",
 			"textOnlyMessage": "텍스트 메시지만 지원됩니다.",
 			"failed": "대화가 실패했습니다",
-			"noOutput": "에이전트가 출력을 생성하지 않았습니다."
+			"noOutput": "에이전트가 출력을 생성하지 않았습니다.",
+			"loadingOlder": "불러오는 중…",
+			"newBelow_one": "새 메시지 {{count}}개",
+			"newBelow_other": "새 메시지 {{count}}개"
 		},
 		"thread": {
 			"composerPlaceholder": "에이전트에게 메시지…",

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "Esta conversa foi encerrada.",
 			"textOnlyMessage": "Apenas mensagens de texto são suportadas.",
 			"failed": "A conversa falhou",
-			"noOutput": "O agente não produziu nenhuma saída."
+			"noOutput": "O agente não produziu nenhuma saída.",
+			"loadingOlder": "Carregando…",
+			"newBelow_one": "{{count}} nova mensagem",
+			"newBelow_other": "{{count}} novas mensagens"
 		},
 		"thread": {
 			"composerPlaceholder": "Enviar mensagem ao agente…",

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -267,7 +267,12 @@
 			"conversationEnded": "Этот диалог завершён.",
 			"textOnlyMessage": "Поддерживаются только текстовые сообщения.",
 			"failed": "Диалог завершился с ошибкой",
-			"noOutput": "Агент не выдал результат."
+			"noOutput": "Агент не выдал результат.",
+			"loadingOlder": "Загрузка…",
+			"newBelow_one": "{{count}} новое сообщение",
+			"newBelow_few": "{{count}} новых сообщения",
+			"newBelow_many": "{{count}} новых сообщений",
+			"newBelow_other": "{{count}} новых сообщения"
 		},
 		"thread": {
 			"composerPlaceholder": "Сообщение агенту…",

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "Cuộc trò chuyện này đã kết thúc.",
 			"textOnlyMessage": "Chỉ hỗ trợ tin nhắn văn bản.",
 			"failed": "Cuộc trò chuyện thất bại",
-			"noOutput": "Agent không tạo ra kết quả nào."
+			"noOutput": "Agent không tạo ra kết quả nào.",
+			"loadingOlder": "Đang tải…",
+			"newBelow_one": "{{count}} tin nhắn mới",
+			"newBelow_other": "{{count}} tin nhắn mới"
 		},
 		"thread": {
 			"composerPlaceholder": "Nhắn tin cho agent…",

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -261,7 +261,10 @@
 			"conversationEnded": "此对话已结束。",
 			"textOnlyMessage": "仅支持文本消息。",
 			"failed": "对话失败",
-			"noOutput": "代理未生成任何输出。"
+			"noOutput": "代理未生成任何输出。",
+			"loadingOlder": "加载中…",
+			"newBelow_one": "{{count}} 条新消息",
+			"newBelow_other": "{{count}} 条新消息"
 		},
 		"thread": {
 			"composerPlaceholder": "给代理发消息…",

--- a/apps/web/src/lib/agent-api.test.ts
+++ b/apps/web/src/lib/agent-api.test.ts
@@ -33,6 +33,7 @@ import {
 	getGlobalConversation,
 	heartbeatGlobalConversation,
 	listAgents,
+	listConversationEventWindow,
 	listConversations,
 	listGlobalAgents,
 	listGlobalChatSessions,
@@ -483,6 +484,36 @@ describe("agent-api", () => {
 				`/admin/agents/${AGENT_ID}/acp-bridge-status`,
 			);
 			expect(result).toEqual({ connected: true });
+		});
+	});
+	describe("listConversationEventWindow", () => {
+		it("requests exactly the window it was asked for", async () => {
+			mockGet.mockResolvedValueOnce(ok({ items: [], total: 900 }));
+
+			const page = await listConversationEventWindow(PROJECT_ID, "conv-1", {
+				offset: 700,
+				limit: 200,
+			});
+
+			expect(mockGet).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/conversations/conv-1/events`,
+				{ params: { limit: 200, offset: 700 } },
+			);
+			expect(page.total).toBe(900);
+		});
+
+		it("infers a total from the window when the API omits one", async () => {
+			mockGet.mockResolvedValueOnce(
+				ok({ items: [{ event_index: 10 }, { event_index: 11 }] }),
+			);
+
+			const page = await listConversationEventWindow(PROJECT_ID, "conv-1", {
+				offset: 10,
+				limit: 200,
+			});
+
+			expect(page.total).toBe(12);
+			expect(page.items).toHaveLength(2);
 		});
 	});
 });

--- a/apps/web/src/lib/agent-api.test.ts
+++ b/apps/web/src/lib/agent-api.test.ts
@@ -487,33 +487,54 @@ describe("agent-api", () => {
 		});
 	});
 	describe("listConversationEventWindow", () => {
-		it("requests exactly the window it was asked for", async () => {
-			mockGet.mockResolvedValueOnce(ok({ items: [], total: 900 }));
+		it("requests the newest page when no cursor is given", async () => {
+			mockGet.mockResolvedValueOnce(
+				ok({ items: [], total: 900, next_cursor: null, prev_cursor: "cur-a" }),
+			);
 
 			const page = await listConversationEventWindow(PROJECT_ID, "conv-1", {
-				offset: 700,
 				limit: 200,
 			});
 
 			expect(mockGet).toHaveBeenCalledWith(
 				`/projects/${PROJECT_ID}/conversations/conv-1/events`,
-				{ params: { limit: 200, offset: 700 } },
+				{ params: { limit: 200 } },
 			);
 			expect(page.total).toBe(900);
+			expect(page.prev_cursor).toBe("cur-a");
+			expect(page.next_cursor).toBeNull();
 		});
 
-		it("infers a total from the window when the API omits one", async () => {
+		it("forwards an after cursor, not before", async () => {
 			mockGet.mockResolvedValueOnce(
-				ok({ items: [{ event_index: 10 }, { event_index: 11 }] }),
+				ok({ items: [], total: 900, next_cursor: null, prev_cursor: null }),
 			);
 
-			const page = await listConversationEventWindow(PROJECT_ID, "conv-1", {
-				offset: 10,
+			await listConversationEventWindow(PROJECT_ID, "conv-1", {
+				after: "cur-b",
 				limit: 200,
 			});
 
-			expect(page.total).toBe(12);
-			expect(page.items).toHaveLength(2);
+			expect(mockGet).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/conversations/conv-1/events`,
+				{ params: { limit: 200, after: "cur-b" } },
+			);
+		});
+
+		it("forwards a before cursor, not after", async () => {
+			mockGet.mockResolvedValueOnce(
+				ok({ items: [], total: 900, next_cursor: null, prev_cursor: null }),
+			);
+
+			await listConversationEventWindow(PROJECT_ID, "conv-1", {
+				before: "cur-c",
+				limit: 200,
+			});
+
+			expect(mockGet).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/conversations/conv-1/events`,
+				{ params: { limit: 200, before: "cur-c" } },
+			);
 		});
 	});
 });

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -175,12 +175,6 @@ export interface AgentConversation {
 	actor_user_id?: string | null;
 	status: ConversationStatus;
 	iteration_count: number;
-	/**
-	 * Number of persisted events. Present on a single-conversation read only,
-	 * which is what lets a view open on the newest events without first asking
-	 * how many there are.
-	 */
-	event_count?: number;
 	error_message?: string | null;
 	branch_name?: string | null;
 	pr_url?: string | null;
@@ -422,36 +416,65 @@ export async function getGlobalConversation(
 	return data.data;
 }
 
-/** The API rejects any limit above this (see parseOffsetLimit). */
+/** The API rejects any limit above this (see parseConversationEventWindowQuery). */
 export const CONVERSATION_EVENTS_PAGE_SIZE = 200;
+
+/** At most one of after/before is set — see fetchConversationEventWindow. */
+export type ConversationEventWindowParam = {
+	after?: string;
+	before?: string;
+	limit: number;
+};
 
 export type ConversationEventPage = {
 	items: AgentConversationEvent[];
 	/** Total events in the conversation, as reported by the server. */
 	total: number;
+	/** Opaque cursor resuming forward (toward newer events) from this page's
+	 *  last item — pass as `after` — or null once it is the newest known. */
+	next_cursor: string | null;
+	/** Opaque cursor resuming backward (toward older events) from this
+	 *  page's first item — pass as `before` — or null at the start of the
+	 *  stream (its first event is event_index 0). */
+	prev_cursor: string | null;
 };
 
 /**
  * Fetch one window of a conversation's events, oldest first.
  *
- * `event_index` is gapless, so `offset` addresses events directly: offset 200 is
- * event_index 200, and stays so however many events arrive later.
+ * Neither `after` nor `before` set opens on the newest `limit` events, the
+ * same "start from page one" cursor concept conversationsQueryOptions and
+ * epicTasksInfiniteQueryOptions use — a conversation can be read without
+ * first learning how many events it holds. Passing back a page's own
+ * next_cursor/prev_cursor pages forward/backward from there.
  */
 async function fetchConversationEventWindow(
 	path: string,
-	{ offset, limit }: { offset: number; limit: number },
+	{ after, before, limit }: ConversationEventWindowParam,
 ): Promise<ConversationEventPage> {
+	const params: Record<string, string | number> = { limit };
+	if (after) params.after = after;
+	if (before) params.before = before;
 	const { data } = await apiClient.instance.get<
-		SuccessEnvelope<{ items: AgentConversationEvent[]; total?: number }>
-	>(path, { params: { limit, offset } });
-	const items = data.data.items ?? [];
-	return { items, total: data.data.total ?? offset + items.length };
+		SuccessEnvelope<{
+			items: AgentConversationEvent[];
+			total: number;
+			next_cursor: string | null;
+			prev_cursor: string | null;
+		}>
+	>(path, { params });
+	return {
+		items: data.data.items ?? [],
+		total: data.data.total,
+		next_cursor: data.data.next_cursor,
+		prev_cursor: data.data.prev_cursor,
+	};
 }
 
 export const listConversationEventWindow = (
 	projectId: string,
 	conversationId: string,
-	window: { offset: number; limit: number },
+	window: ConversationEventWindowParam,
 ) =>
 	fetchConversationEventWindow(
 		`/projects/${projectId}/conversations/${conversationId}/events`,
@@ -460,7 +483,7 @@ export const listConversationEventWindow = (
 
 export const listGlobalConversationEventWindow = (
 	conversationId: string,
-	window: { offset: number; limit: number },
+	window: ConversationEventWindowParam,
 ) =>
 	fetchConversationEventWindow(
 		`/agents/conversations/${conversationId}/events`,
@@ -1375,7 +1398,11 @@ export const conversationEventsTailQueryOptions = (conversationId: string) =>
 	});
 
 /**
- * One window of a conversation's events, paged by offset in both directions.
+ * One window of a conversation's events, paged by cursor in both
+ * directions — the same opaque-cursor concept conversationsQueryOptions and
+ * epicTasksInfiniteQueryOptions use for next_cursor, extended with a
+ * prev_cursor since this reader opens on the tail and grows outward in both
+ * directions rather than listing forward from page one.
  *
  * Keyed outside ["projects", …] and ["global-chat", …] on purpose: an infinite
  * query refetches every page it holds, so an incidental prefix invalidation
@@ -1387,47 +1414,16 @@ export const conversationEventWindowKey = (conversationId: string) => [
 	conversationId,
 ];
 
-export const conversationEventCountQueryOptions = ({
-	projectId,
-	conversationId,
-}: {
-	projectId?: string | undefined;
-	conversationId: string;
-}) =>
-	queryOptions({
-		queryKey: [...conversationEventWindowKey(conversationId), "count"],
-		// One row, for its `total`. Only needed against an API that does not
-		// report `event_count` on the conversation itself.
-		queryFn: async () =>
-			(
-				await (projectId === undefined
-					? listGlobalConversationEventWindow(conversationId, {
-							offset: 0,
-							limit: 1,
-						})
-					: listConversationEventWindow(projectId, conversationId, {
-							offset: 0,
-							limit: 1,
-						}))
-			).total,
-		staleTime: Number.POSITIVE_INFINITY,
-	});
-
-/** A page carries its own limit so a short hop cannot overlap what is loaded. */
-type ConversationEventWindowParam = { offset: number; limit: number };
-
 export const conversationEventWindowInfiniteOptions = ({
 	projectId,
 	conversationId,
-	/** Events the conversation is known to hold, used to open on the newest page. */
-	count,
-	/** Highest index realtime has reported, which can be ahead of `count`. */
+	/** Highest index realtime has reported, which can be ahead of a page's
+	 *  own `total` — see ConversationEventPage['next_cursor']. */
 	tailIndex,
 	pageSize = CONVERSATION_EVENTS_PAGE_SIZE,
 }: {
 	projectId?: string | undefined;
 	conversationId: string;
-	count: number;
 	tailIndex: number | null;
 	pageSize?: number;
 }) =>
@@ -1437,34 +1433,25 @@ export const conversationEventWindowInfiniteOptions = ({
 			projectId === undefined
 				? listGlobalConversationEventWindow(conversationId, pageParam)
 				: listConversationEventWindow(projectId, conversationId, pageParam),
-		initialPageParam: {
-			offset: Math.max(0, count - pageSize),
-			limit: pageSize,
-		} as ConversationEventWindowParam,
+		// No cursor: opens on the newest page, without needing to already know
+		// how many events the conversation holds.
+		initialPageParam: { limit: pageSize } as ConversationEventWindowParam,
 		getPreviousPageParam: (
-			_first,
-			_all,
-			firstPageParam,
+			firstPage,
 		): ConversationEventWindowParam | undefined =>
-			firstPageParam.offset > 0
-				? {
-						offset: Math.max(0, firstPageParam.offset - pageSize),
-						// Clamped: the last hop backwards is usually shorter than a full
-						// page, and a full one would refetch events already held.
-						limit: Math.min(pageSize, firstPageParam.offset),
-					}
+			firstPage.prev_cursor
+				? { before: firstPage.prev_cursor, limit: pageSize }
 				: undefined,
-		getNextPageParam: (
-			lastPage,
-			_all,
-			lastPageParam,
-		): ConversationEventWindowParam | undefined => {
-			// An empty page means the server has nothing further, whatever the
-			// counts say — without this the next param would not advance.
-			if (lastPage.items.length === 0) return undefined;
-			const next = lastPageParam.offset + lastPage.items.length;
+		getNextPageParam: (lastPage): ConversationEventWindowParam | undefined => {
+			// No cursor means an empty page (see ConversationEventPage) — the
+			// server has nothing to resume from, whatever the counts say.
+			if (!lastPage.next_cursor) return undefined;
+			const lastEvent = lastPage.items.at(-1);
+			const loadedThrough = (lastEvent?.event_index ?? -1) + 1;
 			const known = Math.max(lastPage.total, (tailIndex ?? -1) + 1);
-			return next < known ? { offset: next, limit: pageSize } : undefined;
+			return loadedThrough < known
+				? { after: lastPage.next_cursor, limit: pageSize }
+				: undefined;
 		},
 		staleTime: Number.POSITIVE_INFINITY,
 		refetchOnWindowFocus: false,

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -175,6 +175,12 @@ export interface AgentConversation {
 	actor_user_id?: string | null;
 	status: ConversationStatus;
 	iteration_count: number;
+	/**
+	 * Number of persisted events. Present on a single-conversation read only,
+	 * which is what lets a view open on the newest events without first asking
+	 * how many there are.
+	 */
+	event_count?: number;
 	error_message?: string | null;
 	branch_name?: string | null;
 	pr_url?: string | null;
@@ -415,6 +421,51 @@ export async function getGlobalConversation(
 	>(`/agents/conversations/${conversationId}`);
 	return data.data;
 }
+
+/** The API rejects any limit above this (see parseOffsetLimit). */
+export const CONVERSATION_EVENTS_PAGE_SIZE = 200;
+
+export type ConversationEventPage = {
+	items: AgentConversationEvent[];
+	/** Total events in the conversation, as reported by the server. */
+	total: number;
+};
+
+/**
+ * Fetch one window of a conversation's events, oldest first.
+ *
+ * `event_index` is gapless, so `offset` addresses events directly: offset 200 is
+ * event_index 200, and stays so however many events arrive later.
+ */
+async function fetchConversationEventWindow(
+	path: string,
+	{ offset, limit }: { offset: number; limit: number },
+): Promise<ConversationEventPage> {
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<{ items: AgentConversationEvent[]; total?: number }>
+	>(path, { params: { limit, offset } });
+	const items = data.data.items ?? [];
+	return { items, total: data.data.total ?? offset + items.length };
+}
+
+export const listConversationEventWindow = (
+	projectId: string,
+	conversationId: string,
+	window: { offset: number; limit: number },
+) =>
+	fetchConversationEventWindow(
+		`/projects/${projectId}/conversations/${conversationId}/events`,
+		window,
+	);
+
+export const listGlobalConversationEventWindow = (
+	conversationId: string,
+	window: { offset: number; limit: number },
+) =>
+	fetchConversationEventWindow(
+		`/agents/conversations/${conversationId}/events`,
+		window,
+	);
 
 export async function listGlobalConversationEvents(
 	conversationId: string,
@@ -1292,6 +1343,132 @@ export const globalConversationQueryOptions = (conversationId: string) =>
 	queryOptions({
 		queryKey: ["global-chat", "conversations", conversationId],
 		queryFn: () => getGlobalConversation(conversationId),
+	});
+
+// Must stay outside both ["projects", …] and ["global-chat", …]: the realtime
+// hooks invalidate those prefixes, which would reset this entry.
+export const conversationEventsTailKey = (conversationId: string) => [
+	"conversation-events-tail",
+	conversationId,
+];
+
+/**
+ * Notification channel, not a data source: the realtime hooks write the highest
+ * `event_index` they have seen and observers re-render.
+ */
+export type ConversationEventsTail = { tick: number; index: number | null };
+
+const CONVERSATION_EVENTS_TAIL_INITIAL: ConversationEventsTail = {
+	tick: 0,
+	index: null,
+};
+
+export const conversationEventsTailQueryOptions = (conversationId: string) =>
+	queryOptions({
+		queryKey: conversationEventsTailKey(conversationId),
+		// Never fetched: a refetch would replace the signal with the initial value.
+		queryFn: (): ConversationEventsTail => CONVERSATION_EVENTS_TAIL_INITIAL,
+		enabled: false,
+		initialData: CONVERSATION_EVENTS_TAIL_INITIAL,
+		staleTime: Number.POSITIVE_INFINITY,
+		gcTime: Number.POSITIVE_INFINITY,
+	});
+
+/**
+ * One window of a conversation's events, paged by offset in both directions.
+ *
+ * Keyed outside ["projects", …] and ["global-chat", …] on purpose: an infinite
+ * query refetches every page it holds, so an incidental prefix invalidation
+ * would re-read the whole stream. Nothing may refetch this implicitly, hence the
+ * infinite stale time.
+ */
+export const conversationEventWindowKey = (conversationId: string) => [
+	"conversation-event-window",
+	conversationId,
+];
+
+export const conversationEventCountQueryOptions = ({
+	projectId,
+	conversationId,
+}: {
+	projectId?: string | undefined;
+	conversationId: string;
+}) =>
+	queryOptions({
+		queryKey: [...conversationEventWindowKey(conversationId), "count"],
+		// One row, for its `total`. Only needed against an API that does not
+		// report `event_count` on the conversation itself.
+		queryFn: async () =>
+			(
+				await (projectId === undefined
+					? listGlobalConversationEventWindow(conversationId, {
+							offset: 0,
+							limit: 1,
+						})
+					: listConversationEventWindow(projectId, conversationId, {
+							offset: 0,
+							limit: 1,
+						}))
+			).total,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+
+/** A page carries its own limit so a short hop cannot overlap what is loaded. */
+type ConversationEventWindowParam = { offset: number; limit: number };
+
+export const conversationEventWindowInfiniteOptions = ({
+	projectId,
+	conversationId,
+	/** Events the conversation is known to hold, used to open on the newest page. */
+	count,
+	/** Highest index realtime has reported, which can be ahead of `count`. */
+	tailIndex,
+	pageSize = CONVERSATION_EVENTS_PAGE_SIZE,
+}: {
+	projectId?: string | undefined;
+	conversationId: string;
+	count: number;
+	tailIndex: number | null;
+	pageSize?: number;
+}) =>
+	infiniteQueryOptions({
+		queryKey: conversationEventWindowKey(conversationId),
+		queryFn: ({ pageParam }: { pageParam: ConversationEventWindowParam }) =>
+			projectId === undefined
+				? listGlobalConversationEventWindow(conversationId, pageParam)
+				: listConversationEventWindow(projectId, conversationId, pageParam),
+		initialPageParam: {
+			offset: Math.max(0, count - pageSize),
+			limit: pageSize,
+		} as ConversationEventWindowParam,
+		getPreviousPageParam: (
+			_first,
+			_all,
+			firstPageParam,
+		): ConversationEventWindowParam | undefined =>
+			firstPageParam.offset > 0
+				? {
+						offset: Math.max(0, firstPageParam.offset - pageSize),
+						// Clamped: the last hop backwards is usually shorter than a full
+						// page, and a full one would refetch events already held.
+						limit: Math.min(pageSize, firstPageParam.offset),
+					}
+				: undefined,
+		getNextPageParam: (
+			lastPage,
+			_all,
+			lastPageParam,
+		): ConversationEventWindowParam | undefined => {
+			// An empty page means the server has nothing further, whatever the
+			// counts say — without this the next param would not advance.
+			if (lastPage.items.length === 0) return undefined;
+			const next = lastPageParam.offset + lastPage.items.length;
+			const known = Math.max(lastPage.total, (tailIndex ?? -1) + 1);
+			return next < known ? { offset: next, limit: pageSize } : undefined;
+		},
+		staleTime: Number.POSITIVE_INFINITY,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
 	});
 
 export const globalConversationEventsQueryOptions = (conversationId: string) =>

--- a/apps/web/src/routes/_authenticated/conversations/$conversationId.tsx
+++ b/apps/web/src/routes/_authenticated/conversations/$conversationId.tsx
@@ -1,23 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ConversationView } from "@/components/projects/agents/conversation-view";
 import { RouteErrorComponent } from "@/components/route-error-boundary";
-import {
-	globalConversationEventsQueryOptions,
-	globalConversationQueryOptions,
-} from "@/lib/agent-api";
+import { globalConversationQueryOptions } from "@/lib/agent-api";
 
 export const Route = createFileRoute(
 	"/_authenticated/conversations/$conversationId",
 )({
 	loader: async ({ context: { queryClient }, params: { conversationId } }) => {
-		await Promise.all([
-			queryClient.ensureQueryData(
-				globalConversationQueryOptions(conversationId),
-			),
-			queryClient.ensureQueryData(
-				globalConversationEventsQueryOptions(conversationId),
-			),
-		]);
+		// The conversation only: it carries `event_count`, which is all the
+		// view needs to open on the newest events.
+		await queryClient.ensureQueryData(
+			globalConversationQueryOptions(conversationId),
+		);
 	},
 	// Without an errorComponent, a loader failure (e.g. deleted conversation,
 	// API 500) bubbles up and crashes the router's internal Lazy wrapper.

--- a/apps/web/src/routes/_authenticated/conversations/$conversationId.tsx
+++ b/apps/web/src/routes/_authenticated/conversations/$conversationId.tsx
@@ -7,8 +7,9 @@ export const Route = createFileRoute(
 	"/_authenticated/conversations/$conversationId",
 )({
 	loader: async ({ context: { queryClient }, params: { conversationId } }) => {
-		// The conversation only: it carries `event_count`, which is all the
-		// view needs to open on the newest events.
+		// Prefetches the conversation itself (agent, status, etc.) — the events
+		// window is fetched separately by useConversationEventWindow and opens
+		// on the newest page on its own, with no dependency on this data.
 		await queryClient.ensureQueryData(
 			globalConversationQueryOptions(conversationId),
 		);

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/$conversationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/$conversationId.tsx
@@ -10,8 +10,9 @@ export const Route = createFileRoute(
 		context: { queryClient },
 		params: { projectId, conversationId },
 	}) => {
-		// The conversation only: it carries `event_count`, which is all the
-		// view needs to open on the newest events.
+		// Prefetches the conversation itself (agent, status, etc.) — the events
+		// window is fetched separately by useConversationEventWindow and opens
+		// on the newest page on its own, with no dependency on this data.
 		await queryClient.ensureQueryData(
 			conversationQueryOptions(projectId, conversationId),
 		);

--- a/apps/web/src/routes/_authenticated/projects/$projectId/conversations/$conversationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/conversations/$conversationId.tsx
@@ -1,10 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ConversationView } from "@/components/projects/agents/conversation-view";
 import { RouteErrorComponent } from "@/components/route-error-boundary";
-import {
-	conversationEventsQueryOptions,
-	conversationQueryOptions,
-} from "@/lib/agent-api";
+import { conversationQueryOptions } from "@/lib/agent-api";
 
 export const Route = createFileRoute(
 	"/_authenticated/projects/$projectId/conversations/$conversationId",
@@ -13,14 +10,11 @@ export const Route = createFileRoute(
 		context: { queryClient },
 		params: { projectId, conversationId },
 	}) => {
-		await Promise.all([
-			queryClient.ensureQueryData(
-				conversationQueryOptions(projectId, conversationId),
-			),
-			queryClient.ensureQueryData(
-				conversationEventsQueryOptions(projectId, conversationId),
-			),
-		]);
+		// The conversation only: it carries `event_count`, which is all the
+		// view needs to open on the newest events.
+		await queryClient.ensureQueryData(
+			conversationQueryOptions(projectId, conversationId),
+		);
 	},
 	// Without an errorComponent, a loader failure (e.g. deleted conversation,
 	// API 500) bubbles up and crashes the router's internal Lazy wrapper.

--- a/services/ai-agent/src/agent/executor.py
+++ b/services/ai-agent/src/agent/executor.py
@@ -370,7 +370,10 @@ async def persist_conversation_event(
             "status": "running",
         }
     )
+    # The index lets a client holding a window of events fetch only what it is
+    # missing. Stringified to match publish_event above.
     await stream_store.publish_realtime(
+        extra_payload={"event_index": str(event_index)},
         project_id=project_id,
         conversation_id=conversation_id,
         event_type=f"agent.{event_type.lower()}",

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -299,6 +299,8 @@ const (
 	CodeAgentConversationInvalidCursor Code = "AGENT_CONVERSATION_INVALID_CURSOR"
 	// CodeAgentActivityInvalidCursor indicates a client-supplied activity feed pagination cursor failed to decode.
 	CodeAgentActivityInvalidCursor Code = "AGENT_ACTIVITY_INVALID_CURSOR"
+	// CodeAgentConversationEventInvalidCursor indicates a client-supplied conversation-events window cursor failed to decode.
+	CodeAgentConversationEventInvalidCursor Code = "AGENT_CONVERSATION_EVENT_INVALID_CURSOR"
 	// CodeAgentChatSessionNotFound indicates the requested chat session does not exist.
 	CodeAgentChatSessionNotFound Code = "AGENT_CHAT_SESSION_NOT_FOUND"
 	// CodeAgentEnvVarNotFound indicates the requested environment variable does not exist.

--- a/services/api/internal/domain/agent/cursor.go
+++ b/services/api/internal/domain/agent/cursor.go
@@ -37,6 +37,38 @@ func DecodeConversationCursor(s string) (*ConversationCursor, error) {
 	return &c, nil
 }
 
+// ConversationEventCursor holds the stable ordering field for keyset-based
+// pagination over a single conversation's events, which are always ordered
+// by event_index ASC. event_index alone is enough to seek by — it is unique
+// and gapless per conversation — unlike the (CreatedAt, ID) tuple the other
+// cursors below need to break ties on a non-unique timestamp.
+type ConversationEventCursor struct {
+	EventIndex int `json:"idx"`
+}
+
+// EncodeConversationEventCursor builds an opaque base64 cursor from an event
+// on the boundary of a page (its first or last item, depending on which
+// direction the cursor will be used to page in).
+func EncodeConversationEventCursor(e *AgentConversationEvent) string {
+	cur := ConversationEventCursor{EventIndex: e.EventIndex}
+	b, _ := json.Marshal(cur)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// DecodeConversationEventCursor parses a cursor token produced by
+// EncodeConversationEventCursor.
+func DecodeConversationEventCursor(s string) (*ConversationEventCursor, error) {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decode cursor base64: %w", err)
+	}
+	var c ConversationEventCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("decode cursor json: %w", err)
+	}
+	return &c, nil
+}
+
 // ActivityFeedCursor holds the stable ordering fields for keyset-based
 // pagination over an agent's activity feed, which is always ordered by
 // created_at DESC, id DESC.

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -209,6 +209,9 @@ type AgentConversation struct {
 	ContainerID    *string
 	HostPort       *int
 	IterationCount int
+	// EventCount is the number of persisted events. Only loaded when a single
+	// conversation is read; nil elsewhere.
+	EventCount *int
 	ErrorMessage   *string
 	RepoPluginID   *uuid.UUID
 	RepoCloneURL   *string

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -209,9 +209,6 @@ type AgentConversation struct {
 	ContainerID    *string
 	HostPort       *int
 	IterationCount int
-	// EventCount is the number of persisted events. Only loaded when a single
-	// conversation is read; nil elsewhere.
-	EventCount *int
 	ErrorMessage   *string
 	RepoPluginID   *uuid.UUID
 	RepoCloneURL   *string

--- a/services/api/internal/domain/agent/errors.go
+++ b/services/api/internal/domain/agent/errors.go
@@ -62,6 +62,9 @@ var (
 	// ErrConversationInvalidCursor is returned when a client-supplied
 	// pagination cursor fails to decode.
 	ErrConversationInvalidCursor = errors.New("invalid pagination cursor")
+	// ErrConversationEventInvalidCursor is returned when a client-supplied
+	// conversation-events window cursor (after/before) fails to decode.
+	ErrConversationEventInvalidCursor = errors.New("invalid pagination cursor")
 )
 
 // Chat session errors

--- a/services/api/internal/domain/agent/repository.go
+++ b/services/api/internal/domain/agent/repository.go
@@ -125,7 +125,10 @@ type ConversationRepository interface {
 	// another caller already moved the conversation out of fromStatus).
 	ClaimConversationStatus(ctx context.Context, id uuid.UUID, fromStatus, toStatus string) (bool, error)
 	UpdateConversation(ctx context.Context, c *AgentConversation) error
-	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*AgentConversationEvent, int64, error)
+	// ListConversationEvents returns one page of a conversation's events per
+	// window (see ConversationEventWindow), plus the conversation's current
+	// total event count.
+	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window ConversationEventWindow) ([]*AgentConversationEvent, int64, error)
 	CreateConversationEvent(ctx context.Context, e *AgentConversationEvent) error
 }
 
@@ -177,4 +180,23 @@ type ListConversationsFilter struct {
 	// 000028) contains this text.
 	Search      *string
 	CursorAfter *string // opaque base64 cursor; when set, resumes after this conversation
+}
+
+// ConversationEventWindow selects one keyset-paginated page of a single
+// conversation's events (always returned ascending by event_index). At most
+// one of After/Before is set:
+//   - Neither set: the newest Limit events — opens a conversation on its
+//     tail without needing to know its length upfront.
+//   - After set: events with event_index > After's, ascending — pages
+//     forward, e.g. catching up to events realtime has reported.
+//   - Before set: the Limit events immediately preceding Before's
+//     event_index — pages backward into older history.
+//
+// After/Before carry opaque cursors produced by EncodeConversationEventCursor
+// (mirroring ListConversationsFilter.CursorAfter above); the repository
+// decodes them.
+type ConversationEventWindow struct {
+	After  *string
+	Before *string
+	Limit  int
 }

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -94,7 +94,7 @@ type EnvVarService interface {
 type ConversationService interface {
 	ListConversations(ctx context.Context, in ListConversationsFilter, limit int) (convs []*AgentConversation, hasMore bool, err error)
 	GetConversation(ctx context.Context, projectID, conversationID uuid.UUID) (*AgentConversation, error)
-	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*AgentConversationEvent, int64, error)
+	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window ConversationEventWindow) ([]*AgentConversationEvent, int64, error)
 	// StopConversation interrupts (if running) and permanently tears down the
 	// conversation's sandbox. Unchanged from before.
 	StopConversation(ctx context.Context, projectID, conversationID uuid.UUID) error

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -98,7 +99,6 @@ type agentConversationRecord struct {
 	ContainerID         *string    `db:"container_id"`
 	HostPort            *int       `db:"host_port"`
 	IterationCount      int64      `db:"iteration_count"`
-	EventCount          *int64     `db:"event_count"`
 	ErrorMessage        *string    `db:"error_message"`
 	RepoPluginID        *string    `db:"repo_plugin_id"`
 	RepoCloneURL        *string    `db:"repo_clone_url"`
@@ -932,10 +932,7 @@ func (r *AgentRepository) ListConversations(ctx context.Context, in agentdom.Lis
 // FindConversationByID returns a single conversation by its primary key.
 func (r *AgentRepository) FindConversationByID(ctx context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
 	var rec agentConversationRecord
-	const query = `SELECT ` + conversationCols + `,
-		(SELECT COUNT(*) FROM agent_conversation_events e
-		 WHERE e.conversation_id = agent_conversations.id) AS event_count
-		FROM agent_conversations WHERE id = $1`
+	const query = `SELECT ` + conversationCols + ` FROM agent_conversations WHERE id = $1`
 	if err := r.db.GetContext(ctx, &rec, query, id.String()); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, agentdom.ErrConversationNotFound
@@ -1021,21 +1018,71 @@ func (r *AgentRepository) UpdateConversation(ctx context.Context, c *agentdom.Ag
 	return err
 }
 
-// ListConversationEvents returns a paginated list of events for a conversation.
-func (r *AgentRepository) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+// ListConversationEvents returns one keyset-paginated page of a
+// conversation's events (see agentdom.ConversationEventWindow), always
+// ascending by event_index, plus the conversation's current total event
+// count.
+//
+// Unlike ListConversations above, this needs no separate "fetch one extra
+// row" probe for hasMore-toward-the-start: event_index is gapless and
+// 0-based within a conversation, so the caller
+// (writeConversationEventWindowResponse) gets that for free from
+// first.EventIndex > 0. There is no equivalent probe toward the tail —
+// this is a live stream, so "nothing newer" can never be more than true as
+// of this query — see that function's doc comment for how it handles the
+// asymmetry.
+func (r *AgentRepository) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 	var total int64
 	if err := r.db.GetContext(ctx, &total, `SELECT COUNT(*) FROM agent_conversation_events WHERE conversation_id = $1`, conversationID.String()); err != nil {
 		return nil, 0, err
 	}
 
-	var recs []agentConversationEventRecord
-	if err := r.db.SelectContext(ctx, &recs, `
-		SELECT id, conversation_id, event_index, event_type, event_source, payload, created_at
-		FROM agent_conversation_events
-		WHERE conversation_id = $1
-		ORDER BY event_index ASC
-		OFFSET $2 LIMIT $3`, conversationID.String(), offset, limit); err != nil {
+	var (
+		recs  []agentConversationEventRecord
+		query string
+		args  []any
+	)
+	switch {
+	case window.After != nil:
+		cur, err := agentdom.DecodeConversationEventCursor(*window.After)
+		if err != nil {
+			return nil, 0, fmt.Errorf("%w: %s", agentdom.ErrConversationEventInvalidCursor, err)
+		}
+		query = `
+			SELECT id, conversation_id, event_index, event_type, event_source, payload, created_at
+			FROM agent_conversation_events
+			WHERE conversation_id = $1 AND event_index > $2
+			ORDER BY event_index ASC LIMIT $3`
+		args = []any{conversationID.String(), cur.EventIndex, window.Limit}
+	case window.Before != nil:
+		cur, err := agentdom.DecodeConversationEventCursor(*window.Before)
+		if err != nil {
+			return nil, 0, fmt.Errorf("%w: %s", agentdom.ErrConversationEventInvalidCursor, err)
+		}
+		// Newest-first so LIMIT keeps the events immediately preceding the
+		// cursor rather than the oldest ones in the conversation; reversed
+		// below to the ascending order every caller expects.
+		query = `
+			SELECT id, conversation_id, event_index, event_type, event_source, payload, created_at
+			FROM agent_conversation_events
+			WHERE conversation_id = $1 AND event_index < $2
+			ORDER BY event_index DESC LIMIT $3`
+		args = []any{conversationID.String(), cur.EventIndex, window.Limit}
+	default:
+		// Neither bound: the newest page, so a conversation can be opened on
+		// its tail without a separate round trip to learn its length first.
+		query = `
+			SELECT id, conversation_id, event_index, event_type, event_source, payload, created_at
+			FROM agent_conversation_events
+			WHERE conversation_id = $1
+			ORDER BY event_index DESC LIMIT $2`
+		args = []any{conversationID.String(), window.Limit}
+	}
+	if err := r.db.SelectContext(ctx, &recs, query, args...); err != nil {
 		return nil, 0, err
+	}
+	if window.After == nil {
+		slices.Reverse(recs)
 	}
 
 	result := make([]*agentdom.AgentConversationEvent, 0, len(recs))
@@ -1358,16 +1405,6 @@ func envVarFromRecord(rec agentEnvVarRecord) *agentdom.AgentEnvironmentVariable 
 	}
 }
 
-// eventCountFromRecord narrows the scanned count, leaving it nil when the query
-// did not select one.
-func eventCountFromRecord(v *int64) *int {
-	if v == nil {
-		return nil
-	}
-	n := int(*v)
-	return &n
-}
-
 func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversation {
 	c := &agentdom.AgentConversation{
 		ID:             mustParseUUID(rec.ID),
@@ -1378,7 +1415,6 @@ func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversa
 		ContainerID:    rec.ContainerID,
 		HostPort:       rec.HostPort,
 		IterationCount: int(rec.IterationCount),
-		EventCount:     eventCountFromRecord(rec.EventCount),
 		ErrorMessage:   rec.ErrorMessage,
 		RepoCloneURL:   rec.RepoCloneURL,
 		BranchName:     rec.BranchName,

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -98,6 +98,7 @@ type agentConversationRecord struct {
 	ContainerID         *string    `db:"container_id"`
 	HostPort            *int       `db:"host_port"`
 	IterationCount      int64      `db:"iteration_count"`
+	EventCount          *int64     `db:"event_count"`
 	ErrorMessage        *string    `db:"error_message"`
 	RepoPluginID        *string    `db:"repo_plugin_id"`
 	RepoCloneURL        *string    `db:"repo_clone_url"`
@@ -931,7 +932,11 @@ func (r *AgentRepository) ListConversations(ctx context.Context, in agentdom.Lis
 // FindConversationByID returns a single conversation by its primary key.
 func (r *AgentRepository) FindConversationByID(ctx context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
 	var rec agentConversationRecord
-	if err := r.db.GetContext(ctx, &rec, `SELECT `+conversationCols+` FROM agent_conversations WHERE id = $1`, id.String()); err != nil {
+	const query = `SELECT ` + conversationCols + `,
+		(SELECT COUNT(*) FROM agent_conversation_events e
+		 WHERE e.conversation_id = agent_conversations.id) AS event_count
+		FROM agent_conversations WHERE id = $1`
+	if err := r.db.GetContext(ctx, &rec, query, id.String()); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, agentdom.ErrConversationNotFound
 		}
@@ -1353,6 +1358,16 @@ func envVarFromRecord(rec agentEnvVarRecord) *agentdom.AgentEnvironmentVariable 
 	}
 }
 
+// eventCountFromRecord narrows the scanned count, leaving it nil when the query
+// did not select one.
+func eventCountFromRecord(v *int64) *int {
+	if v == nil {
+		return nil
+	}
+	n := int(*v)
+	return &n
+}
+
 func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversation {
 	c := &agentdom.AgentConversation{
 		ID:             mustParseUUID(rec.ID),
@@ -1363,6 +1378,7 @@ func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversa
 		ContainerID:    rec.ContainerID,
 		HostPort:       rec.HostPort,
 		IterationCount: int(rec.IterationCount),
+		EventCount:     eventCountFromRecord(rec.EventCount),
 		ErrorMessage:   rec.ErrorMessage,
 		RepoCloneURL:   rec.RepoCloneURL,
 		BranchName:     rec.BranchName,

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -982,9 +982,10 @@ func (s *Service) GetConversation(ctx context.Context, projectID, conversationID
 	return c, nil
 }
 
-// ListConversationEvents returns a paginated list of events for a conversation.
-func (s *Service) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
-	return s.repo.ListConversationEvents(ctx, conversationID, offset, limit)
+// ListConversationEvents returns one keyset-paginated window of events for a
+// conversation (see agentdom.ConversationEventWindow), plus its total count.
+func (s *Service) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+	return s.repo.ListConversationEvents(ctx, conversationID, window)
 }
 
 // StopConversation stops a conversation that is not already finished.
@@ -1496,7 +1497,9 @@ func (s *Service) SendGlobalChatMessage(ctx context.Context, sessionID, actorUse
 	return conv, nil
 }
 
-// ListChatMessages returns conversation events for a chat session.
+// ListChatMessages returns conversation events for a chat session. Unreached
+// by any route (see agentdom.ChatSessionService) — kept only to satisfy the
+// interface until it grows a real caller.
 func (s *Service) ListChatMessages(ctx context.Context, sessionID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
 	// TODO: We'd need to aggregate events from all conversations in this session.
 	// For now, return events from the most recent conversation with this session_id.
@@ -1509,7 +1512,8 @@ func (s *Service) ListChatMessages(ctx context.Context, sessionID uuid.UUID, off
 	if len(convs) == 0 {
 		return []*agentdom.AgentConversationEvent{}, 0, nil
 	}
-	return s.repo.ListConversationEvents(ctx, convs[0].ID, offset, limit)
+	_ = offset // offset has no cursor equivalent; unreachable code, see doc comment above
+	return s.repo.ListConversationEvents(ctx, convs[0].ID, agentdom.ConversationEventWindow{Limit: limit})
 }
 
 // -------------------------------------------------------------------------

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -1512,7 +1512,12 @@ func (s *Service) ListChatMessages(ctx context.Context, sessionID uuid.UUID, off
 	if len(convs) == 0 {
 		return []*agentdom.AgentConversationEvent{}, 0, nil
 	}
-	_ = offset // offset has no cursor equivalent; unreachable code, see doc comment above
+	// offset has no cursor equivalent (see agentdom.ConversationEventWindow):
+	// fail loudly rather than silently ignoring it, in case this method ever
+	// grows a real caller that expects offset-based paging to work.
+	if offset != 0 {
+		return nil, 0, fmt.Errorf("ListChatMessages: non-zero offset %d is not supported by cursor-based ListConversationEvents", offset)
+	}
 	return s.repo.ListConversationEvents(ctx, convs[0].ID, agentdom.ConversationEventWindow{Limit: limit})
 }
 

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -58,7 +58,7 @@ type mockAgentRepo struct {
 	updateConversationStatus        func(ctx context.Context, id uuid.UUID, status string) error
 	claimConversationStatus         func(ctx context.Context, id uuid.UUID, fromStatus, toStatus string) (bool, error)
 	updateConversation              func(ctx context.Context, conv *agentdom.AgentConversation) error
-	listConversationEvents          func(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error)
+	listConversationEvents          func(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error)
 	createConversationEvent         func(ctx context.Context, event *agentdom.AgentConversationEvent) error
 	listChatSessions                func(ctx context.Context, agentID, memberID uuid.UUID) ([]*agentdom.AgentChatSession, error)
 	findChatSessionByID             func(ctx context.Context, id uuid.UUID) (*agentdom.AgentChatSession, error)
@@ -379,9 +379,9 @@ func (m *mockAgentRepo) UpdateConversation(ctx context.Context, conv *agentdom.A
 	return nil
 }
 
-func (m *mockAgentRepo) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+func (m *mockAgentRepo) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 	if m.listConversationEvents != nil {
-		return m.listConversationEvents(ctx, conversationID, offset, limit)
+		return m.listConversationEvents(ctx, conversationID, window)
 	}
 	return nil, 0, nil
 }

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -387,8 +387,6 @@ type AgentConversationResponse struct {
 	ActorUserID         *uuid.UUID `json:"actor_user_id,omitempty"`
 	Status              string     `json:"status"`
 	IterationCount      int        `json:"iteration_count"`
-	// Omitted on list responses, which do not load it.
-	EventCount          *int       `json:"event_count,omitempty"`
 	BranchName          *string    `json:"branch_name,omitempty"`
 	PRUrl               *string    `json:"pr_url,omitempty"`
 	StartedAt           *time.Time `json:"started_at,omitempty"`
@@ -426,7 +424,6 @@ func ConversationFromEntity(c *agentdom.AgentConversation) AgentConversationResp
 		ActorUserID:         c.ActorUserID,
 		Status:              c.Status,
 		IterationCount:      c.IterationCount,
-		EventCount:          c.EventCount,
 		BranchName:          c.BranchName,
 		PRUrl:               c.PRUrl,
 		StartedAt:           c.StartedAt,

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -387,6 +387,8 @@ type AgentConversationResponse struct {
 	ActorUserID         *uuid.UUID `json:"actor_user_id,omitempty"`
 	Status              string     `json:"status"`
 	IterationCount      int        `json:"iteration_count"`
+	// Omitted on list responses, which do not load it.
+	EventCount          *int       `json:"event_count,omitempty"`
 	BranchName          *string    `json:"branch_name,omitempty"`
 	PRUrl               *string    `json:"pr_url,omitempty"`
 	StartedAt           *time.Time `json:"started_at,omitempty"`
@@ -424,6 +426,7 @@ func ConversationFromEntity(c *agentdom.AgentConversation) AgentConversationResp
 		ActorUserID:         c.ActorUserID,
 		Status:              c.Status,
 		IterationCount:      c.IterationCount,
+		EventCount:          c.EventCount,
 		BranchName:          c.BranchName,
 		PRUrl:               c.PRUrl,
 		StartedAt:           c.StartedAt,

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -30,7 +30,7 @@ type mockAgentSvc struct {
 	createAgent                   func(ctx context.Context, projectID uuid.UUID, in agentdom.CreateAgentInput) (*agentdom.Agent, error)
 	startChatSession              func(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error)
 	listConversations             func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
-	listConversationEvents        func(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error)
+	listConversationEvents        func(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error)
 	listAgentActivities           func(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error)
 	getGlobalConversation         func(ctx context.Context, conversationID, actorUserID uuid.UUID) (*agentdom.AgentConversation, error)
 	listGlobalConversations       func(ctx context.Context, actorUserID uuid.UUID, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
@@ -118,9 +118,9 @@ func (m *mockAgentSvc) ListAgentActivities(ctx context.Context, filter agentdom.
 func (m *mockAgentSvc) GetConversation(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 	return nil, errors.New("not found")
 }
-func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 	if m.listConversationEvents != nil {
-		return m.listConversationEvents(ctx, conversationID, offset, limit)
+		return m.listConversationEvents(ctx, conversationID, window)
 	}
 	return nil, 0, nil
 }

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -227,6 +228,78 @@ func (h *ConversationHandler) GetConversation(w http.ResponseWriter, r *http.Req
 	presenter.OK(w, r, dto.ConversationFromEntity(conv))
 }
 
+// parseConversationEventWindowQuery parses the query params shared by
+// ListConversationEvents and GetGlobalConversationEvents:
+//   - after=<opaque cursor>   events after this point, ascending — pages
+//     forward/catches up to newly arrived events.
+//   - before=<opaque cursor>  the events immediately preceding this point —
+//     pages backward into older history.
+//   - limit=<1-200>           page size; defaults to 50.
+//
+// after and before are mutually exclusive; supplying both is a 400. Neither
+// supplied selects the newest `limit` events, so a conversation can be
+// opened on its tail without a separate round trip to learn its length.
+func parseConversationEventWindowQuery(r *http.Request) (agentdom.ConversationEventWindow, error) {
+	limit := 50
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			return agentdom.ConversationEventWindow{}, apierr.New(apierr.CodeBadRequest, "limit must be an integer between 1 and 200")
+		}
+		limit = n
+	}
+
+	window := agentdom.ConversationEventWindow{Limit: limit}
+	if raw := r.URL.Query().Get("after"); raw != "" {
+		window.After = &raw
+	}
+	if raw := r.URL.Query().Get("before"); raw != "" {
+		window.Before = &raw
+	}
+	if window.After != nil && window.Before != nil {
+		return agentdom.ConversationEventWindow{}, apierr.New(apierr.CodeBadRequest, "after and before are mutually exclusive")
+	}
+	return window, nil
+}
+
+// writeConversationEventWindowResponse encodes an events page in the
+// {items, total, next_cursor, prev_cursor} envelope shared by
+// ListConversationEvents and GetGlobalConversationEvents.
+//
+// prev_cursor and next_cursor are not symmetric. prev_cursor reports whether
+// older events genuinely remain — event_index is gapless and 0-based, so
+// first.EventIndex > 0 is a stable, permanent fact once true. next_cursor
+// cannot make the equivalent claim about newer events: this is a live
+// stream, so "nothing newer exists" is only ever true as of this query and
+// can be stale by the time the response is read. next_cursor is therefore
+// always present when the page is non-empty — a resume token for the
+// forward direction, not a promise that resuming will find something —
+// leaving the caller (useConversationEventWindow, weighing it against
+// realtime's tail signal) to decide whether using it is worthwhile.
+func writeConversationEventWindowResponse(w http.ResponseWriter, r *http.Request, events []*agentdom.AgentConversationEvent, total int64) {
+	resp := make([]dto.AgentConversationEventResponse, 0, len(events))
+	for _, e := range events {
+		resp = append(resp, dto.ConversationEventFromEntity(e))
+	}
+
+	var nextCursor, prevCursor *string
+	if len(events) > 0 {
+		first, last := events[0], events[len(events)-1]
+		if first.EventIndex > 0 {
+			s := agentdom.EncodeConversationEventCursor(first)
+			prevCursor = &s
+		}
+		s := agentdom.EncodeConversationEventCursor(last)
+		nextCursor = &s
+	}
+	presenter.OK(w, r, map[string]any{
+		"items":       resp,
+		"total":       total,
+		"next_cursor": nextCursor,
+		"prev_cursor": prevCursor,
+	})
+}
+
 // ListConversationEvents handles GET /projects/:projectId/conversations/:conversationId/events.
 func (h *ConversationHandler) ListConversationEvents(w http.ResponseWriter, r *http.Request) {
 	convID, err := parseParamUUID(r, "conversationId")
@@ -235,21 +308,17 @@ func (h *ConversationHandler) ListConversationEvents(w http.ResponseWriter, r *h
 		return
 	}
 
-	offset, limit, err := parseOffsetLimit(r)
+	window, err := parseConversationEventWindowQuery(r)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
-	events, total, err := h.svc.ListConversationEvents(r.Context(), convID, offset, limit)
+	events, total, err := h.svc.ListConversationEvents(r.Context(), convID, window)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
-	resp := make([]dto.AgentConversationEventResponse, 0, len(events))
-	for _, e := range events {
-		resp = append(resp, dto.ConversationEventFromEntity(e))
-	}
-	presenter.OK(w, r, map[string]any{"items": resp, "total": total})
+	writeConversationEventWindowResponse(w, r, events, total)
 }
 
 // StopConversation handles POST /projects/:projectId/conversations/:conversationId/stop.
@@ -384,21 +453,17 @@ func (h *ConversationHandler) GetGlobalConversationEvents(w http.ResponseWriter,
 		presenter.Error(w, r, err)
 		return
 	}
-	offset, limit, err := parseOffsetLimit(r)
+	window, err := parseConversationEventWindowQuery(r)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
-	events, total, err := h.svc.ListConversationEvents(r.Context(), convID, offset, limit)
+	events, total, err := h.svc.ListConversationEvents(r.Context(), convID, window)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
-	resp := make([]dto.AgentConversationEventResponse, 0, len(events))
-	for _, e := range events {
-		resp = append(resp, dto.ConversationEventFromEntity(e))
-	}
-	presenter.OK(w, r, map[string]any{"items": resp, "total": total})
+	writeConversationEventWindowResponse(w, r, events, total)
 }
 
 // StopGlobalConversation handles POST /agents/conversations/:conversationId/stop.

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -150,7 +150,7 @@ func TestListConversations_PageSizeInvalidRejected(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ListConversationEvents: offset/limit handling
+// ListConversationEvents: after/before/limit window handling
 // ---------------------------------------------------------------------------
 
 func doListConversationEvents(t *testing.T, svc agentdom.Service, projectID, conversationID, query string) *httptest.ResponseRecorder {
@@ -166,25 +166,38 @@ func doListConversationEvents(t *testing.T, svc agentdom.Service, projectID, con
 	return rec
 }
 
-func TestListConversationEvents_OffsetLimitValid(t *testing.T) {
+// listConversationEventsResp decodes the {items, total, next_cursor,
+// prev_cursor} envelope returned by both events endpoints.
+type listConversationEventsResp struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Items      []map[string]any `json:"items"`
+		Total      int64            `json:"total"`
+		NextCursor *string          `json:"next_cursor"`
+		PrevCursor *string          `json:"prev_cursor"`
+	} `json:"data"`
+	ErrorCode string `json:"error_code"`
+}
+
+func TestListConversationEvents_WindowValid(t *testing.T) {
 	cases := []struct {
-		name       string
-		query      string
-		wantOffset int
-		wantLimit  int
+		name      string
+		query     string
+		wantAfter *string
+		wantLimit int
 	}{
-		{"absent_defaults", "", 0, 50},
-		{"valid_custom_values_kept", "offset=10&limit=25", 10, 25},
-		{"limit_max_boundary_kept", "limit=200", 0, 200},
-		{"limit_min_boundary_kept", "limit=1", 0, 1},
-		{"offset_zero_kept", "offset=0", 0, 50},
+		{"absent_defaults", "", nil, 50},
+		{"custom_limit_kept", "limit=25", nil, 25},
+		{"limit_max_boundary_kept", "limit=200", nil, 200},
+		{"limit_min_boundary_kept", "limit=1", nil, 1},
+		{"after_cursor_forwarded", "after=some-opaque-cursor&limit=25", ptr("some-opaque-cursor"), 25},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotOffset, gotLimit int
+			var got agentdom.ConversationEventWindow
 			svc := &mockAgentSvc{
-				listConversationEvents: func(_ context.Context, _ uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
-					gotOffset, gotLimit = offset, limit
+				listConversationEvents: func(_ context.Context, _ uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+					got = window
 					return nil, 0, nil
 				},
 			}
@@ -192,24 +205,43 @@ func TestListConversationEvents_OffsetLimitValid(t *testing.T) {
 			if rec.Code != http.StatusOK {
 				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 			}
-			if gotOffset != tc.wantOffset || gotLimit != tc.wantLimit {
-				t.Errorf("expected service called with offset=%d limit=%d, got offset=%d limit=%d",
-					tc.wantOffset, tc.wantLimit, gotOffset, gotLimit)
+			if got.Limit != tc.wantLimit {
+				t.Errorf("expected limit=%d, got %d", tc.wantLimit, got.Limit)
+			}
+			if (got.After == nil) != (tc.wantAfter == nil) || (got.After != nil && *got.After != *tc.wantAfter) {
+				t.Errorf("expected After=%v, got %v", tc.wantAfter, got.After)
 			}
 		})
 	}
 }
 
-// TestListConversationEvents_OffsetLimitInvalidRejected covers the same
+func TestListConversationEvents_BeforeCursorForwarded(t *testing.T) {
+	var got agentdom.ConversationEventWindow
+	svc := &mockAgentSvc{
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			got = window
+			return nil, 0, nil
+		},
+	}
+	rec := doListConversationEvents(t, svc, uuid.New().String(), uuid.New().String(), "before=some-opaque-cursor")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got.Before == nil || *got.Before != "some-opaque-cursor" {
+		t.Errorf("expected Before=%q, got %v", "some-opaque-cursor", got.Before)
+	}
+	if got.After != nil {
+		t.Errorf("expected After nil, got %v", got.After)
+	}
+}
+
+// TestListConversationEvents_LimitInvalidRejected covers the same
 // silent-substitution fix as TestListConversations_PageSizeInvalidRejected,
-// applied to this endpoint's offset/limit pair: an explicitly supplied
-// out-of-range or non-numeric value now fails the request instead of quietly
-// running with a different limit than the caller asked for (which broke
-// offset math for callers advancing offset by their requested limit).
-func TestListConversationEvents_OffsetLimitInvalidRejected(t *testing.T) {
+// applied to this endpoint's limit param: an explicitly supplied
+// out-of-range or non-numeric value now fails the request instead of
+// quietly running with a different limit than the caller asked for.
+func TestListConversationEvents_LimitInvalidRejected(t *testing.T) {
 	cases := []string{
-		"offset=-1",
-		"offset=abc",
 		"limit=0",
 		"limit=-5",
 		"limit=201",
@@ -218,8 +250,8 @@ func TestListConversationEvents_OffsetLimitInvalidRejected(t *testing.T) {
 	for _, query := range cases {
 		t.Run(query, func(t *testing.T) {
 			svc := &mockAgentSvc{
-				listConversationEvents: func(_ context.Context, _ uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
-					t.Fatalf("service should not be called for invalid offset/limit, got offset=%d limit=%d", offset, limit)
+				listConversationEvents: func(_ context.Context, _ uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+					t.Fatalf("service should not be called for invalid limit, got window=%+v", window)
 					return nil, 0, nil
 				},
 			}
@@ -230,6 +262,112 @@ func TestListConversationEvents_OffsetLimitInvalidRejected(t *testing.T) {
 		})
 	}
 }
+
+// TestListConversationEvents_AfterAndBeforeMutuallyExclusiveRejected covers
+// the query-parsing guard against a caller supplying both bounds at once,
+// which would otherwise leave it ambiguous which direction to page in.
+func TestListConversationEvents_AfterAndBeforeMutuallyExclusiveRejected(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			t.Fatalf("service should not be called when after and before are both set, got window=%+v", window)
+			return nil, 0, nil
+		},
+	}
+	rec := doListConversationEvents(t, svc, uuid.New().String(), uuid.New().String(), "after=a&before=b")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListConversationEvents: next_cursor/prev_cursor response wiring
+// ---------------------------------------------------------------------------
+
+func eventAt(index int) *agentdom.AgentConversationEvent {
+	return &agentdom.AgentConversationEvent{ID: uuid.New(), EventIndex: index}
+}
+
+func TestListConversationEvents_PrevCursorAbsentAtStartOfStream(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			return []*agentdom.AgentConversationEvent{eventAt(0), eventAt(1)}, 2, nil
+		},
+	}
+	_, resp := doListConversationEventsDecoded(t, svc, "")
+	if resp.Data.PrevCursor != nil {
+		t.Errorf("expected nil prev_cursor when the first event is index 0, got %q", *resp.Data.PrevCursor)
+	}
+}
+
+func TestListConversationEvents_PrevCursorPresentMidStream(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			return []*agentdom.AgentConversationEvent{eventAt(50), eventAt(51)}, 100, nil
+		},
+	}
+	_, resp := doListConversationEventsDecoded(t, svc, "")
+	if resp.Data.PrevCursor == nil {
+		t.Fatal("expected non-nil prev_cursor when earlier events exist")
+	}
+	cur, err := agentdom.DecodeConversationEventCursor(*resp.Data.PrevCursor)
+	if err != nil {
+		t.Fatalf("decode prev_cursor: %v", err)
+	}
+	if cur.EventIndex != 50 {
+		t.Errorf("expected prev_cursor to encode the first event's index 50, got %d", cur.EventIndex)
+	}
+}
+
+// TestListConversationEvents_NextCursorAlwaysPresentWhenNonEmpty covers the
+// deliberate asymmetry with prev_cursor documented on
+// writeConversationEventWindowResponse: unlike prev_cursor, next_cursor
+// cannot definitively report "nothing more" on a live stream, so it is
+// always returned for a non-empty page — even when this page is, as far as
+// `total` is concerned, already the tail — leaving the decision of whether
+// resuming is worthwhile to the caller (which weighs it against realtime's
+// tail signal instead).
+func TestListConversationEvents_NextCursorAlwaysPresentWhenNonEmpty(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			return []*agentdom.AgentConversationEvent{eventAt(98), eventAt(99)}, 100, nil
+		},
+	}
+	_, resp := doListConversationEventsDecoded(t, svc, "")
+	if resp.Data.NextCursor == nil {
+		t.Fatal("expected non-nil next_cursor even when this page reaches the currently-known tail")
+	}
+	cur, err := agentdom.DecodeConversationEventCursor(*resp.Data.NextCursor)
+	if err != nil {
+		t.Fatalf("decode next_cursor: %v", err)
+	}
+	if cur.EventIndex != 99 {
+		t.Errorf("expected next_cursor to encode the last event's index 99, got %d", cur.EventIndex)
+	}
+}
+
+func TestListConversationEvents_BothCursorsAbsentForEmptyPage(t *testing.T) {
+	svc := &mockAgentSvc{
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			return nil, 0, nil
+		},
+	}
+	_, resp := doListConversationEventsDecoded(t, svc, "")
+	if resp.Data.NextCursor != nil || resp.Data.PrevCursor != nil {
+		t.Errorf("expected both cursors nil for an empty page, got next=%v prev=%v", resp.Data.NextCursor, resp.Data.PrevCursor)
+	}
+}
+
+func doListConversationEventsDecoded(t *testing.T, svc agentdom.Service, query string) (*httptest.ResponseRecorder, listConversationEventsResp) {
+	t.Helper()
+	rec := doListConversationEvents(t, svc, uuid.New().String(), uuid.New().String(), query)
+	var resp listConversationEventsResp
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response body %q: %v", rec.Body.String(), err)
+	}
+	return rec, resp
+}
+
+func ptr(s string) *string { return &s }
 
 // ---------------------------------------------------------------------------
 // Filter wiring
@@ -653,7 +791,7 @@ func TestGetGlobalConversationEvents_ReturnsEvents(t *testing.T) {
 			}
 			return &agentdom.AgentConversation{ID: convID, ActorUserID: &callerID}, nil
 		},
-		listConversationEvents: func(_ context.Context, id uuid.UUID, _, _ int) ([]*agentdom.AgentConversationEvent, int64, error) {
+		listConversationEvents: func(_ context.Context, id uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 			if id != convID {
 				t.Fatalf("unexpected conversation id %s", id)
 			}
@@ -691,7 +829,7 @@ func TestGetGlobalConversationEvents_UnknownConversationNotFound(t *testing.T) {
 		getGlobalConversation: func(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return nil, agentdom.ErrConversationNotFound
 		},
-		listConversationEvents: func(_ context.Context, _ uuid.UUID, _, _ int) ([]*agentdom.AgentConversationEvent, int64, error) {
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 			eventsCalled = true
 			return nil, 0, nil
 		},

--- a/services/api/internal/transport/http/handler/helpers.go
+++ b/services/api/internal/transport/http/handler/helpers.go
@@ -52,30 +52,6 @@ func parsePage(r *http.Request) (int, error) {
 	return n, nil
 }
 
-// parseOffsetLimit reads the offset and limit query parameters. Absent
-// params silently fall back to their defaults (0 and 50); only an explicitly
-// supplied, invalid value is rejected — for the same reason parsePageSize
-// rejects one: a caller advancing offset by the limit it requested (e.g.
-// offset += limit) would otherwise get a different limit back with no
-// signal, skipping or duplicating rows against its own math.
-func parseOffsetLimit(r *http.Request) (offset, limit int, err error) {
-	rawOffset := r.URL.Query().Get("offset")
-	if rawOffset == "" {
-		offset = 0
-	} else if offset, err = strconv.Atoi(rawOffset); err != nil || offset < 0 {
-		return 0, 0, apierr.New(apierr.CodeBadRequest, "offset must be a non-negative integer")
-	}
-
-	rawLimit := r.URL.Query().Get("limit")
-	if rawLimit == "" {
-		limit = 50
-	} else if limit, err = strconv.Atoi(rawLimit); err != nil || limit < 1 || limit > 200 {
-		return 0, 0, apierr.New(apierr.CodeBadRequest, "limit must be an integer between 1 and 200")
-	}
-
-	return offset, limit, nil
-}
-
 // splitCommaList splits a comma-separated query param into its trimmed,
 // non-empty parts (e.g. "running, paused" -> ["running", "paused"]).
 func splitCommaList(raw string) []string {

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -337,6 +337,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeAgentConversationInvalidCursor
 	case errors.Is(err, agentdom.ErrActivityFeedInvalidCursor):
 		return http.StatusBadRequest, apierr.CodeAgentActivityInvalidCursor
+	case errors.Is(err, agentdom.ErrConversationEventInvalidCursor):
+		return http.StatusBadRequest, apierr.CodeAgentConversationEventInvalidCursor
 	case errors.Is(err, agentdom.ErrChatSessionNotFound):
 		return http.StatusNotFound, apierr.CodeAgentChatSessionNotFound
 	case errors.Is(err, agentdom.ErrEnvVarNotFound):

--- a/services/api/test/e2e/conversation_pagination_test.go
+++ b/services/api/test/e2e/conversation_pagination_test.go
@@ -651,22 +651,65 @@ func TestE2EListConversationPagination_SearchFilter(t *testing.T) {
 	})
 }
 
+// listConversationEventsWindow issues GET .../conversations/:id/events with
+// the given query params and asserts a 200 response, returning the decoded
+// data map.
+func listConversationEventsWindow(t *testing.T, env *e2eEnv, client *http.Client, token, projID, convID string, q url.Values) map[string]any {
+	t.Helper()
+	reqURL := fmt.Sprintf("%s/api/v1/projects/%s/conversations/%s/events", env.base, projID, convID)
+	if len(q) > 0 {
+		reqURL += "?" + q.Encode()
+	}
+	req := mustRequest(env.ctx, t, http.MethodGet, reqURL, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := mustDo(t, client, req)
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+	var env2 envelope
+	decodeJSON(t, resp, &env2)
+	return assertDataMap(t, env2)
+}
+
+// prevCursorStr extracts the prev_cursor string from an events-window data
+// map. Returns "" when prev_cursor is absent or null.
+func prevCursorStr(data map[string]any) string {
+	if v, ok := data["prev_cursor"]; ok && v != nil {
+		s, _ := v.(string)
+		return s
+	}
+	return ""
+}
+
+// eventIndices extracts the "event_index" field from every item in an
+// events-window data map, in the order returned.
+func eventIndices(data map[string]any) []int {
+	items, _ := data["items"].([]any)
+	out := make([]int, 0, len(items))
+	for _, raw := range items {
+		item, _ := raw.(map[string]any)
+		idx, _ := item["event_index"].(float64)
+		out = append(out, int(idx))
+	}
+	return out
+}
+
 // ---------------------------------------------------------------------------
-// TestE2EListConversationEvents_OffsetLimitValidation
+// TestE2EListConversationEventsWindow_LimitValidation
 // Mirrors the page_size validation coverage above, applied to this sibling
-// endpoint's offset/limit pair: an explicitly supplied out-of-range or
-// non-numeric value must be rejected rather than silently substituted, for
-// the same reason (a caller advancing offset by its requested limit would
-// otherwise skip or duplicate rows against its own math with no signal).
-// The conversation ID need not exist — invalid offset/limit is rejected
-// before the service layer is ever reached.
+// endpoint's limit param, plus the after/before cursor params that replaced
+// offset — an explicitly supplied out-of-range or non-numeric limit, an
+// unparsable cursor, or after+before supplied together must all be rejected
+// rather than silently substituted or resolved ambiguously. The conversation
+// ID need not exist for the limit/mutual-exclusivity cases — both are
+// rejected before the service layer is ever reached — but the invalid-cursor
+// case needs one, since cursor decoding happens in the repository.
 // ---------------------------------------------------------------------------
 
-func TestE2EListConversationEvents_OffsetLimitValidation(t *testing.T) {
+func TestE2EListConversationEventsWindow_LimitValidation(t *testing.T) {
 	t.Parallel()
 	env := newE2EEnv(t)
-	client, token, projID, _, _ := seedConversationFixture(t, env)
-	convID := uuid.NewString()
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+	convID := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Now())
 
 	eventsURL := func(q url.Values) string {
 		u := fmt.Sprintf("%s/api/v1/projects/%s/conversations/%s/events", env.base, projID, convID)
@@ -676,7 +719,7 @@ func TestE2EListConversationEvents_OffsetLimitValidation(t *testing.T) {
 		return u
 	}
 
-	t.Run("absent_offset_and_limit_default", func(t *testing.T) {
+	t.Run("absent_params_default", func(t *testing.T) {
 		req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(nil), nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := mustDo(t, client, req)
@@ -684,15 +727,13 @@ func TestE2EListConversationEvents_OffsetLimitValidation(t *testing.T) {
 		assertStatus(t, resp, http.StatusOK)
 	})
 
-	invalidCases := []url.Values{
-		{"offset": {"-1"}},
-		{"offset": {"abc"}},
+	invalidLimitCases := []url.Values{
 		{"limit": {"0"}},
 		{"limit": {"-5"}},
 		{"limit": {"201"}},
 		{"limit": {"abc"}},
 	}
-	for _, q := range invalidCases {
+	for _, q := range invalidLimitCases {
 		t.Run(q.Encode(), func(t *testing.T) {
 			req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(q), nil)
 			req.Header.Set("Authorization", "Bearer "+token)
@@ -702,6 +743,168 @@ func TestE2EListConversationEvents_OffsetLimitValidation(t *testing.T) {
 			assertErrorCode(t, resp, "BAD_REQUEST")
 		})
 	}
+
+	t.Run("after_and_before_together_rejected", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(url.Values{
+			"after":  {"anything"},
+			"before": {"anything"},
+		}), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusBadRequest)
+		assertErrorCode(t, resp, "BAD_REQUEST")
+	})
+
+	t.Run("unparsable_after_cursor_rejected", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(url.Values{
+			"after": {"not-a-valid-base64-cursor!!"},
+		}), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusOK {
+			t.Errorf("expected a non-200 error response for an unparsable after cursor, got 200")
+		}
+		assertErrorCode(t, resp, "AGENT_CONVERSATION_EVENT_INVALID_CURSOR")
+	})
+
+	t.Run("unparsable_before_cursor_rejected", func(t *testing.T) {
+		req := mustRequest(env.ctx, t, http.MethodGet, eventsURL(url.Values{
+			"before": {"not-a-valid-base64-cursor!!"},
+		}), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusOK {
+			t.Errorf("expected a non-200 error response for an unparsable before cursor, got 200")
+		}
+		assertErrorCode(t, resp, "AGENT_CONVERSATION_EVENT_INVALID_CURSOR")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// TestE2EListConversationEventsWindow_CursorBased
+// Exercises the keyset SQL in AgentRepository.ListConversationEvents against
+// a real database — the handler-level unit tests drive it through a mocked
+// service, so this is the only coverage of the actual event_index >/< cursor
+// queries and the reverse-then-flip-to-ascending ordering they rely on.
+// ---------------------------------------------------------------------------
+
+func TestE2EListConversationEventsWindow_CursorBased(t *testing.T) {
+	t.Parallel()
+	env := newE2EEnv(t)
+	client, token, projID, agentID, memberID := seedConversationFixture(t, env)
+	convID := createConversationAt(t, env, projID, agentID, memberID, "finished", time.Now())
+
+	// event_index 0..4, five events total.
+	for i := 0; i < 5; i++ {
+		createConversationEvent(t, env, convID, i, "ActionEvent")
+	}
+
+	t.Run("no_cursor_opens_on_the_newest_page", func(t *testing.T) {
+		data := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{"limit": {"3"}})
+		if got := eventIndices(data); !slices.Equal(got, []int{2, 3, 4}) {
+			t.Errorf("expected newest 3 events [2 3 4] ascending, got %v", got)
+		}
+		if total, _ := data["total"].(float64); total != 5 {
+			t.Errorf("expected total=5, got %v", data["total"])
+		}
+		// Older events (0, 1) remain, so prev_cursor must be set.
+		if prevCursorStr(data) == "" {
+			t.Error("expected non-empty prev_cursor when older events remain")
+		}
+		// next_cursor is always present for a non-empty page — see
+		// writeConversationEventWindowResponse's doc comment for why it can't
+		// promise more exists the way prev_cursor can.
+		if nextCursorStr(data) == "" {
+			t.Error("expected non-empty next_cursor for a non-empty page")
+		}
+	})
+
+	t.Run("before_pages_older_events_in_without_duplicating_what_is_held", func(t *testing.T) {
+		first := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{"limit": {"3"}})
+		cursor := prevCursorStr(first)
+		if cursor == "" {
+			t.Fatal("expected non-empty prev_cursor from the newest page")
+		}
+
+		older := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{
+			"before": {cursor},
+			"limit":  {"3"},
+		})
+		if got := eventIndices(older); !slices.Equal(got, []int{0, 1}) {
+			t.Errorf("expected the 2 remaining older events [0 1] ascending, got %v", got)
+		}
+		// event_index 0 is the start of the stream.
+		if prevCursorStr(older) != "" {
+			t.Error("expected empty prev_cursor once event_index 0 is included")
+		}
+	})
+
+	t.Run("after_pages_forward_from_a_cursor", func(t *testing.T) {
+		// prev_cursor from the [2 3 4] page points at event_index 2; paging
+		// forward from there must land back on [3 4].
+		first := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{"limit": {"3"}})
+		cursor := prevCursorStr(first)
+
+		forward := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{
+			"after": {cursor},
+			"limit": {"3"},
+		})
+		if got := eventIndices(forward); !slices.Equal(got, []int{3, 4}) {
+			t.Errorf("expected events after index 2 to be [3 4], got %v", got)
+		}
+	})
+
+	t.Run("after_the_newest_event_returns_an_empty_page_with_no_cursors", func(t *testing.T) {
+		first := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{"limit": {"3"}})
+		cursor := nextCursorStr(first)
+		if cursor == "" {
+			t.Fatal("expected non-empty next_cursor from the newest page")
+		}
+
+		data := listConversationEventsWindow(t, env, client, token, projID, convID, url.Values{
+			"after": {cursor},
+			"limit": {"3"},
+		})
+		if got := eventIndices(data); len(got) != 0 {
+			t.Errorf("expected no events past the newest one, got %v", got)
+		}
+		if nextCursorStr(data) != "" || prevCursorStr(data) != "" {
+			t.Error("expected both cursors empty for an empty page")
+		}
+	})
+
+	t.Run("full_backward_traversal_returns_every_event_exactly_once", func(t *testing.T) {
+		seen := make(map[int]int)
+		cursor := ""
+		for {
+			q := url.Values{"limit": {"2"}}
+			if cursor != "" {
+				q.Set("before", cursor)
+			}
+			data := listConversationEventsWindow(t, env, client, token, projID, convID, q)
+			for _, idx := range eventIndices(data) {
+				seen[idx]++
+			}
+			// Always continues backward from prev_cursor — including from the
+			// first (tail-open) hop, where next_cursor is also present but
+			// points the wrong way for this traversal.
+			cursor = prevCursorStr(data)
+			if cursor == "" {
+				break
+			}
+		}
+		if len(seen) != 5 {
+			t.Errorf("expected 5 unique events after full backward traversal, got %d: %v", len(seen), seen)
+		}
+		for i := 0; i < 5; i++ {
+			if seen[i] != 1 {
+				t.Errorf("event_index %d was returned %d times (expected exactly once)", i, seen[i])
+			}
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Reworked per @pikann's review: the client-side loop is gone. The conversation view now reads its events with `useInfiniteQuery` — the primitive the conversation and activity lists already use — instead of assembling the whole stream up front.

## Why it matters

Measured on a live instance (249 conversations):

| | |
|---|---|
| Conversations past a single 200-event page | **51 (one in five)** |
| Largest stream | 3.4 MB stored / **~5 MB as JSON** |
| Median event | ~5.4 kB |
| Largest single event | **781 kB** (`raw_output` is 780 kB of it) |

`persist_conversation_event` publishes one realtime message **per event**, and the view re-read the stream on each one — a 622-event turn re-read it 622 times. Opening that conversation now costs one request (~1.1 MB) instead of four (~5 MB).

## Shape

- **Opening** fetches the newest page. `event_count` on the single-conversation read gives the tail offset with no extra round trip; without it the client asks for one row.
- **Live events** extend the window by exactly the pages it lacks. Scrolled away, the reader gets a count and a jump-to-latest affordance, and nothing is fetched.
- **Scrolling up** pages older events in and holds position.
- Both scopes: `ConversationView` serves the project and global routes, so the reader takes an optional `projectId`.

## Also in here: realtime stopped refetching the conversation itself per event

Both realtime hooks invalidated the whole `conversations` prefix for every message, so each event refetched the conversation list *and* the detail. From a live instance's API log:

```
busiest second:  list=12  detail=12  events=2
3-hour totals:   list=240 detail=254 events=52
```

A persisted event carries an `event_index` and changes only the event stream; the conversation's own fields change on the lifecycle messages, which arrive separately and still invalidate exactly as before. A payload without an `event_index` is treated as lifecycle, so an API predating the field keeps today's behaviour.

## Four things a reviewer should look at

**Keys sit outside `["projects", …]` and `["global-chat", …]`.** An invalidated infinite query refetches every page it holds — the cost this removes. The tail signal is also never fetched, so nothing can replace what was written into it. Two tests fail if either key moves back under a prefix.

**Paging a stream that is still growing.** `getNextPageParam` widens the end with the highest index realtime has reported, because a page's `total` is only as fresh as when it was fetched. The query stays disabled until at least one event exists, so a conversation empty at open begins fetching when realtime reports its first — and an empty page then unambiguously means end-of-stream.

**A page carries its own limit.** The last hop backwards is usually shorter than a full page; requesting a full one there refetched events already held, which showed up as duplicated messages at the start of a long conversation.

**`event_count` is a pointer, omitted from list responses.** Only the detail read loads it (both scopes share `FindConversationByID`), so list pages neither compute nor report it.

## Verification

- **69 unit tests.** The reader is driven against a growing stream **through the HTTP client**, so the query options are exercised rather than mocked over: newest-page open, paging back without duplication, paging to the start, realtime append, count-without-fetch while scrolled away, empty-at-open, a burst outrunning one page, the count probe, the global route. Plus two on which realtime messages invalidate what.
- `biome check` clean across 393 files; `tsc -b && vite build` green.
- `go build`, `go vet`, and the api handler + repository tests pass.

**Not covered by tests:** scroll behaviour — opening at the newest message, pinning while at the bottom, holding position on a prepend. It is reasoned from `ThreadPrimitive.Viewport`'s implementation and wants a look in a browser.

## Deliberately out of scope

- **`raw_output` truncation** — 40% of all payload bytes (63 MB of 157 MB) and the reason a page's size is unpredictable (usually ~1.1 MB, occasionally 10 MB). A bigger lever than paging, and a separate change.
- **The chat floats** still read a single page, exactly as today.
- **Virtualization**, and **downward paging** — unnecessary while the window is tail-anchored and nothing is evicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
