### PR TITLE
feat: add Helm chart README, values schema, and cosign signing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -441,6 +441,17 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ${{ env.REGISTRY }} \
             --username ${{ github.actor }} --password-stdin
 
+      # Resolved once here and signed by digest below rather than by tag —
+      # tags are mutable, so cosign's own guidance is to sign the immutable
+      # digest a tag happened to resolve to at push time, not the tag itself.
+      - name: Resolve chart digest
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          DIGEST=$(oras resolve "${{ env.REGISTRY }}/paca-ai/charts/paca:${VERSION}")
+          echo "digest=${DIGEST}" >> "$GITHUB_ENV"
+
       # Keyless signing (no key material to generate/store/rotate): cosign
       # trades this job's GitHub OIDC token for a short-lived cert from
       # Sigstore's Fulcio, signs with that, and records the signature in
@@ -448,15 +459,20 @@ jobs:
       # for exactly this — see HasCosignSignature in artifacthub/hub. Runs
       # after the oras login above since cosign reads the same Docker
       # credential store oras does (not Helm's registry config).
+      #
+      # cosign-release is pinned so the exact signing binary is
+      # reproducible between runs — every run writes a permanent entry to
+      # Rekor's public transparency log, so an unpinned, drifting cosign
+      # version would make those log entries harder to reason about after
+      # the fact.
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v3.1.3"
 
       - name: Sign chart with cosign
         run: |
-          set -euo pipefail
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          cosign sign --yes "${{ env.REGISTRY }}/paca-ai/charts/paca:${VERSION}"
+          cosign sign --yes "${{ env.REGISTRY }}/paca-ai/charts/paca@${{ env.digest }}"
 
       - name: Push Artifact Hub repository metadata
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -363,6 +363,13 @@ jobs:
     name: Package and push Helm chart
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+      # Needed for cosign's keyless signing below — it exchanges this job's
+      # OIDC token for a short-lived cert from Sigstore's Fulcio instead of
+      # a stored private key.
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -433,6 +440,23 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ${{ env.REGISTRY }} \
             --username ${{ github.actor }} --password-stdin
+
+      # Keyless signing (no key material to generate/store/rotate): cosign
+      # trades this job's GitHub OIDC token for a short-lived cert from
+      # Sigstore's Fulcio, signs with that, and records the signature in
+      # Rekor's transparency log. Artifact Hub's OCI Helm tracker checks
+      # for exactly this — see HasCosignSignature in artifacthub/hub. Runs
+      # after the oras login above since cosign reads the same Docker
+      # credential store oras does (not Helm's registry config).
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign chart with cosign
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          cosign sign --yes "${{ env.REGISTRY }}/paca-ai/charts/paca:${VERSION}"
 
       - name: Push Artifact Hub repository metadata
         run: |

--- a/deploy/helm/paca/README.md
+++ b/deploy/helm/paca/README.md
@@ -1,0 +1,170 @@
+# paca
+
+Paca — self-hosted AI-powered project management, deployed on Kubernetes.
+
+This chart mirrors [`deploy/docker-compose.prod.yml`](https://github.com/Paca-AI/paca/blob/master/deploy/docker-compose.prod.yml)
+component-for-component: PostgreSQL, Valkey (Redis-compatible), MinIO
+(S3-compatible), the Go API, the React web app served via Caddy, a
+Socket.IO realtime hub, an AI agent runner, and a Caddy gateway in front
+of all of it.
+
+For deployment details that go beyond this chart's configuration
+reference — the Kubernetes AI agent sandbox, its RBAC scoping, storage
+class requirements, and TLS/ingress guidance — see the full
+[Kubernetes deployment guide](https://github.com/Paca-AI/paca/blob/master/deploy/helm/README.md).
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.8+ (OCI registry support)
+- A `ReadWriteMany`-capable StorageClass if you want `api.plugins.persistence`
+  enabled (installed plugins shared between the `api` and gateway Pods) —
+  see the deployment guide linked above
+
+## Installing
+
+This chart is published as an OCI artifact, not a traditional `index.yaml`
+repo — install it directly by reference, no `helm repo add` needed:
+
+```console
+helm install paca oci://ghcr.io/paca-ai/charts/paca --version <version>
+```
+
+Every value under `secrets.*` is required for a real deployment (there's
+no auto-generated default) — set them explicitly or point
+`secrets.existingSecret` at a Secret you manage yourself. See the
+Configuration table below and the deployment guide for how to generate
+them.
+
+## Configuration
+
+### Global
+
+| Key | Description | Default |
+|---|---|---|
+| `publicUrl` | Externally reachable base URL for this deployment (e.g. `https://paca.example.com`). Leave empty for a ClusterIP/NodePort-only deployment. | `""` |
+| `imagePullSecrets` | Image pull secrets applied to every Pod this chart creates | `[]` |
+
+### Secrets
+
+Generate strong values yourself, e.g. `openssl rand -hex 32`.
+
+| Key | Description | Default |
+|---|---|---|
+| `secrets.existingSecret` | Name of a Secret you manage yourself instead of the fields below (same key names — see `templates/secret.yaml`) | `""` |
+| `secrets.jwtSecret` | JWT signing secret | `""` |
+| `secrets.adminPassword` | Initial admin account password | `""` |
+| `secrets.encryptionKey` | 64-char hex string encrypting plugin secrets and (when `agentRunner.enabled`) LLM API keys at rest | `""` |
+| `secrets.internalApiKey` | Pre-shared key authenticating `api` <-> `agent-runner`'s internal routes (only required when `agentRunner.enabled`) | `""` |
+| `secrets.agentApiKey` | Agent API key | `""` |
+| `secrets.postgresPassword` | PostgreSQL password | `""` |
+| `secrets.storageAccessKeyId` | Object storage access key ID | `""` |
+| `secrets.storageSecretAccessKey` | Object storage secret access key | `""` |
+
+### PostgreSQL (bundled)
+
+| Key | Description | Default |
+|---|---|---|
+| `postgres.enabled` | Deploy the bundled PostgreSQL. Set `false` and provide `externalDatabaseUrl` to use your own instead. | `true` |
+| `postgres.image.repository` / `.tag` | | `postgres` / `16-alpine` |
+| `postgres.database` / `.username` | | `paca` / `paca` |
+| `postgres.persistence.enabled` / `.size` / `.storageClassName` | | `true` / `10Gi` / `""` |
+| `postgres.resources` | Requests/limits for the PostgreSQL Pod | see `values.yaml` |
+| `externalDatabaseUrl` | Full connection string used instead of the bundled postgres when `postgres.enabled: false` | `""` |
+
+### Valkey (bundled cache / pub-sub)
+
+| Key | Description | Default |
+|---|---|---|
+| `valkey.enabled` | Deploy the bundled Valkey. Set `false` and provide `externalRedisUrl` to use your own instead. | `true` |
+| `valkey.image.repository` / `.tag` | | `valkey/valkey` / `8-alpine` |
+| `valkey.persistence.enabled` / `.size` / `.storageClassName` | | `true` / `5Gi` / `""` |
+| `valkey.resources` | Requests/limits for the Valkey Pod | see `values.yaml` |
+| `externalRedisUrl` | Used instead of the bundled valkey when `valkey.enabled: false` | `""` |
+
+### Object storage
+
+| Key | Description | Default |
+|---|---|---|
+| `minio.enabled` | Deploy bundled MinIO. Set `false`, `storage.provider: s3`, and real AWS credentials to use S3 instead. | `true` |
+| `minio.image.repository` / `.tag` | | `minio/minio` / `latest` |
+| `minio.persistence.enabled` / `.size` / `.storageClassName` | | `true` / `20Gi` / `""` |
+| `minio.resources` | Requests/limits for the MinIO Pod | see `values.yaml` |
+| `storage.provider` | `minio` or `s3` | `minio` |
+| `storage.endpoint` | Empty defaults to the bundled MinIO's in-cluster Service address | `""` |
+| `storage.publicUrl` | Empty defaults to `<publicUrl>/storage` | `""` |
+| `storage.region` / `.bucket` / `.useSSL` | | `us-east-1` / `paca` / `false` |
+
+### API (Go backend)
+
+| Key | Description | Default |
+|---|---|---|
+| `api.replicaCount` | | `1` |
+| `api.image.repository` / `.tag` / `.pullPolicy` | | `ghcr.io/paca-ai/paca-api` / `latest` / `IfNotPresent` |
+| `api.resources` | Requests/limits for the API Pod | see `values.yaml` |
+| `api.admin.username` | | `admin` |
+| `api.jwt.accessTtl` / `.refreshTtl` / `.refreshSessionTtl` | | `15m` / `168h` / `24h` |
+| `api.cookieSecure` | Set `false` only when TLS isn't terminated anywhere in front of this deployment — otherwise browsers silently drop the auth cookie and login never sticks | `true` |
+| `api.plugins.persistence.enabled` | Shared storage for installed plugins (backend WASM, frontend/MCP/skills bundles) — needs a `ReadWriteMany` StorageClass; set `false` to fall back to a per-Pod `emptyDir` (installed plugins then won't survive a restart or be visible to the gateway) | `true` |
+| `api.plugins.persistence.accessMode` / `.storageClassName` / `.size` | | `ReadWriteMany` / `""` / `5Gi` |
+
+### Web (React SPA via Caddy)
+
+| Key | Description | Default |
+|---|---|---|
+| `web.enabled` | Disable to serve the SPA from an external CDN instead | `true` |
+| `web.replicaCount` | | `1` |
+| `web.image.repository` / `.tag` / `.pullPolicy` | | `ghcr.io/paca-ai/paca-web` / `latest` / `IfNotPresent` |
+| `web.resources` | Requests/limits for the web Pod | see `values.yaml` |
+
+### Realtime (Socket.IO event hub)
+
+| Key | Description | Default |
+|---|---|---|
+| `realtime.replicaCount` | | `1` |
+| `realtime.image.repository` / `.tag` / `.pullPolicy` | | `ghcr.io/paca-ai/paca-realtime` / `latest` / `IfNotPresent` |
+| `realtime.resources` | Requests/limits for the realtime Pod | see `values.yaml` |
+| `realtime.logLevel` | | `info` |
+| `realtime.corsOrigins` | Empty defaults to `publicUrl` (or `http://localhost` when that's also empty) | `""` |
+
+### Agent Runner (AI agent conversation executor + sandbox)
+
+| Key | Description | Default |
+|---|---|---|
+| `agentRunner.enabled` | Disable to run Paca without the AI agent feature | `true` |
+| `agentRunner.replicaCount` | | `1` |
+| `agentRunner.image.repository` / `.tag` / `.pullPolicy` | | `ghcr.io/paca-ai/paca-agent-runner` / `latest` / `IfNotPresent` |
+| `agentRunner.resources` | Requests/limits for the agent-runner Pod | see `values.yaml` |
+| `agentRunner.allowedAgentIds` | `"*"` for every agent, or a comma-separated list of agent UUIDs to stage a gradual rollout | `"*"` |
+| `agentRunner.workerConcurrency` | | `10` |
+| `agentRunner.chatSandboxIdleTimeoutMinutes` | | `3` |
+| `agentRunner.logLevel` | | `info` |
+| `agentRunner.sandbox.backend` | `kubernetes` (one Job per conversation) or `docker` (needs a mounted Docker socket — most managed clusters don't have one) | `kubernetes` |
+| `agentRunner.sandbox.image.repository` / `.tag` | | `ghcr.io/paca-ai/paca-agent-server-goose` / `latest` |
+| `agentRunner.sandbox.namespace` | Namespace sandbox Jobs/Pods run in. Empty defaults to this release's own namespace — see the deployment guide's RBAC section before changing this | `""` |
+| `agentRunner.sandbox.cpuLimit` / `.memoryLimit` | Requests == limits on every sandbox Pod's primary container | `2` / `4Gi` |
+| `agentRunner.sandbox.imagePullSecrets` | Needed when `sandbox.image` is pulled from a private registry | `[]` |
+
+### Gateway (Caddy reverse proxy)
+
+| Key | Description | Default |
+|---|---|---|
+| `gateway.replicaCount` | | `1` |
+| `gateway.image.repository` / `.tag` / `.pullPolicy` | | `caddy` / `2-alpine` / `IfNotPresent` |
+| `gateway.resources` | Requests/limits for the gateway Pod | see `values.yaml` |
+| `gateway.service.type` | `ClusterIP` (pair with `ingress.enabled`) or `LoadBalancer` (standalone, no ingress controller needed) | `ClusterIP` |
+| `gateway.service.port` | | `80` |
+
+### Ingress (optional)
+
+| Key | Description | Default |
+|---|---|---|
+| `ingress.enabled` | | `false` |
+| `ingress.className` / `.annotations` | | `""` / `{}` |
+| `ingress.host` | Required when `ingress.enabled` | `""` |
+| `ingress.tls.enabled` | | `false` |
+| `ingress.tls.secretName` | Defaults to `<release-name>-tls` when empty | `""` |
+
+## Source Code
+
+* <https://github.com/Paca-AI/paca>

--- a/deploy/helm/paca/values.schema.json
+++ b/deploy/helm/paca/values.schema.json
@@ -1,0 +1,298 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "paca",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "publicUrl": { "type": "string" },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": { "type": "string" }
+        }
+      }
+    },
+    "secrets": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "jwtSecret": { "type": "string" },
+        "adminPassword": { "type": "string" },
+        "encryptionKey": { "type": "string" },
+        "internalApiKey": { "type": "string" },
+        "agentApiKey": { "type": "string" },
+        "postgresPassword": { "type": "string" },
+        "storageAccessKeyId": { "type": "string" },
+        "storageSecretAccessKey": { "type": "string" }
+      }
+    },
+    "postgres": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" }
+          }
+        },
+        "database": { "type": "string" },
+        "username": { "type": "string" },
+        "persistence": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "size": { "type": "string" },
+            "storageClassName": { "type": "string" }
+          }
+        },
+        "resources": { "$ref": "#/definitions/resources" }
+      }
+    },
+    "externalDatabaseUrl": { "type": "string" },
+    "valkey": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "size": { "type": "string" },
+            "storageClassName": { "type": "string" }
+          }
+        },
+        "resources": { "$ref": "#/definitions/resources" }
+      }
+    },
+    "externalRedisUrl": { "type": "string" },
+    "minio": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "size": { "type": "string" },
+            "storageClassName": { "type": "string" }
+          }
+        },
+        "resources": { "$ref": "#/definitions/resources" }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "provider": { "type": "string", "enum": ["minio", "s3"] },
+        "endpoint": { "type": "string" },
+        "publicUrl": { "type": "string" },
+        "region": { "type": "string" },
+        "bucket": { "type": "string" },
+        "useSSL": { "type": "boolean" }
+      }
+    },
+    "api": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/image" },
+        "resources": { "$ref": "#/definitions/resources" },
+        "admin": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "username": { "type": "string" }
+          }
+        },
+        "jwt": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "accessTtl": { "type": "string" },
+            "refreshTtl": { "type": "string" },
+            "refreshSessionTtl": { "type": "string" }
+          }
+        },
+        "cookieSecure": { "type": "boolean" },
+        "plugins": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "accessMode": { "type": "string" },
+                "storageClassName": { "type": "string" },
+                "size": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "web": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/image" },
+        "resources": { "$ref": "#/definitions/resources" }
+      }
+    },
+    "realtime": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/image" },
+        "resources": { "$ref": "#/definitions/resources" },
+        "logLevel": { "type": "string" },
+        "corsOrigins": { "type": "string" }
+      }
+    },
+    "agentRunner": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/image" },
+        "resources": { "$ref": "#/definitions/resources" },
+        "allowedAgentIds": { "type": "string" },
+        "workerConcurrency": { "type": "integer", "minimum": 1 },
+        "chatSandboxIdleTimeoutMinutes": { "type": "integer", "minimum": 0 },
+        "logLevel": { "type": "string" },
+        "sandbox": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "backend": { "type": "string", "enum": ["kubernetes", "docker"] },
+            "image": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" }
+              }
+            },
+            "namespace": { "type": "string" },
+            "cpuLimit": { "type": "string" },
+            "memoryLimit": { "type": "string" },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "replicaCount": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/image" },
+        "resources": { "$ref": "#/definitions/resources" },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP", "LoadBalancer", "NodePort"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": true },
+        "host": { "type": "string" },
+        "tls": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "secretName": { "type": "string" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `deploy/helm/paca/README.md` — install instructions and a full configuration reference table for the chart
- Add `deploy/helm/paca/values.schema.json` — a permissive JSON Schema for `values.yaml` (typed, `additionalProperties: true` throughout so existing overrides keep working)
- Sign the chart with cosign (keyless, via GitHub Actions OIDC) right after it's pushed in the `helm-chart` job

## Why
Artifact Hub's package page for `paca` was flagging three gaps: no README, no values schema, not signed. This closes all three:
- Artifact Hub reads `README.md` at the chart root (packaged into the `.tgz`) for the package's documentation
- `values.schema.json` flips `has_values_schema` to `true` and gets Helm itself to validate installs/upgrades against it
- Cosign keyless signing is what Artifact Hub's OCI Helm tracker checks for (`HasCosignSignature` in artifacthub/hub) — no key material to generate, store, or rotate, since it trades the job's GitHub OIDC token for a short-lived Sigstore cert

## Test plan
- [x] `helm lint deploy/helm/paca` passes against the new schema
- [x] `helm package` + `tar -tzf` confirms `README.md` and `values.schema.json` are included in the packaged chart
- [ ] On the next release, confirm `cosign verify` succeeds against `ghcr.io/paca-ai/charts/paca:<version>`
- [ ] Artifact Hub shows the README, values schema, and "Signed" badge for `paca` after its next re-index