### PR TITLE
feat: enhance interaction layout with previous data retention during …

### DIFF
--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -105,6 +105,8 @@ import {
 	getDefaultInitialPageSize,
 	getDefaultPageSize,
 	getTaskColumnKeys,
+	resolveSelectedTask,
+	shouldClearColumnExtras,
 	type TaskFieldUpdate,
 	type ViewContext,
 } from "./view-utils";
@@ -912,7 +914,14 @@ export function InteractionLayout({
 		// of an unrelated column) used to make already-loaded tasks flash out
 		// of the list — and out from under an open task detail dialog — until
 		// that column's own expanded refetch caught up. Only drop a column's
-		// extras once its own base data has actually reached that depth.
+		// extras once its own base data has actually reached that depth —
+		// or, if the true total has shrunk below that depth (a loaded task
+		// got deleted or moved out of the column/filter), once the base
+		// query reports there's nothing left to fetch (`next_cursor: null`),
+		// since that response is authoritative even though it's shorter than
+		// expected. Without the second condition, a permanently-shrunk total
+		// would never satisfy the length check, leaving deleted/moved tasks
+		// stuck as unclearable ghosts in colExtraTasks indefinitely.
 		setColExtraTasks((prev) => {
 			let changed = false;
 			const next = { ...prev };
@@ -921,7 +930,7 @@ export function InteractionLayout({
 				const idx = fetchColumnDefs.findIndex((col) => col.key === key);
 				const data = idx >= 0 ? columnQueries[idx]?.data : undefined;
 				const expectedDepth = colExpandedPageSizes[key] ?? initialColPageSize;
-				if (data && data.items.length >= expectedDepth) {
+				if (shouldClearColumnExtras(data, expectedDepth)) {
 					delete next[key];
 					changed = true;
 				}
@@ -939,7 +948,13 @@ export function InteractionLayout({
 	// — confirmed via a network capture showing the resulting request had
 	// every filter field unchanged, only a reverted page_size. Compare by
 	// value instead, so only a genuine filter/sort/search change resets it.
-	const colBaseOptsKey = JSON.stringify(colBaseOpts);
+	const colBaseOptsKey = useMemo(
+		() => JSON.stringify(colBaseOpts),
+		[colBaseOpts],
+	);
+	// colBaseOptsKey is a value-equality fingerprint of colBaseOpts, kept in
+	// the dep array purely to control *when* this effect re-runs even though
+	// the body doesn't read it.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset only when the *value* of colBaseOpts changes
 	useEffect(() => {
 		setColExpandedPageSizes({});
@@ -1204,18 +1219,13 @@ export function InteractionLayout({
 	// and only clears when the selection itself changes.
 	const lastSelectedTaskRef = useRef<Task | null>(null);
 	const selectedTask = useMemo(() => {
-		if (!selectedTaskId) {
-			lastSelectedTaskRef.current = null;
-			return null;
-		}
-		const found = tasks.find((t) => t.id === selectedTaskId);
-		if (found) {
-			lastSelectedTaskRef.current = found;
-			return found;
-		}
-		return lastSelectedTaskRef.current?.id === selectedTaskId
-			? lastSelectedTaskRef.current
-			: null;
+		const { resolved, nextLastKnown } = resolveSelectedTask(
+			tasks,
+			selectedTaskId,
+			lastSelectedTaskRef.current,
+		);
+		lastSelectedTaskRef.current = nextLastKnown;
+		return resolved;
 	}, [selectedTaskId, tasks]);
 
 	const restoredFromUrl = useRef(false);

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1,5 +1,4 @@
 import {
-	keepPreviousData,
 	useInfiniteQuery,
 	useMutation,
 	useQueries,
@@ -105,6 +104,7 @@ import {
 	getDefaultInitialPageSize,
 	getDefaultPageSize,
 	getTaskColumnKeys,
+	keepPreviousDataOnPageSizeChangeOnly,
 	resolveSelectedTask,
 	shouldClearColumnExtras,
 	type TaskFieldUpdate,
@@ -817,8 +817,11 @@ export function InteractionLayout({
 						// back to undefined for the new key until it resolves, making
 						// already-visible tasks disappear from the list mid-fetch.
 						// Keeping the previous (smaller) page's data displayed avoids
-						// that gap.
-						placeholderData: keepPreviousData,
+						// that gap. Scoped to pageSize-only key changes so a genuine
+						// filter/sort/search change still drops to `undefined` and
+						// shows the loading skeleton, instead of silently rendering
+						// the previous (non-matching) filter's results.
+						placeholderData: keepPreviousDataOnPageSizeChangeOnly(colOpts),
 					};
 				})
 			: [],
@@ -869,18 +872,20 @@ export function InteractionLayout({
 
 	const initialGlobalPageSize =
 		configuredInitialPageSize ?? getDefaultInitialPageSize(activeView?.layout);
-	const fallbackQueryOpts = allTasksQueryOptions(projectId, {
+	const fallbackOpts = {
 		...fallbackBaseOpts,
 		pageSize: globalExpandedPageSize ?? initialGlobalPageSize,
-	});
+	};
+	const fallbackQueryOpts = allTasksQueryOptions(projectId, fallbackOpts);
 	const fallbackQuery = useQuery({
 		...fallbackQueryOpts,
 		enabled: !colQueriesEnabled && !viewsQuery.isLoading,
 		// See the matching comment on the column queries above: "load more"
 		// grows pageSize (and thus the queryKey), so keep showing the smaller
 		// page's data while the larger one fetches instead of dropping to
-		// undefined.
-		placeholderData: keepPreviousData,
+		// undefined — scoped to pageSize-only key changes so a genuine
+		// filter/sort/search change still shows the loading skeleton.
+		placeholderData: keepPreviousDataOnPageSizeChangeOnly(fallbackOpts),
 	});
 
 	// Per-column load-more state

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1,4 +1,5 @@
 import {
+	keepPreviousData,
 	useInfiniteQuery,
 	useMutation,
 	useQueries,
@@ -809,6 +810,13 @@ export function InteractionLayout({
 						] as const,
 						queryFn: () => listAllTasks(projectId, colOpts),
 						staleTime: 15_000,
+						// "Load more" grows this column's pageSize, which changes the
+						// queryKey above — without this, React Query would drop `data`
+						// back to undefined for the new key until it resolves, making
+						// already-visible tasks disappear from the list mid-fetch.
+						// Keeping the previous (smaller) page's data displayed avoids
+						// that gap.
+						placeholderData: keepPreviousData,
 					};
 				})
 			: [],
@@ -866,6 +874,11 @@ export function InteractionLayout({
 	const fallbackQuery = useQuery({
 		...fallbackQueryOpts,
 		enabled: !colQueriesEnabled && !viewsQuery.isLoading,
+		// See the matching comment on the column queries above: "load more"
+		// grows pageSize (and thus the queryKey), so keep showing the smaller
+		// page's data while the larger one fetches instead of dropping to
+		// undefined.
+		placeholderData: keepPreviousData,
 	});
 
 	// Per-column load-more state
@@ -879,7 +892,8 @@ export function InteractionLayout({
 		{},
 	);
 
-	// Sync next cursors from initial column query results; reset extras on re-fetch
+	// Sync next cursors from initial column query results; reset extras once
+	// each column's own base query has re-fetched at its expanded depth.
 	const colDataUpdatedKey = columnQueries.map((q) => q.dataUpdatedAt).join(",");
 	// biome-ignore lint/correctness/useExhaustiveDependencies: re-sync only when column query data changes
 	useEffect(() => {
@@ -890,16 +904,46 @@ export function InteractionLayout({
 			if (data) updated[col.key] = data.next_cursor ?? null;
 		});
 		setColNextCursors(updated);
-		// Clear load-more extras so stale tasks don't linger after a WS refetch.
-		// A brief flash is expected; colExpandedPageSizes ensures the next refetch
-		// re-fetches the same depth, restoring all visible items from the server.
-		setColExtraTasks({});
+		// "Load more" bumps colExpandedPageSizes[col.key], which changes that
+		// column's query to fetch the same expanded depth directly — once it
+		// resolves, the base data already covers what the extras held, so the
+		// extras are redundant and can be dropped. Dropping extras for every
+		// column on *any* column's refetch (e.g. a WS-triggered invalidation
+		// of an unrelated column) used to make already-loaded tasks flash out
+		// of the list — and out from under an open task detail dialog — until
+		// that column's own expanded refetch caught up. Only drop a column's
+		// extras once its own base data has actually reached that depth.
+		setColExtraTasks((prev) => {
+			let changed = false;
+			const next = { ...prev };
+			for (const [key, extras] of Object.entries(prev)) {
+				if (extras.length === 0) continue;
+				const idx = fetchColumnDefs.findIndex((col) => col.key === key);
+				const data = idx >= 0 ? columnQueries[idx]?.data : undefined;
+				const expectedDepth = colExpandedPageSizes[key] ?? initialColPageSize;
+				if (data && data.items.length >= expectedDepth) {
+					delete next[key];
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
 	}, [colDataUpdatedKey, colQueriesEnabled]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset only when base opts change
+	// colBaseOpts is a useMemo, but an upstream dependency (e.g. apiFilters,
+	// which depends on customFields/sprints — queries the task detail modal
+	// re-observes on open, both without an explicit staleTime) can recompute
+	// to a *new object* with the *same values* once that background refetch
+	// resolves. Comparing colBaseOpts by reference treated that as "filters
+	// changed" and wiped the "load more" depth back to the initial page size
+	// — confirmed via a network capture showing the resulting request had
+	// every filter field unchanged, only a reverted page_size. Compare by
+	// value instead, so only a genuine filter/sort/search change resets it.
+	const colBaseOptsKey = JSON.stringify(colBaseOpts);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset only when the *value* of colBaseOpts changes
 	useEffect(() => {
 		setColExpandedPageSizes({});
-	}, [colBaseOpts]);
+	}, [colBaseOptsKey]);
 
 	const handleLoadMoreColumn = useCallback(
 		async (colKey: string) => {
@@ -1072,11 +1116,24 @@ export function InteractionLayout({
 		[epicTasks, missingEpics],
 	);
 
+	// A column's queryKey changes every time its page size grows ("load
+	// more" bumps colExpandedPageSizes), which makes React Query treat it as
+	// a brand-new query — `isLoading` (isPending && isFetching) is true for
+	// that key until it resolves, even though `placeholderData` is already
+	// showing the previous page's tasks. Driving the full-list skeleton off
+	// `isLoading` therefore replaced the whole list with a skeleton on every
+	// "load more" and every background refetch of an expanded column. Check
+	// for the absence of data instead: with `keepPreviousData` in place that
+	// only happens on a column's genuine first fetch (disabled/noop columns
+	// are excluded via fetchStatus, since they'll never fetch).
 	const tasksLoading =
 		viewsQuery.isLoading ||
 		(colQueriesEnabled
-			? columnQueries.some((q) => q.isLoading)
-			: fallbackQuery.isLoading);
+			? columnQueries.some(
+					(q) => q.data === undefined && q.fetchStatus !== "idle",
+				)
+			: fallbackQuery.data === undefined &&
+				fallbackQuery.fetchStatus !== "idle");
 
 	// Per-column pagination props for views
 	const columnPagination = useMemo(() => {
@@ -1136,13 +1193,30 @@ export function InteractionLayout({
 		[projectId],
 	);
 
-	const selectedTask = useMemo(
-		() =>
-			selectedTaskId
-				? (tasks.find((t) => t.id === selectedTaskId) ?? null)
-				: null,
-		[selectedTaskId, tasks],
-	);
+	// `tasks` is the paginated/grouped list currently loaded for the active
+	// view, so it can transiently stop containing the selected task even
+	// while the detail modal is open — e.g. the per-column "load more" extras
+	// are cleared on every background refetch (see the colExtraTasks reset
+	// effect below) before the expanded page is re-fetched. If `selectedTask`
+	// tracked `tasks` directly, that gap would flip `open` to false and the
+	// modal would flash closed. Cache the last resolved task per id so the
+	// modal stays open (backed by its own fresh-task query) across such gaps,
+	// and only clears when the selection itself changes.
+	const lastSelectedTaskRef = useRef<Task | null>(null);
+	const selectedTask = useMemo(() => {
+		if (!selectedTaskId) {
+			lastSelectedTaskRef.current = null;
+			return null;
+		}
+		const found = tasks.find((t) => t.id === selectedTaskId);
+		if (found) {
+			lastSelectedTaskRef.current = found;
+			return found;
+		}
+		return lastSelectedTaskRef.current?.id === selectedTaskId
+			? lastSelectedTaskRef.current
+			: null;
+	}, [selectedTaskId, tasks]);
 
 	const restoredFromUrl = useRef(false);
 	useEffect(() => {

--- a/apps/web/src/components/projects/interactions/view-utils.test.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.test.ts
@@ -1,0 +1,129 @@
+// Regression tests for the "load more" pagination / task-detail-modal fixes
+// in interaction-layout.tsx (see the fix's commit for the full root-cause
+// write-up). These exercise the extracted pure logic directly rather than
+// mounting the full InteractionLayout component, which requires a large
+// amount of router/query/plugin-registry context.
+
+import { describe, expect, it } from "vitest";
+import type { Task, TaskListResult } from "@/lib/interaction-api";
+import { resolveSelectedTask, shouldClearColumnExtras } from "./view-utils";
+
+const PROJECT_ID = "proj-1";
+
+const makeTask = (overrides: Partial<Task> = {}): Task => ({
+	id: "task-1",
+	project_id: PROJECT_ID,
+	title: "Do the thing",
+	task_number: 0,
+	sprint_id: null,
+	status_id: "status-todo",
+	task_type_id: null,
+	parent_task_id: null,
+	description: null,
+	importance: 0,
+	assignee_ids: [],
+	reporter_id: null,
+	custom_fields: {},
+	view_position: null,
+	view_group_key: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+	...overrides,
+});
+
+const makeResult = (
+	overrides: Partial<TaskListResult> = {},
+): TaskListResult => ({
+	items: [],
+	page_size: 20,
+	next_cursor: null,
+	...overrides,
+});
+
+describe("shouldClearColumnExtras", () => {
+	it("does not clear while the base query has no data yet", () => {
+		expect(shouldClearColumnExtras(undefined, 35)).toBe(false);
+	});
+
+	it("does not clear while the base query hasn't caught up and more pages remain", () => {
+		const data = makeResult({
+			items: [makeTask(), makeTask({ id: "task-2" })],
+			next_cursor: "cursor-1",
+		});
+		expect(shouldClearColumnExtras(data, 35)).toBe(false);
+	});
+
+	it("clears once the base query has reached the expected depth", () => {
+		const items = Array.from({ length: 35 }, (_, i) =>
+			makeTask({ id: `task-${i}` }),
+		);
+		const data = makeResult({ items, next_cursor: "cursor-more" });
+		expect(shouldClearColumnExtras(data, 35)).toBe(true);
+	});
+
+	it("clears when the base query is exhausted even if shorter than expected depth (regression: deleted/moved task)", () => {
+		// A column expanded to depth 35 via "load more", then one of those
+		// tasks got deleted (or moved out of the column) by someone else —
+		// the true total is now 34, which the base query can never re-reach.
+		// The base query reporting `next_cursor: null` (nothing left to
+		// fetch) must be treated as authoritative so extras don't linger
+		// forever holding the deleted/moved task.
+		const items = Array.from({ length: 34 }, (_, i) =>
+			makeTask({ id: `task-${i}` }),
+		);
+		const data = makeResult({ items, next_cursor: null });
+		expect(shouldClearColumnExtras(data, 35)).toBe(true);
+	});
+
+	it("treats an undefined next_cursor the same as null (exhausted)", () => {
+		const items = [makeTask()];
+		const data: Pick<TaskListResult, "items" | "next_cursor"> = { items };
+		expect(shouldClearColumnExtras(data, 35)).toBe(true);
+	});
+});
+
+describe("resolveSelectedTask", () => {
+	it("resolves to null and clears the cache when nothing is selected", () => {
+		const cached = makeTask({ id: "task-cached" });
+		expect(resolveSelectedTask([], null, cached)).toEqual({
+			resolved: null,
+			nextLastKnown: null,
+		});
+	});
+
+	it("resolves the task straight from the list and caches it when present", () => {
+		const task = makeTask({ id: "task-1", title: "Fresh title" });
+		const result = resolveSelectedTask([task], "task-1", null);
+		expect(result.resolved).toBe(task);
+		expect(result.nextLastKnown).toBe(task);
+	});
+
+	it("falls back to the cached task when the selection transiently drops out of the list (regression: modal flash-close)", () => {
+		// Simulates the reported bug: the task detail dialog is open for
+		// "task-1", a background refetch (triggered by the dialog itself
+		// re-observing sprints/customFields) briefly empties `tasks` before
+		// the expanded page re-resolves.
+		const cached = makeTask({ id: "task-1", title: "Cached title" });
+		const result = resolveSelectedTask([], "task-1", cached);
+		expect(result.resolved).toBe(cached);
+		// Untouched — still available if the next lookup is also a miss.
+		expect(result.nextLastKnown).toBe(cached);
+	});
+
+	it("does not fall back to a cached task belonging to a different id", () => {
+		const cached = makeTask({ id: "task-other" });
+		const result = resolveSelectedTask([], "task-1", cached);
+		expect(result.resolved).toBeNull();
+		// The stale cache for the other id is left untouched rather than
+		// wiped, so it can still resolve if that id is re-selected later.
+		expect(result.nextLastKnown).toBe(cached);
+	});
+
+	it("prefers a freshly-found task over the cached one for the same id", () => {
+		const cached = makeTask({ id: "task-1", title: "Stale title" });
+		const fresh = makeTask({ id: "task-1", title: "Fresh title" });
+		const result = resolveSelectedTask([fresh], "task-1", cached);
+		expect(result.resolved).toBe(fresh);
+		expect(result.nextLastKnown).toBe(fresh);
+	});
+});

--- a/apps/web/src/components/projects/interactions/view-utils.test.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.test.ts
@@ -5,8 +5,16 @@
 // amount of router/query/plugin-registry context.
 
 import { describe, expect, it } from "vitest";
-import type { Task, TaskListResult } from "@/lib/interaction-api";
-import { resolveSelectedTask, shouldClearColumnExtras } from "./view-utils";
+import type {
+	ListTasksOptions,
+	Task,
+	TaskListResult,
+} from "@/lib/interaction-api";
+import {
+	keepPreviousDataOnPageSizeChangeOnly,
+	resolveSelectedTask,
+	shouldClearColumnExtras,
+} from "./view-utils";
 
 const PROJECT_ID = "proj-1";
 
@@ -125,5 +133,55 @@ describe("resolveSelectedTask", () => {
 		const result = resolveSelectedTask([fresh], "task-1", cached);
 		expect(result.resolved).toBe(fresh);
 		expect(result.nextLastKnown).toBe(fresh);
+	});
+});
+
+describe("keepPreviousDataOnPageSizeChangeOnly", () => {
+	const prevData = makeResult({ items: [makeTask()] });
+
+	it("returns undefined when there is no previous query (first-ever fetch)", () => {
+		const placeholderFn = keepPreviousDataOnPageSizeChangeOnly({
+			pageSize: 20,
+		});
+		expect(placeholderFn(undefined, undefined)).toBeUndefined();
+	});
+
+	it("returns undefined when the previous query never resolved (no data to reuse)", () => {
+		const placeholderFn = keepPreviousDataOnPageSizeChangeOnly({
+			pageSize: 20,
+		});
+		const previousQuery = { queryKey: ["col", { pageSize: 5 }] as const };
+		expect(placeholderFn(undefined, previousQuery)).toBeUndefined();
+	});
+
+	it("keeps the previous page's data when only pageSize changed (regression: 'load more')", () => {
+		const opts: ListTasksOptions = { statusIds: ["status-todo"], pageSize: 5 };
+		const grownOpts: ListTasksOptions = { ...opts, pageSize: 20 };
+		const placeholderFn = keepPreviousDataOnPageSizeChangeOnly(grownOpts);
+		const previousQuery = { queryKey: ["col", opts] as const };
+		expect(placeholderFn(prevData, previousQuery)).toBe(prevData);
+	});
+
+	it("drops previous data when a filter changed alongside pageSize (regression: stale filter results)", () => {
+		// Reported issue: because these queries key on the full options object,
+		// blindly reusing previous data across *any* key change (the stock
+		// `keepPreviousData` helper) would keep showing a stale, non-matching
+		// result set when a user changes a filter — with no loading indicator.
+		const opts: ListTasksOptions = { statusIds: ["status-todo"], pageSize: 5 };
+		const filterChanged: ListTasksOptions = {
+			statusIds: ["status-done"],
+			pageSize: 5,
+		};
+		const placeholderFn = keepPreviousDataOnPageSizeChangeOnly(filterChanged);
+		const previousQuery = { queryKey: ["col", opts] as const };
+		expect(placeholderFn(prevData, previousQuery)).toBeUndefined();
+	});
+
+	it("drops previous data when the search term changed", () => {
+		const opts: ListTasksOptions = { search: "foo", pageSize: 5 };
+		const searchChanged: ListTasksOptions = { search: "bar", pageSize: 5 };
+		const placeholderFn = keepPreviousDataOnPageSizeChangeOnly(searchChanged);
+		const previousQuery = { queryKey: ["col", opts] as const };
+		expect(placeholderFn(prevData, previousQuery)).toBeUndefined();
 	});
 });

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next";
 import {
 	type FilterConfig,
+	type ListTasksOptions,
 	resolveFilterConfig,
 	type Sprint,
 	type Task,
@@ -557,4 +558,42 @@ export function resolveSelectedTask(
 	}
 	const fallback = lastKnownTask?.id === selectedTaskId ? lastKnownTask : null;
 	return { resolved: fallback, nextLastKnown: lastKnownTask };
+}
+
+// ── Scoped placeholder data for pagination queries ────────────────────────────
+
+/**
+ * Builds a React Query `placeholderData` function that keeps the previous
+ * query's result only when the *only* difference between the previous
+ * request's options and `currentOpts` is `pageSize` — i.e. this queryKey
+ * change is a "load more" page-size bump or a WS-triggered depth-restore
+ * refetch, not a genuine filter/sort/search change.
+ *
+ * These queries key on the full filter-options object, so the stock
+ * `keepPreviousData` helper (which keeps previous data across *any* queryKey
+ * change) would also kick in when a user edits a filter or types a search:
+ * the previous, now non-matching results would keep rendering — with no
+ * loading skeleton and no `isPlaceholderData` indicator — until the new
+ * request resolves. Scoping the reuse to pageSize-only changes restores the
+ * loading state for genuine filter/sort/search changes while still avoiding
+ * the pagination flash this was introduced to fix.
+ */
+export function keepPreviousDataOnPageSizeChangeOnly(
+	currentOpts: ListTasksOptions,
+) {
+	return (
+		previousData: TaskListResult | undefined,
+		previousQuery: { queryKey: readonly unknown[] } | undefined,
+	): TaskListResult | undefined => {
+		if (previousData === undefined || !previousQuery) return undefined;
+		const prevOpts = previousQuery.queryKey.at(-1) as
+			| ListTasksOptions
+			| undefined;
+		if (!prevOpts || typeof prevOpts !== "object") return undefined;
+		const { pageSize: _prevPageSize, ...prevRest } = prevOpts;
+		const { pageSize: _currPageSize, ...currRest } = currentOpts;
+		return JSON.stringify(prevRest) === JSON.stringify(currRest)
+			? previousData
+			: undefined;
+	};
 }

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -4,6 +4,7 @@ import {
 	resolveFilterConfig,
 	type Sprint,
 	type Task,
+	type TaskListResult,
 	type ViewLayout,
 } from "@/lib/interaction-api";
 import type {
@@ -499,4 +500,61 @@ export function buildColumnDropUpdate(
 	}
 
 	return {};
+}
+
+// ── Per-column "load more" extras reconciliation ─────────────────────────────
+
+/**
+ * Whether a column's `colExtraTasks` ("load more" overflow, tracked
+ * separately from the column's base query result) is now redundant and can
+ * be dropped in favor of the base query's own data.
+ *
+ * True once the base query's data either (a) has caught up to the expanded
+ * depth the extras represent, or (b) reports there's nothing left to fetch
+ * (`next_cursor` is null/undefined) — which is authoritative even when
+ * shorter than the expected depth. (b) matters when the true total has
+ * permanently shrunk below the expected depth (an already-loaded task got
+ * deleted, or moved out of this column/filter by someone else): without it,
+ * the base query can never again return `expectedDepth` items, so extras
+ * would never clear and a deleted/moved task would linger as an unclearable
+ * ghost row indefinitely.
+ */
+export function shouldClearColumnExtras(
+	data: Pick<TaskListResult, "items" | "next_cursor"> | undefined,
+	expectedDepth: number,
+): boolean {
+	if (!data) return false;
+	return data.items.length >= expectedDepth || data.next_cursor == null;
+}
+
+// ── Selected-task resolution (survives transient gaps in the task list) ──────
+
+/**
+ * Resolves the task detail dialog's target task from the currently-loaded
+ * `tasks` list, falling back to the last-resolved task for the same id when
+ * `tasks` transiently doesn't contain it (e.g. a background refetch drops it
+ * from the loaded page right before a re-fetch restores it). Without this
+ * fallback, that gap flips the dialog's `open` prop to false and it flashes
+ * closed.
+ *
+ * `nextLastKnown` mirrors exactly what the caller should store for the next
+ * call: it only changes on a genuine selection change (cleared) or a
+ * successful lookup (updated) — a transient miss for the *same* selection
+ * leaves it untouched, so a later miss can't be masked by an unrelated
+ * earlier selection's cached task.
+ */
+export function resolveSelectedTask(
+	tasks: Task[],
+	selectedTaskId: string | null,
+	lastKnownTask: Task | null,
+): { resolved: Task | null; nextLastKnown: Task | null } {
+	if (!selectedTaskId) {
+		return { resolved: null, nextLastKnown: null };
+	}
+	const found = tasks.find((t) => t.id === selectedTaskId) ?? null;
+	if (found) {
+		return { resolved: found, nextLastKnown: found };
+	}
+	const fallback = lastKnownTask?.id === selectedTaskId ? lastKnownTask : null;
+	return { resolved: fallback, nextLastKnown: lastKnownTask };
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in the Product Backlog **Table** view (`interaction-layout.tsx`), both triggered by opening a task's detail dialog after using "View more":

1. The task detail dialog would flash open and immediately close.
2. The list would lose its "View more" expansion and collapse back down to the initial page size.

Both traced back to the same underlying issue: the per-column "load more" pagination state wasn't resilient to normal React Query background refetches (which the task detail modal triggers on open, since it re-observes `sprints`/`customFields` — queries without an explicit `staleTime`).

## Root causes & fixes

- **Modal closing itself**: `selectedTask` (which drives the modal's `open` prop) was derived by looking up the selected id in the currently-loaded `tasks` list. Any refetch that transiently dropped the task out of that list flipped `open` to `false`. Now caches the last-resolved task per id so the modal stays open across such gaps, backed by its own internal fresh-task query.
- **"Load more" extras wiped too eagerly**: the effect that cleared per-column "load more" extras (`colExtraTasks`) fired on *any* column's data update, not just the column whose depth actually changed — dropping already-loaded tasks before the corresponding expanded-depth query resolved. Now only drops a column's extras once its own base query has reached that depth.
- **Query key transition dropped data to `undefined`**: bumping a column's page size changes its React Query key, and by default the old page's data is discarded while the new key is in flight. Added `placeholderData: keepPreviousData` so the previous (smaller) page keeps rendering during that transition instead of leaving a gap.
- **Skeleton flash on every page-size bump**: `tasksLoading` was driven by `.isLoading` (`isPending && isFetching`), which is `true` for any *brand-new* query key regardless of `placeholderData` — so the whole list swapped to a loading skeleton on every "load more" and background refetch. Now checks for the absence of `data` instead, which `keepPreviousData` keeps populated through the transition.
- **The actual collapse trigger**: `colExpandedPageSizes` (the "load more" depth per column) was reset by a `useEffect` keyed on `colBaseOpts`'s *object reference*. A network capture showed the request that fired on modal-open had every filter field unchanged (`sprint_id`, `task_type_ids`, `view_id`) — only the page size had reverted to the initial value. That's the signature of a referentially-new-but-value-identical `colBaseOpts`, most likely from `apiFilters` recomputing after the modal's `sprints`/`customFields` refetch resolved. Now compares `colBaseOpts` by value (`JSON.stringify`) instead of by reference, so the reset only fires on a genuine filter/sort/search change.

## Testing

- `tsc -b` — clean
- `biome check` on the changed file — clean
- `vitest run src/components/projects/` — 97 tests passed
- Root-caused interactively with the reporting user via a live network capture (see fix above); UI verification in a real browser is still pending since I didn't have interactive browser access during this change.
