### PR TITLE
feat(acp-bridge): stream assistant text in position instead of one end-of-turn block

### DIFF
--- a/apps/acp-bridge/README.md
+++ b/apps/acp-bridge/README.md
@@ -86,3 +86,17 @@ where the agent actually ran.
 
 Keep this process running for as long as you want the agent to be reachable
 from Paca — it reconnects automatically on a dropped connection.
+
+### Assistant text arrives in position
+
+`ACPAgent` streams tool calls as they happen, but buffers the agent's own
+text for the entire turn and persists it only at the end, inside the
+`FinishAction` of the turn's closing event. On its own that means everything
+the agent *said* shows up after everything it *did*.
+
+The daemon subscribes to the conversation's token callbacks and forwards each
+run of buffered text as a `MessageEvent` just before whatever event came next,
+so narration is interleaved with the tool calls it describes. Because the
+`FinishAction` message is the join of those same chunks, it is blanked when it
+would be an exact duplicate — the text is still persisted, in the events it
+was split into.

--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -125,7 +125,18 @@ class _AssistantTextRelay:
             try:
                 text = self._mask(text)
             except Exception:
-                logger.debug("Secret masking failed for streamed text", exc_info=True)
+                # Fail closed. Emitting the unmasked text could persist a secret,
+                # which is the same reason the SDK treats a masking failure as
+                # fatal to the turn rather than shipping what it could not mask
+                # (``_raise_masking_error``). Dropping the segment also leaves
+                # ``_emitted`` short of the closing FinishAction message, so that
+                # message is kept and the text still reaches the conversation —
+                # masked by the SDK, at the end of the turn as it was before.
+                logger.warning(
+                    "Secret masking failed for streamed text; dropping this segment",
+                    exc_info=True,
+                )
+                return None
         if not text:
             return None
         self._emitted.append(text)
@@ -289,8 +300,8 @@ class ConversationRunner:
                 "Failed to report status for conversation %s", conversation_id, exc_info=True
             )
 
-    def _strip_duplicated_finish_message(self, payload: str, relay: _AssistantTextRelay) -> str:
-        """Blank a FinishAction message that was already streamed as text.
+    def _event_payload(self, event: Any, relay: _AssistantTextRelay | None) -> str:
+        """Serialize an event, dropping a FinishAction message already streamed.
 
         The SDK builds that message by joining every chunk of the turn, so once
         those chunks have gone out as ``MessageEvent``s it is a verbatim second
@@ -302,32 +313,34 @@ class ConversationRunner:
         Only an exact match is removed. If the two ever diverge — the SDK masks
         the join a second time, which can catch a secret split across two chunks
         — the message is left alone and shown as-is rather than discarded.
+
+        The message is cleared on a copy, and the payload is produced by
+        Pydantic's serializer exactly once. ``ActionEvent`` and ``FinishAction``
+        are both frozen, so it cannot be cleared in place — and the SDK keeps
+        this event in conversation history, so it must not be mutated anyway.
         """
-        try:
-            data = json.loads(payload)
-        except (TypeError, ValueError):
-            return payload
-        if not isinstance(data, dict) or data.get("tool_name") not in (None, "finish"):
-            return payload
-        action = data.get("action")
-        if not isinstance(action, dict):
-            return payload
-        message = action.get("message")
-        if not isinstance(message, str) or not relay.already_emitted(message):
-            return payload
-        action["message"] = ""
-        return json.dumps(data)
+        if not hasattr(event, "model_dump_json"):
+            return "{}"
+        if relay is not None and getattr(event, "tool_name", None) == "finish":
+            action = getattr(event, "action", None)
+            message = getattr(action, "message", None)
+            if isinstance(message, str) and relay.already_emitted(message):
+                event = event.model_copy(
+                    update={"action": action.model_copy(update={"message": ""})}
+                )
+        return event.model_dump_json()
 
     def _make_event_callback(self, conversation_id: str, project_id: str) -> Callable[[Any], None]:
         def callback(event: Any) -> None:
             event_type = type(event).__name__
             try:
-                payload = event.model_dump_json() if hasattr(event, "model_dump_json") else "{}"
                 relay = self._text_relays.get(conversation_id)
                 if relay is not None:
                     # Flush what the agent said since the previous event before
                     # forwarding this one, so its narration is ordered against
-                    # the tool calls it describes.
+                    # the tool calls it describes. This has to happen before the
+                    # payload is built: the flushed segment is what makes the
+                    # closing FinishAction message a duplicate.
                     streamed = relay.take_pending()
                     if streamed is not None:
                         self._dispatch_event(
@@ -337,12 +350,12 @@ class ConversationRunner:
                                 "project_id": project_id,
                                 "event_type": "MessageEvent",
                                 "event_source": "agent",
-                                "payload": json.dumps({"content": streamed}),
+                                "payload": json.dumps({"content": streamed}, ensure_ascii=False),
                             },
                             "MessageEvent",
                             conversation_id,
                         )
-                    payload = self._strip_duplicated_finish_message(payload, relay)
+                payload = self._event_payload(event, relay)
                 message = {
                     "type": "event",
                     "conversation_id": conversation_id,

--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -50,6 +51,89 @@ SendFn = Callable[[dict[str, Any]], Awaitable[None]]
 class _ConversationHandle:
     conversation: Conversation
     task: asyncio.Task[None]
+
+
+def _chunk_text(chunk: Any) -> str:
+    """Pull the text out of whatever a token callback was handed.
+
+    ``ACPAgent`` invokes the conversation's token callbacks with a plain ``str``
+    — the already-masked ``AgentMessageChunk`` text — while the SDK's own
+    ``TokenCallbackType`` alias describes a litellm ``ModelResponseStream``.
+    Handle both, so this keeps working whichever way that inconsistency is
+    eventually settled.
+    """
+    if isinstance(chunk, str):
+        return chunk
+    text = ""
+    for choice in getattr(chunk, "choices", None) or []:
+        content = getattr(getattr(choice, "delta", None), "content", None)
+        if isinstance(content, str):
+            text += content
+    return text
+
+
+class _AssistantTextRelay:
+    """Collects streamed assistant text so it can be emitted in position.
+
+    ``ACPAgent`` accumulates every ``AgentMessageChunk`` for the whole turn and
+    persists the joined result only at the end, as the ``FinishAction`` message
+    on the turn's closing ``ActionEvent``. Tool calls, by contrast, are emitted
+    as they happen. The result is that everything the agent *said* arrives in
+    one block after everything it *did*, with no way to tell which narration
+    belonged to which step.
+
+    This relay buffers the chunks and hands them back in segments. The runner
+    emits each segment as a ``MessageEvent`` immediately before the next event
+    it forwards, which puts the narration back between the tool calls it
+    describes.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[str] = []
+        self._emitted: list[str] = []
+        self._mask: Callable[[str], str] | None = None
+
+    def bind_masker(self, conversation: Any) -> None:
+        """Adopt the conversation's secret masker, if it exposes one.
+
+        The chunks arrive individually masked, but a secret split across two of
+        them only becomes matchable once they are joined — which is exactly why
+        the SDK re-masks at its own persistence boundary. Segments are a
+        persistence boundary too, so re-mask here for the same reason.
+        """
+        registry = getattr(getattr(conversation, "state", None), "secret_registry", None)
+        mask = getattr(registry, "mask_secrets_in_output", None)
+        if callable(mask):
+            self._mask = mask
+
+    def start_turn(self) -> None:
+        self._pending.clear()
+        self._emitted.clear()
+
+    def on_token(self, chunk: Any) -> None:
+        text = _chunk_text(chunk)
+        if text:
+            self._pending.append(text)
+
+    def take_pending(self) -> str | None:
+        """Return (and consume) the text streamed since the last call."""
+        if not self._pending:
+            return None
+        text = "".join(self._pending)
+        self._pending.clear()
+        if self._mask is not None:
+            try:
+                text = self._mask(text)
+            except Exception:
+                logger.debug("Secret masking failed for streamed text", exc_info=True)
+        if not text:
+            return None
+        self._emitted.append(text)
+        return text
+
+    def already_emitted(self, message: str) -> bool:
+        """True if `message` is exactly the text already sent as MessageEvents."""
+        return bool(self._emitted) and "".join(self._emitted) == message
 
 
 def resolve_acp_command(acp_provider: str | None, acp_command: list[str]) -> list[str]:
@@ -89,6 +173,7 @@ class ConversationRunner:
         # coroutines back onto it (e.g. mid-turn streaming events).
         self._loop: asyncio.AbstractEventLoop | None = None
         self._conversations: dict[str, _ConversationHandle] = {}
+        self._text_relays: dict[str, _AssistantTextRelay] = {}
 
     async def start_turn(self, data: dict[str, Any]) -> None:
         self._loop = asyncio.get_running_loop()
@@ -119,6 +204,9 @@ class ConversationRunner:
                 return
             # Resume — reply on the conversation object already running from
             # an earlier turn in this same chat session.
+            relay = self._text_relays.get(conversation_id)
+            if relay is not None:
+                relay.start_turn()
             existing.task = asyncio.create_task(
                 self._run_conversation(existing.conversation, conversation_id, project_id, message)
             )
@@ -132,11 +220,15 @@ class ConversationRunner:
             return
 
         agent = ACPAgent(acp_command=command)
+        relay = _AssistantTextRelay()
+        self._text_relays[conversation_id] = relay
         conversation = Conversation(
             agent=agent,
             workspace=self.workspace,
             callbacks=[self._make_event_callback(conversation_id, project_id)],
+            token_callbacks=[relay.on_token],
         )
+        relay.bind_masker(conversation)
         task = asyncio.create_task(
             self._run_conversation(conversation, conversation_id, project_id, message)
         )
@@ -197,11 +289,60 @@ class ConversationRunner:
                 "Failed to report status for conversation %s", conversation_id, exc_info=True
             )
 
+    def _strip_duplicated_finish_message(self, payload: str, relay: _AssistantTextRelay) -> str:
+        """Blank a FinishAction message that was already streamed as text.
+
+        The SDK builds that message by joining every chunk of the turn, so once
+        those chunks have gone out as ``MessageEvent``s it is a verbatim second
+        copy — the whole turn's narration repeated after the tool calls. Nothing
+        server-side reads it (it is rendered, not consumed), and the same text
+        is still persisted in the events it was split into, so dropping it loses
+        nothing.
+
+        Only an exact match is removed. If the two ever diverge — the SDK masks
+        the join a second time, which can catch a secret split across two chunks
+        — the message is left alone and shown as-is rather than discarded.
+        """
+        try:
+            data = json.loads(payload)
+        except (TypeError, ValueError):
+            return payload
+        if not isinstance(data, dict) or data.get("tool_name") not in (None, "finish"):
+            return payload
+        action = data.get("action")
+        if not isinstance(action, dict):
+            return payload
+        message = action.get("message")
+        if not isinstance(message, str) or not relay.already_emitted(message):
+            return payload
+        action["message"] = ""
+        return json.dumps(data)
+
     def _make_event_callback(self, conversation_id: str, project_id: str) -> Callable[[Any], None]:
         def callback(event: Any) -> None:
             event_type = type(event).__name__
             try:
                 payload = event.model_dump_json() if hasattr(event, "model_dump_json") else "{}"
+                relay = self._text_relays.get(conversation_id)
+                if relay is not None:
+                    # Flush what the agent said since the previous event before
+                    # forwarding this one, so its narration is ordered against
+                    # the tool calls it describes.
+                    streamed = relay.take_pending()
+                    if streamed is not None:
+                        self._dispatch_event(
+                            {
+                                "type": "event",
+                                "conversation_id": conversation_id,
+                                "project_id": project_id,
+                                "event_type": "MessageEvent",
+                                "event_source": "agent",
+                                "payload": json.dumps({"content": streamed}),
+                            },
+                            "MessageEvent",
+                            conversation_id,
+                        )
+                    payload = self._strip_duplicated_finish_message(payload, relay)
                 message = {
                     "type": "event",
                     "conversation_id": conversation_id,
@@ -210,48 +351,7 @@ class ConversationRunner:
                     "event_source": str(getattr(event, "source", "agent")),
                     "payload": payload,
                 }
-                try:
-                    called_from_our_loop = asyncio.get_running_loop() is self._loop
-                except RuntimeError:
-                    called_from_our_loop = False
-                if called_from_our_loop:
-                    # Most on_event calls now happen this way: arun() runs as
-                    # a task directly on this daemon's own loop, and things
-                    # like finalizing a turn or emitting InterruptEvent on
-                    # cancellation call back into this callback synchronously
-                    # from that same task. Blocking here with
-                    # run_coroutine_threadsafe(...).result() would deadlock —
-                    # the loop can't run the coroutine it just scheduled
-                    # while its own thread is stuck waiting on it (always
-                    # timing out after the full 10s). Just schedule it — but
-                    # still log if _send ends up failing, same as the
-                    # cross-thread branch below, rather than letting it
-                    # become a silent unretrieved-exception warning.
-                    def _log_send_failure(
-                        task: asyncio.Task[None],
-                        _event_type: str = event_type,
-                        _conversation_id: str = conversation_id,
-                    ) -> None:
-                        if task.cancelled():
-                            return
-                        exc = task.exception()
-                        if exc is not None:
-                            logger.warning(
-                                "Failed to report event %s for conversation %s",
-                                _event_type,
-                                _conversation_id,
-                                exc_info=exc,
-                            )
-
-                    asyncio.get_running_loop().create_task(self._send(message)).add_done_callback(
-                        _log_send_failure
-                    )
-                else:
-                    # Mid-turn ACP streaming updates fire from ACPAgent's own
-                    # background ("portal") thread, so this hop really is
-                    # cross-thread there, and safe to wait on.
-                    future = asyncio.run_coroutine_threadsafe(self._send(message), self._loop)
-                    future.result(timeout=10)
+                self._dispatch_event(message, event_type, conversation_id)
             except Exception:
                 logger.warning(
                     "Failed to report event %s for conversation %s",
@@ -261,6 +361,52 @@ class ConversationRunner:
                 )
 
         return callback
+
+    def _dispatch_event(
+        self, message: dict[str, Any], event_type: str, conversation_id: str
+    ) -> None:
+        try:
+            called_from_our_loop = asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            called_from_our_loop = False
+        if called_from_our_loop:
+            # Most on_event calls now happen this way: arun() runs as
+            # a task directly on this daemon's own loop, and things
+            # like finalizing a turn or emitting InterruptEvent on
+            # cancellation call back into this callback synchronously
+            # from that same task. Blocking here with
+            # run_coroutine_threadsafe(...).result() would deadlock —
+            # the loop can't run the coroutine it just scheduled
+            # while its own thread is stuck waiting on it (always
+            # timing out after the full 10s). Just schedule it — but
+            # still log if _send ends up failing, same as the
+            # cross-thread branch below, rather than letting it
+            # become a silent unretrieved-exception warning.
+            def _log_send_failure(
+                task: asyncio.Task[None],
+                _event_type: str = event_type,
+                _conversation_id: str = conversation_id,
+            ) -> None:
+                if task.cancelled():
+                    return
+                exc = task.exception()
+                if exc is not None:
+                    logger.warning(
+                        "Failed to report event %s for conversation %s",
+                        _event_type,
+                        _conversation_id,
+                        exc_info=exc,
+                    )
+
+            asyncio.get_running_loop().create_task(self._send(message)).add_done_callback(
+                _log_send_failure
+            )
+        else:
+            # Mid-turn ACP streaming updates fire from ACPAgent's own
+            # background ("portal") thread, so this hop really is
+            # cross-thread there, and safe to wait on.
+            future = asyncio.run_coroutine_threadsafe(self._send(message), self._loop)
+            future.result(timeout=10)
 
     async def _report_status(
         self, conversation_id: str, project_id: str, status: str, error_message: str | None = None

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -11,6 +11,7 @@ import logging
 import threading
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from paca_acp_bridge.runner import (
     ConversationRunner,
@@ -302,15 +303,32 @@ async def test_event_callback_logs_when_send_fails_on_loop(caplog):
     assert any("Failed to report event" in record.getMessage() for record in caplog.records)
 
 
-class _FakeFinishEvent:
+class _FakeFinishAction(BaseModel):
+    """Frozen like the SDK's FinishAction, so clearing the message in place is
+    impossible and the copy path is the one under test."""
+
+    model_config = ConfigDict(frozen=True)
+
+    message: str
+
+
+class _FakeFinishEvent(BaseModel):
     """Stands in for the ActionEvent that closes an ACP turn: a FinishAction
-    whose message is the whole turn's assistant text, joined by the SDK."""
+    whose message is the whole turn's assistant text, joined by the SDK.
 
-    def __init__(self, message: str) -> None:
-        self._message = message
+    A real (frozen) model rather than a hand-rolled stub, so the payload is
+    produced by Pydantic's serializer exactly as the SDK's own events are.
+    """
 
-    def model_dump_json(self):
-        return json.dumps({"tool_name": "finish", "action": {"message": self._message}})
+    model_config = ConfigDict(frozen=True)
+
+    action: _FakeFinishAction
+    tool_name: str = "finish"
+    reasoning_content: str | None = None
+    source: str = "agent"
+
+    def __init__(self, message: str, **kwargs) -> None:
+        super().__init__(action=_FakeFinishAction(message=message), **kwargs)
 
 
 async def _drain():
@@ -477,3 +495,83 @@ def test_start_turn_drops_state_from_the_previous_turn():
     assert relay.take_pending() is None
     # The previous turn's text must no longer suppress this turn's finish message.
     assert not relay.already_emitted("text from the previous turn")
+
+
+async def test_blanking_the_finish_message_leaves_the_rest_of_the_payload_byte_intact():
+    """The payload is serialized once, by Pydantic. Parsing it and re-encoding
+    with json.dumps would escape non-ASCII elsewhere in the event and re-space
+    the JSON; both models are frozen, so the message is cleared on a copy."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    event = _FakeFinishEvent("done ✅", reasoning_content="café ✅ déjà vu")
+    untouched = event.model_dump_json()
+
+    relay.on_token("done ✅")
+    callback(event)
+    await _drain()
+
+    payload = sent[-1]["payload"]
+    # Non-ASCII stays as written, exactly as Pydantic emits it.
+    assert "café ✅ déjà vu" in payload
+    assert "\\u00e9" not in payload
+    assert json.loads(payload)["action"]["message"] == ""
+    # The SDK keeps this event in conversation history — it must not be mutated.
+    assert event.action.message == "done ✅"
+    assert event.model_dump_json() == untouched
+
+
+async def test_a_masking_failure_drops_the_segment_and_keeps_the_finish_message():
+    """Fail closed: unmaskable text is never emitted. Dropping the segment also
+    leaves the FinishAction message un-blanked, so the text still reaches the
+    conversation at the end of the turn, masked by the SDK."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    class _Registry:
+        @staticmethod
+        def mask_secrets_in_output(_text):
+            raise RuntimeError("secret registry unavailable")
+
+    class _State:
+        secret_registry = _Registry()
+
+    class _Conversation:
+        state = _State()
+
+    runner, relay = _runner_with_relay(send)
+    relay.bind_masker(_Conversation())
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("text that could not be masked")
+    callback(_FakeFinishEvent("text that could not be masked"))
+    await _drain()
+
+    assert [m["event_type"] for m in sent] == ["_FakeFinishEvent"]
+    assert json.loads(sent[0]["payload"])["action"]["message"] == ("text that could not be masked")
+
+
+async def test_non_finish_events_are_never_rewritten():
+    """The guard is `tool_name == "finish"`; SDK ActionEvents always carry a
+    tool_name, so anything else must pass through untouched."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    event = _FakeFinishEvent("identical text", tool_name="str_replace_editor")
+    relay.on_token("identical text")
+    callback(event)
+    await _drain()
+
+    assert json.loads(sent[-1]["payload"])["action"]["message"] == "identical text"

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -6,12 +6,18 @@ than a real `openhands.sdk.Conversation`.
 """
 
 import asyncio
+import json
 import logging
 import threading
 
 import pytest
 
-from paca_acp_bridge.runner import ConversationRunner, resolve_acp_command
+from paca_acp_bridge.runner import (
+    ConversationRunner,
+    _AssistantTextRelay,
+    _chunk_text,
+    resolve_acp_command,
+)
 
 
 def test_resolve_builtin_provider_uses_sdk_default_command():
@@ -294,3 +300,180 @@ async def test_event_callback_logs_when_send_fails_on_loop(caplog):
         await asyncio.sleep(0)
 
     assert any("Failed to report event" in record.getMessage() for record in caplog.records)
+
+
+class _FakeFinishEvent:
+    """Stands in for the ActionEvent that closes an ACP turn: a FinishAction
+    whose message is the whole turn's assistant text, joined by the SDK."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def model_dump_json(self):
+        return json.dumps({"tool_name": "finish", "action": {"message": self._message}})
+
+
+async def _drain():
+    # The on-loop dispatch path schedules tasks rather than awaiting them.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+def _runner_with_relay(send):
+    runner = ConversationRunner(workspace="/tmp", send=send)
+    runner._loop = asyncio.get_running_loop()
+    relay = _AssistantTextRelay()
+    runner._text_relays["conv-1"] = relay
+    return runner, relay
+
+
+def test_chunk_text_accepts_a_plain_string_and_a_stream_chunk():
+    """ACPAgent calls token callbacks with a str; the SDK's TokenCallbackType
+    alias says litellm ModelResponseStream. Both have to work."""
+
+    class _Delta:
+        content = "from a stream chunk"
+
+    class _Choice:
+        delta = _Delta()
+
+    class _Chunk:
+        choices = [_Choice()]
+
+    assert _chunk_text("from a string") == "from a string"
+    assert _chunk_text(_Chunk()) == "from a stream chunk"
+    assert _chunk_text(object()) == ""
+
+
+async def test_streamed_text_is_emitted_before_the_event_that_follows_it():
+    """The whole point of the relay: narration reaches Paca positioned against
+    the tool call it describes, rather than in one lump at the end of the turn."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("Checking the failing test")
+    relay.on_token(" first.")
+    callback(_FakeEvent())
+    await _drain()
+
+    assert [m["event_type"] for m in sent] == ["MessageEvent", "_FakeEvent"]
+    assert sent[0]["event_source"] == "agent"
+    assert json.loads(sent[0]["payload"]) == {"content": "Checking the failing test first."}
+
+
+async def test_nothing_extra_is_emitted_when_no_text_was_streamed():
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, _relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    callback(_FakeEvent())
+    await _drain()
+
+    assert [m["event_type"] for m in sent] == ["_FakeEvent"]
+
+
+async def test_finish_message_is_blanked_once_its_text_has_been_streamed():
+    """The SDK builds the FinishAction message by joining the same chunks, so
+    forwarding it verbatim would repeat the whole turn's narration."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("First I read the file.")
+    callback(_FakeEvent())
+    relay.on_token(" Then I fixed it.")
+    callback(_FakeFinishEvent("First I read the file. Then I fixed it."))
+    await _drain()
+
+    assert [m["event_type"] for m in sent] == [
+        "MessageEvent",
+        "_FakeEvent",
+        "MessageEvent",
+        "_FakeFinishEvent",
+    ]
+    assert json.loads(sent[3]["payload"])["action"]["message"] == ""
+    # The text itself survives — split across the two MessageEvents.
+    streamed = "".join(json.loads(sent[i]["payload"])["content"] for i in (0, 2))
+    assert streamed == "First I read the file. Then I fixed it."
+
+
+async def test_finish_message_is_kept_when_it_differs_from_the_streamed_text():
+    """Only an exact duplicate is dropped. The SDK masks the joined text a
+    second time, which can catch a secret split across two chunks; if that
+    makes the two differ, the message must still be shown."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("streamed text")
+    callback(_FakeFinishEvent("a differently masked version"))
+    await _drain()
+
+    assert json.loads(sent[1]["payload"])["action"]["message"] == ("a differently masked version")
+
+
+async def test_segments_are_re_masked_before_they_are_emitted():
+    """Chunks arrive individually masked, so a secret spanning two of them is
+    only matchable once joined — the same reason the SDK re-masks at its own
+    persistence boundary."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    class _Registry:
+        @staticmethod
+        def mask_secrets_in_output(text):
+            return text.replace("sk-secret", "<masked>")
+
+    class _State:
+        secret_registry = _Registry()
+
+    class _Conversation:
+        state = _State()
+
+    runner, relay = _runner_with_relay(send)
+    relay.bind_masker(_Conversation())
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("token is sk-")
+    relay.on_token("secret now")
+    callback(_FakeEvent())
+    await _drain()
+
+    assert json.loads(sent[0]["payload"]) == {"content": "token is <masked> now"}
+
+
+def test_bind_masker_tolerates_a_conversation_without_a_registry():
+    relay = _AssistantTextRelay()
+    relay.bind_masker(object())
+    relay.on_token("unmasked but still forwarded")
+    assert relay.take_pending() == "unmasked but still forwarded"
+
+
+def test_start_turn_drops_state_from_the_previous_turn():
+    relay = _AssistantTextRelay()
+    relay.on_token("text from the previous turn")
+    assert relay.take_pending() is not None
+
+    relay.start_turn()
+    assert relay.take_pending() is None
+    # The previous turn's text must no longer suppress this turn's finish message.
+    assert not relay.already_emitted("text from the previous turn")


### PR DESCRIPTION
## Summary

All of an ACP agent's text arrives in one block at the end of the turn, after every tool call, instead of interleaved with the work it describes.

The cause is an asymmetry in `ACPAgent.session_update`. Tool calls are emitted as they happen:

```python
elif isinstance(update, ToolCallStart):
    ...
    self._emit_tool_call_event(entry)     # streamed live
```

Text is not — it is buffered and handed to a callback nothing had subscribed to:

```python
if isinstance(update, AgentMessageChunk):
    self.accumulated_text.append(text)    # buffered for the whole turn
    if self.on_token is not None:
        self.on_token(text)               # nobody was listening
```

It surfaces only at the end, in `_finalize_successful_turn`:

```python
response_text = mask("".join(self._client.accumulated_text))
finish_action = FinishAction(message=response_text)
```

So the whole turn's narration is concatenated — with no separators — into a single `FinishAction` message. On one conversation I traced, that was **13,253 characters** in one event at index 620, following 618 tool-call events. You cannot tell which sentence went with which step, and there is no partial output while the turn runs.

The SDK already supports this and the bridge simply never opted in: `Conversation` accepts `token_callbacks`, and `LocalConversation` forwards them to the agent on every step (`agent.step(self, on_event=..., on_token=self._on_token)`). This subscribes a relay, buffers the chunks, and flushes each run as a `MessageEvent` immediately before the next event the bridge forwards.

**No UI or server change is required.** The web transformer already renders agent-sourced `MessageEvent`s as inline text in event order, and bridge event ingestion passes `event_type` straight through.

## Type of Change

Other — behaviour change in how ACP conversation events are emitted. No API, schema, or UI change.

## Why blanking the duplicate finish message is safe

The `FinishAction` message is the join of the very chunks now sent as `MessageEvent`s, so relaying both shows the entire turn's text twice.

- Nothing server-side consumes that field — there is no `FinishAction`/`finish` reference anywhere in `services/`. It is rendered, not read.
- The transformer only pushes the message when it is truthy, so an empty one renders as nothing.
- The text is still persisted, in the events it was split into. Nothing is lost.
- Only an exact match is dropped. The SDK masks the joined text a second time, which can catch a secret split across two chunks; if that ever makes the two differ, the message is shown as-is rather than discarded.

If you would rather not touch that field at all, the alternative is suppressing it in `conversation-to-thread-messages.ts` when the turn already produced streamed text. I chose the bridge because it keeps the change in one app and avoids persisting the same text twice — happy to switch if you prefer the presentation-layer fix.

## Two things reviewers should know

**The token-callback argument type is inconsistent in the SDK.** `TokenCallbackType` is `Callable[[LLMStreamChunk], None]` (a litellm `ModelResponseStream`), but the ACP path calls `self.on_token(text)` with a plain `str`. `_chunk_text` handles both so this keeps working whichever way that is reconciled.

**Masking.** Chunks are masked individually, so a secret split across two of them only becomes matchable once joined — exactly why the SDK re-masks at its own persistence boundary. Segments are a persistence boundary too, so each is re-masked with the conversation's own `secret_registry` before emission. Residual gap: a secret split across a *segment* boundary (interrupted by a tool call) still would not match — the same class of limitation the SDK has across turns.

## Verification

8 tests added to `test_runner.py`, 31 pass total:

- text emitted as a `MessageEvent` before the following event, correctly ordered
- nothing extra emitted when no text was streamed
- duplicate finish message blanked, with the text verified intact across the segments
- a finish message that differs is preserved
- segments re-masked via the conversation registry, including a secret split across two chunks
- `bind_masker` tolerates a conversation without a registry
- per-turn reset clears both buffers
- `_chunk_text` accepts a `str`, a stream chunk, and neither

`ruff check src/` and `ruff format --check src/` clean.

## Checklist

- **The change is focused and scoped.** One concern: where ACP assistant text is emitted. The dispatch half of `_make_event_callback` moved into `_dispatch_event` so the synthetic and real events share one path, keeping the loop/thread handling identical — the two existing callback tests cover it unchanged.
- **Related documentation is updated.** New "Assistant text arrives in position" section in `apps/acp-bridge/README.md`.
- **New structure or direction is explained clearly.** Rationale is in the relay's docstrings and the commit message.
- **I avoided unnecessary detail or premature abstraction.** One small relay class holding the buffer, the masker, and the duplicate check; no new configuration or public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
