### PR TITLE
fix: update API endpoint for plugin deletion in remove-plugin script

### DIFF
--- a/scripts/remove-plugin.sh
+++ b/scripts/remove-plugin.sh
@@ -240,7 +240,7 @@ if [[ "$REMOVE_ARTIFACTS_ONLY" = false ]]; then
 
     # Remove plugin registration
     print_step "Removing plugin registration..."
-    DELETE_RESPONSE=$(curl -s -X DELETE "${API_ENDPOINT}/plugins/${PLUGIN_UUID}" \
+    DELETE_RESPONSE=$(curl -s -X DELETE "${API_ENDPOINT}/admin/plugins/${PLUGIN_UUID}" \
         -H "${AUTH_HEADER}" \
         -w "\n%{http_code}")
 


### PR DESCRIPTION
## Summary
`scripts/remove-plugin.sh` was calling `DELETE ${API_ENDPOINT}/plugins/{uuid}` to unregister a plugin, but that path was never routed to a delete handler — it only matches the plugin proxy wildcard (`/plugins/{pluginId}/*`, which requires a trailing sub-path) in `services/api/internal/transport/http/router/router.go`. The actual delete-by-id route is registered under the admin group as `DELETE /admin/plugins/{pluginId}`, which additionally requires `PermissionUsersWrite`.

This caused the script to always fail with `HTTP 404 page not found` when removing a plugin's API registration, even when the plugin was found successfully via `GET /plugins`.

## Fix
Point the DELETE call at `${API_ENDPOINT}/admin/plugins/${PLUGIN_UUID}` to match the registered route.

## Test plan
- [x] Run `./scripts/remove-plugin.sh <plugin_id> --api-key <key>` against a running API and confirm the registration is removed (HTTP 200/204) instead of 404
