### PR TITLE
Cd/update cd workflow to use lowercase GitHub owner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -571,10 +571,14 @@ jobs:
           set -euo pipefail
           VERSION="${{ github.event.release.tag_name }}"
           TAG="${VERSION#v}"
+          # ghcr.io repository paths must be lowercase. github.repository_owner
+          # preserves the org's display casing (Paca-AI), which fails here, so
+          # hardcode the lowercase form instead of deriving it at runtime.
+          OWNER="paca-ai"
           for image in paca-api paca-realtime paca-web paca-ai-agent paca-agent-server; do
             docker buildx imagetools create \
-              -t "${{ env.REGISTRY }}/${{ toLower(github.repository_owner) }}/${image}:latest" \
-              "${{ env.REGISTRY }}/${{ toLower(github.repository_owner) }}/${image}:${TAG}"
+              -t "${{ env.REGISTRY }}/${OWNER}/${image}:latest" \
+              "${{ env.REGISTRY }}/${OWNER}/${image}:${TAG}"
             docker buildx imagetools create \
               -t "${{ secrets.DOCKERHUB_USERNAME }}/${image}:latest" \
               "${{ secrets.DOCKERHUB_USERNAME }}/${image}:${TAG}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,6 +109,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -164,6 +166,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -217,6 +221,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -267,6 +273,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -318,6 +326,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -574,8 +584,8 @@ jobs:
           TAG="${VERSION#v}"
           for image in paca-api paca-realtime paca-web paca-ai-agent paca-agent-server; do
             docker buildx imagetools create \
-              -t "${{ env.REGISTRY }}/${{ github.repository_owner }}/${image}:latest" \
-              "${{ env.REGISTRY }}/${{ github.repository_owner }}/${image}:${TAG}"
+              -t "${{ env.REGISTRY }}/${{ toLower(github.repository_owner) }}/${image}:latest" \
+              "${{ env.REGISTRY }}/${{ toLower(github.repository_owner) }}/${image}:${TAG}"
             docker buildx imagetools create \
               -t "${{ secrets.DOCKERHUB_USERNAME }}/${image}:latest" \
               "${{ secrets.DOCKERHUB_USERNAME }}/${image}:${TAG}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,14 +25,24 @@ name: cd
 #     Caddyfile          — Caddy gateway configuration
 #     .env.production.example — environment variable template
 #
-# "Latest" label sequencing (hold-release-label / promote-release below):
-# no image is pushed with a :latest Docker tag, and the GitHub release itself
-# is held off the "Latest" release marker, until every job in this workflow
-# has succeeded. This keeps /releases/latest and every :latest image tag
-# pointing at the previous, fully-shipped release for the whole ~20-30 minute
-# build window instead of a half-published one. install.sh/upgrade.sh are
-# also stamped with this exact release's tag as their default target, so a
-# plain `bash install.sh` never depends on the :latest tag being current.
+# "Latest" tag sequencing (promote-release, the last job below): no image is
+# pushed with a :latest Docker tag until every job in this workflow has
+# succeeded, so :latest keeps pointing at the previous, fully-shipped release
+# for the whole ~20-30 minute build window instead of a half-published one.
+# install.sh/upgrade.sh are also stamped with this exact release's tag as
+# their default target, so a plain `bash install.sh` never depends on the
+# :latest tag being current.
+#
+# The GitHub release page itself is NOT held back the same way: GitHub marks
+# a release "Latest" (and /releases/latest resolves to it) the instant it's
+# published, before this workflow even starts, and there is no reliable way
+# to make that not so (see git history of this file for why the previous
+# hold-release-label job that tried was removed — `--latest=false` on the
+# just-published release doesn't actually demote it). So for the whole build
+# window, the release page can say "Latest" while its Docker images are still
+# on the old :latest tag and /releases/latest/download/* still 404s. Keep
+# that in mind when publishing: the release isn't actually ready just because
+# GitHub calls it "Latest".
 
 on:
   release:
@@ -47,30 +57,6 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # ─────────────────────────────────────────────────────────────────────────────
-  # Hold the "Latest" release label until every artefact has actually shipped
-  # ─────────────────────────────────────────────────────────────────────────────
-  # GitHub marks a newly published release "Latest" (and /releases/latest
-  # resolves to it) immediately on publish by default. This workflow takes
-  # 20-30 minutes, so during that window /releases/latest/download/* would
-  # 404 (release-assets hasn't run yet) and any :latest Docker pull would
-  # still be fine (see below) but the release page itself would look "live"
-  # before it is. Demote it back to no label here — promote-release (the
-  # last job in this file) re-marks it "Latest" only once everything below
-  # has succeeded.
-  hold-release-label:
-    name: Hold "Latest" label until release is complete
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Unmark this release as "Latest"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        run: gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --latest=false
-
   # ─────────────────────────────────────────────────────────────────────────────
   # API service image
   # ─────────────────────────────────────────────────────────────────────────────
@@ -469,9 +455,10 @@ jobs:
   #
   # Waits for every image/package job so these assets — and the exact version
   # they're stamped with below — are never uploaded for a release that isn't
-  # fully shippable. If any of those jobs fail, this job is skipped and the
-  # previous release (still the "Latest" one; see hold-release-label /
-  # promote-release) keeps serving installs/upgrades until it's fixed.
+  # fully shippable. If any of those jobs fail, this job is skipped, so
+  # /releases/latest/download/* keeps 404ing on this release's assets even
+  # though GitHub already labeled it "Latest" at publish time (see the note
+  # at the top of this file) until the underlying issue is fixed.
   # ─────────────────────────────────────────────────────────────────────────────
   release-assets:
     name: Upload deployment assets to release
@@ -535,10 +522,13 @@ jobs:
   # target. Two things happen together here, deliberately in the same job:
   #   1. Every image gets a :latest tag pointing at this version's manifest,
   #      via `imagetools create` (a registry-side copy, no rebuild needed).
-  #   2. The GitHub release is marked "Latest" (undoing hold-release-label),
-  #      so /releases/latest/download/* starts serving this release's assets.
-  # Reversing the order (label first, tags second) would let /releases/latest
-  # briefly resolve to a release whose :latest images aren't there yet.
+  #   2. The GitHub release is (re-)marked "Latest". GitHub already marked it
+  #      "Latest" at publish time regardless (see the note at the top of this
+  #      file), so this step is a no-op on the happy path — it only matters
+  #      if this specific release ever needs re-promoting after a fix.
+  # Tags before label so /releases/latest never resolves to a release whose
+  # :latest images aren't there yet, for the (now purely cosmetic) window
+  # where this step hasn't run.
   # ─────────────────────────────────────────────────────────────────────────────
   promote-release:
     name: Promote release to "Latest"
@@ -546,7 +536,6 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     needs:
       [
-        hold-release-label,
         api-image,
         realtime-image,
         web-image,


### PR DESCRIPTION
## Summary

Fixes the `cd` workflow, broken since the v0.12.0 release run ([failing job](https://github.com/Paca-AI/paca/actions/runs/31298655363/job/93208468756)):

- **Lowercase the ghcr.io owner in `promote-release`'s retag step.** It built the image ref with `${{ github.repository_owner }}` (`Paca-AI`) via raw bash interpolation instead of going through `docker/metadata-action` (which auto-lowercases), so the retag failed with `invalid reference format: repository name (Paca-AI/paca-api) must be lowercase`. Wrapped both the source and target refs in `toLower()`.
- **Stop `docker/metadata-action` from auto-tagging `:latest` early.** It defaults to `flavor: latest=auto`, which tags `:latest` for any non-prerelease semver git tag — none of the five image jobs overrode this, so each one pushed `:latest` itself the moment it finished building, regardless of whether later jobs in the release succeeded. Confirmed on v0.12.0: `ghcr.io/paca-ai/paca-api:latest` and `:0.12.0` already shared the same digest ~7 minutes before `promote-release` even started. Added `flavor: latest=false` to all five jobs so `:latest` only moves in the (now-fixed) `promote-release` retag step, once everything has actually shipped.
- **Removed the `hold-release-label` job.** It called `gh release edit --latest=false` on the just-published release, intending to keep the GitHub release page pointed at the previous release until the whole pipeline finished. That doesn't work: `--latest=false` only means "don't force this one", it doesn't hand the label to anything else, and since this release is already the newest non-prerelease/non-draft release, GitHub's fallback resolution keeps `/releases/latest` pointing right back at it regardless. Confirmed on the live repo: `/releases/latest` already resolved to v0.12.0 even though `hold-release-label` ran and succeeded, and `promote-release`'s "Mark release as Latest" step never even executed. Rather than build the more involved fix (re-pinning the previous release as latest via an explicit override, then handing it back), we're accepting the tradeoff and documenting it in the workflow: the release page will say "Latest" the moment it's published, while Docker `:latest` and `/releases/latest/download/*` assets stay on the previous release until this workflow actually finishes.

## Test plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cd.yml'))"` — YAML validates
- [ ] Re-run the failed `promote-release` job on the [v0.12.0 release run](https://github.com/Paca-AI/paca/actions/runs/31298655363) once this merges, and confirm it now retags `:latest` successfully (this is idempotent — `docker buildx imagetools create` is a registry-side copy, no rebuild needed)
- [ ] Confirm no newer release has shipped in the meantime before re-running the old v0.12.0 job — the retag script doesn't do a version comparison, so re-running a stale run could move `:latest` backward
