### PR TITLE
Add MiniMax-M2.7 to the model catalog

### DIFF
--- a/services/ai-agent/data/llm_models.json
+++ b/services/ai-agent/data/llm_models.json
@@ -1804,6 +1804,7 @@
       "MiniMax-M2.1-lightning",
       "MiniMax-M2.5",
       "MiniMax-M2.5-lightning",
+      "MiniMax-M2.7",
       "MiniMax-M3",
       "speech-02-hd",
       "speech-02-turbo",

--- a/services/ai-agent/scripts/generate_llm_models.py
+++ b/services/ai-agent/scripts/generate_llm_models.py
@@ -43,6 +43,11 @@ _KNOWN_BASE_URLS: dict[str, str] = {
     "minimax": "https://api.minimax.io/v1",
 }
 
+# Keep newly released models available while the pinned LiteLLM catalog catches up.
+_REQUIRED_MODELS: dict[str, tuple[str, ...]] = {
+    "minimax": ("MiniMax-M2.7",),
+}
+
 # These providers launch interactive device-auth flows (GitHub OAuth, ChatGPT
 # OAuth) when get_api_base is called, blocking forever on stdin.  Skip them.
 _SKIP_PROVIDERS: frozenset[str] = frozenset({"chatgpt", "github_copilot"})
@@ -88,6 +93,11 @@ async def _build() -> dict[str, dict]:
         while bare.lower().startswith(prefix):
             bare = bare[len(prefix):]
         provider_to_models[provider].append(bare)
+
+    for provider, models in _REQUIRED_MODELS.items():
+        for model in models:
+            if model not in provider_to_models[provider]:
+                provider_to_models[provider].append(model)
 
     providers = sorted(provider_to_models.items())
     print(f"Resolving base URLs for {len(providers)} providers…", flush=True)

--- a/services/ai-agent/tests/test_generate_llm_models.py
+++ b/services/ai-agent/tests/test_generate_llm_models.py
@@ -1,0 +1,16 @@
+from unittest.mock import AsyncMock
+
+from scripts import generate_llm_models
+
+
+async def test_build_includes_required_minimax_model(monkeypatch):
+    monkeypatch.setattr(generate_llm_models.litellm, "model_cost", {})
+    monkeypatch.setattr(
+        generate_llm_models,
+        "_base_url",
+        AsyncMock(return_value="https://api.minimax.io/v1"),
+    )
+
+    catalog = await generate_llm_models._build()
+
+    assert catalog["minimax"]["models"] == ["MiniMax-M2.7"]

--- a/services/ai-agent/tests/test_routes.py
+++ b/services/ai-agent/tests/test_routes.py
@@ -63,6 +63,12 @@ async def test_llm_models_returns_dict(client):
         assert isinstance(info["models"], list)
 
 
+async def test_llm_models_includes_minimax_m2_7(client):
+    resp = await client.get("/llm/models")
+    assert resp.status_code == 200
+    assert "MiniMax-M2.7" in resp.json()["minimax"]["models"]
+
+
 # ─── Conversations — auth ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Reason: The MiniMax catalog omitted the current MiniMax-M2.7 model.

This adds MiniMax-M2.7 to the committed model catalog and preserves it in future catalog refreshes while the pinned LiteLLM metadata catches up. Regression coverage verifies both the generator and the `/llm/models` response.

Checks:

- `uv run pytest -q`
- `uv run pytest tests/test_generate_llm_models.py tests/test_routes.py -q`
- `uv run ruff check scripts/generate_llm_models.py tests/test_generate_llm_models.py tests/test_routes.py`
- `python3 -m json.tool data/llm_models.json`
- `git diff --check`
