### PR TITLE
chore: add Artifact Hub badge to README for better visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/Paca-AI/paca/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License" /></a>
   <a href="https://github.com/Paca-AI/paca/releases"><img src="https://img.shields.io/github/v/release/Paca-AI/paca" alt="Latest Release" /></a>
   <a href="https://github.com/Paca-AI/paca/stargazers"><img src="https://img.shields.io/github/stars/Paca-AI/paca?style=social" alt="Stars" /></a>
+  <a href="https://artifacthub.io/packages/helm/paca/paca"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/paca" alt="Artifact Hub" /></a>
 </p>
 
 <p align="center"><sub>✨ Sponsored by</sub></p>


### PR DESCRIPTION
## Summary
- Add an Artifact Hub badge to the README badge row, linking to Paca's listing on Artifact Hub for better discoverability.

## Test plan
- [ ] Verify the badge renders correctly on GitHub and the link resolves to the Artifact Hub package page.