### PR TITLE
fix: update acp-bridge upload path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -497,7 +497,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
-            "apps/acp-bridge/${{ steps.package.outputs.asset }}" --clobber
+            "${{ steps.package.outputs.asset }}" --clobber
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Deployment assets → GitHub Release


### PR DESCRIPTION
## Problem

CD [run #32219906367](https://github.com/Paca-AI/paca/actions/runs/32219906367) for `v0.13.0-rc.1` failed in `build-acp-bridge`: every platform failed to upload its archive to the release, so `v0.13.0-rc.1` currently has zero ACP bridge binaries attached.

## Root cause

`build-acp-bridge` sets a job-level default:

```yaml
defaults:
  run:
    working-directory: apps/acp-bridge
```

which applies to every step, including "Upload archive to GitHub Release". That step already runs with cwd `apps/acp-bridge`, but its `gh release upload` call re-prefixed the asset path with `apps/acp-bridge/` again:

```
gh release upload "$TAG" "apps/acp-bridge/${{ steps.package.outputs.asset }}" --clobber
```

which resolves to `apps/acp-bridge/apps/acp-bridge/<asset>` — a path that never exists. `windows/amd64` hit this first and failed outright; the matrix's fail-fast default then cancelled the remaining four legs (`linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`) before they reached the upload step either.

## Fix

Drop the redundant `apps/acp-bridge/` prefix so the path is resolved relative to the step's actual working directory.

## Follow-up

This only fixes future releases. `v0.13.0-rc.1` itself still has no ACP bridge binaries attached and will need those uploaded separately (e.g. by cutting `v0.13.0-rc.2` once this merges, or uploading them manually).
