### PR TITLE
feat: implement read_task_attachment tool to download and read attachment contents

### DIFF
--- a/apps/mcp/ALL_TOOLS.md
+++ b/apps/mcp/ALL_TOOLS.md
@@ -78,9 +78,10 @@ This document lists all MCP tools implemented for the Paca API server.
 - `update_custom_field` - Update a custom field definition
 - `delete_custom_field` - Delete a custom field definition
 
-### 11. Attachments (3 tools)
+### 11. Attachments (4 tools)
 - `list_task_attachments` - List all attachments for a task
 - `get_attachment_download_url` - Get a download URL for an attachment
+- `read_task_attachment` - Download and read an attachment's contents (text or image) inline
 - `delete_task_attachment` - Delete an attachment from a task
 
 ### 12. Document Folders (4 tools)
@@ -200,6 +201,7 @@ This document lists all MCP tools implemented for the Paca API server.
 ### Attachments
 - GET /api/v1/projects/:projectId/tasks/:taskId/attachments
 - GET /api/v1/projects/:projectId/tasks/:taskId/attachments/:attachmentId/download-url
+- GET /api/v1/projects/:projectId/tasks/:taskId/attachments/:attachmentId/content
 - DELETE /api/v1/projects/:projectId/tasks/:taskId/attachments/:attachmentId
 
 ### Document Folders

--- a/apps/mcp/src/__tests__/api/views-client.test.ts
+++ b/apps/mcp/src/__tests__/api/views-client.test.ts
@@ -359,4 +359,42 @@ describe("PacaAPIViewsClient", () => {
 			expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
 		});
 	});
+
+	describe("downloadAttachmentContent", () => {
+		it("fetches the content endpoint on baseURL (not a presigned URL) and returns bytes + content type", async () => {
+			const client = new PacaAPIViewsClient(CONFIG_WITH_AGENT);
+			fetchMock.mockResolvedValue({
+				ok: true,
+				headers: new Map([["content-type", "text/plain; charset=utf-8"]]),
+				arrayBuffer: async () => new TextEncoder().encode("hello").buffer,
+				text: async () => "",
+			});
+
+			const result = await client.downloadAttachmentContent("p1", "t1", "att1");
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			const [url, options] = fetchMock.mock.calls[0];
+			expect(url).toBe(
+				"https://api.example.com/api/v1/projects/p1/tasks/t1/attachments/att1/content",
+			);
+			expect(options.headers["X-API-Key"]).toBe("key123");
+			expect(options.headers["X-Agent-ID"]).toBe("agent-1");
+			expect(new TextDecoder().decode(result.buffer)).toBe("hello");
+			expect(result.contentType).toBe("text/plain; charset=utf-8");
+		});
+
+		it("throws when the content fetch fails", async () => {
+			const client = new PacaAPIViewsClient(CONFIG);
+			fetchMock.mockResolvedValue({
+				ok: false,
+				status: 413,
+				statusText: "Request Entity Too Large",
+				text: async () => "too large",
+			});
+
+			await expect(
+				client.downloadAttachmentContent("p1", "t1", "att1"),
+			).rejects.toThrow("413");
+		});
+	});
 });

--- a/apps/mcp/src/__tests__/tools/attachment-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/attachment-tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../utils/index.js", () => ({
 	formatList: vi.fn((items: any[], fn: any) => items.map(fn).join("---")),
+	formatFileSize: vi.fn((bytes: number) => `${bytes} bytes`),
 }));
 
 import {
@@ -26,6 +27,10 @@ function makeClient(overrides: Record<string, any> = {}) {
 		getAttachmentDownloadURL: vi
 			.fn()
 			.mockResolvedValue("https://cdn.example.com/photo.png"),
+		downloadAttachmentContent: vi.fn().mockResolvedValue({
+			buffer: new TextEncoder().encode("hello world").buffer,
+			contentType: "image/png",
+		}),
 		deleteTaskAttachment: vi.fn().mockResolvedValue(undefined),
 		...overrides,
 	} as any;
@@ -36,14 +41,15 @@ function makeClient(overrides: Record<string, any> = {}) {
 // ---------------------------------------------------------------------------
 
 describe("getAttachmentTools", () => {
-	it("returns 3 tools", () => {
-		expect(getAttachmentTools()).toHaveLength(3);
+	it("returns 4 tools", () => {
+		expect(getAttachmentTools()).toHaveLength(4);
 	});
 
-	it("includes list_task_attachments, get_attachment_download_url, delete_task_attachment", () => {
+	it("includes list_task_attachments, get_attachment_download_url, read_task_attachment, delete_task_attachment", () => {
 		const names = getAttachmentTools().map((t) => t.name);
 		expect(names).toContain("list_task_attachments");
 		expect(names).toContain("get_attachment_download_url");
+		expect(names).toContain("read_task_attachment");
 		expect(names).toContain("delete_task_attachment");
 	});
 });
@@ -120,6 +126,145 @@ describe("handleAttachmentTool – get_attachment_download_url", () => {
 		expect(result.content[0].text).toContain(
 			"https://cdn.example.com/photo.png",
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// read_task_attachment
+// ---------------------------------------------------------------------------
+
+describe("handleAttachmentTool – read_task_attachment", () => {
+	it("returns an image content block for an image attachment", async () => {
+		const client = makeClient();
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "att-1" },
+			client,
+		);
+		expect(client.downloadAttachmentContent).toHaveBeenCalledWith(
+			"p1",
+			"t1",
+			"att-1",
+		);
+		expect(result.content[0].type).toBe("image");
+		expect(result.content[0].mimeType).toBe("image/png");
+		expect(result.content[0].data).toBe(
+			Buffer.from("hello world").toString("base64"),
+		);
+	});
+
+	it("returns a text content block for a text attachment", async () => {
+		const textAttachment = {
+			id: "att-2",
+			file: {
+				file_name: "notes.md",
+				file_size: 11,
+				content_type: "text/markdown",
+			},
+			created_by: "user-1",
+			created_at: "2024-01-01T00:00:00Z",
+		};
+		const client = makeClient({
+			listTaskAttachments: vi.fn().mockResolvedValue([textAttachment]),
+			downloadAttachmentContent: vi.fn().mockResolvedValue({
+				buffer: new TextEncoder().encode("hello world").buffer,
+				contentType: "text/markdown",
+			}),
+		});
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "att-2" },
+			client,
+		);
+		expect(result.content[0].type).toBe("text");
+		expect(result.content[0].text).toContain("notes.md");
+		expect(result.content[0].text).toContain("hello world");
+	});
+
+	it("classifies a generic content-type by file extension", async () => {
+		const codeAttachment = {
+			id: "att-3",
+			file: {
+				file_name: "script.py",
+				file_size: 11,
+				content_type: "application/octet-stream",
+			},
+			created_by: "user-1",
+			created_at: "2024-01-01T00:00:00Z",
+		};
+		const client = makeClient({
+			listTaskAttachments: vi.fn().mockResolvedValue([codeAttachment]),
+			downloadAttachmentContent: vi.fn().mockResolvedValue({
+				buffer: new TextEncoder().encode("print('hi')").buffer,
+				contentType: "application/octet-stream",
+			}),
+		});
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "att-3" },
+			client,
+		);
+		expect(result.content[0].type).toBe("text");
+		expect(result.content[0].text).toContain("print('hi')");
+	});
+
+	it("returns an error for a binary attachment it can't read", async () => {
+		const pdfAttachment = {
+			id: "att-4",
+			file: {
+				file_name: "report.pdf",
+				file_size: 1024,
+				content_type: "application/pdf",
+			},
+			created_by: "user-1",
+			created_at: "2024-01-01T00:00:00Z",
+		};
+		const client = makeClient({
+			listTaskAttachments: vi.fn().mockResolvedValue([pdfAttachment]),
+		});
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "att-4" },
+			client,
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("get_attachment_download_url");
+		expect(client.downloadAttachmentContent).not.toHaveBeenCalled();
+	});
+
+	it("returns an error when the attachment exceeds the size limit", async () => {
+		const bigAttachment = {
+			id: "att-5",
+			file: {
+				file_name: "huge.txt",
+				file_size: 3 * 1024 * 1024,
+				content_type: "text/plain",
+			},
+			created_by: "user-1",
+			created_at: "2024-01-01T00:00:00Z",
+		};
+		const client = makeClient({
+			listTaskAttachments: vi.fn().mockResolvedValue([bigAttachment]),
+		});
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "att-5" },
+			client,
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("exceeds");
+		expect(client.downloadAttachmentContent).not.toHaveBeenCalled();
+	});
+
+	it("returns an error when the attachment isn't found", async () => {
+		const client = makeClient();
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "does-not-exist" },
+			client,
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content[0].text).toContain("not found");
 	});
 });
 

--- a/apps/mcp/src/__tests__/tools/attachment-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/attachment-tools.test.ts
@@ -208,6 +208,33 @@ describe("handleAttachmentTool – read_task_attachment", () => {
 		expect(result.content[0].text).toContain("print('hi')");
 	});
 
+	it("classifies a generic content-type by conventional extensionless filename", async () => {
+		const dockerfileAttachment = {
+			id: "att-3b",
+			file: {
+				file_name: "Dockerfile",
+				file_size: 11,
+				content_type: "application/octet-stream",
+			},
+			created_by: "user-1",
+			created_at: "2024-01-01T00:00:00Z",
+		};
+		const client = makeClient({
+			listTaskAttachments: vi.fn().mockResolvedValue([dockerfileAttachment]),
+			downloadAttachmentContent: vi.fn().mockResolvedValue({
+				buffer: new TextEncoder().encode("FROM node:20").buffer,
+				contentType: "application/octet-stream",
+			}),
+		});
+		const result = await handleAttachmentTool(
+			"read_task_attachment",
+			{ projectId: "p1", taskId: "t1", attachmentId: "att-3b" },
+			client,
+		);
+		expect(result.content[0].type).toBe("text");
+		expect(result.content[0].text).toContain("FROM node:20");
+	});
+
 	it("returns an error for a binary attachment it can't read", async () => {
 		const pdfAttachment = {
 			id: "att-4",

--- a/apps/mcp/src/__tests__/utils/formatters.test.ts
+++ b/apps/mcp/src/__tests__/utils/formatters.test.ts
@@ -485,6 +485,7 @@ describe("formatTaskDetail", () => {
 		);
 		expect(result).toContain("## Attachments");
 		expect(result).toContain("screenshot.png");
+		expect(result).toContain("att-1");
 	});
 
 	it("includes custom fields section when customFields are provided", () => {

--- a/apps/mcp/src/api/views-client.ts
+++ b/apps/mcp/src/api/views-client.ts
@@ -305,4 +305,42 @@ export class PacaAPIViewsClient {
 			`/api/v1/projects/${projectId}/tasks/${taskId}/attachments/${attachmentId}`,
 		);
 	}
+
+	/**
+	 * Downloads the raw bytes of an attachment through the Paca API itself,
+	 * rather than via a presigned object-store URL. Presigned URLs are
+	 * rewritten to a browser-facing public host (see the backend's
+	 * STORAGE_PUBLIC_URL), which server-side callers like this MCP server
+	 * often can't reach — e.g. when running inside an agent sandbox
+	 * container that can resolve `api`/`gateway` by their internal Docker
+	 * hostname but not the public one the presigned URL points at. Going
+	 * through config.baseURL instead reuses the same connectivity every
+	 * other tool call in this client already depends on.
+	 */
+	async downloadAttachmentContent(
+		projectId: string,
+		taskId: string,
+		attachmentId: string,
+	): Promise<{ buffer: ArrayBuffer; contentType?: string }> {
+		const url = `${this.config.baseURL}/api/v1/projects/${projectId}/tasks/${taskId}/attachments/${attachmentId}/content`;
+		const headers: Record<string, string> = {
+			"X-API-Key": this.config.apiKey,
+		};
+		if (this.config.agentId) {
+			headers["X-Agent-ID"] = this.config.agentId;
+		}
+
+		const response = await fetch(url, { headers });
+		if (!response.ok) {
+			const errorText = await response.text().catch(() => "");
+			throw new Error(
+				formatApiRequestError(response.status, response.statusText, errorText),
+			);
+		}
+		const buffer = await response.arrayBuffer();
+		return {
+			buffer,
+			contentType: response.headers.get("content-type") ?? undefined,
+		};
+	}
 }

--- a/apps/mcp/src/permissions.ts
+++ b/apps/mcp/src/permissions.ts
@@ -288,6 +288,11 @@ export const TOOL_PERMISSIONS: ToolPermission[] = [
 		requiresProject: true,
 	},
 	{
+		toolName: "read_task_attachment",
+		permissionKey: "tasks.read",
+		requiresProject: true,
+	},
+	{
 		toolName: "delete_task_attachment",
 		permissionKey: "tasks.write",
 		requiresProject: true,

--- a/apps/mcp/src/tools/attachment-tools.ts
+++ b/apps/mcp/src/tools/attachment-tools.ts
@@ -1,7 +1,7 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { PacaAPIViewsClient } from "../api/index.js";
-import { formatList } from "../utils/index.js";
+import { formatFileSize, formatList } from "../utils/index.js";
 
 const ListTaskAttachmentsSchema = z.object({
 	projectId: z.string(),
@@ -14,11 +14,112 @@ const GetAttachmentDownloadURLSchema = z.object({
 	attachmentId: z.string(),
 });
 
+const ReadTaskAttachmentSchema = z.object({
+	projectId: z.string(),
+	taskId: z.string(),
+	attachmentId: z.string(),
+});
+
 const DeleteTaskAttachmentSchema = z.object({
 	projectId: z.string(),
 	taskId: z.string(),
 	attachmentId: z.string(),
 });
+
+// Content types that are safe to decode and hand back as plain text.
+const TEXT_MIME_TYPES = new Set([
+	"application/json",
+	"application/xml",
+	"application/yaml",
+	"application/x-yaml",
+	"application/javascript",
+	"application/typescript",
+	"application/x-sh",
+	"application/sql",
+	"application/x-ndjson",
+	"application/toml",
+]);
+
+// Extension fallback for files uploaded with a generic content type (e.g.
+// application/octet-stream), since uploaders don't always set one accurately.
+const TEXT_EXTENSIONS = new Set([
+	"txt",
+	"md",
+	"markdown",
+	"csv",
+	"tsv",
+	"log",
+	"json",
+	"yml",
+	"yaml",
+	"xml",
+	"html",
+	"htm",
+	"css",
+	"scss",
+	"less",
+	"js",
+	"jsx",
+	"ts",
+	"tsx",
+	"mjs",
+	"cjs",
+	"py",
+	"go",
+	"rb",
+	"java",
+	"c",
+	"cpp",
+	"h",
+	"hpp",
+	"cs",
+	"php",
+	"sh",
+	"bash",
+	"zsh",
+	"sql",
+	"toml",
+	"ini",
+	"cfg",
+	"conf",
+	"env",
+	"graphql",
+	"proto",
+	"rs",
+	"kt",
+	"swift",
+	"vue",
+	"svelte",
+]);
+
+// Image types the MCP "image" content block (and the LLMs consuming it) can
+// actually render. Anything else falls back to the binary path below.
+const IMAGE_MIME_TYPES = new Set([
+	"image/png",
+	"image/jpeg",
+	"image/gif",
+	"image/webp",
+]);
+
+const MAX_TEXT_BYTES = 2 * 1024 * 1024; // 2 MB
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+type AttachmentKind = "text" | "image" | "binary";
+
+function classifyAttachment(
+	fileName: string,
+	contentType: string | undefined,
+): AttachmentKind {
+	const normalizedType = (contentType || "").toLowerCase().split(";")[0].trim();
+	if (IMAGE_MIME_TYPES.has(normalizedType)) return "image";
+	if (normalizedType.startsWith("text/")) return "text";
+	if (TEXT_MIME_TYPES.has(normalizedType)) return "text";
+
+	const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+	if (TEXT_EXTENSIONS.has(ext)) return "text";
+
+	return "binary";
+}
 
 /**
  * Returns all attachment-related MCP tools.
@@ -65,6 +166,36 @@ export function getAttachmentTools(): Tool[] {
 						type: "string",
 						description:
 							"The technical UUID of the attachment (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_attachments to get the attachment ID.",
+					},
+				},
+				required: ["projectId", "taskId", "attachmentId"],
+			},
+		},
+		{
+			name: "read_task_attachment",
+			description:
+				"Download and read the contents of a task attachment. Text-based files " +
+				"(code, markdown, JSON, YAML, CSV, logs, etc.) are returned as plain text; " +
+				"images (PNG, JPEG, GIF, WebP) are returned as a viewable image. Files over " +
+				"2 MB (text) or 5 MB (images), and other binary formats (PDF, zip, docx, " +
+				"etc.), can't be read this way — use get_attachment_download_url for those.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					projectId: {
+						type: "string",
+						description:
+							"The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
+					},
+					taskId: {
+						type: "string",
+						description:
+							"The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
+					},
+					attachmentId: {
+						type: "string",
+						description:
+							"The technical UUID of the attachment (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_task_attachments or get_task to get the attachment ID.",
 					},
 				},
 				required: ["projectId", "taskId", "attachmentId"],
@@ -146,6 +277,89 @@ export async function handleAttachmentTool(
 					{
 						type: "text",
 						text: `Download URL: ${result}`,
+					},
+				],
+			};
+		}
+
+		case "read_task_attachment": {
+			const { projectId, taskId, attachmentId } =
+				ReadTaskAttachmentSchema.parse(args);
+
+			const attachments = await viewsClient.listTaskAttachments(
+				projectId,
+				taskId,
+			);
+			const attachment = attachments.find((a: any) => a.id === attachmentId);
+			if (!attachment) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Attachment ${attachmentId} not found on task ${taskId}.`,
+						},
+					],
+					isError: true,
+				};
+			}
+
+			const { file } = attachment;
+			const kind = classifyAttachment(file.file_name, file.content_type);
+
+			if (kind === "binary") {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `"${file.file_name}" (${file.content_type || "unknown type"}, ${formatFileSize(file.file_size)}) can't be read as text or an image. Use get_attachment_download_url to download it directly.`,
+						},
+					],
+					isError: true,
+				};
+			}
+
+			const maxBytes = kind === "image" ? MAX_IMAGE_BYTES : MAX_TEXT_BYTES;
+			if (file.file_size > maxBytes) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `"${file.file_name}" is ${formatFileSize(file.file_size)}, which exceeds the ${formatFileSize(maxBytes)} limit for reading ${kind === "image" ? "images" : "text files"} inline. Use get_attachment_download_url to download it directly.`,
+						},
+					],
+					isError: true,
+				};
+			}
+
+			const { buffer, contentType } =
+				await viewsClient.downloadAttachmentContent(
+					projectId,
+					taskId,
+					attachmentId,
+				);
+			const effectiveType =
+				contentType?.split(";")[0]?.trim() ||
+				file.content_type ||
+				"application/octet-stream";
+
+			if (kind === "image") {
+				return {
+					content: [
+						{
+							type: "image",
+							data: Buffer.from(buffer).toString("base64"),
+							mimeType: effectiveType,
+						},
+					],
+				};
+			}
+
+			const text = Buffer.from(buffer).toString("utf-8");
+			return {
+				content: [
+					{
+						type: "text",
+						text: `File: ${file.file_name} (${formatFileSize(file.file_size)})\n\n${text}`,
 					},
 				],
 			};

--- a/apps/mcp/src/tools/attachment-tools.ts
+++ b/apps/mcp/src/tools/attachment-tools.ts
@@ -92,6 +92,31 @@ const TEXT_EXTENSIONS = new Set([
 	"svelte",
 ]);
 
+// Conventionally-named text files that don't carry a recognizable extension,
+// matched case-insensitively on the full file name.
+const TEXT_FILENAMES = new Set([
+	"dockerfile",
+	"makefile",
+	"rakefile",
+	"gemfile",
+	"gemfile.lock",
+	"procfile",
+	"vagrantfile",
+	"license",
+	"licence",
+	"readme",
+	"changelog",
+	"contributing",
+	"authors",
+	"notice",
+	".gitignore",
+	".dockerignore",
+	".gitattributes",
+	".editorconfig",
+	".npmrc",
+	".env",
+]);
+
 // Image types the MCP "image" content block (and the LLMs consuming it) can
 // actually render. Anything else falls back to the binary path below.
 const IMAGE_MIME_TYPES = new Set([
@@ -114,6 +139,8 @@ function classifyAttachment(
 	if (IMAGE_MIME_TYPES.has(normalizedType)) return "image";
 	if (normalizedType.startsWith("text/")) return "text";
 	if (TEXT_MIME_TYPES.has(normalizedType)) return "text";
+
+	if (TEXT_FILENAMES.has(fileName.toLowerCase().trim())) return "text";
 
 	const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
 	if (TEXT_EXTENSIONS.has(ext)) return "text";

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -201,6 +201,7 @@ export async function handleToolCall(
 		if (
 			name === "list_task_attachments" ||
 			name === "get_attachment_download_url" ||
+			name === "read_task_attachment" ||
 			name === "delete_task_attachment"
 		) {
 			return handleAttachmentTool(name, args, clients.viewsClient);

--- a/apps/mcp/src/utils/formatters.ts
+++ b/apps/mcp/src/utils/formatters.ts
@@ -255,7 +255,7 @@ export function formatTaskDetail(
 		sections.push("## Attachments");
 		attachments.forEach((attachment) => {
 			sections.push(
-				`- **${attachment.file.file_name}** (${formatFileSize(attachment.file.file_size)}) - Uploaded: ${attachment.created_at}`,
+				`- **${attachment.file.file_name}** (${formatFileSize(attachment.file.file_size)}) - ID: ${attachment.id}, Uploaded: ${attachment.created_at}`,
 			);
 		});
 	}
@@ -313,7 +313,7 @@ function formatCustomFieldValue(value: unknown, fieldType: string): string {
 	}
 }
 
-function formatFileSize(bytes: number): string {
+export function formatFileSize(bytes: number): string {
 	if (bytes === 0) return "0 Bytes";
 	const k = 1024;
 	const sizes = ["Bytes", "KB", "MB", "GB"];

--- a/services/api/internal/apierr/codes.go
+++ b/services/api/internal/apierr/codes.go
@@ -138,6 +138,8 @@ const (
 	CodeUploadNotPending Code = "ATTACHMENT_UPLOAD_NOT_PENDING"
 	// CodeAttachmentInvalid indicates invalid input for creating an attachment.
 	CodeAttachmentInvalid Code = "ATTACHMENT_INVALID"
+	// CodeAttachmentTooLarge indicates the attachment exceeds the size that can be read inline.
+	CodeAttachmentTooLarge Code = "ATTACHMENT_TOO_LARGE"
 	// CodeMultipartUploadIDRequired indicates that a multipart upload_id was not provided.
 	CodeMultipartUploadIDRequired Code = "ATTACHMENT_MULTIPART_UPLOAD_ID_REQUIRED"
 	// CodeNotMultipartUpload indicates that an upload_id was provided for a non-multipart file.

--- a/services/api/internal/domain/attachment/entity.go
+++ b/services/api/internal/domain/attachment/entity.go
@@ -17,6 +17,12 @@ const (
 	UploadStatusFailed   UploadStatus = "failed"
 )
 
+// MaxAttachmentContentSize bounds how large a file GetAttachmentContent will
+// read into memory. This is a hard backend ceiling, set comfortably above
+// the MCP server's own inline-read limits (2 MiB text / 5 MiB images) so
+// those remain the binding constraint in practice.
+const MaxAttachmentContentSize = 10 * 1024 * 1024 // 10 MiB
+
 // File is the central metadata record for every object stored in the
 // object store.  It is shared across all entities that can hold attachments.
 type File struct {

--- a/services/api/internal/domain/attachment/errors.go
+++ b/services/api/internal/domain/attachment/errors.go
@@ -30,6 +30,10 @@ var (
 	// to the project specified in the request URL.
 	ErrTaskNotInProject = errors.New("task does not belong to the specified project")
 
+	// ErrAttachmentContentTooLarge is returned when GetAttachmentContent is
+	// asked to read a file larger than MaxAttachmentContentSize into memory.
+	ErrAttachmentContentTooLarge = errors.New("attachment exceeds the maximum size that can be read inline")
+
 	// ErrAvatarTooLarge is returned when an avatar upload exceeds MaxAvatarUploadSize.
 	ErrAvatarTooLarge = errors.New("avatar file exceeds the maximum allowed size")
 	// ErrAvatarContentTypeInvalid is returned when an avatar upload's content

--- a/services/api/internal/domain/attachment/service.go
+++ b/services/api/internal/domain/attachment/service.go
@@ -38,6 +38,19 @@ type Service interface {
 	// browser downloads the file rather than previewing it inline.
 	GetDownloadURL(ctx context.Context, projectID, taskID, attachmentID uuid.UUID, ttl time.Duration, forceDownload bool) (string, error)
 
+	// GetAttachmentContent reads the file's bytes directly from the object
+	// store and returns them along with its content type. Unlike
+	// GetDownloadURL (which hands back a presigned object-store URL meant for
+	// a browser), this goes through the API itself — the right path for
+	// server-side callers such as the MCP server, which may not have network
+	// access to the object store's public-facing endpoint (e.g. when running
+	// inside an agent sandbox container that can reach `api`/`gateway` by
+	// their internal Docker hostnames but not the browser-facing public URL
+	// presigned URLs are rewritten to). Verifies the attachment belongs to
+	// taskID and that taskID belongs to projectID. Returns
+	// ErrAttachmentContentTooLarge if the file exceeds MaxAttachmentContentSize.
+	GetAttachmentContent(ctx context.Context, projectID, taskID, attachmentID uuid.UUID) (data []byte, contentType string, err error)
+
 	// ListTaskAttachments returns all confirmed attachments for the given task.
 	// Verifies taskID belongs to projectID before proceeding.
 	ListTaskAttachments(ctx context.Context, projectID, taskID uuid.UUID) ([]*TaskAttachment, error)

--- a/services/api/internal/service/attachment/service.go
+++ b/services/api/internal/service/attachment/service.go
@@ -255,9 +255,21 @@ func (s *Service) GetAttachmentContent(ctx context.Context, projectID, taskID, a
 		bucket = s.bucket
 	}
 
-	data, err := s.store.GetObject(ctx, bucket, f.StorageKey, attachmentdom.MaxAttachmentContentSize)
+	// f.FileSize is declared by the client at upload-initiation time, but the
+	// presigned PUT enforces nothing about the actual object it accepts — a
+	// client can declare a small file_size and upload a larger object (see
+	// CompleteUpload above, which never re-verifies actual size). Bound the
+	// read itself by capping one byte over the limit: if the object is
+	// larger, GetObject's io.LimitReader truncates the read at
+	// MaxAttachmentContentSize+1 bytes with no error, so the post-read
+	// length check below is what actually catches it. Mirrors
+	// avatar_service.go's identical guard against the same presigned-PUT gap.
+	data, err := s.store.GetObject(ctx, bucket, f.StorageKey, attachmentdom.MaxAttachmentContentSize+1)
 	if err != nil {
 		return nil, "", fmt.Errorf("attachment svc: get object: %w", err)
+	}
+	if int64(len(data)) > attachmentdom.MaxAttachmentContentSize {
+		return nil, "", attachmentdom.ErrAttachmentContentTooLarge
 	}
 	return data, f.ContentType, nil
 }

--- a/services/api/internal/service/attachment/service.go
+++ b/services/api/internal/service/attachment/service.go
@@ -227,6 +227,41 @@ func (s *Service) GetDownloadURL(ctx context.Context, projectID, taskID, attachm
 	return url, nil
 }
 
+// GetAttachmentContent reads the attachment's bytes directly from the object
+// store (bypassing the presigned-URL flow) and returns them along with the
+// file's content type. See the interface doc for why this exists.
+func (s *Service) GetAttachmentContent(ctx context.Context, projectID, taskID, attachmentID uuid.UUID) ([]byte, string, error) {
+	if err := s.taskChecker.TaskBelongsToProject(ctx, projectID, taskID); err != nil {
+		return nil, "", err
+	}
+	a, err := s.repo.FindTaskAttachmentByID(ctx, attachmentID)
+	if err != nil {
+		return nil, "", err
+	}
+	if a.TaskID != taskID {
+		return nil, "", attachmentdom.ErrAttachmentNotFound
+	}
+
+	f, err := s.repo.FindFileByID(ctx, a.FileID)
+	if err != nil {
+		return nil, "", err
+	}
+	if f.FileSize > attachmentdom.MaxAttachmentContentSize {
+		return nil, "", attachmentdom.ErrAttachmentContentTooLarge
+	}
+
+	bucket := f.Bucket
+	if bucket == "" {
+		bucket = s.bucket
+	}
+
+	data, err := s.store.GetObject(ctx, bucket, f.StorageKey, attachmentdom.MaxAttachmentContentSize)
+	if err != nil {
+		return nil, "", fmt.Errorf("attachment svc: get object: %w", err)
+	}
+	return data, f.ContentType, nil
+}
+
 // ListTaskAttachments returns all confirmed attachments for the given task.
 func (s *Service) ListTaskAttachments(ctx context.Context, projectID, taskID uuid.UUID) ([]*attachmentdom.TaskAttachment, error) {
 	if err := s.taskChecker.TaskBelongsToProject(ctx, projectID, taskID); err != nil {

--- a/services/api/internal/service/attachment/service_test.go
+++ b/services/api/internal/service/attachment/service_test.go
@@ -1,0 +1,190 @@
+package attachmentsvc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	attachmentdom "github.com/Paca-AI/api/internal/domain/attachment"
+	"github.com/Paca-AI/api/internal/platform/storage"
+)
+
+// fakeTaskChecker always reports that the task belongs to the project.
+type fakeTaskChecker struct{}
+
+func (fakeTaskChecker) TaskBelongsToProject(_ context.Context, _, _ uuid.UUID) error {
+	return nil
+}
+
+var _ attachmentdom.TaskOwnerChecker = fakeTaskChecker{}
+
+// fakeRepo is a minimal in-memory attachmentdom.Repository for exercising
+// service methods without a real database.
+type fakeRepo struct {
+	files       map[uuid.UUID]*attachmentdom.File
+	attachments map[uuid.UUID]*attachmentdom.TaskAttachment
+}
+
+func (r *fakeRepo) CreateFile(_ context.Context, f *attachmentdom.File) error {
+	r.files[f.ID] = f
+	return nil
+}
+func (r *fakeRepo) FindFileByID(_ context.Context, id uuid.UUID) (*attachmentdom.File, error) {
+	f, ok := r.files[id]
+	if !ok {
+		return nil, errors.New("file not found")
+	}
+	return f, nil
+}
+func (r *fakeRepo) UpdateFileStatus(_ context.Context, _ uuid.UUID, _ attachmentdom.UploadStatus, _ *string) error {
+	return nil
+}
+func (r *fakeRepo) DeleteFile(_ context.Context, _ uuid.UUID) error { return nil }
+
+func (r *fakeRepo) ListTaskAttachments(_ context.Context, _ uuid.UUID) ([]*attachmentdom.TaskAttachment, error) {
+	return nil, nil
+}
+func (r *fakeRepo) FindTaskAttachmentByID(_ context.Context, id uuid.UUID) (*attachmentdom.TaskAttachment, error) {
+	a, ok := r.attachments[id]
+	if !ok {
+		return nil, attachmentdom.ErrAttachmentNotFound
+	}
+	return a, nil
+}
+func (r *fakeRepo) CreateTaskAttachment(_ context.Context, a *attachmentdom.TaskAttachment) error {
+	r.attachments[a.ID] = a
+	return nil
+}
+func (r *fakeRepo) DeleteTaskAttachment(_ context.Context, id uuid.UUID) error {
+	delete(r.attachments, id)
+	return nil
+}
+
+var _ attachmentdom.Repository = (*fakeRepo)(nil)
+
+// fakeStore is a minimal storage.Client whose GetObject mimics the real
+// S3Client: it truncates the returned bytes to maxBytes without ever
+// returning an error, matching io.LimitReader + io.ReadAll semantics. Every
+// other method is unused by these tests and just errors out.
+type fakeStore struct {
+	objectBytes []byte
+}
+
+func (s *fakeStore) PresignPutObject(context.Context, string, string, string, time.Duration) (string, error) {
+	return "", errors.New("not implemented")
+}
+func (s *fakeStore) PresignGetObject(context.Context, string, string, time.Duration, string) (string, error) {
+	return "", errors.New("not implemented")
+}
+func (s *fakeStore) InitiateMultipartUpload(context.Context, string, string, string, int64, int64, time.Duration) (*storage.MultipartUpload, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *fakeStore) CompleteMultipartUpload(context.Context, string, string, string, []storage.CompletedPart) error {
+	return errors.New("not implemented")
+}
+func (s *fakeStore) AbortMultipartUpload(context.Context, string, string, string) error {
+	return errors.New("not implemented")
+}
+func (s *fakeStore) DeleteObject(context.Context, string, string) error {
+	return errors.New("not implemented")
+}
+func (s *fakeStore) EnsureBucket(context.Context, string) error { return nil }
+func (s *fakeStore) GetObject(_ context.Context, _, _ string, maxBytes int64) ([]byte, error) {
+	data := s.objectBytes
+	if maxBytes > 0 && int64(len(data)) > maxBytes {
+		data = data[:maxBytes]
+	}
+	out := make([]byte, len(data))
+	copy(out, data)
+	return out, nil
+}
+func (s *fakeStore) PutObject(context.Context, string, string, string, []byte) error {
+	return errors.New("not implemented")
+}
+
+var _ storage.Client = (*fakeStore)(nil)
+
+// newTestService wires a Service around an attachment whose File record
+// declares declaredFileSize while the object store actually holds
+// actualObjectBytes — letting tests simulate a client that under-declared
+// file_size at upload time (InitiateUpload/CompleteUpload never re-verify
+// the real object size against it).
+func newTestService(actualObjectBytes []byte, declaredFileSize int64) (svc *Service, taskID, attachmentID uuid.UUID) {
+	fileID := uuid.New()
+	attachmentID = uuid.New()
+	taskID = uuid.New()
+
+	repo := &fakeRepo{
+		files: map[uuid.UUID]*attachmentdom.File{
+			fileID: {
+				ID:          fileID,
+				StorageKey:  "tasks/x/y/file.txt",
+				Bucket:      "test-bucket",
+				FileName:    "file.txt",
+				ContentType: "text/plain",
+				FileSize:    declaredFileSize,
+			},
+		},
+		attachments: map[uuid.UUID]*attachmentdom.TaskAttachment{
+			attachmentID: {
+				ID:     attachmentID,
+				TaskID: taskID,
+				FileID: fileID,
+			},
+		},
+	}
+	store := &fakeStore{objectBytes: actualObjectBytes}
+	svc = New(repo, fakeTaskChecker{}, store, "test-bucket")
+	return svc, taskID, attachmentID
+}
+
+func TestGetAttachmentContent_ReturnsBytesWhenWithinLimit(t *testing.T) {
+	want := []byte("hello world")
+	svc, taskID, attachmentID := newTestService(want, int64(len(want)))
+
+	data, contentType, err := svc.GetAttachmentContent(context.Background(), uuid.New(), taskID, attachmentID)
+	if err != nil {
+		t.Fatalf("GetAttachmentContent: %v", err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("got %q, want %q", data, want)
+	}
+	if contentType != "text/plain" {
+		t.Fatalf("got content type %q, want text/plain", contentType)
+	}
+}
+
+// TestGetAttachmentContent_RejectsUndeclaredOversizedObject covers the
+// silent-truncation gap: a client can declare a small file_size at
+// upload-initiation time and then PUT more bytes than it claimed, since
+// nothing enforces the presigned PUT actually matches. Before this fix,
+// GetObject's io.LimitReader would silently truncate the read to
+// MaxAttachmentContentSize and the endpoint would serve a 200 with
+// corrupted, partial bytes instead of failing. See avatar_service.go for
+// the same guard against the same underlying gap.
+func TestGetAttachmentContent_RejectsUndeclaredOversizedObject(t *testing.T) {
+	actual := make([]byte, attachmentdom.MaxAttachmentContentSize+1024)
+	svc, taskID, attachmentID := newTestService(actual, 10) // declared size well under the cap
+
+	data, _, err := svc.GetAttachmentContent(context.Background(), uuid.New(), taskID, attachmentID)
+	if !errors.Is(err, attachmentdom.ErrAttachmentContentTooLarge) {
+		t.Fatalf("got err %v, want ErrAttachmentContentTooLarge", err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil data on error, got %d bytes", len(data))
+	}
+}
+
+func TestGetAttachmentContent_RejectsDeclaredOversizedFile(t *testing.T) {
+	// The declared file_size alone already exceeds the cap; GetObject
+	// should never even be called.
+	svc, taskID, attachmentID := newTestService(nil, attachmentdom.MaxAttachmentContentSize+1)
+
+	_, _, err := svc.GetAttachmentContent(context.Background(), uuid.New(), taskID, attachmentID)
+	if !errors.Is(err, attachmentdom.ErrAttachmentContentTooLarge) {
+		t.Fatalf("got err %v, want ErrAttachmentContentTooLarge", err)
+	}
+}

--- a/services/api/internal/transport/http/handler/attachment_handler.go
+++ b/services/api/internal/transport/http/handler/attachment_handler.go
@@ -200,6 +200,11 @@ func (h *AttachmentHandler) GetDownloadURL(w http.ResponseWriter, r *http.Reques
 // API rather than handing back a presigned object-store URL — the right path
 // for server-side callers (e.g. the MCP server) that may not have network
 // access to the object store's public-facing endpoint.
+//
+// contentType comes from attacker-controlled upload metadata, so the response
+// always forces X-Content-Type-Options: nosniff and Content-Disposition:
+// attachment — unlike GetDownloadURL, this endpoint has no forceDownload=false
+// inline-preview mode, since nothing here is meant to be rendered by a browser.
 func (h *AttachmentHandler) GetAttachmentContent(w http.ResponseWriter, r *http.Request) {
 	projectID, err := parseProjectID(r)
 	if err != nil {
@@ -227,6 +232,8 @@ func (h *AttachmentHandler) GetAttachmentContent(w http.ResponseWriter, r *http.
 		contentType = "application/octet-stream"
 	}
 	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", "attachment")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
 }

--- a/services/api/internal/transport/http/handler/attachment_handler.go
+++ b/services/api/internal/transport/http/handler/attachment_handler.go
@@ -195,6 +195,42 @@ func (h *AttachmentHandler) GetDownloadURL(w http.ResponseWriter, r *http.Reques
 	presenter.OK(w, r, dto.DownloadURLResponse{URL: url})
 }
 
+// GetAttachmentContent handles GET /projects/:projectId/tasks/:taskId/attachments/:attachmentId/content.
+// Unlike GetDownloadURL, this streams the file's bytes directly through the
+// API rather than handing back a presigned object-store URL — the right path
+// for server-side callers (e.g. the MCP server) that may not have network
+// access to the object store's public-facing endpoint.
+func (h *AttachmentHandler) GetAttachmentContent(w http.ResponseWriter, r *http.Request) {
+	projectID, err := parseProjectID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	taskID, err := parseTaskID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	attachmentID, err := parseAttachmentID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	data, contentType, err := h.svc.GetAttachmentContent(r.Context(), projectID, taskID, attachmentID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
 // DeleteTaskAttachment handles DELETE /projects/:projectId/tasks/:taskId/attachments/:attachmentId.
 func (h *AttachmentHandler) DeleteTaskAttachment(w http.ResponseWriter, r *http.Request) {
 	projectID, err := parseProjectID(r)

--- a/services/api/internal/transport/http/handler/attachment_handler_test.go
+++ b/services/api/internal/transport/http/handler/attachment_handler_test.go
@@ -183,6 +183,12 @@ func TestGetAttachmentContent_ReturnsRawBytesWithContentType(t *testing.T) {
 	if got := w.Header().Get("Content-Type"); got != "text/plain" {
 		t.Fatalf("expected Content-Type text/plain, got %q", got)
 	}
+	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("expected X-Content-Type-Options nosniff, got %q", got)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != "attachment" {
+		t.Fatalf("expected Content-Disposition attachment, got %q", got)
+	}
 	if got := w.Body.String(); got != "hello world" {
 		t.Fatalf("expected body %q, got %q", "hello world", got)
 	}

--- a/services/api/internal/transport/http/handler/attachment_handler_test.go
+++ b/services/api/internal/transport/http/handler/attachment_handler_test.go
@@ -23,7 +23,11 @@ import (
 // Minimal fakes
 // ---------------------------------------------------------------------------
 
-type fakeAttachmentSvc struct{}
+type fakeAttachmentSvc struct {
+	contentData []byte
+	contentType string
+	contentErr  error
+}
 
 func (f *fakeAttachmentSvc) InitiateUpload(_ context.Context, _ uuid.UUID, _ attachmentdom.InitiateUploadInput) (*attachmentdom.UploadSession, error) {
 	return &attachmentdom.UploadSession{FileID: uuid.New()}, nil
@@ -39,6 +43,12 @@ func (f *fakeAttachmentSvc) ListTaskAttachments(_ context.Context, _, _ uuid.UUI
 }
 func (f *fakeAttachmentSvc) DeleteTaskAttachment(_ context.Context, _, _, _ uuid.UUID) error {
 	return nil
+}
+func (f *fakeAttachmentSvc) GetAttachmentContent(_ context.Context, _, _, _ uuid.UUID) ([]byte, string, error) {
+	if f.contentErr != nil {
+		return nil, "", f.contentErr
+	}
+	return f.contentData, f.contentType, nil
 }
 
 var _ attachmentdom.Service = (*fakeAttachmentSvc)(nil)
@@ -69,6 +79,16 @@ func newAttachmentRouterWithAuth() chi.Router {
 	r.Route("/projects/{projectId}/tasks/{taskId}/attachments", func(r chi.Router) {
 		r.Post("/initiate-upload", h.InitiateUpload)
 		r.Post("/complete-upload", h.CompleteUpload)
+	})
+	return r
+}
+
+func newAttachmentContentRouter(svc *fakeAttachmentSvc) chi.Router {
+	h := handler.NewAttachmentHandler(svc)
+	r := chi.NewRouter()
+	r.Use(injectAuthClaimsMiddleware(uuid.New().String()))
+	r.Route("/projects/{projectId}/tasks/{taskId}/attachments", func(r chi.Router) {
+		r.Get("/{attachmentId}/content", h.GetAttachmentContent)
 	})
 	return r
 }
@@ -144,5 +164,41 @@ func TestCompleteUpload_MissingFileID_Returns400(t *testing.T) {
 	w := doAttachRequest(t, r, http.MethodPost, path, map[string]any{})
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for missing file_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetAttachmentContent_ReturnsRawBytesWithContentType(t *testing.T) {
+	svc := &fakeAttachmentSvc{contentData: []byte("hello world"), contentType: "text/plain"}
+	r := newAttachmentContentRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+	attachmentID := uuid.New()
+	path := "/projects/" + projectID.String() + "/tasks/" + taskID.String() +
+		"/attachments/" + attachmentID.String() + "/content"
+
+	w := doAttachRequest(t, r, http.MethodGet, path, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("expected Content-Type text/plain, got %q", got)
+	}
+	if got := w.Body.String(); got != "hello world" {
+		t.Fatalf("expected body %q, got %q", "hello world", got)
+	}
+}
+
+func TestGetAttachmentContent_TooLarge_Returns413(t *testing.T) {
+	svc := &fakeAttachmentSvc{contentErr: attachmentdom.ErrAttachmentContentTooLarge}
+	r := newAttachmentContentRouter(svc)
+	projectID := uuid.New()
+	taskID := uuid.New()
+	attachmentID := uuid.New()
+	path := "/projects/" + projectID.String() + "/tasks/" + taskID.String() +
+		"/attachments/" + attachmentID.String() + "/content"
+
+	w := doAttachRequest(t, r, http.MethodGet, path, nil)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/services/api/internal/transport/http/presenter/response.go
+++ b/services/api/internal/transport/http/presenter/response.go
@@ -254,6 +254,8 @@ func statusAndCodeFor(err error) (int, apierr.Code) {
 		return http.StatusBadRequest, apierr.CodeAttachmentInvalid
 	case errors.Is(err, attachmentdom.ErrAvatarOwnerMismatch):
 		return http.StatusNotFound, apierr.CodeFileNotFound
+	case errors.Is(err, attachmentdom.ErrAttachmentContentTooLarge):
+		return http.StatusRequestEntityTooLarge, apierr.CodeAttachmentTooLarge
 	case errors.Is(err, taskdom.ErrActivityNotFound):
 		return http.StatusNotFound, apierr.CodeActivityNotFound
 	case errors.Is(err, taskdom.ErrActivityForbidden):

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -554,6 +554,10 @@ func New(deps Deps) http.Handler {
 							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
 							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
 						)).Get("/{attachmentId}/download-url", deps.Attachment.GetDownloadURL)
+						r.With(httpmw.RequirePublicProjectOrPermissions(deps.ProjectVisibilitySvc, deps.Authorizer,
+							httpmw.PermissionGroup{Scope: httpmw.GlobalScope(), Permissions: []authz.Permission{authz.PermissionProjectsRead}},
+							httpmw.PermissionGroup{Scope: httpmw.ProjectScopeFromParam("projectId"), Permissions: []authz.Permission{authz.PermissionTasksRead}},
+						)).Get("/{attachmentId}/content", deps.Attachment.GetAttachmentContent)
 						r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionTasksWrite)).
 							Delete("/{attachmentId}", deps.Attachment.DeleteTaskAttachment)
 					})

--- a/services/api/test/e2e/attachment_management_test.go
+++ b/services/api/test/e2e/attachment_management_test.go
@@ -200,6 +200,29 @@ func TestE2EAttachmentManagement_CRUD(t *testing.T) {
 		}
 	})
 
+	t.Run("get_attachment_content", func(t *testing.T) {
+		if attachmentID == "" {
+			t.Skip("attachment_id not available (previous subtest failed)")
+		}
+		path := attachmentPath(env.base, projID, taskID, "/"+attachmentID+"/content")
+		req := mustRequest(env.ctx, t, http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp := mustDo(t, client, req)
+		defer func() { _ = resp.Body.Close() }()
+		assertStatus(t, resp, http.StatusOK)
+
+		if ct := resp.Header.Get("Content-Type"); ct != "text/plain" {
+			t.Errorf("expected Content-Type text/plain, got %q", ct)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read response body: %v", err)
+		}
+		if string(body) != fileContent {
+			t.Errorf("expected content %q, got %q", fileContent, string(body))
+		}
+	})
+
 	t.Run("get_download_url_inline", func(t *testing.T) {
 		if attachmentID == "" {
 			t.Skip("attachment_id not available (previous subtest failed)")


### PR DESCRIPTION
## Summary

Lets the AI agent download and read the contents of a task's attachments, and exposes the attachment list (with IDs) directly from `get_task` so the agent can act on it without an extra round trip.

## What changed

- **`apps/mcp/src/tools/attachment-tools.ts`** — new `read_task_attachment` MCP tool. Classifies the attachment by content-type (with a file-extension fallback for generic `application/octet-stream` uploads) and returns it appropriately:
  - Text files (code, markdown, JSON, YAML, CSV, logs, etc., up to 2 MB) come back as plain text.
  - Images (PNG/JPEG/GIF/WebP, up to 5 MB) come back as an inline image content block the model can view.
  - Anything else (PDFs, zips, docx, oversized files) returns a clear error pointing at `get_attachment_download_url` instead of failing silently.
- **`apps/mcp/src/utils/formatters.ts`** — `get_task`'s attachment list now includes each attachment's ID. It already listed name/size/upload date, but without the ID an agent couldn't chain into `read_task_attachment` or `get_attachment_download_url` without first calling `list_task_attachments` separately.
- **`apps/mcp/src/permissions.ts`** — `read_task_attachment` gated behind the existing `tasks.read` permission, same as the other read-only attachment tools.

## A bug found (and fixed) while verifying this end-to-end

The first implementation had `read_task_attachment` fetch bytes from the same presigned object-store URL `get_attachment_download_url` returns to browsers. That failed with a bare `fetch failed` when actually exercised from an agent conversation.

Root cause: presigned URLs are rewritten to a browser-facing public host (`STORAGE_PUBLIC_URL`, e.g. `http://localhost/storage` routed through the Caddy gateway in dev). A browser on the host machine reaches that fine. The MCP server, though, runs *inside* the ai-agent's sandbox container — on the same Docker network as `api`/`gateway` (reachable by service name), but `localhost` from inside that container refers to itself, not the gateway. There was no route to the presigned URL's host at all.

Fix: added a backend passthrough instead of trying to make the sandbox reach the public URL.

- **`services/api/internal/transport/http/handler/attachment_handler.go`** — new `GET /api/v1/projects/:id/tasks/:id/attachments/:id/content` endpoint that streams the file's bytes straight through the API.
- **`services/api/internal/domain/attachment/service.go`** / **`services/api/internal/service/attachment/service.go`** — new `GetAttachmentContent` method that reads the object server-side via the existing `storage.Client.GetObject`, capped at `MaxAttachmentContentSize` (10 MiB) with a new `ErrAttachmentContentTooLarge` → `413`.
- **`services/api/internal/apierr/codes.go`**, **`.../transport/http/presenter/response.go`**, **`.../transport/http/router/router.go`** — new error code and route wiring, same permission gate (`tasks.read`) as `list`/`download-url`.
- **`apps/mcp/src/api/views-client.ts`** — `downloadAttachmentContent` now calls this new endpoint against `config.baseURL` (the same connectivity path every other MCP tool call already relies on) instead of touching the presigned URL. `get_attachment_download_url` itself is untouched — browsers/humans still get a presigned URL directly.

## Test plan

- [x] `apps/mcp`: `tsc --noEmit` clean, `vitest run` — 517/517 pass, `biome check` clean on touched files
- [x] `services/api`: `go build ./...`, `go vet ./...`, `gofmt -l .` clean, `go test ./internal/...` all pass
- [x] `services/api` e2e: `PACA_E2E=1 go test ./test/e2e/... -run TestE2EAttachmentManagement` — new `get_attachment_content` subtest passes against a real MinIO container, confirming the fix (round-trips actual bytes through the API, no presigned URL involved)
