### PR TITLE
fix: use Codex skill syntax for ACP messages

### DIFF
--- a/services/ai-agent/src/agent/acp_dispatch.py
+++ b/services/ai-agent/src/agent/acp_dispatch.py
@@ -118,7 +118,7 @@ async def dispatch_acp_trigger(trigger: TriggerMessage, agent_config: AgentConfi
             "type": "start_turn",
             "conversation_id": trigger.conversation_id,
             "project_id": trigger.project_id,
-            "message": build_acp_message(trigger),
+            "message": build_acp_message(trigger, agent_config.acp_provider),
             "trigger_type": trigger.trigger_type,
             "acp_provider": agent_config.acp_provider,
             "acp_command": agent_config.acp_command,

--- a/services/ai-agent/src/agent/prompt.py
+++ b/services/ai-agent/src/agent/prompt.py
@@ -81,12 +81,13 @@ def build_project_context_suffix(project_id: str | None) -> str:
 # way the LLM/sandbox path does (see the "paca" entry in
 # services/api/internal/platform/bundledskills/bundledskills.go) — the only
 # way to route a local ACP CLI (Claude Code, Codex, ...) through the Paca
-# skill is the literal slash command, so prefix every dispatched message
-# with it.
-_ACP_SKILL_TRIGGER = "/paca"
+# skill is the provider's explicit skill syntax, so prefix every dispatched
+# message with it.
+def _acp_skill_trigger(acp_provider: str | None) -> str:
+    return "$paca" if acp_provider == "codex" else "/paca"
 
 
-def build_acp_message(trigger: TriggerMessage) -> str:
+def build_acp_message(trigger: TriggerMessage, acp_provider: str | None = None) -> str:
     """Build the message sent to trigger an ACP agent.
 
     The LLM/sandbox path (executor.py) carries project and trigger context in
@@ -96,9 +97,10 @@ def build_acp_message(trigger: TriggerMessage) -> str:
     no separate system-suffix argument. So instead of a suffix, that same
     context (minus the repo section, which points at sandbox-only tools like
     clone_repository — ACP agents already have local repo access) is folded
-    directly into this message, prefixed with the `/paca` skill trigger.
+    directly into this message, prefixed with the provider-specific Paca
+    skill trigger.
     """
-    message = f"{_ACP_SKILL_TRIGGER} {build_initial_prompt(trigger)}"
+    message = f"{_acp_skill_trigger(acp_provider)} {build_initial_prompt(trigger)}"
     message += build_project_context_suffix(trigger.project_id)
     message += build_trigger_suffix(trigger)
     return message

--- a/services/ai-agent/tests/test_acp_dispatch.py
+++ b/services/ai-agent/tests/test_acp_dispatch.py
@@ -82,7 +82,7 @@ async def test_offline_bridge_fails_conversation(monkeypatch):
     assert publish_realtime.await_args.kwargs["event_type"] == "agent.conversation.failed"
 
 
-async def test_online_bridge_dispatches_start_turn(monkeypatch):
+async def test_online_bridge_dispatches_codex_skill_syntax(monkeypatch):
     monkeypatch.setattr(acp_dispatch.acp_bridge, "is_online", AsyncMock(return_value=True))
     dispatch_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(acp_dispatch.acp_bridge, "dispatch", dispatch_mock)
@@ -95,6 +95,7 @@ async def test_online_bridge_dispatches_start_turn(monkeypatch):
 
     trigger = _trigger()
     config = _acp_config()
+    config.acp_provider = "codex"
     await acp_dispatch.dispatch_acp_trigger(trigger, config)
 
     update_status.assert_awaited_once_with("conv-1", ConversationStatus.RUNNING)
@@ -104,9 +105,9 @@ async def test_online_bridge_dispatches_start_turn(monkeypatch):
             "type": "start_turn",
             "conversation_id": "conv-1",
             "project_id": "proj-1",
-            "message": build_acp_message(trigger),
+            "message": build_acp_message(trigger, "codex"),
             "trigger_type": "chat_message",
-            "acp_provider": "claude-code",
+            "acp_provider": "codex",
             "acp_command": [],
         },
     )
@@ -118,7 +119,7 @@ async def test_online_bridge_dispatches_start_turn_global_chat_forwards_actor_us
 ):
     """Regression test for actor_user_id actually being threaded through a
     global-chat (project_id=None) dispatch, not just compared None-to-None
-    the way test_online_bridge_dispatches_start_turn's trigger fixture does."""
+    the way the project-scoped dispatch test's trigger fixture does."""
     monkeypatch.setattr(acp_dispatch.acp_bridge, "is_online", AsyncMock(return_value=True))
     dispatch_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(acp_dispatch.acp_bridge, "dispatch", dispatch_mock)

--- a/services/ai-agent/tests/test_prompt.py
+++ b/services/ai-agent/tests/test_prompt.py
@@ -80,6 +80,17 @@ def test_acp_message_prefixes_paca_skill():
     assert result.startswith("/paca Do something")
 
 
+def test_acp_message_uses_codex_skill_syntax():
+    result = build_acp_message(_trigger(message="Do something"), "codex")
+    assert result.startswith("$paca Do something")
+
+
+def test_acp_message_keeps_slash_syntax_for_other_providers():
+    for provider in ("claude-code", "gemini-cli", "custom", None):
+        result = build_acp_message(_trigger(message="Do something"), provider)
+        assert result.startswith("/paca Do something")
+
+
 def test_acp_message_uses_task_assigned_fallback():
     result = build_acp_message(_trigger(trigger_type="task_assigned", message=""))
     assert result.startswith("/paca ")


### PR DESCRIPTION
## Summary

Use `$paca` for Codex ACP messages while preserving `/paca` for other providers.

Closes #389.

## Type of Change

- Other: bug fix

## Checklist

- The change is focused and scoped.
- Documentation is unchanged because the user-facing behavior is unchanged.
- Regression tests cover Codex and non-Codex providers.
- I avoided unnecessary detail or premature abstraction.

## Tests

- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv run pytest --tb=short` (219 passed, 3 skipped)
- `docker build -t paca-ai-agent-codex-syntax-test .`
