### PR TITLE
feat: replace bare loading dot with setup/thinking status

### DIFF
--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -100,12 +100,26 @@ export type ThreadProps = {
 	 * overrides a caller that is positioning the scroll itself.
 	 */
 	scrollToBottomOnRunStart?: boolean | undefined;
+	/**
+	 * Whether the sandbox/session backing this thread is confirmed ready to
+	 * run a turn (a fresh sandbox finished starting, an ACP local-bridge
+	 * conversation — which has no sandbox to start — or a resumed session).
+	 * Governs the empty-message indicator's wording: "setting up your
+	 * environment" beforehand, "thinking" after. Callers derive this from
+	 * `hasEnvironmentReadyEvent`/`isACP`; defaults to `false` (the more
+	 * conservative "still setting up" reading) so a caller that hasn't
+	 * wired this up yet doesn't claim readiness it can't back up.
+	 */
+	environmentReady?: boolean | undefined;
 };
 
 const EMPTY_COMPONENTS: ThreadComponents = {};
 
 const ThreadComponentsContext =
 	createContext<ThreadComponents>(EMPTY_COMPONENTS);
+const ThreadStatusContext = createContext<{ environmentReady: boolean }>({
+	environmentReady: false,
+});
 
 // Startup exposes a loading placeholder thread; treat it as a new chat so
 // the composer mounts centered. Loads after startup keep the docked layout.
@@ -119,18 +133,21 @@ export const Thread: FC<ThreadProps> = ({
 	viewportOverlay,
 	turnAnchor = "top",
 	scrollToBottomOnRunStart = true,
+	environmentReady = false,
 }) => {
 	const isEmpty = useAuiState(isNewChatView);
 
 	return (
 		<ThreadComponentsContext.Provider value={components}>
-			<ThreadRoot
-				isEmpty={isEmpty}
-				viewportHeader={viewportHeader}
-				viewportOverlay={viewportOverlay}
-				turnAnchor={turnAnchor}
-				scrollToBottomOnRunStart={scrollToBottomOnRunStart}
-			/>
+			<ThreadStatusContext.Provider value={{ environmentReady }}>
+				<ThreadRoot
+					isEmpty={isEmpty}
+					viewportHeader={viewportHeader}
+					viewportOverlay={viewportOverlay}
+					turnAnchor={turnAnchor}
+					scrollToBottomOnRunStart={scrollToBottomOnRunStart}
+				/>
+			</ThreadStatusContext.Provider>
 		</ThreadComponentsContext.Provider>
 	);
 };
@@ -404,6 +421,17 @@ const AssistantMessage: FC = () => {
 		ToolGroup,
 		ReasoningGroup,
 	} = useContext(ThreadComponentsContext);
+	// A message with zero parts and no content yet is the optimistic
+	// placeholder assistant-ui's external-store runtime synthesizes while
+	// `isRunning` is true but nothing assistant-authored has arrived (queued
+	// conversation, or a sandbox still spinning up before its first ACP
+	// event) — see hasUpcomingMessage in
+	// @assistant-ui/core's external-store-thread-runtime-core. Distinguished
+	// from a real in-progress message that merely ended on a tool call (also
+	// "no-text" mode, but has parts already), which should keep showing the
+	// plain working dot rather than claim the environment is still starting.
+	const hasNoParts = useAuiState((s) => s.message.parts.length === 0);
+	const { environmentReady } = useContext(ThreadStatusContext);
 
 	// reserves space for action bar and compensates with `-mb` for consistent msg spacing
 	// keeps hovered action bar from shifting layout (autohide doesn't support absolute positioning well)
@@ -471,7 +499,17 @@ const AssistantMessage: FC = () => {
 							case "data":
 								return part.dataRendererUI;
 							case "indicator":
-								return (
+								return hasNoParts ? (
+									<span
+										data-slot="aui_assistant-message-indicator"
+										role="status"
+										className="animate-pulse text-muted-foreground"
+									>
+										{environmentReady
+											? t("agents.thread.thinking")
+											: t("agents.thread.environmentInitializing")}
+									</span>
+								) : (
 									<span
 										data-slot="aui_assistant-message-indicator"
 										role="status"

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AgentConversationEvent } from "@/lib/agent-api";
-import { eventsToThreadMessages } from "./conversation-to-thread-messages";
+import {
+	eventsToThreadMessages,
+	hasEnvironmentReadyEvent,
+} from "./conversation-to-thread-messages";
 
 let nextIndex = 0;
 
@@ -211,6 +214,23 @@ function acpToolCallEvent(opts: {
 	};
 }
 
+// Mirrors handler.Handle's persistAndPublish("user_message", "user", ...)
+// shape — distinct from userMessage() above, which builds the legacy
+// MessageEvent vocabulary. Only conversations using this ACP vocabulary
+// ever get an environment_ready marker, so hasEnvironmentReadyEvent's
+// turn-boundary comparison needs this shape, not userMessage()'s.
+function acpUserMessage(text: string): AgentConversationEvent {
+	return {
+		id: `evt-${nextIndex}`,
+		conversation_id: "conv-1",
+		event_index: nextIndex++,
+		event_type: "user_message",
+		event_source: "user",
+		payload: { content: { type: "text", text } },
+		created_at: "2026-01-01T00:00:00.250Z",
+	};
+}
+
 function agentMessageChunk(text: string): AgentConversationEvent {
 	return {
 		id: `evt-${nextIndex}`,
@@ -314,6 +334,18 @@ function turnUsage(opts: {
 			...(opts.costUSD !== undefined ? { cost_usd: opts.costUSD } : {}),
 		},
 		created_at: "2026-01-01T00:00:11.000Z",
+	};
+}
+
+function environmentReadyEvent(): AgentConversationEvent {
+	return {
+		id: `evt-${nextIndex}`,
+		conversation_id: "conv-1",
+		event_index: nextIndex++,
+		event_type: "environment_ready",
+		event_source: "system",
+		payload: {},
+		created_at: "2026-01-01T00:00:00.500Z",
 	};
 }
 
@@ -1009,6 +1041,23 @@ describe("eventsToThreadMessages", () => {
 			expect(parts[0]).toMatchObject({ type: "text", text: "hello!" });
 		});
 
+		it("ignores environment_ready — it's a readiness marker, never a transcript bubble", () => {
+			const events = [
+				userMessage("hi"),
+				environmentReadyEvent(),
+				agentMessageChunk("hello!"),
+			];
+
+			const messages = eventsToThreadMessages(events, false);
+
+			expect(messages).toHaveLength(2);
+			const parts = messages[1].content as unknown as Array<
+				Record<string, unknown>
+			>;
+			expect(parts).toHaveLength(1);
+			expect(parts[0]).toMatchObject({ type: "text", text: "hello!" });
+		});
+
 		it("renders a full chat turn: reply chunks, a tool call, then more reply chunks", () => {
 			const events = [
 				userMessage("what files are here?"),
@@ -1041,5 +1090,53 @@ describe("eventsToThreadMessages", () => {
 				text: "There's one file: a.txt",
 			});
 		});
+	});
+});
+
+describe("hasEnvironmentReadyEvent", () => {
+	it("returns true once an environment_ready event is present", () => {
+		const events = [
+			userMessage("hi"),
+			environmentReadyEvent(),
+			agentMessageChunk("hello!"),
+		];
+
+		expect(hasEnvironmentReadyEvent(events)).toBe(true);
+	});
+
+	it("returns false when no environment_ready event has arrived yet", () => {
+		const events = [userMessage("hi")];
+
+		expect(hasEnvironmentReadyEvent(events)).toBe(false);
+	});
+
+	it("returns false for an empty event window", () => {
+		expect(hasEnvironmentReadyEvent([])).toBe(false);
+	});
+
+	it("returns false once a new turn starts before its own environment_ready arrives", () => {
+		// A prior turn's marker is still in the window (e.g. the sandbox was
+		// idle-reaped and needs a fresh cold start for this reply) — the stale
+		// marker predates the new user_message, so this must not read as ready.
+		const events = [
+			acpUserMessage("hi"),
+			environmentReadyEvent(),
+			agentMessageChunk("hello!"),
+			acpUserMessage("are you still there?"),
+		];
+
+		expect(hasEnvironmentReadyEvent(events)).toBe(false);
+	});
+
+	it("returns true again once the new turn gets its own environment_ready", () => {
+		const events = [
+			acpUserMessage("hi"),
+			environmentReadyEvent(),
+			agentMessageChunk("hello!"),
+			acpUserMessage("are you still there?"),
+			environmentReadyEvent(),
+		];
+
+		expect(hasEnvironmentReadyEvent(events)).toBe(true);
 	});
 });

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
@@ -3,6 +3,7 @@ import type { AgentConversationEvent } from "@/lib/agent-api";
 import {
 	eventsToThreadMessages,
 	hasEnvironmentReadyEvent,
+	isEnvironmentReady,
 } from "./conversation-to-thread-messages";
 
 let nextIndex = 0;
@@ -1138,5 +1139,21 @@ describe("hasEnvironmentReadyEvent", () => {
 		];
 
 		expect(hasEnvironmentReadyEvent(events)).toBe(true);
+	});
+});
+
+describe("isEnvironmentReady", () => {
+	it("is always ready for an ACP conversation, even with no environment_ready event", () => {
+		const events = [userMessage("hi")];
+
+		expect(isEnvironmentReady(true, events)).toBe(true);
+	});
+
+	it("defers to hasEnvironmentReadyEvent for a non-ACP conversation", () => {
+		const notReady = [userMessage("hi")];
+		const ready = [userMessage("hi"), environmentReadyEvent()];
+
+		expect(isEnvironmentReady(false, notReady)).toBe(false);
+		expect(isEnvironmentReady(false, ready)).toBe(true);
 	});
 });

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
@@ -212,6 +212,23 @@ export function hasEnvironmentReadyEvent(
 }
 
 /**
+ * Whether the Thread's empty-message indicator should read "thinking"
+ * instead of "setting up your environment" — the single computation all
+ * three chat surfaces (conversation-view, ai-chat-float,
+ * ai-chat-float-global) need, so it lives here once instead of being
+ * re-derived at each call site. ACP (local bridge) conversations have no
+ * sandbox to provision at all (see conversation-view.tsx's isACP doc
+ * comment), so they're always ready; everything else defers to
+ * hasEnvironmentReadyEvent's turn-boundary check.
+ */
+export function isEnvironmentReady(
+	isACP: boolean,
+	events: AgentConversationEvent[],
+): boolean {
+	return isACP || hasEnvironmentReadyEvent(events);
+}
+
+/**
  * Converts raw conversation events into assistant-ui's ThreadMessageLike[],
  * grouping each agent turn's thought/tool-calls/reply into one assistant
  * message's content parts (rather than one bubble per raw event) — the

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
@@ -183,6 +183,21 @@ function toThreadMessage(
 }
 
 /**
+ * Whether the given event window has seen an `environment_ready` marker —
+ * services/agent-runner persists one right before every session/prompt call
+ * (see executor.Run's `onReady`), once the sandbox/ACP session is actually
+ * ready to run a turn. Callers use this to switch the Thread's empty-message
+ * indicator from "setting up your environment" to "thinking": before this
+ * event, any wait is container/handshake setup; after it, any further wait
+ * is the LLM itself.
+ */
+export function hasEnvironmentReadyEvent(
+	events: AgentConversationEvent[],
+): boolean {
+	return events.some((e) => e.event_type === "environment_ready");
+}
+
+/**
  * Converts raw conversation events into assistant-ui's ThreadMessageLike[],
  * grouping each agent turn's thought/tool-calls/reply into one assistant
  * message's content parts (rather than one bubble per raw event) — the
@@ -212,10 +227,14 @@ export function eventsToThreadMessages(
 
 		// Non-user-visible bookkeeping events — already filtered server-side,
 		// skipped here too as a defensive guard against legacy/unfiltered data.
+		// environment_ready never renders as a bubble either — it's a marker
+		// consumed separately via hasEnvironmentReadyEvent below, not part of
+		// the transcript.
 		if (
 			t === "ConversationStateUpdateEvent" ||
 			t === "SystemPromptEvent" ||
-			t === "StreamingDeltaEvent"
+			t === "StreamingDeltaEvent" ||
+			t === "environment_ready"
 		) {
 			continue;
 		}

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
@@ -183,18 +183,32 @@ function toThreadMessage(
 }
 
 /**
- * Whether the given event window has seen an `environment_ready` marker —
- * services/agent-runner persists one right before every session/prompt call
- * (see executor.Run's `onReady`), once the sandbox/ACP session is actually
- * ready to run a turn. Callers use this to switch the Thread's empty-message
- * indicator from "setting up your environment" to "thinking": before this
- * event, any wait is container/handshake setup; after it, any further wait
- * is the LLM itself.
+ * Whether the *current* turn's environment is ready — services/agent-runner
+ * persists an `environment_ready` marker right before every session/prompt
+ * call (see executor.Run's `onReady`), once the sandbox/ACP session is
+ * actually ready to run a turn. Callers use this to switch the Thread's
+ * empty-message indicator from "setting up your environment" to "thinking":
+ * before this event, any wait is container/handshake setup; after it, any
+ * further wait is the LLM itself.
+ *
+ * Compares the latest `environment_ready` against the latest `user_message`
+ * rather than just checking presence anywhere in the window: a chat
+ * conversation whose sandbox got idle-reaped and needs a fresh cold start
+ * still has an *older* turn's `environment_ready` sitting in the loaded
+ * window, which a bare "has one ever appeared" check would misread as
+ * ready. Every trigger with real message text gets its own `user_message`
+ * (see handler.Handle's persistAndPublish call), so its index marks where
+ * the current turn began.
  */
 export function hasEnvironmentReadyEvent(
 	events: AgentConversationEvent[],
 ): boolean {
-	return events.some((e) => e.event_type === "environment_ready");
+	const lastReadyIndex =
+		events.findLast((e) => e.event_type === "environment_ready")?.event_index ??
+		-1;
+	const lastUserMessageIndex =
+		events.findLast((e) => e.event_type === "user_message")?.event_index ?? -1;
+	return lastReadyIndex > lastUserMessageIndex;
 }
 
 /**

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -45,7 +45,7 @@ import { ConversationErrorBox } from "./conversation-error-box";
 import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
-	hasEnvironmentReadyEvent,
+	isEnvironmentReady,
 } from "./conversation-to-thread-messages";
 import { LoadOlderEvents, TailFollowIndicator } from "./event-window-controls";
 import { useConversationEventWindow } from "./use-conversation-event-window";
@@ -199,7 +199,7 @@ export function ConversationView({
 	// entirely on the user's own machine — see internal/acpbridge/dispatch.go's
 	// doc comment), so there's no "setting up your environment" phase for
 	// them at all; they're ready as soon as they're dispatched.
-	const environmentReady = isACP || hasEnvironmentReadyEvent(events);
+	const environmentReady = isEnvironmentReady(isACP, events);
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -45,6 +45,7 @@ import { ConversationErrorBox } from "./conversation-error-box";
 import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
+	hasEnvironmentReadyEvent,
 } from "./conversation-to-thread-messages";
 import { LoadOlderEvents, TailFollowIndicator } from "./event-window-controls";
 import { useConversationEventWindow } from "./use-conversation-event-window";
@@ -194,6 +195,11 @@ export function ConversationView({
 		? projectAgent
 		: chattableAgents.find((a) => a.id === conversation?.agent_id);
 	const isACP = agent?.agent_type === "acp";
+	// ACP conversations never spin up a sandbox (the local bridge daemon runs
+	// entirely on the user's own machine — see internal/acpbridge/dispatch.go's
+	// doc comment), so there's no "setting up your environment" phase for
+	// them at all; they're ready as soon as they're dispatched.
+	const environmentReady = isACP || hasEnvironmentReadyEvent(events);
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";
@@ -463,6 +469,7 @@ export function ConversationView({
 						// A run starting must not pull a reader who is paging back
 						// through history.
 						scrollToBottomOnRunStart={false}
+						environmentReady={environmentReady}
 						viewportHeader={
 							<LoadOlderEvents
 								hasOlder={hasOlder}

--- a/apps/web/src/components/projects/ai-chat-float-global.tsx
+++ b/apps/web/src/components/projects/ai-chat-float-global.tsx
@@ -32,7 +32,7 @@ import { ConversationErrorBox } from "./agents/conversation-error-box";
 import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
-	hasEnvironmentReadyEvent,
+	isEnvironmentReady,
 } from "./agents/conversation-to-thread-messages";
 
 // Global sibling of ai-chat-float.tsx's AIChatFloat — same floating-panel UX,
@@ -103,9 +103,7 @@ export function GlobalAIChatFloat() {
 	const { data: agents = [] } = useQuery(chattableAgentsQueryOptions);
 	const agent = agents.find((a) => a.id === conversation?.agent_id);
 	const isACP = agent?.agent_type === "acp";
-	// See conversation-view.tsx's identical computation: ACP conversations
-	// have no sandbox to set up, so they're always "ready".
-	const environmentReady = isACP || hasEnvironmentReadyEvent(events);
+	const environmentReady = isEnvironmentReady(isACP, events);
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";

--- a/apps/web/src/components/projects/ai-chat-float-global.tsx
+++ b/apps/web/src/components/projects/ai-chat-float-global.tsx
@@ -32,6 +32,7 @@ import { ConversationErrorBox } from "./agents/conversation-error-box";
 import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
+	hasEnvironmentReadyEvent,
 } from "./agents/conversation-to-thread-messages";
 
 // Global sibling of ai-chat-float.tsx's AIChatFloat — same floating-panel UX,
@@ -102,6 +103,9 @@ export function GlobalAIChatFloat() {
 	const { data: agents = [] } = useQuery(chattableAgentsQueryOptions);
 	const agent = agents.find((a) => a.id === conversation?.agent_id);
 	const isACP = agent?.agent_type === "acp";
+	// See conversation-view.tsx's identical computation: ACP conversations
+	// have no sandbox to set up, so they're always "ready".
+	const environmentReady = isACP || hasEnvironmentReadyEvent(events);
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";
@@ -282,6 +286,7 @@ export function GlobalAIChatFloat() {
 								<AssistantRuntimeProvider runtime={runtime}>
 									<Thread
 										components={THREAD_COMPONENTS}
+										environmentReady={environmentReady}
 										// A chat_message trigger always persists the user's own
 										// message before the agent runs (see handler.Handle), so
 										// a failed/recoverable turn almost never has

--- a/apps/web/src/components/projects/ai-chat-float.tsx
+++ b/apps/web/src/components/projects/ai-chat-float.tsx
@@ -31,6 +31,7 @@ import { ConversationErrorBox } from "./agents/conversation-error-box";
 import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
+	hasEnvironmentReadyEvent,
 } from "./agents/conversation-to-thread-messages";
 
 interface AIChatFloatProps {
@@ -103,6 +104,9 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		enabled: !!conversation?.agent_id,
 	});
 	const isACP = agent?.agent_type === "acp";
+	// See conversation-view.tsx's identical computation: ACP conversations
+	// have no sandbox to set up, so they're always "ready".
+	const environmentReady = isACP || hasEnvironmentReadyEvent(events);
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";
@@ -319,6 +323,7 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 								<AssistantRuntimeProvider runtime={runtime}>
 									<Thread
 										components={THREAD_COMPONENTS}
+										environmentReady={environmentReady}
 										// A chat_message trigger always persists the user's own
 										// message before the agent runs (see handler.Handle), so
 										// a failed/recoverable turn almost never has

--- a/apps/web/src/components/projects/ai-chat-float.tsx
+++ b/apps/web/src/components/projects/ai-chat-float.tsx
@@ -31,7 +31,7 @@ import { ConversationErrorBox } from "./agents/conversation-error-box";
 import {
 	eventsToThreadMessages,
 	extractTextOnlyContent,
-	hasEnvironmentReadyEvent,
+	isEnvironmentReady,
 } from "./agents/conversation-to-thread-messages";
 
 interface AIChatFloatProps {
@@ -104,9 +104,7 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		enabled: !!conversation?.agent_id,
 	});
 	const isACP = agent?.agent_type === "acp";
-	// See conversation-view.tsx's identical computation: ACP conversations
-	// have no sandbox to set up, so they're always "ready".
-	const environmentReady = isACP || hasEnvironmentReadyEvent(events);
+	const environmentReady = isEnvironmentReady(isACP, events);
 
 	const isRunning =
 		conversation?.status === "queued" || conversation?.status === "running";

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "Send message",
 			"stopGeneratingAriaLabel": "Stop generating",
 			"assistantWorkingAriaLabel": "Assistant is working",
+			"environmentInitializing": "Setting up your environment…",
+			"thinking": "Thinking…",
 			"copy": "Copy",
 			"refresh": "Refresh",
 			"more": "More",

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "Enviar mensaje",
 			"stopGeneratingAriaLabel": "Detener generación",
 			"assistantWorkingAriaLabel": "El agente está trabajando",
+			"environmentInitializing": "Configurando tu entorno…",
+			"thinking": "Pensando…",
 			"copy": "Copiar",
 			"refresh": "Actualizar",
 			"more": "Más",

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "Envoyer le message",
 			"stopGeneratingAriaLabel": "Arrêter la génération",
 			"assistantWorkingAriaLabel": "L'agent travaille",
+			"environmentInitializing": "Configuration de votre environnement…",
+			"thinking": "Réflexion en cours…",
 			"copy": "Copier",
 			"refresh": "Actualiser",
 			"more": "Plus",

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "メッセージを送信",
 			"stopGeneratingAriaLabel": "生成を停止",
 			"assistantWorkingAriaLabel": "エージェントが作業中です",
+			"environmentInitializing": "環境をセットアップしています…",
+			"thinking": "考えています…",
 			"copy": "コピー",
 			"refresh": "更新",
 			"more": "その他",

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "메시지 보내기",
 			"stopGeneratingAriaLabel": "생성 중지",
 			"assistantWorkingAriaLabel": "에이전트가 작업 중입니다",
+			"environmentInitializing": "환경을 설정하는 중입니다…",
+			"thinking": "생각하는 중입니다…",
 			"copy": "복사",
 			"refresh": "새로고침",
 			"more": "더 보기",

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "Enviar mensagem",
 			"stopGeneratingAriaLabel": "Parar geração",
 			"assistantWorkingAriaLabel": "O assistente está trabalhando",
+			"environmentInitializing": "Configurando seu ambiente…",
+			"thinking": "Pensando…",
 			"copy": "Copiar",
 			"refresh": "Atualizar",
 			"more": "Mais",

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -300,6 +300,8 @@
 			"sendMessage": "Отправить сообщение",
 			"stopGeneratingAriaLabel": "Остановить генерацию",
 			"assistantWorkingAriaLabel": "Ассистент работает",
+			"environmentInitializing": "Настройка среды…",
+			"thinking": "Обдумывание…",
 			"copy": "Копировать",
 			"refresh": "Обновить",
 			"more": "Ещё",

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "Gửi tin nhắn",
 			"stopGeneratingAriaLabel": "Dừng tạo phản hồi",
 			"assistantWorkingAriaLabel": "Agent đang xử lý",
+			"environmentInitializing": "Đang thiết lập môi trường…",
+			"thinking": "Đang suy nghĩ…",
 			"copy": "Sao chép",
 			"refresh": "Làm mới",
 			"more": "Thêm",

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -292,6 +292,8 @@
 			"sendMessage": "发送消息",
 			"stopGeneratingAriaLabel": "停止生成",
 			"assistantWorkingAriaLabel": "代理正在处理",
+			"environmentInitializing": "正在设置环境…",
+			"thinking": "正在思考…",
 			"copy": "复制",
 			"refresh": "刷新",
 			"more": "更多",

--- a/services/agent-runner/internal/executor/executor.go
+++ b/services/agent-runner/internal/executor/executor.go
@@ -133,7 +133,7 @@ type Result struct {
 // AgentConversationEvent and publishing/persisting it, the same role
 // make_event_callback plays in executor.py. Not done inside this package so
 // Run stays testable without a live Valkey/Postgres connection.
-func (e *Executor) Run(ctx context.Context, cfg agent.Config, trigger agent.Trigger, resume *chatsandbox.State, onEvent func(acp.Event)) (Result, error) {
+func (e *Executor) Run(ctx context.Context, cfg agent.Config, trigger agent.Trigger, resume *chatsandbox.State, onEvent func(acp.Event), onReady func()) (Result, error) {
 	timeoutMinutes := cfg.TimeoutMinutes
 	if timeoutMinutes <= 0 {
 		timeoutMinutes = defaultTimeoutMinutes
@@ -163,6 +163,18 @@ func (e *Executor) Run(ctx context.Context, cfg agent.Config, trigger agent.Trig
 			return Result{Handle: handle}, err
 		}
 		message = buildInitialMessage(trigger)
+	}
+
+	// Fires once the sandbox/session is ready to receive session/prompt,
+	// whether it was just cold-started or resumed from a paused chat
+	// sandbox — the UI's cue to stop saying "setting up your environment"
+	// and start saying "thinking", since from here on any further wait is
+	// the LLM itself, not container/ACP-handshake setup. Called on every
+	// turn (not just cold starts) rather than relying on an earlier turn's
+	// marker still being loaded — a long conversation's event window is
+	// paginated, so an old turn's readiness event can page out.
+	if onReady != nil {
+		onReady()
 	}
 
 	maxToolCalls := cfg.MaxIterations

--- a/services/agent-runner/internal/handler/handler.go
+++ b/services/agent-runner/internal/handler/handler.go
@@ -388,7 +388,16 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 		persistAndPublish(string(e.Kind), "agent", e.Raw)
 	}
 
-	result, runErr := h.Executor.Run(runCtx, *cfg, trigger, resume, onEvent)
+	// Marks the point the frontend should stop showing "setting up your
+	// environment" and switch to "thinking" — see executor.Run's onReady
+	// doc comment. Persisted (not just published) like any other event so
+	// it survives a page reload and stays visible even once older turns'
+	// events page out of the frontend's loaded window.
+	onReady := func() {
+		persistAndPublish("environment_ready", "system", []byte("{}"))
+	}
+
+	result, runErr := h.Executor.Run(runCtx, *cfg, trigger, resume, onEvent, onReady)
 	// Whatever's still buffered when the turn ends — successfully,
 	// interrupted, or failed — is a genuine partial reply, not scratch
 	// state to discard; flush it unconditionally before any of the

--- a/services/agent-runner/test/e2e/executor_sandbox_test.go
+++ b/services/agent-runner/test/e2e/executor_sandbox_test.go
@@ -75,7 +75,7 @@ func TestExecutorRun(t *testing.T) {
 	var events []acp.Event
 	result, err := exec.Run(ctx, cfg, trigger, nil, func(e acp.Event) {
 		events = append(events, e)
-	})
+	}, nil)
 	if result.Handle != nil {
 		t.Cleanup(func() {
 			if err := exec.StopSandbox(context.Background(), result.Handle); err != nil {
@@ -200,7 +200,7 @@ func TestExecutorRunWithMCP(t *testing.T) {
 	var events []acp.Event
 	result, err := exec.Run(ctx, cfg, trigger, nil, func(e acp.Event) {
 		events = append(events, e)
-	})
+	}, nil)
 	if result.Handle != nil {
 		t.Cleanup(func() {
 			if err := exec.StopSandbox(context.Background(), result.Handle); err != nil {

--- a/services/agent-runner/test/e2e/system_prompt_delivery_test.go
+++ b/services/agent-runner/test/e2e/system_prompt_delivery_test.go
@@ -107,7 +107,7 @@ func TestExecutorRun_SystemPromptDeliveredViaGooseHints(t *testing.T) {
 	var events []acp.Event
 	result, err := exec.Run(ctx, cfg, trigger, nil, func(e acp.Event) {
 		events = append(events, e)
-	})
+	}, nil)
 	if result.Handle != nil {
 		t.Cleanup(func() {
 			if err := exec.StopSandbox(context.Background(), result.Handle); err != nil {

--- a/services/agent-runner/test/e2e/trigger_orchestration_test.go
+++ b/services/agent-runner/test/e2e/trigger_orchestration_test.go
@@ -131,4 +131,52 @@ func TestTriggerOrchestration(t *testing.T) {
 	if lastEventType != "turn_end" {
 		t.Fatalf("last persisted event type = %q, want %q", lastEventType, "turn_end")
 	}
+
+	// Phase 2: executor.Run's onReady fired handler.Handle's
+	// "environment_ready" marker exactly once, persisted (not just
+	// published) after the user's own message and before the sandbox's
+	// first agent event — see executor.go's onReady doc comment and
+	// conversation-to-thread-messages.ts's hasEnvironmentReadyEvent, which
+	// depends on this exact ordering to decide when the frontend should
+	// stop showing "setting up your environment".
+	var eventRows []struct {
+		EventIndex  int    `db:"event_index"`
+		EventType   string `db:"event_type"`
+		EventSource string `db:"event_source"`
+	}
+	if err := env.db.SelectContext(ctx, &eventRows,
+		`SELECT event_index, event_type, event_source FROM agent_conversation_events
+		 WHERE conversation_id = $1 ORDER BY event_index`, convID); err != nil {
+		t.Fatalf("verify environment_ready ordering: %v", err)
+	}
+
+	var userMessageIndex, readyIndex, firstAgentEventIndex = -1, -1, -1
+	readyCount := 0
+	for _, row := range eventRows {
+		switch {
+		case row.EventType == "user_message" && userMessageIndex == -1:
+			userMessageIndex = row.EventIndex
+		case row.EventType == "environment_ready":
+			readyCount++
+			readyIndex = row.EventIndex
+			if row.EventSource != "system" {
+				t.Fatalf("environment_ready event_source = %q, want %q", row.EventSource, "system")
+			}
+		case row.EventSource == "agent" && firstAgentEventIndex == -1:
+			firstAgentEventIndex = row.EventIndex
+		}
+	}
+
+	if readyCount != 1 {
+		t.Fatalf("expected exactly one environment_ready event, got %d", readyCount)
+	}
+	if userMessageIndex == -1 {
+		t.Fatalf("expected a user_message event to have been persisted for this trigger, found none among %+v", eventRows)
+	}
+	if readyIndex <= userMessageIndex {
+		t.Fatalf("environment_ready event_index (%d) must be greater than user_message event_index (%d) — the frontend reads this ordering to detect a fresh turn's own readiness", readyIndex, userMessageIndex)
+	}
+	if firstAgentEventIndex != -1 && readyIndex >= firstAgentEventIndex {
+		t.Fatalf("environment_ready event_index (%d) must precede the first agent-sourced event (index %d) — it marks readiness before the LLM turn starts, not after", readyIndex, firstAgentEventIndex)
+	}
 }


### PR DESCRIPTION
## Summary
- While a conversation's sandbox was queued or still spinning up, the chat thread showed nothing but a bare pulsing `●` dot with no explanation.
- Added a "Setting up your environment…" status in that window, shown until the sandbox/ACP session is confirmed ready.
- `agent-runner` now persists a lightweight `environment_ready` event right before handing a turn to the LLM (on every turn — cold-started or resumed), giving the frontend a reliable signal to tell "still provisioning" apart from "the LLM is now thinking."
- Once that event has been seen, the same indicator switches to "Thinking…" instead, until real content starts streaming in.
- ACP (local bridge) conversations skip the "setting up" phase entirely — there's no sandbox to provision for them.
- Both new strings are translated into all 9 supported locales.

## Test plan
- [x] `go build ./...` and `go test ./internal/executor/... ./internal/handler/...` in `services/agent-runner`
- [x] `tsc -b --noEmit`, `biome check`, and `vitest run` for the touched files in `apps/web`
- [ ] Manually verify in the browser: start a new chat conversation and confirm "Setting up your environment…" appears, then flips to "Thinking…" once the sandbox is ready, then the reply streams in normally
- [ ] Verify an ACP (local bridge) conversation goes straight to "Thinking…" with no "setting up" phase