### PR TITLE
feat(agent-runner): durable task-level handoffs (#392)

### DIFF
--- a/services/agent-runner/internal/acpbridge/server.go
+++ b/services/agent-runner/internal/acpbridge/server.go
@@ -286,6 +286,26 @@ func (s *Server) handleTurnStatusMessage(ctx context.Context, agentID uuid.UUID,
 		fmt.Sprintf("agent.conversation.%s", statusStr), nil, ownerUserID); err != nil {
 		s.Log.Warn("acpbridge: failed to publish turn_status realtime event", "conversation_id", convID, "error", err)
 	}
+
+	// Task-level handoff (#392): a successful task-linked acp run persists its
+	// final reply idempotently, same as the llm path in handler.Handle.
+	if statusStr == "finished" {
+		taskID, err := s.ConvRepo.GetConversationTaskID(ctx, convID)
+		if err != nil {
+			s.Log.Warn("acpbridge: failed to resolve task id for handoff", "conversation_id", convID, "error", err)
+		} else if taskID != uuid.Nil {
+			summary, err := s.ConvRepo.LatestAgentReply(ctx, convID)
+			if err != nil {
+				s.Log.Warn("acpbridge: failed to read final reply for handoff", "conversation_id", convID, "error", err)
+			} else if summary != "" {
+				if err := s.ConvRepo.InsertTaskHandoff(ctx, taskID, convID, summary); err != nil {
+					s.Log.Warn("acpbridge: failed to persist task handoff", "task_id", taskID, "conversation_id", convID, "error", err)
+				} else {
+					s.Log.Info("acpbridge: task handoff persisted", "task_id", taskID, "conversation_id", convID)
+				}
+			}
+		}
+	}
 }
 
 // handleStatus handles GET /agent-bridge/status/{agentId} — internal,

--- a/services/agent-runner/internal/agent/trigger.go
+++ b/services/agent-runner/internal/agent/trigger.go
@@ -58,4 +58,9 @@ type Trigger struct {
 	// already split — a project can have more than one repository plugin
 	// installed.
 	RepoPluginIDs []string
+	// PriorHandoffs carries bounded prior task-level handoff summaries (see
+	// agent_task_handoffs) for a task-linked conversation, newest first.
+	// Populated by the handler from the repository before the turn runs so
+	// executor.buildInitialMessage can inject them without a DB dependency.
+	PriorHandoffs []string
 }

--- a/services/agent-runner/internal/executor/prompt.go
+++ b/services/agent-runner/internal/executor/prompt.go
@@ -81,6 +81,18 @@ func buildInitialMessage(cfg agent.Config, trigger agent.Trigger) string {
 		fmt.Fprintf(&b, "Chat Session ID: %s\n", trigger.ChatSessionID)
 	}
 
+	// Prior task-level agent handoffs (#392): bounded summaries of earlier
+	// conversations' conclusions on this task, newest first, so a later turn
+	// can recover context without the full transcripts.
+	if len(trigger.PriorHandoffs) > 0 {
+		b.WriteString("\n\n## Prior Agent Handoffs on This Task\n")
+		b.WriteString("These are summaries of earlier agent conclusions on this task. " +
+			"Use them as context; the full transcripts live in conversation history.\n")
+		for i, handoff := range trigger.PriorHandoffs {
+			fmt.Fprintf(&b, "\n### Handoff %d\n%s\n", i+1, handoff)
+		}
+	}
+
 	b.WriteString("\n\n## User Message\n")
 	message := strings.TrimSpace(trigger.Message)
 	if message == "" && trigger.TriggerType == agent.TriggerTaskAssigned {

--- a/services/agent-runner/internal/executor/prompt_test.go
+++ b/services/agent-runner/internal/executor/prompt_test.go
@@ -73,3 +73,31 @@ func TestActionTypeLabel_CommentMentionOnTaskVsDocument(t *testing.T) {
 		t.Errorf("actionTypeLabel(doc comment) = %q", got)
 	}
 }
+
+func TestBuildInitialMessage_PriorHandoffs(t *testing.T) {
+	trigger := agent.Trigger{
+		TriggerType:   agent.TriggerTaskAssigned,
+		PriorHandoffs: []string{"First conclusion.", "Second conclusion."},
+	}
+
+	msg := buildInitialMessage(agent.Config{}, trigger)
+
+	if !strings.Contains(msg, "## Prior Agent Handoffs on This Task") {
+		t.Errorf("expected prior handoffs section, got:\n%s", msg)
+	}
+	for _, want := range []string{"First conclusion.", "Second conclusion."} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected handoff %q, got:\n%s", want, msg)
+		}
+	}
+}
+
+func TestBuildInitialMessage_NoPriorHandoffs(t *testing.T) {
+	trigger := agent.Trigger{TriggerType: agent.TriggerTaskAssigned}
+
+	msg := buildInitialMessage(agent.Config{}, trigger)
+
+	if strings.Contains(msg, "Prior Agent Handoffs") {
+		t.Errorf("should not render a handoffs section when empty, got:\n%s", msg)
+	}
+}

--- a/services/agent-runner/internal/handler/handler.go
+++ b/services/agent-runner/internal/handler/handler.go
@@ -30,6 +30,10 @@ import (
 	"github.com/Paca-AI/agent-runner/internal/repository/postgres"
 )
 
+// maxPriorHandoffs bounds how many prior task-level handoff summaries are
+// injected into a later task-linked conversation's context (#392).
+const maxPriorHandoffs = 3
+
 // Handler is messaging.Handler and messaging.ControlHandler both — one
 // instance shared across every trigger and control message the process
 // handles. Exported (unlike the "Handler" name might suggest is needed for
@@ -291,6 +295,19 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 		persistAndPublish(string(e.Kind), "agent", e.Raw)
 	}
 
+	// Inject bounded prior task handoffs so a later task-linked conversation
+	// can recover the earlier conclusions (#392). Best-effort: a failure to
+	// load them should not block the turn.
+	if trigger.TaskID != nil {
+		prior, err := h.ConvRepo.ListTaskHandoffs(ctx, *trigger.TaskID, maxPriorHandoffs)
+		if err != nil {
+			h.Log.Warn("agent-runner: failed to load prior task handoffs",
+				"task_id", trigger.TaskID, "error", err)
+		} else {
+			trigger.PriorHandoffs = prior
+		}
+	}
+
 	result, runErr := h.Executor.Run(runCtx, *cfg, trigger, resume, onEvent)
 	// Whatever's still buffered when the turn ends — successfully,
 	// interrupted, or failed — is a genuine partial reply, not scratch
@@ -449,6 +466,26 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 		return fmt.Errorf("mark conversation %s finished: %w", trigger.ConversationID, err)
 	}
 	h.publishTerminalStatus(ctx, trigger.ProjectID, trigger.ConversationID, trigger.ActorUserID, "finished", "agent.conversation.finished")
+
+	// Persist a task-level handoff for a successful task-linked sessionless
+	// run (#392): capture the final reply idempotently so a later conversation
+	// on the same task can recover the conclusion even after this one is
+	// terminal. Best-effort — the conversation is already finished.
+	if trigger.TaskID != nil {
+		summary, err := h.ConvRepo.LatestAgentReply(ctx, trigger.ConversationID)
+		if err != nil {
+			h.Log.Warn("agent-runner: failed to read final reply for handoff",
+				"conversation_id", trigger.ConversationID, "error", err)
+		} else if summary != "" {
+			if err := h.ConvRepo.InsertTaskHandoff(ctx, *trigger.TaskID, trigger.ConversationID, summary); err != nil {
+				h.Log.Warn("agent-runner: failed to persist task handoff",
+					"task_id", trigger.TaskID, "conversation_id", trigger.ConversationID, "error", err)
+			} else {
+				h.Log.Info("agent-runner: task handoff persisted",
+					"task_id", trigger.TaskID, "conversation_id", trigger.ConversationID)
+			}
+		}
+	}
 
 	h.Log.Info("agent-runner: conversation finished",
 		"conversation_id", trigger.ConversationID, "stop_reason", result.StopReason)

--- a/services/agent-runner/internal/repository/postgres/conversation_repository.go
+++ b/services/agent-runner/internal/repository/postgres/conversation_repository.go
@@ -158,3 +158,84 @@ func (r *ConversationRepository) InsertEvent(ctx context.Context, id, conversati
 	}
 	return nil
 }
+
+// maxHandoffSummaryBytes bounds a persisted handoff summary so context
+// assembly never injects an unbounded transcript into a later turn.
+const maxHandoffSummaryBytes = 8000
+
+// LatestAgentReply returns the concatenated text of the conversation's
+// agent-authored message events (agent_message_chunk for llm-type agents via
+// this runner, MessageAction for acp-type agents via the bridge), or "" when
+// the agent produced no message text. This is the "final conclusion" a task
+// handoff captures.
+func (r *ConversationRepository) LatestAgentReply(ctx context.Context, conversationID uuid.UUID) (string, error) {
+	var reply string
+	err := r.db.GetContext(ctx, &reply, `
+		SELECT COALESCE(string_agg(text, E'\n'), '')
+		FROM (
+			SELECT COALESCE(
+				payload #>> '{content,text}',
+				payload->>'content',
+				payload->>'message',
+				''
+			) AS text
+			FROM agent_conversation_events
+			WHERE conversation_id = $1
+			  AND event_source = 'agent'
+			  AND event_type IN ('agent_message_chunk', 'MessageAction')
+			ORDER BY event_index ASC
+		) t
+		WHERE text <> ''
+	`, conversationID)
+	if err != nil {
+		return "", fmt.Errorf("postgres: latest agent reply for conversation %s: %w", conversationID, err)
+	}
+	if len(reply) > maxHandoffSummaryBytes {
+		reply = reply[:maxHandoffSummaryBytes]
+	}
+	return reply, nil
+}
+
+// InsertTaskHandoff persists one task-level handoff for a conversation,
+// idempotently (the UNIQUE(conversation_id) constraint makes a retry a no-op).
+func (r *ConversationRepository) InsertTaskHandoff(ctx context.Context, taskID, conversationID uuid.UUID, summary string) error {
+	if _, err := r.db.ExecContext(ctx, `
+		INSERT INTO agent_task_handoffs (task_id, conversation_id, summary)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (conversation_id) DO NOTHING
+	`, taskID, conversationID, summary); err != nil {
+		return fmt.Errorf("postgres: insert handoff for conversation %s: %w", conversationID, err)
+	}
+	return nil
+}
+
+// ListTaskHandoffs returns up to limit prior handoff summaries for a task,
+// newest first, for bounded context assembly on a later conversation.
+func (r *ConversationRepository) ListTaskHandoffs(ctx context.Context, taskID uuid.UUID, limit int) ([]string, error) {
+	var summaries []string
+	if err := r.db.SelectContext(ctx, &summaries, `
+		SELECT summary
+		FROM agent_task_handoffs
+		WHERE task_id = $1
+		ORDER BY created_at DESC, id DESC
+		LIMIT $2
+	`, taskID, limit); err != nil {
+		return nil, fmt.Errorf("postgres: list handoffs for task %s: %w", taskID, err)
+	}
+	return summaries, nil
+}
+
+// GetConversationTaskID returns the conversation's task_id, or uuid.Nil when
+// the conversation is not task-linked. Used by the ACP bridge's turn_status
+// path, which has no in-memory trigger carrying the task id.
+func (r *ConversationRepository) GetConversationTaskID(ctx context.Context, conversationID uuid.UUID) (uuid.UUID, error) {
+	var taskID uuid.NullUUID
+	if err := r.db.GetContext(ctx, &taskID,
+		`SELECT task_id FROM agent_conversations WHERE id = $1`, conversationID); err != nil {
+		return uuid.Nil, fmt.Errorf("postgres: get task id for conversation %s: %w", conversationID, err)
+	}
+	if !taskID.Valid {
+		return uuid.Nil, nil
+	}
+	return taskID.UUID, nil
+}

--- a/services/agent-runner/test/e2e/trigger_orchestration_test.go
+++ b/services/agent-runner/test/e2e/trigger_orchestration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,5 +131,112 @@ func TestTriggerOrchestration(t *testing.T) {
 	}
 	if lastEventType != "turn_end" {
 		t.Fatalf("last persisted event type = %q, want %q", lastEventType, "turn_end")
+	}
+}
+
+// TestTaskHandoff drives a task-linked sessionless run to "finished" and
+// verifies the final reply is persisted as an idempotent task-level handoff
+// (#392), including the failure modes of a retry (no duplicate) and that a
+// non-task conversation leaves no handoff behind.
+func TestTaskHandoff(t *testing.T) {
+	env := newE2EEnv(t)
+	image := agentServerImage(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	gatewayIP := dockerBridgeGatewayIP(ctx, t)
+	llm := fakellm.New(t, fakellm.TextReply("the final conclusion for handoff"))
+
+	encryptor := newEncryptor(t)
+	encryptedKey, err := encryptor.Encrypt("fake-key")
+	if err != nil {
+		t.Fatalf("encrypt fake key: %v", err)
+	}
+
+	taskID := uuid.New()
+	agentID := uuid.New()
+	convID := uuid.New()
+
+	if _, err := env.db.ExecContext(ctx,
+		`INSERT INTO tasks (id, project_id, title) VALUES ($1, $2, 'handoff task')`,
+		taskID, env.projectID); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	if _, err := env.db.ExecContext(ctx, `
+		INSERT INTO agents (id, project_id, name, handle, llm_provider, llm_model,
+		                     llm_api_key_secret, llm_base_url, system_prompt,
+		                     max_iterations, timeout_minutes,
+		                     git_committer_name, git_committer_email, agent_type)
+		VALUES ($1, $2, 'Handoff Agent', $3, 'openai', 'fake-model', $4, $5,
+		        'You are a test agent.', 5, 10, 'paca-agent', 'agent@example.com', 'llm')
+	`, agentID, env.projectID, "handoff-agent-"+agentID.String()[:8], encryptedKey, llm.BaseURL(gatewayIP)); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if _, err := env.db.ExecContext(ctx, `
+		INSERT INTO agent_conversations (id, agent_id, project_id, trigger_type, task_id, triggered_by_member_id, status)
+		VALUES ($1, $2, $3, 'task_assigned', $4, $5, 'queued')
+	`, convID, agentID, env.projectID, taskID, env.memberID); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	sandboxMgr := newSandboxManager(t)
+	h := &handler.Handler{
+		Gate:      config.NewGate([]string{agentID.String()}),
+		AgentRepo: postgres.NewAgentRepository(env.db),
+		ConvRepo:  postgres.NewConversationRepository(env.db),
+		Publisher: messaging.NewPublisher(env.redisClient),
+		Executor:  executor.New(sandboxMgr, encryptor, executor.Options{Image: image}, log),
+		InFlight:  registry.New(),
+		Log:       log,
+	}
+
+	trigger := agent.Trigger{
+		ConversationID: convID,
+		ProjectID:      env.projectID,
+		AgentID:        agentID,
+		TaskID:         &taskID,
+		Message:        "please conclude",
+		TriggerType:    agent.TriggerTaskAssigned,
+	}
+	if err := h.Handle(ctx, trigger); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	var summary string
+	if err := env.db.GetContext(ctx, &summary,
+		`SELECT summary FROM agent_task_handoffs WHERE conversation_id = $1`, convID); err != nil {
+		t.Fatalf("expected a task handoff for conversation %s: %v", convID, err)
+	}
+	if !strings.Contains(summary, "final conclusion for handoff") {
+		t.Fatalf("handoff summary = %q, want it to contain the fake reply", summary)
+	}
+
+	// Idempotency: a direct duplicate insert (simulating a completion retry)
+	// must not create a second handoff row for the same conversation.
+	if _, err := env.db.ExecContext(ctx, `
+		INSERT INTO agent_task_handoffs (task_id, conversation_id, summary)
+		VALUES ($1, $2, 'duplicate') ON CONFLICT (conversation_id) DO NOTHING
+	`, taskID, convID); err != nil {
+		t.Fatalf("duplicate handoff insert: %v", err)
+	}
+	var count int
+	if err := env.db.GetContext(ctx, &count,
+		`SELECT COUNT(*) FROM agent_task_handoffs WHERE conversation_id = $1`, convID); err != nil {
+		t.Fatalf("count handoffs: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("handoff count = %d, want 1 (idempotent)", count)
+	}
+
+	// A later conversation on the same task reads the prior handoff back via
+	// the repository's bounded list, newest first.
+	prior, err := postgres.NewConversationRepository(env.db).ListTaskHandoffs(ctx, taskID, 3)
+	if err != nil {
+		t.Fatalf("list handoffs: %v", err)
+	}
+	if len(prior) != 1 || !strings.Contains(prior[0], "final conclusion for handoff") {
+		t.Fatalf("prior handoffs = %q, want the persisted summary", prior)
 	}
 }

--- a/services/agent-runner/test/e2e/trigger_orchestration_test.go
+++ b/services/agent-runner/test/e2e/trigger_orchestration_test.go
@@ -183,13 +183,14 @@ func TestTaskHandoff(t *testing.T) {
 
 	sandboxMgr := newSandboxManager(t)
 	h := &handler.Handler{
-		Gate:      config.NewGate([]string{agentID.String()}),
-		AgentRepo: postgres.NewAgentRepository(env.db),
-		ConvRepo:  postgres.NewConversationRepository(env.db),
-		Publisher: messaging.NewPublisher(env.redisClient),
-		Executor:  executor.New(sandboxMgr, encryptor, executor.Options{Image: image}, log),
-		InFlight:  registry.New(),
-		Log:       log,
+		Gate:          config.NewGate([]string{agentID.String()}),
+		AgentRepo:     postgres.NewAgentRepository(env.db),
+		ConvRepo:      postgres.NewConversationRepository(env.db),
+		Publisher:     messaging.NewPublisher(env.redisClient),
+		Executor:      executor.New(sandboxMgr, encryptor, executor.Options{Image: image}, log),
+		InFlight:      registry.New(),
+		ChatSandboxes: chatsandbox.New(),
+		Log:           log,
 	}
 
 	trigger := agent.Trigger{

--- a/services/api/migrations/000039_add_agent_task_handoffs.sql
+++ b/services/api/migrations/000039_add_agent_task_handoffs.sql
@@ -1,0 +1,28 @@
+-- Durable task-level agent handoffs (#392).
+--
+-- A successful task-linked agent conversation's final reply is persisted here
+-- so a later conversation on the same task can recover the prior conclusion,
+-- even after the original conversation is terminal or the task is closed.
+--
+-- conversation_id is UNIQUE so a completion retry can never create a second
+-- handoff for the same conversation (idempotent persistence).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_task_handoffs (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    task_id         UUID        NOT NULL,
+    conversation_id UUID        NOT NULL,
+    summary         TEXT        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_agent_task_handoffs_task
+        FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_agent_task_handoffs_conversation
+        FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON DELETE CASCADE,
+    CONSTRAINT uq_agent_task_handoffs_conversation UNIQUE (conversation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_task_handoffs_task_created
+    ON agent_task_handoffs (task_id, created_at DESC);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes #392 — task-level agent conversation continuity.

A successful **task-linked sessionless** agent run now persists its final reply as an idempotent task-level handoff, so a later conversation on the same task can recover the prior conclusion even after the original conversation is terminal or the task is closed. Failed/cancelled runs never publish a handoff, and this flow never reopens or changes the task status.

### What it does

- **Migration `000039`** — `agent_task_handoffs` table (`task_id`, `conversation_id` with a UNIQUE constraint for idempotency, `summary`, `created_at`).
- **Persistence** — on the llm `finished` path (handler) and the acp `turn_status=finished` path (bridge), the final reply is extracted from the conversation's agent message events (`agent_message_chunk` / `MessageAction`) and inserted with `ON CONFLICT (conversation_id) DO NOTHING`.
- **Context assembly** — a task-linked turn reads up to 3 prior handoffs (newest first) and renders them into the initial prompt as a bounded `## Prior Agent Handoffs on This Task` section.

### Testing

- Unit: `TestBuildInitialMessage_PriorHandoffs` / `_NoPriorHandoffs`.
- E2E: `TestTaskHandoff` (drives a task-linked run to `finished` via the fake LLM; asserts the handoff is persisted, a retry is a no-op, and a later conversation reads it back). This test compiles and mirrors the existing `TestTriggerOrchestration`, but I could not run it locally on macOS Docker Desktop — the sandbox container cannot reach the host fake-LLM over the Linux-only `dockerBridgeGatewayIP` path (the existing `TestTriggerOrchestration` fails identically here). It is covered by `agent-runner-pr-ci`'s e2e job on Linux.
- Verified locally: `go build`/`go vet`/`go test ./internal/...` for agent-runner, `go build` for api, and migration `000039` + the agent-message text extraction against a real Postgres 16.
