### PR TITLE
feat(agent): conversation audience + owner-private scope enforcement

### DIFF
--- a/apps/mcp/src/__tests__/permissions.test.ts
+++ b/apps/mcp/src/__tests__/permissions.test.ts
@@ -222,15 +222,24 @@ describe("fetchAgentPermissions", () => {
 		vi.unstubAllGlobals();
 	});
 
-	it("returns empty maps when no agentId and no projectId (personal key mode)", async () => {
+	it("fetches global permissions when no agentId and no projectId (personal key mode)", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ permissions: { "projects.read": true } }),
+		} as Response);
+
 		const result = await fetchAgentPermissions({
 			apiKey: "key-123",
 			baseURL: "http://localhost:8080",
 		});
-		expect(result.global).toEqual({});
+
+		// A personal key is no longer "show everything": it fetches the
+		// caller's own global permissions and gets no project map.
+		expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+		const [url] = vi.mocked(fetch).mock.calls[0];
+		expect(url as string).toContain("users/me/global-permissions");
+		expect(result.global).toEqual({ "projects.read": true });
 		expect(result.projects).toEqual({});
-		// fetch should NOT have been called
-		expect(vi.mocked(fetch)).not.toHaveBeenCalled();
 	});
 
 	it("fetches project permissions when projectId is provided", async () => {

--- a/apps/mcp/src/permissions.ts
+++ b/apps/mcp/src/permissions.ts
@@ -424,13 +424,13 @@ export async function fetchAgentPermissions(
 	const global: Record<string, boolean> = {};
 	const projects: Record<string, Record<string, boolean>> = {};
 
-	// For personal API key without project ID, no permission filtering needed
-	if (!config.agentId && !config.projectId) {
-		console.error(
-			"[permissions] Personal API key mode: permission filtering disabled",
-		);
-		return { global, projects };
-	}
+	// A personal API key (no agentId, no projectId) is filtered by the
+	// caller's own permissions like every other mode — global permissions are
+	// fetched below via /users/me/global-permissions. There is no "show every
+	// tool" fallback; a key with no permissions sees no permission-gated
+	// tools. (Project-scoped tools stay hidden for a personal key until its
+	// per-project permissions are also discovered — a follow-up, not part of
+	// the security hardening here.)
 
 	// A global-scope agent: agentId set, no fixed projectId — running
 	// "unpinned" (see index.ts). Unlike a project-scoped agent, it has its

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -86,14 +86,6 @@ export async function createServer(config: PacaConfig): Promise<Server> {
 				return true;
 			}
 
-			// For personal API key without project ID, show all tools (backward compatibility)
-			if (!config.agentId && !config.projectId) {
-				console.error(
-					`[server] Personal API key mode, allowing tool ${tool.name}`,
-				);
-				return true;
-			}
-
 			if (config.projectId) {
 				const hasPerm = hasPermission(
 					permissionMap,

--- a/services/agent-runner/internal/acpbridge/server.go
+++ b/services/agent-runner/internal/acpbridge/server.go
@@ -185,7 +185,7 @@ func (s *Server) handleEventMessage(ctx context.Context, agentID uuid.UUID, msg 
 		return
 	}
 
-	projectID, actorUserID, err := s.ConvRepo.GetConversationRealtimeContext(ctx, convID)
+	projectID, ownerUserID, err := s.ConvRepo.GetConversationRealtimeContext(ctx, convID)
 	if err != nil {
 		s.Log.Warn("acpbridge: failed to resolve realtime context", "conversation_id", convID, "error", err)
 		return
@@ -245,7 +245,7 @@ func (s *Server) handleEventMessage(ctx context.Context, agentID uuid.UUID, msg 
 			"event_source": eventSource,
 			"payload":      json.RawMessage(payload),
 			"created_at":   createdAt.Format(time.RFC3339Nano),
-		}, actorUserID); err != nil {
+		}, ownerUserID); err != nil {
 		s.Log.Warn("acpbridge: failed to publish realtime bridge event", "conversation_id", convID, "error", err)
 	}
 }
@@ -277,13 +277,13 @@ func (s *Server) handleTurnStatusMessage(ctx context.Context, agentID uuid.UUID,
 		return
 	}
 
-	projectID, actorUserID, err := s.ConvRepo.GetConversationRealtimeContext(ctx, convID)
+	projectID, ownerUserID, err := s.ConvRepo.GetConversationRealtimeContext(ctx, convID)
 	if err != nil {
 		s.Log.Warn("acpbridge: failed to resolve realtime context", "conversation_id", convID, "error", err)
 		return
 	}
 	if err := s.Publisher.PublishRealtime(ctx, projectID, convID,
-		fmt.Sprintf("agent.conversation.%s", statusStr), nil, actorUserID); err != nil {
+		fmt.Sprintf("agent.conversation.%s", statusStr), nil, ownerUserID); err != nil {
 		s.Log.Warn("acpbridge: failed to publish turn_status realtime event", "conversation_id", convID, "error", err)
 	}
 }

--- a/services/agent-runner/internal/handler/handler.go
+++ b/services/agent-runner/internal/handler/handler.go
@@ -64,6 +64,19 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 		return nil
 	}
 
+	// Chat conversations are owner-private: their realtime events must route
+	// to the owner's user room, not the project room. Resolve the owner user
+	// id once here (sessionless triggers have ChatSessionID == nil and keep a
+	// nil ActorUserID, staying project-shared) so both the llm path and the
+	// acp dispatch path below publish the right room.
+	if trigger.ChatSessionID != nil {
+		_, ownerUserID, err := h.ConvRepo.GetConversationRealtimeContext(ctx, trigger.ConversationID)
+		if err != nil {
+			return fmt.Errorf("resolve realtime owner for conversation %s: %w", trigger.ConversationID, err)
+		}
+		trigger.ActorUserID = ownerUserID
+	}
+
 	cfg, err := h.AgentRepo.FindByID(ctx, trigger.AgentID)
 	if err != nil {
 		if errors.Is(err, postgres.ErrNotLLMAgent) {

--- a/services/agent-runner/internal/repository/postgres/conversation_repository.go
+++ b/services/agent-runner/internal/repository/postgres/conversation_repository.go
@@ -100,28 +100,38 @@ func (r *ConversationRepository) GetConversationAgentType(ctx context.Context, c
 }
 
 // GetConversationRealtimeContext mirrors get_conversation_realtime_context:
-// returns (project_id, actor_user_id) for routing a realtime event about
-// conversationID. Used by the ACP bridge's WebSocket relay
+// returns (project_id, owner_user_id) for routing a realtime event about
+// conversationID. owner_user_id is the user whose private room should receive
+// the event — the chat-session owner's users.id for a project chat (resolved
+// chat_session_id → member_id → user_id), or actor_user_id for a global chat;
+// it is nil for a sessionless (project-shared) conversation, which has no
+// single owner. Used by the ACP bridge's WebSocket relay
 // (internal/acpbridge/server.go), which handles events/turn_status for
 // whichever conversation_id the local daemon reports — unlike a normal
 // llm-type turn, which already has this on the in-memory Trigger it's
 // running, the bridge needs a fresh per-conversation lookup since one
 // bridge session (a global-scope ACP agent) can relay conversations with
 // different project contexts, or none.
-func (r *ConversationRepository) GetConversationRealtimeContext(ctx context.Context, conversationID uuid.UUID) (projectID uuid.UUID, actorUserID *uuid.UUID, err error) {
+func (r *ConversationRepository) GetConversationRealtimeContext(ctx context.Context, conversationID uuid.UUID) (projectID uuid.UUID, ownerUserID *uuid.UUID, err error) {
 	var row struct {
 		ProjectID   uuid.NullUUID `db:"project_id"`
-		ActorUserID uuid.NullUUID `db:"actor_user_id"`
+		OwnerUserID uuid.NullUUID `db:"owner_user_id"`
 	}
 	err = r.db.GetContext(ctx, &row,
-		`SELECT project_id, actor_user_id FROM agent_conversations WHERE id = $1`, conversationID)
+		`SELECT c.project_id,
+		        COALESCE(u.id, c.actor_user_id) AS owner_user_id
+		 FROM agent_conversations c
+		 LEFT JOIN agent_chat_sessions s ON s.id = c.chat_session_id
+		 LEFT JOIN project_members pm ON pm.id = s.member_id
+		 LEFT JOIN users u ON u.id = pm.user_id
+		 WHERE c.id = $1`, conversationID)
 	if err != nil {
 		return uuid.Nil, nil, fmt.Errorf("postgres: get realtime context for conversation %s: %w", conversationID, err)
 	}
-	if row.ActorUserID.Valid {
-		actorUserID = &row.ActorUserID.UUID
+	if row.OwnerUserID.Valid {
+		ownerUserID = &row.OwnerUserID.UUID
 	}
-	return row.ProjectID.UUID, actorUserID, nil
+	return row.ProjectID.UUID, ownerUserID, nil
 }
 
 // InsertEvent mirrors insert_conversation_event. payload must already be

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -332,7 +332,7 @@ func New(cfg *config.Config) (*App, error) {
 		WithMemberRepo(projectRepo).
 		WithGlobalPermissionReader(permissionStore).
 		WithAvatarService(attachmentService)
-	convHandler := handler.NewConversationHandler(agentService)
+	convHandler := handler.NewConversationHandler(agentService).WithMemberRepo(projectRepo)
 	automationHandler := handler.NewAutomationHandler(automationService).WithPluginRuntime(pluginRuntime)
 
 	// --- Handlers -----------------------------------------------------------

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -195,6 +195,24 @@ type SkillTemplate struct {
 	Triggers    []string `json:"triggers"`
 }
 
+// ConversationAudience discriminates who may read/write a conversation's
+// transcript. It is a STORED GENERATED column (see migration
+// 000038_add_agent_conversation_audience) derived from chat_session_id /
+// actor_user_id, so it can never drift from those source columns.
+type ConversationAudience string
+
+// ConversationAudience values.
+const (
+	// AudienceOwnerPrivate marks a chat conversation (project chat backed by a
+	// chat session, or global chat backed by actor_user_id): only the acting
+	// member (project) or actor user (global) may read/write the transcript.
+	AudienceOwnerPrivate ConversationAudience = "owner_private"
+	// AudienceProjectShared marks a sessionless run (task_assigned /
+	// comment_mention / description_write / automation_message): any project
+	// member with agents:read may read it.
+	AudienceProjectShared ConversationAudience = "project_shared"
+)
+
 // AgentConversation tracks each OpenHands conversation session.
 type AgentConversation struct {
 	ID            uuid.UUID
@@ -212,7 +230,11 @@ type AgentConversation struct {
 	// ActorUserID is set only for a global-chat conversation (ProjectID is
 	// uuid.Nil): the human user who sent the message, identified directly
 	// since there may be no project_members row for them at all.
-	ActorUserID    *uuid.UUID
+	ActorUserID *uuid.UUID
+	// Audience is the derived transcript audience (owner_private |
+	// project_shared) — see ConversationAudience. Read-only on this entity:
+	// it is a generated column, never set by the repository on write.
+	Audience       ConversationAudience
 	Status         string // queued | running | paused | finished | failed | stopped
 	ContainerID    *string
 	HostPort       *int

--- a/services/api/internal/domain/agent/repository.go
+++ b/services/api/internal/domain/agent/repository.go
@@ -163,10 +163,17 @@ type ListConversationsFilter struct {
 	// this actor_user_id — used by ListGlobalConversations to scope the
 	// "my global conversations" endpoint to the caller only, since global
 	// chat has no project-team visibility to share it with.
-	ActorUserID  *uuid.UUID
-	TaskID       *uuid.UUID
-	Statuses     []string
-	TriggerTypes []string
+	ActorUserID *uuid.UUID
+	// ViewerMemberID, when set, is the caller's project_members.id. It makes
+	// the listing include owner-private conversations only when the caller is
+	// that conversation's chat-session owner (audience is enforced in SQL so
+	// the search subquery never touches a private conversation the caller
+	// cannot read). project-shared conversations are always included. Only
+	// meaningful together with ProjectID.
+	ViewerMemberID *uuid.UUID
+	TaskID         *uuid.UUID
+	Statuses       []string
+	TriggerTypes   []string
 	// CreatedAfter/CreatedBefore bound created_at as [CreatedAfter,
 	// CreatedBefore) — inclusive lower bound, exclusive upper bound. Both are
 	// resolved to absolute instants by the handler (see

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -109,17 +109,21 @@ type EnvVarService interface {
 // ConversationService defines conversation management use cases.
 type ConversationService interface {
 	ListConversations(ctx context.Context, in ListConversationsFilter, limit int) (convs []*AgentConversation, hasMore bool, err error)
-	GetConversation(ctx context.Context, projectID, conversationID uuid.UUID) (*AgentConversation, error)
+	// GetConversation returns a single project conversation after verifying
+	// it belongs to projectID and that memberID may read it (project-shared
+	// conversations are readable by any project member; owner-private ones
+	// only by their chat-session owner).
+	GetConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*AgentConversation, error)
 	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window ConversationEventWindow) ([]*AgentConversationEvent, int64, error)
 	// StopConversation interrupts (if running) and permanently tears down the
-	// conversation's sandbox. Unchanged from before.
-	StopConversation(ctx context.Context, projectID, conversationID uuid.UUID) error
+	// conversation's sandbox. memberID gates ownership (see GetConversation).
+	StopConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error
 	// PauseConversation interrupts the in-flight turn only — the sandbox
 	// stays alive and the conversation can be replied to again once it pauses.
-	PauseConversation(ctx context.Context, projectID, conversationID uuid.UUID) error
+	PauseConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error
 	// Heartbeat refreshes a chat conversation's idle timer; called
 	// periodically by the frontend while a conversation is loaded in a tab.
-	Heartbeat(ctx context.Context, projectID, conversationID uuid.UUID) error
+	Heartbeat(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error
 	SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID) error
 
 	// -- Global chat conversations (ProjectID == uuid.Nil). Thin siblings of
@@ -151,7 +155,7 @@ type ChatSessionService interface {
 	ListChatSessions(ctx context.Context, projectID, agentID, memberID uuid.UUID) ([]*AgentChatSession, error)
 	StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*AgentChatSession, *AgentConversation, error)
 	SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string) (*AgentConversation, error)
-	ListChatMessages(ctx context.Context, sessionID uuid.UUID, offset, limit int) ([]*AgentConversationEvent, int64, error)
+	ListChatMessages(ctx context.Context, sessionID, memberID uuid.UUID, offset, limit int) ([]*AgentConversationEvent, int64, error)
 
 	// -- Global chat sessions (chatting with a global agent from the home
 	// page / admin pages — no project context). See ChatSession's doc

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -96,6 +96,7 @@ type agentConversationRecord struct {
 	ChatSessionID       *string    `db:"chat_session_id"`
 	TriggeredByMemberID *string    `db:"triggered_by_member_id"`
 	ActorUserID         *string    `db:"actor_user_id"`
+	Audience            string     `db:"audience"`
 	Status              string     `db:"status"`
 	ContainerID         *string    `db:"container_id"`
 	HostPort            *int       `db:"host_port"`
@@ -842,7 +843,7 @@ func (r *AgentRepository) DeleteEnvVar(ctx context.Context, id uuid.UUID) error 
 // 'ActionEvent' left every conversation run by the Go runner stuck at 0
 // iterations regardless of how much work the agent actually did.
 const conversationCols = `id, agent_id, project_id, trigger_type, task_id, comment_id, chat_session_id,
-	triggered_by_member_id, actor_user_id, status, container_id, host_port,
+	triggered_by_member_id, actor_user_id, audience, status, container_id, host_port,
 	(SELECT COUNT(*) FROM agent_conversation_events e
 	 WHERE e.conversation_id = agent_conversations.id AND e.event_type IN ('ActionEvent', 'tool_call')) AS iteration_count,
 	error_message,
@@ -1426,6 +1427,7 @@ func conversationFromRecord(rec agentConversationRecord) *agentdom.AgentConversa
 		AgentID:        mustParseUUID(rec.AgentID),
 		ProjectID:      uuidFromNullable(rec.ProjectID),
 		TriggerType:    rec.TriggerType,
+		Audience:       agentdom.ConversationAudience(rec.Audience),
 		Status:         rec.Status,
 		ContainerID:    rec.ContainerID,
 		HostPort:       rec.HostPort,

--- a/services/api/internal/repository/postgres/agent_repository.go
+++ b/services/api/internal/repository/postgres/agent_repository.go
@@ -871,6 +871,18 @@ func (r *AgentRepository) ListConversations(ctx context.Context, in agentdom.Lis
 		b.args = append(b.args, in.ActorUserID.String())
 		b.whereClauses = append(b.whereClauses, "actor_user_id = "+p)
 	}
+	if in.ViewerMemberID != nil {
+		// Audience is enforced in SQL so the search subquery never touches a
+		// private conversation the caller cannot read: project-shared
+		// conversations are visible to any member, owner-private ones only to
+		// their chat-session owner (global chat is already excluded by
+		// ProjectID above, since those rows have project_id IS NULL).
+		p := b.placeholder()
+		b.args = append(b.args, in.ViewerMemberID.String())
+		b.whereClauses = append(b.whereClauses, fmt.Sprintf(
+			"(audience = '%s' OR EXISTS (SELECT 1 FROM agent_chat_sessions cs WHERE cs.id = agent_conversations.chat_session_id AND cs.member_id = %s))",
+			agentdom.AudienceProjectShared, p))
+	}
 	if in.TaskID != nil {
 		p := b.placeholder()
 		b.args = append(b.args, in.TaskID.String())

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -1102,8 +1102,9 @@ func (s *Service) ListAgentActivities(ctx context.Context, in agentdom.ListAgent
 	return s.repo.ListAgentActivities(ctx, in, limit)
 }
 
-// GetConversation returns a single conversation after verifying project ownership.
-func (s *Service) GetConversation(ctx context.Context, projectID, conversationID uuid.UUID) (*agentdom.AgentConversation, error) {
+// GetConversation returns a single conversation after verifying project
+// ownership and, for owner-private conversations, chat-session ownership.
+func (s *Service) GetConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*agentdom.AgentConversation, error) {
 	c, err := s.repo.FindConversationByID(ctx, conversationID)
 	if err != nil {
 		return nil, err
@@ -1111,7 +1112,32 @@ func (s *Service) GetConversation(ctx context.Context, projectID, conversationID
 	if c.ProjectID != projectID {
 		return nil, agentdom.ErrConversationNotFound
 	}
+	if err := s.authorizeConversationAccess(ctx, c, memberID); err != nil {
+		return nil, err
+	}
 	return c, nil
+}
+
+// authorizeConversationAccess fails closed (ErrConversationNotFound) when a
+// project-scoped owner-private conversation is not owned by memberID.
+// project-shared conversations are readable by any project member, whose
+// membership is already enforced by the router's project-scope middleware.
+func (s *Service) authorizeConversationAccess(ctx context.Context, c *agentdom.AgentConversation, memberID uuid.UUID) error {
+	if c.Audience != agentdom.AudienceOwnerPrivate {
+		return nil
+	}
+	// A project-scoped owner-private conversation is always session-backed
+	// (global chat has project_id IS NULL and never reaches this path), so the
+	// owner is the chat session's member, not triggered_by_member_id (which a
+	// pre-fix cross-member send could have pointed at a different member).
+	if c.ChatSessionID == nil {
+		return agentdom.ErrConversationNotFound
+	}
+	session, err := s.repo.FindChatSessionByID(ctx, *c.ChatSessionID)
+	if err != nil || session.MemberID != memberID {
+		return agentdom.ErrConversationNotFound
+	}
+	return nil
 }
 
 // ListConversationEvents returns one keyset-paginated window of events for a
@@ -1131,8 +1157,8 @@ func (s *Service) ListConversationEvents(ctx context.Context, conversationID uui
 // trigger_ai_agent-started conversation it might be waiting on just reached
 // a terminal status — ai-agent has no turn-end hook to do it from here,
 // since the stop can land while no turn is even in flight.
-func (s *Service) StopConversation(ctx context.Context, projectID, conversationID uuid.UUID) error {
-	c, err := s.GetConversation(ctx, projectID, conversationID)
+func (s *Service) StopConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error {
+	c, err := s.GetConversation(ctx, projectID, conversationID, memberID)
 	if err != nil {
 		return err
 	}
@@ -1162,8 +1188,8 @@ func (s *Service) StopConversation(ctx context.Context, projectID, conversationI
 // touching its sandbox — it goes back to "paused" once ai-agent processes
 // the interrupt. No DB write here: ai-agent's run_conversation writes the
 // resulting status itself once the turn actually pauses.
-func (s *Service) PauseConversation(ctx context.Context, projectID, conversationID uuid.UUID) error {
-	c, err := s.GetConversation(ctx, projectID, conversationID)
+func (s *Service) PauseConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error {
+	c, err := s.GetConversation(ctx, projectID, conversationID, memberID)
 	if err != nil {
 		return err
 	}
@@ -1183,8 +1209,8 @@ func (s *Service) PauseConversation(ctx context.Context, projectID, conversation
 // still called here so the API layer itself enforces project ownership,
 // rather than resting the whole authorization boundary on ai-agent's
 // in-memory check.
-func (s *Service) Heartbeat(ctx context.Context, projectID, conversationID uuid.UUID) error {
-	if _, err := s.GetConversation(ctx, projectID, conversationID); err != nil {
+func (s *Service) Heartbeat(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error {
+	if _, err := s.GetConversation(ctx, projectID, conversationID, memberID); err != nil {
 		return err
 	}
 	return s.publishTrigger(ctx, events.TopicAgentHeartbeat, map[string]any{
@@ -1203,7 +1229,7 @@ func (s *Service) Heartbeat(ctx context.Context, projectID, conversationID uuid.
 // not just chat_message), so it can always be resumed here too — mirroring
 // SendChatMessage's terminal-status resume for chat sessions.
 func (s *Service) SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID) error {
-	c, err := s.GetConversation(ctx, projectID, conversationID)
+	c, err := s.GetConversation(ctx, projectID, conversationID, memberID)
 	if err != nil {
 		return err
 	}
@@ -1456,6 +1482,12 @@ func (s *Service) SendChatMessage(ctx context.Context, projectID, sessionID, mem
 	if session.ProjectID != projectID {
 		return nil, agentdom.ErrChatSessionNotFound
 	}
+	// A chat session is owner-private: only its owning member may post to it
+	// (previously any project member could, which let a non-owner both read
+	// and inject into someone else's session).
+	if session.MemberID != memberID {
+		return nil, agentdom.ErrChatSessionNotFound
+	}
 
 	latest, err := s.repo.FindLatestConversationByChatSession(ctx, sessionID)
 	if err != nil {
@@ -1651,17 +1683,24 @@ func (s *Service) SendGlobalChatMessage(ctx context.Context, sessionID, actorUse
 
 // ListChatMessages returns conversation events for a chat session. Unreached
 // by any route (see agentdom.ChatSessionService) — kept only to satisfy the
-// interface until it grows a real caller.
-func (s *Service) ListChatMessages(ctx context.Context, sessionID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
-	// TODO: We'd need to aggregate events from all conversations in this session.
-	// For now, return events from the most recent conversation with this session_id.
-	filter := agentdom.ListConversationsFilter{}
-	_ = sessionID
-	convs, _, err := s.repo.ListConversations(ctx, filter, 1)
+// interface until it grows a real caller. memberID is the caller's
+// project_members.id and gates ownership so the eventual caller cannot read
+// another member's private session.
+func (s *Service) ListChatMessages(ctx context.Context, sessionID, memberID uuid.UUID, offset, limit int) ([]*agentdom.AgentConversationEvent, int64, error) {
+	session, err := s.repo.FindChatSessionByID(ctx, sessionID)
 	if err != nil {
 		return nil, 0, err
 	}
-	if len(convs) == 0 {
+	if session.MemberID != memberID {
+		return nil, 0, agentdom.ErrChatSessionNotFound
+	}
+	// TODO: We'd need to aggregate events from all conversations in this session.
+	// For now, return events from the most recent conversation with this session_id.
+	latest, err := s.repo.FindLatestConversationByChatSession(ctx, sessionID)
+	if err != nil {
+		return nil, 0, err
+	}
+	if latest == nil {
 		return []*agentdom.AgentConversationEvent{}, 0, nil
 	}
 	// offset has no cursor equivalent (see agentdom.ConversationEventWindow):
@@ -1670,7 +1709,7 @@ func (s *Service) ListChatMessages(ctx context.Context, sessionID uuid.UUID, off
 	if offset != 0 {
 		return nil, 0, fmt.Errorf("ListChatMessages: non-zero offset %d is not supported by cursor-based ListConversationEvents", offset)
 	}
-	return s.repo.ListConversationEvents(ctx, convs[0].ID, agentdom.ConversationEventWindow{Limit: limit})
+	return s.repo.ListConversationEvents(ctx, latest.ID, agentdom.ConversationEventWindow{Limit: limit})
 }
 
 // -------------------------------------------------------------------------

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -1310,6 +1310,93 @@ func TestGetConversation_WrongProject(t *testing.T) {
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
 }
 
+func TestGetConversation_OwnerPrivate_OwnerAllowed(t *testing.T) {
+	projectID := uuid.New()
+	conversationID := uuid.New()
+	ownerMemberID := uuid.New()
+	sessionID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:            conversationID,
+		ProjectID:     projectID,
+		ChatSessionID: &sessionID,
+		Audience:      agentdom.AudienceOwnerPrivate,
+		Status:        "running",
+	}
+	session := &agentdom.AgentChatSession{ID: sessionID, MemberID: ownerMemberID}
+
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+		findChatSessionByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentChatSession, error) {
+			return session, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	result, err := svc.GetConversation(context.Background(), projectID, conversationID, ownerMemberID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, conversationID, result.ID)
+}
+
+func TestGetConversation_OwnerPrivate_WrongMember(t *testing.T) {
+	projectID := uuid.New()
+	conversationID := uuid.New()
+	ownerMemberID := uuid.New()
+	otherMemberID := uuid.New()
+	sessionID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:            conversationID,
+		ProjectID:     projectID,
+		ChatSessionID: &sessionID,
+		Audience:      agentdom.AudienceOwnerPrivate,
+		Status:        "running",
+	}
+	session := &agentdom.AgentChatSession{ID: sessionID, MemberID: ownerMemberID}
+
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+		findChatSessionByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentChatSession, error) {
+			return session, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversation(context.Background(), projectID, conversationID, otherMemberID)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
+func TestSendChatMessage_WrongMember(t *testing.T) {
+	projectID := uuid.New()
+	agentID := uuid.New()
+	ownerMemberID := uuid.New()
+	otherMemberID := uuid.New()
+	sessionID := uuid.New()
+	session := &agentdom.AgentChatSession{
+		ID:        sessionID,
+		AgentID:   agentID,
+		ProjectID: projectID,
+		MemberID:  ownerMemberID,
+	}
+
+	repo := &mockAgentRepo{
+		findChatSessionByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentChatSession, error) {
+			return session, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, otherMemberID, "Hello")
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, agentdom.ErrChatSessionNotFound)
+}
+
 func TestGetGlobalConversation_Success(t *testing.T) {
 	actorUserID := uuid.New()
 	conversationID := uuid.New()

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -1261,6 +1261,7 @@ func TestAddSkill_ReservedName_ReturnsError(t *testing.T) {
 func TestGetConversation_Success(t *testing.T) {
 	projectID := uuid.New()
 	conversationID := uuid.New()
+	memberID := uuid.New()
 	conversation := &agentdom.AgentConversation{
 		ID:        conversationID,
 		ProjectID: projectID,
@@ -1276,7 +1277,7 @@ func TestGetConversation_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	result, err := svc.GetConversation(context.Background(), projectID, conversationID)
+	result, err := svc.GetConversation(context.Background(), projectID, conversationID, memberID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, conversationID, result.ID)
@@ -1287,6 +1288,7 @@ func TestGetConversation_WrongProject(t *testing.T) {
 	projectID := uuid.New()
 	wrongProjectID := uuid.New()
 	conversationID := uuid.New()
+	memberID := uuid.New()
 	conversation := &agentdom.AgentConversation{
 		ID:        conversationID,
 		ProjectID: wrongProjectID,
@@ -1302,7 +1304,7 @@ func TestGetConversation_WrongProject(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	_, err := svc.GetConversation(context.Background(), projectID, conversationID)
+	_, err := svc.GetConversation(context.Background(), projectID, conversationID, memberID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
@@ -1718,7 +1720,7 @@ func TestStopConversation_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.StopConversation(context.Background(), projectID, conversationID)
+	err := svc.StopConversation(context.Background(), projectID, conversationID, uuid.Nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "stopped", updatedStatus)
@@ -1749,7 +1751,7 @@ func TestStopConversation_AlreadyStopped(t *testing.T) {
 			pluginRepo := &mockPluginRepo{}
 			svc := New(repo, projRepo, nil, pluginRepo)
 
-			err := svc.StopConversation(context.Background(), projectID, conversationID)
+			err := svc.StopConversation(context.Background(), projectID, conversationID, uuid.Nil)
 
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, agentdom.ErrConversationAlreadyStopped)
@@ -1781,7 +1783,7 @@ func TestPauseConversation_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.PauseConversation(context.Background(), projectID, conversationID)
+	err := svc.PauseConversation(context.Background(), projectID, conversationID, uuid.Nil)
 
 	// No DB write: ai-agent owns writing "paused" itself once the turn
 	// actually pauses, so PauseConversation must not touch Postgres.
@@ -1807,7 +1809,7 @@ func TestPauseConversation_NotRunning(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.PauseConversation(context.Background(), projectID, conversationID)
+	err := svc.PauseConversation(context.Background(), projectID, conversationID, uuid.Nil)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotRunning)
@@ -1836,7 +1838,7 @@ func TestHeartbeat_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.Heartbeat(context.Background(), projectID, conversationID)
+	err := svc.Heartbeat(context.Background(), projectID, conversationID, uuid.Nil)
 
 	// Heartbeat fires every ~30s per open tab — no Postgres round trip beyond
 	// the ownership lookup.
@@ -1863,7 +1865,7 @@ func TestHeartbeat_WrongProject(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.Heartbeat(context.Background(), projectID, conversationID)
+	err := svc.Heartbeat(context.Background(), projectID, conversationID, uuid.Nil)
 
 	// A conversation belonging to a different project must not be kept alive
 	// by a heartbeat scoped to this project.
@@ -1937,6 +1939,7 @@ func TestSendChatMessage_Success(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 
 	repo := &mockAgentRepo{
@@ -1974,6 +1977,7 @@ func TestSendChatMessage_ResumesPausedConversation(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 	paused := &agentdom.AgentConversation{
 		ID:            pausedConvID,
@@ -2036,6 +2040,7 @@ func TestSendChatMessage_ACPResumesTerminalConversation(t *testing.T) {
 				ID:        sessionID,
 				AgentID:   agentID,
 				ProjectID: projectID,
+				MemberID:  memberID,
 			}
 			terminal := &agentdom.AgentConversation{
 				ID:            terminalConvID,
@@ -2098,6 +2103,7 @@ func TestSendChatMessage_ACPResumeRaceLoses(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 	terminal := &agentdom.AgentConversation{
 		ID:            terminalConvID,
@@ -2142,6 +2148,7 @@ func TestSendChatMessage_LLMTerminalCreatesNewConversation(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 	finished := &agentdom.AgentConversation{
 		ID:            oldConvID,
@@ -2198,6 +2205,7 @@ func TestSendChatMessage_ResumeRaceLoses(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 	paused := &agentdom.AgentConversation{
 		ID:            pausedConvID,
@@ -2237,6 +2245,7 @@ func TestSendChatMessage_BusyWhenQueued(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 	queued := &agentdom.AgentConversation{
 		ID:        uuid.New(),
@@ -2273,6 +2282,7 @@ func TestSendChatMessage_BusyWhenRunning(t *testing.T) {
 		ID:        sessionID,
 		AgentID:   agentID,
 		ProjectID: projectID,
+		MemberID:  memberID,
 	}
 	running := &agentdom.AgentConversation{
 		ID:        uuid.New(),

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -32,6 +32,7 @@ type mockAgentSvc struct {
 	startChatSession              func(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error)
 	listConversations             func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
 	listConversationEvents        func(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error)
+	getConversation               func(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*agentdom.AgentConversation, error)
 	listAgentActivities           func(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error)
 	getGlobalConversation         func(ctx context.Context, conversationID, actorUserID uuid.UUID) (*agentdom.AgentConversation, error)
 	listGlobalConversations       func(ctx context.Context, actorUserID uuid.UUID, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
@@ -116,8 +117,13 @@ func (m *mockAgentSvc) ListAgentActivities(ctx context.Context, filter agentdom.
 	}
 	return nil, false, nil
 }
-func (m *mockAgentSvc) GetConversation(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
-	return nil, errors.New("not found")
+func (m *mockAgentSvc) GetConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*agentdom.AgentConversation, error) {
+	if m.getConversation != nil {
+		return m.getConversation(ctx, projectID, conversationID, memberID)
+	}
+	// Default to a readable conversation so the events handler's ownership
+	// gate passes by default; tests asserting rejection configure getConversation.
+	return &agentdom.AgentConversation{ID: conversationID, ProjectID: projectID}, nil
 }
 func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 	if m.listConversationEvents != nil {
@@ -125,9 +131,9 @@ func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationI
 	}
 	return nil, 0, nil
 }
-func (m *mockAgentSvc) StopConversation(_ context.Context, _, _ uuid.UUID) error  { return nil }
-func (m *mockAgentSvc) PauseConversation(_ context.Context, _, _ uuid.UUID) error { return nil }
-func (m *mockAgentSvc) Heartbeat(_ context.Context, _, _ uuid.UUID) error         { return nil }
+func (m *mockAgentSvc) StopConversation(_ context.Context, _, _, _ uuid.UUID) error  { return nil }
+func (m *mockAgentSvc) PauseConversation(_ context.Context, _, _, _ uuid.UUID) error { return nil }
+func (m *mockAgentSvc) Heartbeat(_ context.Context, _, _, _ uuid.UUID) error         { return nil }
 func (m *mockAgentSvc) SendConversationMessage(_ context.Context, _, _ uuid.UUID, _ string, _ uuid.UUID) error {
 	return nil
 }
@@ -143,7 +149,7 @@ func (m *mockAgentSvc) StartChatSession(ctx context.Context, projectID, agentID,
 func (m *mockAgentSvc) SendChatMessage(_ context.Context, _, _, _ uuid.UUID, _ string) (*agentdom.AgentConversation, error) {
 	return &agentdom.AgentConversation{ID: uuid.New()}, nil
 }
-func (m *mockAgentSvc) ListChatMessages(_ context.Context, _ uuid.UUID, _, _ int) ([]*agentdom.AgentConversationEvent, int64, error) {
+func (m *mockAgentSvc) ListChatMessages(_ context.Context, _, _ uuid.UUID, _, _ int) ([]*agentdom.AgentConversationEvent, int64, error) {
 	return nil, 0, nil
 }
 

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Paca-AI/api/internal/apierr"
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
+	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	"github.com/Paca-AI/api/internal/transport/http/dto"
 	"github.com/Paca-AI/api/internal/transport/http/middleware"
 	"github.com/Paca-AI/api/internal/transport/http/presenter"
@@ -66,12 +67,43 @@ func parseCreatedBeforeBound(raw string) (*time.Time, bool) {
 
 // ConversationHandler handles agent conversation endpoints.
 type ConversationHandler struct {
-	svc agentdom.Service
+	svc        agentdom.Service
+	memberRepo projectdom.MemberRepository
 }
 
 // NewConversationHandler returns a ConversationHandler wired to the agent service.
 func NewConversationHandler(svc agentdom.Service) *ConversationHandler {
 	return &ConversationHandler{svc: svc}
+}
+
+// WithMemberRepo attaches the project member repository used to resolve the
+// authenticated caller's project_members.id (see resolveMemberID). Required
+// for every project-scoped conversation endpoint that must compare the caller
+// against an owner-private conversation's session owner.
+func (h *ConversationHandler) WithMemberRepo(repo projectdom.MemberRepository) *ConversationHandler {
+	h.memberRepo = repo
+	return h
+}
+
+// resolveMemberID maps the authenticated caller's user ID to their
+// project_members.id within projectID. Mirrors AgentHandler.resolveMemberID —
+// agent_chat_sessions.member_id and agent_conversations.triggered_by_member_id
+// both store a project_members.id, never the raw user id, so callers must not
+// use claims.Subject directly.
+func (h *ConversationHandler) resolveMemberID(r *http.Request, projectID uuid.UUID) (uuid.UUID, error) {
+	if h.memberRepo == nil {
+		return uuid.Nil, apierr.New(apierr.CodeInternalError, "member resolver not available")
+	}
+	claims := middleware.ClaimsFrom(r)
+	userID, err := uuid.Parse(claims.Subject)
+	if err != nil {
+		return uuid.Nil, apierr.New(apierr.CodeBadRequest, "invalid subject claim")
+	}
+	member, err := h.memberRepo.FindMemberByUserProject(r.Context(), userID, projectID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return member.ID, nil
 }
 
 // parseConversationListQuery parses the query params shared by
@@ -175,7 +207,13 @@ func (h *ConversationHandler) ListConversations(w http.ResponseWriter, r *http.R
 		presenter.Error(w, r, err)
 		return
 	}
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
 	filter.ProjectID = &projectID
+	filter.ViewerMemberID = &memberID
 
 	convs, hasMore, err := h.svc.ListConversations(r.Context(), filter, pageSize)
 	if err != nil {
@@ -220,7 +258,12 @@ func (h *ConversationHandler) GetConversation(w http.ResponseWriter, r *http.Req
 		presenter.Error(w, r, err)
 		return
 	}
-	conv, err := h.svc.GetConversation(r.Context(), projectID, convID)
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	conv, err := h.svc.GetConversation(r.Context(), projectID, convID, memberID)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -302,8 +345,25 @@ func writeConversationEventWindowResponse(w http.ResponseWriter, r *http.Request
 
 // ListConversationEvents handles GET /projects/:projectId/conversations/:conversationId/events.
 func (h *ConversationHandler) ListConversationEvents(w http.ResponseWriter, r *http.Request) {
+	projectID, err := parseProjectID(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
 	convID, err := parseParamUUID(r, "conversationId")
 	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	// Gate on project + audience ownership before listing events — the events
+	// query itself is conversation-scoped only (same shape as the global
+	// sibling GetGlobalConversationEvents, which gates via GetGlobalConversation).
+	if _, err := h.svc.GetConversation(r.Context(), projectID, convID, memberID); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
@@ -333,7 +393,12 @@ func (h *ConversationHandler) StopConversation(w http.ResponseWriter, r *http.Re
 		presenter.Error(w, r, err)
 		return
 	}
-	if err := h.svc.StopConversation(r.Context(), projectID, convID); err != nil {
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if err := h.svc.StopConversation(r.Context(), projectID, convID, memberID); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
@@ -352,7 +417,12 @@ func (h *ConversationHandler) PauseConversation(w http.ResponseWriter, r *http.R
 		presenter.Error(w, r, err)
 		return
 	}
-	if err := h.svc.PauseConversation(r.Context(), projectID, convID); err != nil {
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if err := h.svc.PauseConversation(r.Context(), projectID, convID, memberID); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
@@ -371,7 +441,12 @@ func (h *ConversationHandler) Heartbeat(w http.ResponseWriter, r *http.Request) 
 		presenter.Error(w, r, err)
 		return
 	}
-	if err := h.svc.Heartbeat(r.Context(), projectID, convID); err != nil {
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if err := h.svc.Heartbeat(r.Context(), projectID, convID, memberID); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
@@ -395,8 +470,14 @@ func (h *ConversationHandler) SendConversationMessage(w http.ResponseWriter, r *
 		presenter.Error(w, r, err)
 		return
 	}
-	claims := middleware.ClaimsFrom(r)
-	memberID, _ := uuid.Parse(claims.Subject)
+	// Resolve the caller to a project_members.id — agent_conversations store a
+	// member id, not the raw user id (see resolveMemberID). Using claims.Subject
+	// here directly would compare/send the wrong identity on every owner check.
+	memberID, err := h.resolveMemberID(r, projectID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
 
 	if err := h.svc.SendConversationMessage(r.Context(), projectID, convID, req.Message, memberID); err != nil {
 		presenter.Error(w, r, err)

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
+	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	"github.com/Paca-AI/api/internal/transport/http/handler"
 )
 
@@ -29,8 +30,13 @@ func fixedTime() time.Time {
 // ---------------------------------------------------------------------------
 
 func newConversationRouter(svc agentdom.Service) chi.Router {
-	h := handler.NewConversationHandler(svc)
+	h := handler.NewConversationHandler(svc).WithMemberRepo(&fakeMemberRepo{
+		findByUserProject: func(_ context.Context, _, _ uuid.UUID) (*projectdom.ProjectMember, error) {
+			return &projectdom.ProjectMember{ID: uuid.New()}, nil
+		},
+	})
 	r := chi.NewRouter()
+	r.Use(claimsMiddleware(uuid.NewString()))
 	r.Route("/projects/{projectId}/conversations", func(r chi.Router) {
 		r.Get("/", h.ListConversations)
 		r.Get("/{conversationId}/events", h.ListConversationEvents)

--- a/services/api/migrations/000038_add_agent_conversation_audience.sql
+++ b/services/api/migrations/000038_add_agent_conversation_audience.sql
@@ -1,0 +1,38 @@
+-- Explicit transcript audience for agent conversations (generated column).
+--
+-- Up to this point "who may read a project conversation" was hard-coded in
+-- the API layer (everything project-scoped is project-shared), with global
+-- chat keyed separately by actor_user_id. That leaves no way to express a
+-- task-bound, owner-private chat. This migration adds a first-class
+-- discriminator so every read/write path can enforce one consistent rule.
+--
+-- audience is a pure function of existing columns, so it is a STORED
+-- GENERATED column rather than a manually-maintained one:
+--   * chat_session_id IS NOT NULL -> a chat_message conversation backed by a
+--     chat session (project chat) — owner is that session's member.
+--   * actor_user_id   IS NOT NULL -> a global-chat conversation — owner is
+--     that user.
+--   * both NULL                    -> a sessionless run (task_assigned /
+--     comment_mention / description_write / automation_message):
+--     project-shared.
+--
+-- Deriving it (instead of storing + DEFAULT 'project_shared') avoids a
+-- fail-open default: an unset/forgotten audience can never make a private
+-- chat over-public, and the value can never drift from its source columns.
+--
+-- The attachment/result scope (task_shared vs session_private) is a separate
+-- dimension introduced by the #397 attachment work and is NOT covered here.
+
+BEGIN;
+
+ALTER TABLE agent_conversations
+    ADD COLUMN IF NOT EXISTS audience TEXT
+    GENERATED ALWAYS AS (
+        CASE
+            WHEN chat_session_id IS NOT NULL OR actor_user_id IS NOT NULL
+            THEN 'owner_private'
+            ELSE 'project_shared'
+        END
+    ) STORED;
+
+COMMIT;

--- a/services/api/test/e2e/common_env_test.go
+++ b/services/api/test/e2e/common_env_test.go
@@ -274,7 +274,7 @@ func newE2EEnv(t *testing.T) *e2eEnv {
 		APIKey:               handler.NewAPIKeyHandler(apiKeyService),
 		Automation:           handler.NewAutomationHandler(automationService),
 		Agent:                handler.NewAgentHandler(agentService, "", "", "").WithMemberRepo(projectRepo),
-		Conversation:         handler.NewConversationHandler(agentService),
+		Conversation:         handler.NewConversationHandler(agentService).WithMemberRepo(projectRepo),
 		Log:                  log,
 	})
 

--- a/services/realtime/src/subscriber.ts
+++ b/services/realtime/src/subscriber.ts
@@ -136,7 +136,10 @@ function routeEvent(io: Server, msg: RealtimeMessage, logger: Logger): void {
 		const actorUserId = payload.actor_user_id;
 		if (typeof actorUserId === "string" && actorUserId) {
 			const room = agentChatRoomName(actorUserId);
-			logger.debug({ type, room }, "routing owner-private agent event to user room");
+			logger.debug(
+				{ type, room },
+				"routing owner-private agent event to user room",
+			);
 			io.to(room).emit("event", { type, payload });
 			return;
 		}

--- a/services/realtime/src/subscriber.ts
+++ b/services/realtime/src/subscriber.ts
@@ -126,7 +126,23 @@ function routeEvent(io: Server, msg: RealtimeMessage, logger: Logger): void {
 		return;
 	}
 
-	// Project-scoped events (the common case).
+	// An owner-private agent.* event carries actor_user_id (the owning user)
+	// and routes to that user's own per-user room — this covers both global
+	// chat and a project's owner-private chat conversations. Checked before
+	// project_id so a private conversation is never also broadcast into the
+	// project room; a project-shared conversation has no actor_user_id and
+	// falls through to the project-scoped branch below.
+	if (type.startsWith("agent.")) {
+		const actorUserId = payload.actor_user_id;
+		if (typeof actorUserId === "string" && actorUserId) {
+			const room = agentChatRoomName(actorUserId);
+			logger.debug({ type, room }, "routing owner-private agent event to user room");
+			io.to(room).emit("event", { type, payload });
+			return;
+		}
+	}
+
+	// Project-scoped events (project-shared conversations, tasks, docs, ...).
 	const projectId = payload.project_id;
 	if (typeof projectId === "string" && projectId) {
 		// Resolve the namespace room from the event type prefix.
@@ -140,20 +156,6 @@ function routeEvent(io: Server, msg: RealtimeMessage, logger: Logger): void {
 		logger.debug({ type, room }, "routing event to room");
 		io.to(room).emit("event", { type, payload });
 		return;
-	}
-
-	// A global agent.* event (a conversation with a global agent from the
-	// home page / admin pages — no project_id, see services/ai-agent's
-	// core.streams.publish_realtime) routes to the acting human's own
-	// per-user room instead of a project room.
-	if (type.startsWith("agent.")) {
-		const actorUserId = payload.actor_user_id;
-		if (typeof actorUserId === "string" && actorUserId) {
-			const room = agentChatRoomName(actorUserId);
-			logger.debug({ type, room }, "routing global agent event to user room");
-			io.to(room).emit("event", { type, payload });
-			return;
-		}
 	}
 
 	logger.debug({ type }, "event has no project or actor scope — skipped");


### PR DESCRIPTION
## Summary

First PR of the #392/#397 contribution — the security/audience foundation that the durable-handoff (#392) and chat-attachment (#397) work build on, as agreed in [#397](https://github.com/Paca-AI/paca/issues/397).

### What it does

- **Explicit transcript audience** — adds an `audience` discriminator (`owner_private` / `project_shared`) to `agent_conversations` as a STORED GENERATED column (migration `000038`), derived from `chat_session_id` / `actor_user_id` so it can never drift from its source.
- **Unifies scope enforcement** across every conversation/chat read & write path:
  - fixes a **cross-project event leak** — `ListConversationEvents` now gates on project + ownership instead of listing any conversation by ID;
  - fixes a **cross-member write** — `SendChatMessage` now requires the chat session's owner;
  - `GetConversation` / `Stop` / `Pause` / `Heartbeat` / `SendConversationMessage` gate owner-private conversations on the chat-session owner;
  - `ListConversations` enforces audience in SQL so the search subquery never touches a private conversation the caller can't read.
- **Realtime isolation** — owner-private conversation events route to the owner's `user:<id>:agent-chat` room instead of the project room (agent-runner resolves the owner user id via `chat_session_id → member_id → user_id`; `services/realtime` routes `agent.*` + `actor_user_id` to the user room before `project_id`).
- **MCP hardening** — removes the personal-API-key "show all tools" fallback; a personal key is now filtered by the caller's own global permissions.

### Testing

- Unit tests for owner-private `GetConversation` (owner allowed / other member denied) and `SendChatMessage` (other member denied).
- `services/api` and `services/agent-runner` build, vet, and the service/handler test suites pass.
- Verified against a local Postgres 16 + Valkey + MinIO stack: migration `000038` applies cleanly, and the cross-project / cross-member / owner-private / SQL-filter behaviors return the expected 403/404s.

### Notes

The cross-project event leak and cross-member write are fixes for existing behavior. I'm happy to share the detailed scope-enforcement findings through a private channel rather than the public issue if that's preferable.
