### PR TITLE
feat: enhance task selection logic to support deep linking via URL ta…

### DIFF
--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1254,6 +1254,23 @@ export function InteractionLayout({
 		return final;
 	}, [selectedTaskId, tasks, selectedTaskDirectQuery.data]);
 
+	// A selected id that's absent from the loaded list AND fails to load
+	// directly (deleted, moved to another project, or a mistyped id) can
+	// never resolve to a task. Without this, a broken `?taskId=` deep link
+	// leaves the param in the URL forever with no dialog and no feedback.
+	useEffect(() => {
+		if (!selectedTaskId || !selectedTaskDirectQuery.isError) return;
+		if (tasks.some((t) => t.id === selectedTaskId)) return;
+		setSelectedTaskId(null);
+		try {
+			const url = new URL(window.location.href);
+			url.searchParams.delete("taskId");
+			window.history.pushState({}, "", url.toString());
+		} catch {
+			/* ignore */
+		}
+	}, [selectedTaskId, selectedTaskDirectQuery.isError, tasks]);
+
 	const handleTaskClick = (task: Task) => {
 		setSelectedTaskId(task.id);
 		onTaskClick?.(task);

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1265,10 +1265,12 @@ export function InteractionLayout({
 	const selectedTaskDirectQuery = useQuery({
 		...taskQueryOptions(projectId, selectedTaskId ?? ""),
 		enabled: !!selectedTaskId && !selectedTaskInList,
-		// Don't retry: a 404 is never worth retrying, and any other error just
-		// leaves the dialog closed (see `isTaskNotFoundError` below, which only
-		// clears `?taskId=` on a confirmed 404 — not on this).
-		retry: false,
+		// A confirmed 404 is never worth retrying — fail fast so the `?taskId=`
+		// cleanup below runs promptly. Any other error (network, 5xx) keeps the
+		// default bounded retry, since those are transient and a valid deep
+		// link shouldn't be abandoned after a single blip.
+		retry: (failureCount, error) =>
+			!isTaskNotFoundError(error) && failureCount < 3,
 	});
 	const selectedTask = useMemo(() => {
 		const { resolved, nextLastKnown } = resolveSelectedTask(

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -548,7 +548,13 @@ export function InteractionLayout({
 	);
 	const [searchOpen, setSearchOpen] = useState(false);
 	const searchRef = useRef<HTMLInputElement>(null);
-	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(() => {
+		try {
+			return new URL(window.location.href).searchParams.get("taskId");
+		} catch {
+			return null;
+		}
+	});
 
 	const { data: members = [] } = useQuery(
 		projectMembersQueryOptions(projectId),
@@ -1223,33 +1229,30 @@ export function InteractionLayout({
 	// modal stays open (backed by its own fresh-task query) across such gaps,
 	// and only clears when the selection itself changes.
 	const lastSelectedTaskRef = useRef<Task | null>(null);
+	// A task opened via a direct `?taskId=` URL (deep link, bookmark, share)
+	// may not be among the currently loaded/filtered `tasks` at all — e.g. the
+	// backlog view only paginates a page at a time, or the task doesn't match
+	// the active view's filters. Fetch it by id directly so the dialog can
+	// still open; this shares its query key with the mutations below, so it
+	// stays in sync with edits made elsewhere.
+	const selectedTaskDirectQuery = useQuery({
+		...taskQueryOptions(projectId, selectedTaskId ?? ""),
+		enabled: !!selectedTaskId,
+	});
 	const selectedTask = useMemo(() => {
 		const { resolved, nextLastKnown } = resolveSelectedTask(
 			tasks,
 			selectedTaskId,
 			lastSelectedTaskRef.current,
 		);
-		lastSelectedTaskRef.current = nextLastKnown;
-		return resolved;
-	}, [selectedTaskId, tasks]);
-
-	const restoredFromUrl = useRef(false);
-	useEffect(() => {
-		if (restoredFromUrl.current || tasks.length === 0) return;
-		try {
-			const url = new URL(window.location.href);
-			const taskId = url.searchParams.get("taskId");
-			if (taskId) {
-				const found = tasks.find((t) => t.id === taskId);
-				if (found) {
-					setSelectedTaskId(found.id);
-					restoredFromUrl.current = true;
-				}
-			}
-		} catch {
-			/* ignore */
-		}
-	}, [tasks]);
+		const directFetched =
+			selectedTaskId && selectedTaskDirectQuery.data?.id === selectedTaskId
+				? selectedTaskDirectQuery.data
+				: null;
+		const final = resolved ?? directFetched;
+		lastSelectedTaskRef.current = final ?? nextLastKnown;
+		return final;
+	}, [selectedTaskId, tasks, selectedTaskDirectQuery.data]);
 
 	const handleTaskClick = (task: Task) => {
 		setSelectedTaskId(task.id);

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDebouncedCallback } from "@/hooks/use-debounced-callback";
+import { isTaskNotFoundError } from "@/lib/api-error";
 import {
 	allTasksQueryOptions,
 	bulkMoveViewTaskPositions,
@@ -281,6 +282,28 @@ function buildColumnFilter(
 		}
 		default:
 			return null;
+	}
+}
+
+/** Sets `?taskId=` on the current URL without triggering a route navigation. */
+function setTaskIdSearchParam(taskId: string) {
+	try {
+		const url = new URL(window.location.href);
+		url.searchParams.set("taskId", taskId);
+		window.history.pushState({}, "", url.toString());
+	} catch {
+		/* ignore */
+	}
+}
+
+/** Removes `?taskId=` from the current URL without triggering a route navigation. */
+function clearTaskIdSearchParam() {
+	try {
+		const url = new URL(window.location.href);
+		url.searchParams.delete("taskId");
+		window.history.pushState({}, "", url.toString());
+	} catch {
+		/* ignore */
 	}
 }
 
@@ -1234,10 +1257,18 @@ export function InteractionLayout({
 	// backlog view only paginates a page at a time, or the task doesn't match
 	// the active view's filters. Fetch it by id directly so the dialog can
 	// still open; this shares its query key with the mutations below, so it
-	// stays in sync with edits made elsewhere.
+	// stays in sync with edits made elsewhere. Only enabled when the task
+	// isn't already resolvable from `tasks` — the common case of clicking a
+	// task that's already loaded needs no extra request.
+	const selectedTaskInList =
+		!!selectedTaskId && tasks.some((t) => t.id === selectedTaskId);
 	const selectedTaskDirectQuery = useQuery({
 		...taskQueryOptions(projectId, selectedTaskId ?? ""),
-		enabled: !!selectedTaskId,
+		enabled: !!selectedTaskId && !selectedTaskInList,
+		// Don't retry: a 404 is never worth retrying, and any other error just
+		// leaves the dialog closed (see `isTaskNotFoundError` below, which only
+		// clears `?taskId=` on a confirmed 404 — not on this).
+		retry: false,
 	});
 	const selectedTask = useMemo(() => {
 		const { resolved, nextLastKnown } = resolveSelectedTask(
@@ -1254,33 +1285,28 @@ export function InteractionLayout({
 		return final;
 	}, [selectedTaskId, tasks, selectedTaskDirectQuery.data]);
 
-	// A selected id that's absent from the loaded list AND fails to load
-	// directly (deleted, moved to another project, or a mistyped id) can
-	// never resolve to a task. Without this, a broken `?taskId=` deep link
-	// leaves the param in the URL forever with no dialog and no feedback.
+	// A selected id that's absent from the loaded list and the API has
+	// authoritatively confirmed (404 TASK_NOT_FOUND) doesn't exist — deleted,
+	// moved to another project, or a mistyped id — can never resolve to a
+	// task. Without this, a broken `?taskId=` deep link leaves the param in
+	// the URL forever with no dialog and no feedback. Deliberately scoped to
+	// TASK_NOT_FOUND rather than any query error: a transient network/5xx
+	// failure says nothing about whether the task exists, so it must not
+	// wipe out an otherwise-valid deep link.
+	const selectedTaskConfirmedMissing =
+		selectedTaskDirectQuery.isError &&
+		isTaskNotFoundError(selectedTaskDirectQuery.error);
 	useEffect(() => {
-		if (!selectedTaskId || !selectedTaskDirectQuery.isError) return;
+		if (!selectedTaskId || !selectedTaskConfirmedMissing) return;
 		if (tasks.some((t) => t.id === selectedTaskId)) return;
 		setSelectedTaskId(null);
-		try {
-			const url = new URL(window.location.href);
-			url.searchParams.delete("taskId");
-			window.history.pushState({}, "", url.toString());
-		} catch {
-			/* ignore */
-		}
-	}, [selectedTaskId, selectedTaskDirectQuery.isError, tasks]);
+		clearTaskIdSearchParam();
+	}, [selectedTaskId, selectedTaskConfirmedMissing, tasks]);
 
 	const handleTaskClick = (task: Task) => {
 		setSelectedTaskId(task.id);
 		onTaskClick?.(task);
-		try {
-			const url = new URL(window.location.href);
-			url.searchParams.set("taskId", task.id);
-			window.history.pushState({}, "", url.toString());
-		} catch {
-			/* ignore */
-		}
+		setTaskIdSearchParam(task.id);
 	};
 
 	const updateStatusMutation = useMutation({
@@ -2022,13 +2048,7 @@ export function InteractionLayout({
 				onOpenChange={(v) => {
 					if (!v) {
 						setSelectedTaskId(null);
-						try {
-							const url = new URL(window.location.href);
-							url.searchParams.delete("taskId");
-							window.history.pushState({}, "", url.toString());
-						} catch {
-							/* ignore */
-						}
+						clearTaskIdSearchParam();
 					}
 				}}
 				projectId={projectId}

--- a/apps/web/src/lib/api-error.test.ts
+++ b/apps/web/src/lib/api-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { ApiErrorCode, getApiErrorCode } from "./api-error";
+import {
+	ApiErrorCode,
+	getApiErrorCode,
+	isTaskNotFoundError,
+} from "./api-error";
 
 describe("getApiErrorCode", () => {
 	it("returns known API error code", () => {
@@ -34,5 +38,39 @@ describe("getApiErrorCode", () => {
 		};
 
 		expect(getApiErrorCode(error)).toBeNull();
+	});
+});
+
+describe("isTaskNotFoundError", () => {
+	it("returns true for a TASK_NOT_FOUND error", () => {
+		const error = {
+			response: {
+				status: 404,
+				data: { error_code: ApiErrorCode.TaskNotFound },
+			},
+		};
+
+		expect(isTaskNotFoundError(error)).toBe(true);
+	});
+
+	it("returns false for a transient network/5xx error with no error_code", () => {
+		const error = { response: { status: 502, data: {} } };
+
+		expect(isTaskNotFoundError(error)).toBe(false);
+	});
+
+	it("returns false for an unrelated error code", () => {
+		const error = {
+			response: {
+				status: 404,
+				data: { error_code: ApiErrorCode.ProjectNotFound },
+			},
+		};
+
+		expect(isTaskNotFoundError(error)).toBe(false);
+	});
+
+	it("returns false for a plain network error with no response", () => {
+		expect(isTaskNotFoundError(new Error("Network Error"))).toBe(false);
 	});
 });

--- a/apps/web/src/lib/api-error.ts
+++ b/apps/web/src/lib/api-error.ts
@@ -100,6 +100,15 @@ export function isPasswordChangeRequired(err: unknown): boolean {
 	);
 }
 
+/**
+ * Returns true when an Axios error is a 404 TASK_NOT_FOUND — i.e. the API has
+ * authoritatively confirmed the task doesn't exist, as opposed to a network
+ * failure, timeout, or 5xx that says nothing about whether the task exists.
+ */
+export function isTaskNotFoundError(err: unknown): boolean {
+	return getApiErrorCode(err) === ApiErrorCode.TaskNotFound;
+}
+
 /** Shape of the success envelope returned by the API on success. */
 export interface SuccessEnvelope<T> {
 	success: true;


### PR DESCRIPTION
## Summary

Fixes a bug where navigating directly to a project interaction page (backlog/board/sprint) with a `?taskId=<id>` URL param — e.g. `.../interactions/backlog?taskId=f3eba210-34cb-4935-9386-fa8127adfde1` — did not open the task detail dialog, even though the task exists.

## Root cause

`interaction-layout.tsx` only set `selectedTaskId` from the URL via a `useEffect` that looked the id up in `tasks` — the paginated, filtered list currently loaded for the active view (backlog/board queries fetch one page per column at a time). If the target task wasn't in that first page, or didn't match the view's active filters, the lookup silently failed: `selectedTaskId` was never set, and the dialog's `open` prop (`!!selectedTask`) stayed `false` with no error surfaced anywhere.

The standalone `/projects/$projectId/tasks/$taskId` route doesn't have this problem because it fetches the task directly by id via `taskQueryOptions`, independent of any list — this fix brings the same guarantee to the in-page dialog.

## Fix

- Initialize `selectedTaskId` synchronously from the `taskId` URL param on mount, instead of waiting for the paginated list to contain it.
- Added a direct `useQuery(taskQueryOptions(projectId, selectedTaskId))` that fetches the task by id regardless of pagination/filters, used as a fallback whenever the task isn't present in the currently loaded `tasks` list. It shares its query key with the existing task-update mutations, so it stays in sync with edits made elsewhere.
- Removed the now-redundant `restoredFromUrl` effect.

## Testing

- `tsc -b` — clean
- `biome check` on the changed file — clean
- `vitest run src/components/projects/interactions/view-utils.test.ts` — 15 tests passed
- UI verification in a real browser is still pending — no interactive browser access during this change.
