### PR TITLE
fix: prevent self-mention in agent comment triggering to avoid infinite loops

### DIFF
--- a/services/api/internal/service/task/activity_service.go
+++ b/services/api/internal/service/task/activity_service.go
@@ -150,6 +150,12 @@ func (s *ActivitySvc) AddComment(ctx context.Context, in taskdom.AddCommentInput
 				if s.agentTrigger != nil {
 					agentMember, agentErr := s.memberRepo.FindMemberByAgent(ctx, in.ProjectID, mentionedID)
 					if agentErr == nil && agentMember.IsAgent() && agentMember.AgentID != nil {
+						// Skip self-mention: an agent mentioning itself (e.g. re-reading
+						// its own prior comment) must not retrigger its own conversation,
+						// or it can spiral into an unbounded comment loop.
+						if agentMember.ID == member.ID {
+							continue
+						}
 						conv, _ := s.agentTrigger.TriggerCommentMention(ctx, in.ProjectID, *agentMember.AgentID, in.TaskID, a.ID, member.ID, commentText)
 						if conv != nil {
 							content, _ := json.Marshal(map[string]any{

--- a/services/api/internal/service/task/activity_service_test.go
+++ b/services/api/internal/service/task/activity_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	agentdom "github.com/Paca-AI/api/internal/domain/agent"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	taskdom "github.com/Paca-AI/api/internal/domain/task"
 	userdom "github.com/Paca-AI/api/internal/domain/user"
@@ -89,7 +90,38 @@ func (r *fakeCommentMemberRepo) FindMemberByActor(_ context.Context, _ uuid.UUID
 }
 
 func (r *fakeCommentMemberRepo) FindMemberByAgent(_ context.Context, _ uuid.UUID, agentID uuid.UUID) (*projectdom.ProjectMember, error) {
-	return &projectdom.ProjectMember{ID: agentID, MemberType: "agent"}, nil
+	return &projectdom.ProjectMember{ID: agentID, MemberType: "agent", AgentID: &agentID}, nil
+}
+
+// fakeAgentTrigger records TriggerCommentMention invocations so tests can
+// assert whether an agent conversation was (or wasn't) started.
+type fakeAgentTrigger struct {
+	calls []uuid.UUID // agentID passed on each call
+}
+
+func (f *fakeAgentTrigger) TriggerCommentMention(_ context.Context, _, agentID, _, _, _ uuid.UUID, _ string) (*agentdom.AgentConversation, error) {
+	f.calls = append(f.calls, agentID)
+	return &agentdom.AgentConversation{ID: uuid.New()}, nil
+}
+
+// teamMentionContent builds BlockNote block content embedding a single
+// @-mention whose id is mentionedID, matching the shape ExtractTeamMentionsFromBlocks parses.
+func teamMentionContent(mentionedID uuid.UUID) json.RawMessage {
+	blocks := []map[string]any{
+		{
+			"content": []map[string]any{
+				{
+					"type": "teamMention",
+					"props": map[string]any{
+						"id":   mentionedID.String(),
+						"name": "bot",
+					},
+				},
+			},
+		},
+	}
+	b, _ := json.Marshal(blocks)
+	return b
 }
 
 func validCommentContent() json.RawMessage {
@@ -164,6 +196,63 @@ func TestActivitySvc_AddComment_ResolvedMember_Succeeds(t *testing.T) {
 	}
 	if a.ActorID == nil || *a.ActorID != memberID {
 		t.Errorf("expected comment actor_id %s, got %v", memberID, a.ActorID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AddComment: agent self-mention guard
+// ---------------------------------------------------------------------------
+
+// TestActivitySvc_AddComment_AgentSelfMention_DoesNotRetrigger pins the guard
+// that prevents the #354 production incident: an agent re-reading its own
+// prior comment and treating an embedded @mention of itself as a fresh
+// instruction, spawning a new conversation for itself with no cooldown
+// anywhere in the trigger path to break the resulting loop.
+func TestActivitySvc_AddComment_AgentSelfMention_DoesNotRetrigger(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	agentMemberID := uuid.New() // same agent posts the comment and is mentioned in it
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	trigger := &fakeAgentTrigger{}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil).WithAgentTrigger(trigger)
+
+	_, err := svc.AddComment(context.Background(), taskdom.AddCommentInput{
+		TaskID:    uuid.New(),
+		ProjectID: uuid.New(),
+		ActorID:   uuid.New(),
+		AgentID:   &agentMemberID,
+		Content:   teamMentionContent(agentMemberID),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trigger.calls) != 0 {
+		t.Errorf("agent mentioning itself should not retrigger a conversation, got %d call(s): %v", len(trigger.calls), trigger.calls)
+	}
+}
+
+// TestActivitySvc_AddComment_MentioningDifferentAgent_Triggers is the
+// positive control for the self-mention guard above: a mention of a
+// different agent must still start a conversation as before.
+func TestActivitySvc_AddComment_MentioningDifferentAgent_Triggers(t *testing.T) {
+	repo := newFakeCommentActivityRepo()
+	posterAgentID := uuid.New()
+	mentionedAgentID := uuid.New()
+	memberRepo := &fakeCommentMemberRepo{membersByUser: map[uuid.UUID]*projectdom.ProjectMember{}}
+	trigger := &fakeAgentTrigger{}
+	svc := tasksvc.NewActivityService(repo, memberRepo, nil).WithAgentTrigger(trigger)
+
+	_, err := svc.AddComment(context.Background(), taskdom.AddCommentInput{
+		TaskID:    uuid.New(),
+		ProjectID: uuid.New(),
+		ActorID:   uuid.New(),
+		AgentID:   &posterAgentID,
+		Content:   teamMentionContent(mentionedAgentID),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trigger.calls) != 1 || trigger.calls[0] != mentionedAgentID {
+		t.Errorf("expected exactly one trigger call for agent %s, got %v", mentionedAgentID, trigger.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ActivitySvc.AddComment` resolves an `@mention` to an agent and unconditionally calls `TriggerCommentMention` — there's no check that the mentioned agent isn't the same agent that just posted the comment. The parallel human-mention path (`notificationsvc.NotifyMentioned`) already skips self-mentions; the agent-trigger path didn't have the equivalent guard.
- If an agent's own comment ever resolves back to itself (e.g. it re-reads its own prior comment and treats an embedded `@mention` as a fresh instruction), this starts a new conversation for itself with no cooldown or dedup anywhere in the trigger path to break the cycle.
- This is the root cause behind the incident described in #354 — an agent misreading its own prior output as a fresh trigger, causing a 16-hour, ~1,800-comment spam loop.
- Fix: skip the trigger when `agentMember.ID == member.ID`, mirroring the self-mention guard the human-notification path already has.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/service/task/...`

Related to #354 — this fixes the incident that motivated the issue. The broader "structured verification-verdict primitive" ask in that issue is a separate, still-open discussion.
