### PR TITLE
fix: bump cosign-installer to v4.1.2 to unbreak Helm chart signing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -465,8 +465,14 @@ jobs:
       # Rekor's public transparency log, so an unpinned, drifting cosign
       # version would make those log entries harder to reason about after
       # the fact.
+      # @v4.1.2, not the floating @v3 major tag: @v3's installer script only
+      # knows how to verify the legacy .sig/.pem scheme cosign itself
+      # dropped after v3.0.0 (releases now ship a .sigstore.json bundle
+      # instead) — pinning cosign-release below to a 3.x release with an
+      # installer that still expects a .sig file 404s trying to fetch one.
+      # No floating @v4 tag exists yet for this action, only exact ones.
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: "v3.1.3"
 


### PR DESCRIPTION
## Summary
- Bump `sigstore/cosign-installer` from `@v3` to `@v4.1.2` in the `helm-chart` job

## Why
CI was failing on every release at the "Install cosign" step (`exit code 22`, e.g. [this run](https://github.com/Paca-AI/paca/actions/runs/32355158306/job/96382656196)) after pinning `cosign-release: "v3.1.3"` for signing reproducibility. Root cause: `@v3` of the installer action only knows how to verify the legacy `.sig`/`.pem` signature scheme, but cosign itself switched to `.sigstore.json` verification bundles for its own releases starting at v3.0.1+ — so the installer's `curl` for `cosign-linux-amd64.sig` 404'd, since that file no longer exists in cosign's v3.1.3 release assets. `@v4.1.2` added support for verifying the newer bundle format.

There's no floating `@v4` major tag published for this action yet (only exact `v4.0.0`/`v4.1.0`/`v4.1.1`/`v4.1.2` releases), so this pins the exact latest release rather than the `@v4` convention used elsewhere in this workflow.

The chart push itself succeeded before this failure — only signing and the Artifact Hub metadata push were skipped, so no chart was published unsigned. A new release is needed after this merges to get a signed chart out.

## Test plan
- [ ] Next release's `helm-chart` job completes through "Sign chart with cosign" and "Push Artifact Hub repository metadata"
- [ ] `cosign verify` succeeds against the newly released chart tag