### PR TITLE
fix: ACP bridge finish-text dedup gaps + agents table column exhaustion

### DIFF
--- a/apps/acp-bridge/README.md
+++ b/apps/acp-bridge/README.md
@@ -96,7 +96,11 @@ the agent *said* shows up after everything it *did*.
 
 The daemon subscribes to the conversation's token callbacks and forwards each
 run of buffered text as a `MessageEvent` just before whatever event came next,
-so narration is interleaved with the tool calls it describes. Because the
-`FinishAction` message is the join of those same chunks, it is blanked when it
-would be an exact duplicate — the text is still persisted, in the events it
-was split into.
+so narration is interleaved with the tool calls it describes. The turn's
+closing `FinishAction`/`FinishObservation` pair is built from the join of
+those same chunks, so each is blanked when it would be a trailing duplicate
+of what already streamed — the text is still persisted, in the events it was
+split into. "Trailing", not just exact, because a turn retried in place after
+a transient ACP connection error resets the SDK's own accumulated text but
+not this daemon's buffer, so the surviving attempt's text is still an exact
+duplicate of the tail of what streamed, not necessarily the whole thing.

--- a/apps/acp-bridge/src/paca_acp_bridge/runner.py
+++ b/apps/acp-bridge/src/paca_acp_bridge/runner.py
@@ -126,12 +126,15 @@ class _AssistantTextRelay:
                 text = self._mask(text)
             except Exception:
                 # Fail closed. Emitting the unmasked text could persist a secret,
-                # which is the same reason the SDK treats a masking failure as
-                # fatal to the turn rather than shipping what it could not mask
-                # (``_raise_masking_error``). Dropping the segment also leaves
-                # ``_emitted`` short of the closing FinishAction message, so that
-                # message is kept and the text still reaches the conversation —
-                # masked by the SDK, at the end of the turn as it was before.
+                # so a masking failure here drops the segment rather than
+                # shipping what could not be masked — stricter than the SDK's
+                # own ``_mask_value``, which returns the text unmasked on
+                # failure (a deliberate crash-avoidance tradeoff there; nothing
+                # forces the same tradeoff on this new relay). Dropping the
+                # segment also leaves ``_emitted`` short of the closing
+                # FinishAction message, so that message is kept and the text
+                # still reaches the conversation — masked by the SDK, at the
+                # end of the turn as it was before.
                 logger.warning(
                     "Secret masking failed for streamed text; dropping this segment",
                     exc_info=True,
@@ -143,8 +146,24 @@ class _AssistantTextRelay:
         return text
 
     def already_emitted(self, message: str) -> bool:
-        """True if `message` is exactly the text already sent as MessageEvents."""
-        return bool(self._emitted) and "".join(self._emitted) == message
+        """True if `message` is a trailing duplicate of the text already sent
+        as MessageEvents.
+
+        Compared as a suffix, not full equality. ``ACPAgent.step()`` retries a
+        turn in place on a transient connection error: ``_reset_client_for_turn``
+        clears the SDK's own accumulated text for the new attempt, but it
+        re-wires the *same* ``on_token`` callback rather than telling this
+        relay a retry happened, so ``_emitted`` keeps growing across every
+        attempt while the SDK's final message reflects only the attempt that
+        actually succeeded. That message is still an exact duplicate of what
+        streamed — just of the tail, not the whole turn. Matching only full
+        equality would miss it after any retry and let the surviving attempt's
+        text show a second time; a trailing-duplicate check catches that case
+        too, and is exactly the pre-retry behavior when there was no retry.
+        """
+        if not message or not self._emitted:
+            return False
+        return "".join(self._emitted).endswith(message)
 
 
 def resolve_acp_command(acp_provider: str | None, acp_command: list[str]) -> list[str]:
@@ -301,34 +320,52 @@ class ConversationRunner:
             )
 
     def _event_payload(self, event: Any, relay: _AssistantTextRelay | None) -> str:
-        """Serialize an event, dropping a FinishAction message already streamed.
+        """Serialize an event, dropping finish text already streamed.
 
-        The SDK builds that message by joining every chunk of the turn, so once
-        those chunks have gone out as ``MessageEvent``s it is a verbatim second
-        copy — the whole turn's narration repeated after the tool calls. Nothing
-        server-side reads it (it is rendered, not consumed), and the same text
-        is still persisted in the events it was split into, so dropping it loses
-        nothing.
+        ``_finalize_successful_turn`` closes every turn with *two* events built
+        from the same joined text: the ``ActionEvent`` carrying the
+        ``FinishAction`` (``action.message``), and — immediately after, same
+        ``tool_name="finish"`` — an ``ObservationEvent`` carrying a
+        ``FinishObservation`` (``observation.text``, via ``content``). Once
+        those chunks have gone out as ``MessageEvent``s, *both* are a verbatim
+        second copy of the whole turn's narration; blanking only the action
+        half would still leave the observation half persisted server-side
+        (``services/ai-agent`` persists every event unconditionally), even
+        though nothing renders or reads it — it exists only because the SDK
+        pairs every action with an observation. Nothing is lost either way:
+        the same text is still persisted in the events it was split into.
 
-        Only an exact match is removed. If the two ever diverge — the SDK masks
-        the join a second time, which can catch a secret split across two chunks
-        — the message is left alone and shown as-is rather than discarded.
+        Only an exact (trailing) duplicate is removed — see
+        ``_AssistantTextRelay.already_emitted``. If the streamed and final text
+        ever diverge for a reason other than a retry — the SDK masks the join a
+        second time, which can catch a secret split across two chunks — the
+        text is left alone and shown as-is rather than discarded.
 
-        The message is cleared on a copy, and the payload is produced by
-        Pydantic's serializer exactly once. ``ActionEvent`` and ``FinishAction``
-        are both frozen, so it cannot be cleared in place — and the SDK keeps
-        this event in conversation history, so it must not be mutated anyway.
+        The text is cleared on a copy, and the payload is produced by
+        Pydantic's serializer exactly once. ``ActionEvent``/``FinishAction``
+        and ``ObservationEvent``/``FinishObservation`` are all frozen, so
+        neither can be cleared in place — and the SDK keeps this event in
+        conversation history, so it must not be mutated anyway.
         """
         if not hasattr(event, "model_dump_json"):
             return "{}"
         if relay is not None and getattr(event, "tool_name", None) == "finish":
-            action = getattr(event, "action", None)
-            message = getattr(action, "message", None)
-            if isinstance(message, str) and relay.already_emitted(message):
-                event = event.model_copy(
-                    update={"action": action.model_copy(update={"message": ""})}
-                )
+            event = self._blank_duplicate_finish_text(event, relay)
         return event.model_dump_json()
+
+    @staticmethod
+    def _blank_duplicate_finish_text(event: Any, relay: _AssistantTextRelay) -> Any:
+        action = getattr(event, "action", None)
+        message = getattr(action, "message", None)
+        if isinstance(message, str) and relay.already_emitted(message):
+            event = event.model_copy(update={"action": action.model_copy(update={"message": ""})})
+        observation = getattr(event, "observation", None)
+        text = getattr(observation, "text", None)
+        if isinstance(text, str) and relay.already_emitted(text):
+            event = event.model_copy(
+                update={"observation": observation.model_copy(update={"content": []})}
+            )
+        return event
 
     def _make_event_callback(self, conversation_id: str, project_id: str) -> Callable[[Any], None]:
         def callback(event: Any) -> None:

--- a/apps/acp-bridge/tests/test_runner.py
+++ b/apps/acp-bridge/tests/test_runner.py
@@ -331,6 +331,40 @@ class _FakeFinishEvent(BaseModel):
         super().__init__(action=_FakeFinishAction(message=message), **kwargs)
 
 
+class _FakeFinishObservation(BaseModel):
+    """Stands in for the SDK's FinishObservation: content is a list of
+    TextContent-like blocks, and `.text` joins them — same shape `Observation`
+    itself uses, so `_blank_duplicate_finish_text` can be exercised as written
+    (it reads `.text`, not `.content`, and clears via `.content` on a copy)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    content: list[dict[str, str]]
+
+    def __init__(self, text: str, **kwargs) -> None:
+        super().__init__(content=[{"type": "text", "text": text}], **kwargs)
+
+    @property
+    def text(self) -> str:
+        return "".join(item["text"] for item in self.content)
+
+
+class _FakeFinishObservationEvent(BaseModel):
+    """Stands in for the ObservationEvent that always follows a finish
+    ActionEvent — the SDK pairs every action with an observation, and for
+    "finish" both carry the identical joined text (FinishObservation.from_text
+    is built from the same `response_text` as the FinishAction message)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    observation: _FakeFinishObservation
+    tool_name: str = "finish"
+    source: str = "environment"
+
+    def __init__(self, text: str, **kwargs) -> None:
+        super().__init__(observation=_FakeFinishObservation(text), **kwargs)
+
+
 async def _drain():
     # The on-loop dispatch path schedules tasks rather than awaiting them.
     for _ in range(5):
@@ -575,3 +609,97 @@ async def test_non_finish_events_are_never_rewritten():
     await _drain()
 
     assert json.loads(sent[-1]["payload"])["action"]["message"] == "identical text"
+
+
+async def test_finish_observation_is_blanked_alongside_the_finish_action():
+    """The SDK closes every turn with *two* events built from the same text:
+    the ActionEvent (FinishAction.message) and, immediately after, an
+    ObservationEvent (FinishObservation.text) — `_finalize_successful_turn`
+    emits both, always. Blanking only the action half would still leave the
+    observation half persisting the same text a second time server-side
+    (every event is persisted unconditionally), even though nothing renders
+    it — the earlier version of this fix missed this second event entirely."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("First I read the file.")
+    callback(_FakeEvent())
+    relay.on_token(" Then I fixed it.")
+    callback(_FakeFinishEvent("First I read the file. Then I fixed it."))
+    callback(_FakeFinishObservationEvent("First I read the file. Then I fixed it."))
+    await _drain()
+
+    assert [m["event_type"] for m in sent] == [
+        "MessageEvent",
+        "_FakeEvent",
+        "MessageEvent",
+        "_FakeFinishEvent",
+        "_FakeFinishObservationEvent",
+    ]
+    assert json.loads(sent[3]["payload"])["action"]["message"] == ""
+    assert json.loads(sent[4]["payload"])["observation"]["content"] == []
+
+
+async def test_finish_observation_is_kept_when_it_differs_from_the_streamed_text():
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    relay.on_token("streamed text")
+    callback(_FakeFinishObservationEvent("a differently masked version"))
+    await _drain()
+
+    observation = json.loads(sent[-1]["payload"])["observation"]
+    assert observation["content"] == [{"type": "text", "text": "a differently masked version"}]
+
+
+async def test_finish_message_is_blanked_when_it_is_a_trailing_duplicate_after_a_retry():
+    """ACPAgent retries a turn in place on a transient connection error:
+    `_reset_client_for_turn` clears the SDK's own accumulated text for the
+    new attempt but re-wires the *same* on_token callback, so this relay's
+    `_emitted` keeps growing across every attempt while the SDK's eventual
+    FinishAction message reflects only the attempt that actually succeeded.
+    Without a trailing-duplicate check, that survivor message would fail the
+    (exact-match) dedup and be shown again in full — on top of whatever
+    already streamed from the failed attempt."""
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    runner, relay = _runner_with_relay(send)
+    callback = runner._make_event_callback("conv-1", "proj-1")
+
+    # Attempt 1 streams some narration, then the connection drops.
+    relay.on_token("Connecting to the server...")
+    callback(_FakeEvent())
+    # Attempt 2 (the retry) streams its own narration and succeeds; the SDK's
+    # FinishAction message is built only from this attempt's accumulated text.
+    relay.on_token("Retrying now. Done.")
+    callback(_FakeFinishEvent("Retrying now. Done."))
+    await _drain()
+
+    assert json.loads(sent[-1]["payload"])["action"]["message"] == ""
+
+
+async def test_already_emitted_does_not_match_an_unrelated_prefix():
+    """A trailing-duplicate check must still reject text that only shares a
+    prefix (or is unrelated) with what streamed — not every substring match
+    is a real duplicate."""
+    relay = _AssistantTextRelay()
+    relay.on_token("Checking the failing test first.")
+    relay.take_pending()
+
+    assert not relay.already_emitted("Checking the failing")
+    assert not relay.already_emitted("something else entirely")
+    assert relay.already_emitted("Checking the failing test first.")
+    assert relay.already_emitted("test first.")

--- a/services/api/migrations/000010_add_trigger_prompts_to_agents.sql
+++ b/services/api/migrations/000010_add_trigger_prompts_to_agents.sql
@@ -1,8 +1,22 @@
--- Add per-trigger system prompt columns to the agents table.
--- The executor appends the matching column to the base system_prompt at runtime
--- depending on how the agent was invoked (task assignment / comment / chat).
-
-ALTER TABLE agents
-    ADD COLUMN IF NOT EXISTS task_trigger_prompt        TEXT NOT NULL DEFAULT '',
-    ADD COLUMN IF NOT EXISTS doc_comment_trigger_prompt TEXT NOT NULL DEFAULT '',
-    ADD COLUMN IF NOT EXISTS chat_trigger_prompt        TEXT NOT NULL DEFAULT '';
+-- Originally added per-trigger system prompt columns to the agents table.
+-- Dropped again by 000019_drop_agent_trigger_prompts.sql, superseded by the
+-- ai-agent service's fixed trigger-context skills.
+--
+-- This file no longer runs the ADD COLUMN it originally did. This whole
+-- migrations directory is re-executed in full, in lexicographic order, on
+-- every application boot (see database.RunMigrationsFS — there is no
+-- schema_migrations tracking table), and 000019 always runs after this file
+-- in the same boot and drops these same columns again. Postgres never
+-- reclaims a dropped column's slot in pg_attribute (ALTER TABLE ... DROP
+-- COLUMN only marks it attisdropped; the attnum stays consumed until the
+-- table is rebuilt) — so every boot was creating three fresh columns here
+-- only to have 000019 immediately ghost them again, permanently burning
+-- three of the table's hard 1600-column ceiling per boot. After roughly 400
+-- boots this exhausted the limit and took down every subsequent boot with
+-- "ERROR: tables can have at most 1600 columns" the moment this file tried
+-- to add them once more.
+--
+-- Left as a no-op (rather than deleted) so the migration numbering and
+-- historical record stay intact; 000019's DROP COLUMN IF EXISTS remains and
+-- is still correct — it's just a permanent no-op now that these columns are
+-- never re-created.

--- a/services/api/migrations/000011_add_description_write_trigger.sql
+++ b/services/api/migrations/000011_add_description_write_trigger.sql
@@ -1,7 +1,10 @@
--- Add description_write trigger prompt column and extend trigger_type constraint.
-
-ALTER TABLE agents
-    ADD COLUMN IF NOT EXISTS description_write_trigger_prompt TEXT NOT NULL DEFAULT '';
+-- Originally also added agents.description_write_trigger_prompt; that ADD
+-- COLUMN is gone now (see 000010_add_trigger_prompts_to_agents.sql for why —
+-- 000019_drop_agent_trigger_prompts.sql always drops this same column again
+-- in the same boot, and Postgres never reclaims a dropped column's slot, so
+-- re-adding it here every boot was silently burning the agents table's
+-- 1600-column ceiling). The trigger_type constraint change below is still
+-- needed and unaffected.
 
 -- Extend the trigger_type check constraint to include 'description_write' and
 -- 'automation_message'.

--- a/services/api/migrations/000019_drop_agent_trigger_prompts.sql
+++ b/services/api/migrations/000019_drop_agent_trigger_prompts.sql
@@ -2,6 +2,13 @@
 -- Superseded by the ai-agent service's default skill set + fixed
 -- trigger-context skills (services/ai-agent/src/skills/, src/agent/trigger_skills.py) —
 -- action-specific behavior is no longer stored as free-text prompts per agent.
+--
+-- 000010/000011 no longer add these columns (they used to, every boot,
+-- immediately undone by this file — see 000010 for why that leaked ghost
+-- columns), so every clause below is now a permanent no-op. Left in place:
+-- it's still correct, and still the right fix for any database that reaches
+-- this file with the columns actually present (e.g. one restored from a
+-- backup taken before 000010/000011 were neutered).
 
 ALTER TABLE agents
     DROP COLUMN IF EXISTS task_trigger_prompt,


### PR DESCRIPTION
## Summary

Two unrelated fixes, bundled here because both surfaced while following up on the [#370](https://github.com/Paca-AI/paca/pull/370) review:

1. **`apps/acp-bridge`** — the assistant-text dedup added in #370 was incomplete and not retry-safe.
2. **`services/api/migrations`** — a live dev database hit Postgres's hard 1600-column-per-table limit on the `agents` table, caused by a migration pattern that silently leaked a "ghost" column on every single application boot.

## 1. ACP bridge: fix incomplete finish-text dedup

#370 streams assistant narration as it arrives and blanks the turn's closing `FinishAction.message` when it's an exact duplicate of what already streamed, to avoid showing/persisting the same text twice. Two gaps in that logic:

**a) Only half the duplicate was blanked.** The SDK's `_finalize_successful_turn` always closes a turn with *two* events built from the same joined text: the `ActionEvent` (`FinishAction.message`) and, immediately after, an `ObservationEvent` (`FinishObservation`, same text via `content`). The original fix only rewrote the `ActionEvent`. `services/ai-agent` persists every event unconditionally, so the `ObservationEvent` kept storing the full duplicate text server-side — nothing rendered it (the frontend already skips `ObservationEvent` for `tool_name == "finish"`), but the "avoid persisting the same text twice" goal wasn't actually met. `_event_payload` now blanks both via a shared `_blank_duplicate_finish_text` helper.

**b) The dedup check didn't survive an ACP-level retry.** `ACPAgent.step()` can retry a turn in place on a transient connection error. Its `_reset_client_for_turn()` clears the SDK's own accumulated text for the new attempt but re-wires the *same* `on_token` callback — so this bridge's relay buffer (`_AssistantTextRelay._emitted`) keeps growing across every attempt while the SDK's eventual `FinishAction` message reflects only the attempt that succeeded. The old exact-equality check would then fail to match, showing the surviving attempt's text a second time on top of whatever had already streamed from the failed attempt. `already_emitted()` now does a trailing-suffix match instead of full equality — provably correct here since retries run strictly sequentially, never interleaved, so the successful attempt's text is always the tail of everything the relay has seen.

Also corrected a code comment that cited a `_raise_masking_error` SDK function — it doesn't exist anywhere in the pinned `openhands-sdk`; the SDK's actual masking-failure behavior is the opposite (fails open, not closed).

**Verification:** 4 new tests (paired `ObservationEvent` blanking, observation left alone on mismatch, retry-suffix dedup, guard against false-positive substring matches). Full suite: 38 passed. `ruff check` / `ruff format --check` clean.

## 2. Migrations: stop leaking ghost columns on `agents`

`services/api/internal/platform/database.RunMigrationsFS` replays every `.sql` file in `services/api/migrations/` on every application boot — there's no `schema_migrations` tracking table, so idempotency is load-bearing for every file.

`000010_add_trigger_prompts_to_agents.sql` / `000011_add_description_write_trigger.sql` (`ALTER TABLE agents ADD COLUMN IF NOT EXISTS ...`) and `000019_drop_agent_trigger_prompts.sql` (`ALTER TABLE agents DROP COLUMN IF EXISTS ...`, unconditional) both ran on every boot, and 000019 always undid 000010/000011's adds in the same run. Postgres never reclaims a dropped column's slot in `pg_attribute` — `DROP COLUMN` only marks it `attisdropped`; the `attnum` stays consumed until the table is physically rebuilt. So every boot created 4 fresh columns only to have them immediately ghosted again, permanently burning 4 of `agents`'s hard 1600-column ceiling per boot:

```
2026/08/07 05:11:09 bootstrap: bootstrap: auto-migrate: migrations: exec "000010_add_trigger_prompts_to_agents.sql": ERROR: tables can have at most 1600 columns (SQLSTATE 54011)
```

Confirmed directly against the affected dev database: `agents` was at 1599/1600 attribute slots, of which only **25 were live columns** — 1574 were dropped ghosts. No other table in the database showed this pattern (checked all of them); `agents` was the only one where an add-migration and a drop-migration for the same columns both replay on every boot.

**Fix:** `000010`/`000011` no longer run their `ADD COLUMN` statements — since `000019` always undid them in the same boot anyway, the final schema is unchanged; this just stops the pointless churn. `000011`'s still-needed `CHECK` constraint extension is untouched, and `000019`'s drops are left in place (now a permanent no-op, but still correct for a database restored from a backup taken before this fix).

**Verification:** replayed the entire 32-file migration sequence against the actual affected `paca-dev-postgres-1` container, in order — completes with zero errors, and the ghost-column count on `agents` did not grow.

**Known follow-up, not done here:** `agents` is left at 1599/1600 slots (only 25 live) — exactly one more real column can ever be added to it before this recurs. Reclaiming the 1574 wasted slots requires physically rebuilding the table (new table, copied data, every FK that references `agents.id` re-pointed) — out of scope for this fix, which only stops the leak from getting worse.

## Type of Change

- Other — bug fix (no schema/API/UI change; migration file edits are no-ops against the final schema)

## Checklist

- The change is focused and scoped — two independent fixes, each self-contained to the files it touches.
- Related documentation is updated — `apps/acp-bridge/README.md`'s "Assistant text arrives in position" section now describes the trailing-duplicate/retry behavior.
- New structure or direction is explained clearly — rationale is in the code comments at each change site.
- I avoided unnecessary detail or premature abstraction.
