### PR TITLE
feat: pre-pull agent-server image during install and upgrade processes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -258,6 +258,11 @@ download() {
     fi
 }
 
+# get_env_var FILE VAR
+get_env_var() {
+    grep "^${2}=" "$1" 2>/dev/null | head -1 | cut -d= -f2-
+}
+
 # ── Version / URL resolution ──────────────────────────────────────────────────
 
 # CD stamps this to the exact tag of the release install.sh ships with (see
@@ -892,8 +897,18 @@ heading "Starting Paca"
 # entirely on a slow link/large image) instead of just running. Pulling it
 # here too, best-effort: ensureImage's own pull-on-first-use stays the real
 # safety net, so a failure here only costs the win, not correctness.
+#
+# Read back from .env rather than assuming the fresh-install default: when an
+# existing .env was kept (KEEP_ENV=yes above), AGENT_SERVER_IMAGE may already
+# be pinned to something else, and pre-pulling the wrong ref would fetch an
+# image this deployment won't use while leaving the actually-configured one
+# cold — the exact outcome this feature exists to prevent. Falls back to the
+# same default the freshly-written .env above uses when the kept .env
+# predates AGENT_SERVER_IMAGE entirely. Mirrors upgrade.sh's own
+# get_env_var-based read of the effective value.
 if [[ "$INCLUDE_AGENT_RUNNER" != "no" ]]; then
-    _agent_server_image="ghcr.io/paca-ai/paca-agent-server-goose:${IMAGE_TAG}"
+    _agent_server_image="$(get_env_var .env AGENT_SERVER_IMAGE)"
+    _agent_server_image="${_agent_server_image:-ghcr.io/paca-ai/paca-agent-server-goose:${IMAGE_TAG}}"
     info "Pre-pulling agent-server image (${_agent_server_image})..."
     docker pull "$_agent_server_image" || warn "Could not pre-pull ${_agent_server_image} — agent-runner will pull it on first use instead."
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -883,6 +883,21 @@ fi
 
 heading "Starting Paca"
 
+# AGENT_SERVER_IMAGE isn't a docker-compose service, just an env var
+# agent-runner reads and pulls for itself — lazily, the first time a
+# conversation actually needs a sandbox (see
+# services/agent-runner/internal/sandbox/sandbox.go's ensureImage), so
+# `--pull always` below never touches it. Left alone, the very first
+# conversation on a fresh install pays for that cold pull (or times out
+# entirely on a slow link/large image) instead of just running. Pulling it
+# here too, best-effort: ensureImage's own pull-on-first-use stays the real
+# safety net, so a failure here only costs the win, not correctness.
+if [[ "$INCLUDE_AGENT_RUNNER" != "no" ]]; then
+    _agent_server_image="ghcr.io/paca-ai/paca-agent-server-goose:${IMAGE_TAG}"
+    info "Pre-pulling agent-server image (${_agent_server_image})..."
+    docker pull "$_agent_server_image" || warn "Could not pre-pull ${_agent_server_image} — agent-runner will pull it on first use instead."
+fi
+
 SCALE_OPTS=()
 [[ -n "$SCALE_POSTGRES"  ]] && SCALE_OPTS+=($SCALE_POSTGRES)
 [[ -n "$SCALE_DB_BACKUP" ]] && SCALE_OPTS+=($SCALE_DB_BACKUP)

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -345,20 +345,27 @@ fi
 # agent-server protocol — neither the raw upstream image nor Paca's own
 # pre-Agent-Runner build of it works with Agent Runner at all, so an install
 # still on either one needs this value changed for agents to work post
-# upgrade, not just as a nice-to-have. Only offer to rewrite installs still on
-# one of these exact known-old defaults — never touch a value the user
-# deliberately customized. Asked rather than applied silently since it's
-# still worth a confirmation, same as the version re-pin above.
-OLD_AGENT_SERVER_IMAGE_DEFAULTS=(
-    "ghcr.io/openhands/agent-server:latest-python"
-    "ghcr.io/paca-ai/paca-agent-server:latest"
-    "ghcr.io/paca-ai/paca-agent-server:${IMAGE_TAG}"
-)
+# upgrade, not just as a nice-to-have. Matched by repo prefix, not an
+# exact-string allowlist of known tags: an earlier version of this check only
+# matched "ghcr.io/paca-ai/paca-agent-server:latest" or the *current*
+# release's own tag, so an install pinned to any other old version (e.g.
+# ":0.12.2", left over from before this repo existed) sailed through
+# undetected — AGENT_SERVER_IMAGE stayed on the incompatible OpenHands-based
+# image while Agent Runner started fine, and every conversation failed with a
+# sandbox that starts, never answers /status, and is gone (AutoRemove) by the
+# time diagnostics run. A prefix match catches every tag under either old
+# repo, known or not — "ghcr.io/paca-ai/paca-agent-server:" (no trailing
+# "-goose") never matches the current good default, which is always
+# "...-agent-server-goose:...". Never touches a value the user deliberately
+# customized to something outside both old repos. Asked rather than applied
+# silently since it's still worth a confirmation, same as the version re-pin
+# above.
 _current_agent_server_image="$(get_env_var .env AGENT_SERVER_IMAGE)"
 _agent_server_image_is_old=0
-for _old in "${OLD_AGENT_SERVER_IMAGE_DEFAULTS[@]}"; do
-    [[ "$_current_agent_server_image" == "$_old" ]] && _agent_server_image_is_old=1
-done
+case "$_current_agent_server_image" in
+    ghcr.io/openhands/agent-server:*)   _agent_server_image_is_old=1 ;;
+    ghcr.io/paca-ai/paca-agent-server:*) _agent_server_image_is_old=1 ;;
+esac
 if [[ "$_agent_server_image_is_old" == "1" ]]; then
     heading "Agent-server image"
     info "AGENT_SERVER_IMAGE is still set to an OpenHands-based image (${_current_agent_server_image}), which Agent Runner cannot use."
@@ -522,6 +529,22 @@ fi
 # ── Pull and restart ──────────────────────────────────────────────────────────
 
 heading "Pulling images and restarting"
+
+# AGENT_SERVER_IMAGE isn't a docker-compose service, just an env var
+# agent-runner reads and pulls for itself — lazily, the first time a
+# conversation actually needs a sandbox (see
+# services/agent-runner/internal/sandbox/sandbox.go's ensureImage). Left
+# alone, that first conversation after every upgrade pays for a cold pull (or
+# times out entirely on a slow link/large image) instead of just running.
+# Pulling it here too, best-effort: ensureImage's own pull-on-first-use stays
+# the real safety net, so a failure here only costs the win, not correctness.
+if [[ "$(get_env_var .env PACA_AGENT_RUNNER)" != "no" ]]; then
+    _agent_server_image="$(get_env_var .env AGENT_SERVER_IMAGE)"
+    if [[ -n "$_agent_server_image" ]]; then
+        info "Pre-pulling agent-server image (${_agent_server_image})..."
+        docker pull "$_agent_server_image" || warn "Could not pre-pull ${_agent_server_image} — agent-runner will pull it on first use instead."
+    fi
+fi
 
 # shellcheck disable=SC2086
 $COMPOSE_CMD --env-file .env pull


### PR DESCRIPTION
## Problem

A production install upgraded to Agent Runner (the Go/Goose service that replaced the old Python `ai-agent`) but every AI agent conversation failed: the sandbox container was created and started, then vanished (`AutoRemove`) before ever answering `/status`, so `agent-runner`'s own diagnostics couldn't even inspect it.

## Root cause

`AGENT_SERVER_IMAGE` was still pinned to `ghcr.io/paca-ai/paca-agent-server:0.12.2` — an old OpenHands-based image from before the Goose migration, which doesn't understand the `goose serve --host 0.0.0.0 --port 3284` command Agent Runner launches it with, so the container exits almost immediately.

`upgrade.sh` already has a check meant to catch exactly this (the "Agent-server image" migration prompt), but it only matched an exact allowlist — `:latest` or the *current* release's own tag. An install pinned to any other specific old version (like `:0.12.2`) sailed through undetected, so `AGENT_SERVER_IMAGE` was silently carried forward while Agent Runner got enabled against it.

Separately, `AGENT_SERVER_IMAGE` isn't a docker-compose service — it's just an env var `agent-runner` reads and pulls for itself, lazily, the first time a conversation needs a sandbox (`ensureImage` in `services/agent-runner/internal/sandbox/sandbox.go`). Neither `install.sh`'s `--pull always` nor `upgrade.sh`'s `compose pull` ever touch it, so even a correctly-configured install pays for a cold pull (or times out on a slow link) on its very first conversation.

## Changes

- **`upgrade.sh`: broaden stale-image detection.** Replaced the exact-tag allowlist with a repo-prefix `case` match (`ghcr.io/openhands/agent-server:*`, `ghcr.io/paca-ai/paca-agent-server:*`), so an install pinned to *any* tag under either old repo gets flagged and offered the migration — not just the two previously-hardcoded defaults. The trailing colon in the second pattern correctly excludes the current `...-agent-server-goose:` default.
- **`upgrade.sh`: pre-pull the sandbox image.** Best-effort `docker pull` of the effective `AGENT_SERVER_IMAGE` (read from `.env` after the migration above has run), gated on `PACA_AGENT_RUNNER` not being `no`, before the compose pull/restart.
- **`install.sh`: pre-pull the sandbox image.** Same idea for a fresh install — pulls before `compose up --pull always`, gated on Agent Runner being included. Reads the effective value back from `.env` (new `get_env_var` helper, mirroring `upgrade.sh`) rather than assuming the fresh-install default, so a re-run against a kept `.env` (`KEEP_ENV=yes`) with a customized `AGENT_SERVER_IMAGE` still pre-pulls the right image (per [pullfrog's review](https://github.com/Paca-AI/paca/pull/416#discussion_r3811217633)).

Both pre-pulls are best-effort — a failed pre-pull only warns; `ensureImage`'s own pull-on-first-use in `agent-runner` stays the real safety net either way.

## Test plan

- [x] `bash -n scripts/upgrade.sh` / `bash -n scripts/install.sh`
- [x] Reproduced the root cause against a real affected install: `AGENT_SERVER_IMAGE` pinned to an old versioned `paca-agent-server` tag went undetected by the previous exact-match check; the new prefix match flags it correctly and the migration prompt fires.
- [x] Manually verified end-to-end: repointing `AGENT_SERVER_IMAGE` at the Goose-based image and restarting `agent-runner` resolves the failing-conversation symptom.
- [x] Addressed pullfrog's one review finding in a follow-up commit.
