### PR TITLE
chore: update links to Artifact Hub for values reference in README an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ helm install paca oci://ghcr.io/paca-ai/charts/paca --version <release-version> 
 
 `<release-version>` is a [release](https://github.com/Paca-AI/paca/releases) tag without its leading `v` (e.g. `0.13.1` for `v0.13.1`); omit `--version` to install the newest chart published. At minimum, `my-values.yaml` needs `publicUrl` and the required secrets (`jwtSecret`, `adminPassword`, `encryptionKey`, and others) — there are no guessable defaults, so the chart refuses to render without them.
 
-See [deploy/helm/README.md](deploy/helm/README.md) for the full values reference, exposing the app via Ingress/TLS or a LoadBalancer, what's bundled vs. pointing at managed Postgres/Redis/S3, the AI agent sandbox's Kubernetes-specific RBAC, and troubleshooting.
+See [Artifact Hub](https://artifacthub.io/packages/helm/paca/paca) for the full values reference, exposing the app via Ingress/TLS or a LoadBalancer, what's bundled vs. pointing at managed Postgres/Redis/S3, the AI agent sandbox's Kubernetes-specific RBAC, and troubleshooting.
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -48,7 +48,7 @@ helm install paca oci://ghcr.io/paca-ai/charts/paca --version <release-version> 
 
 `<release-version>` is a [release](https://github.com/Paca-AI/paca/releases) tag without its leading `v` (e.g. `0.13.1` for `v0.13.1`); omit `--version` to install the newest chart published. `my-values.yaml` needs `publicUrl` plus the required secrets (`jwtSecret`, `adminPassword`, `encryptionKey`, and others) — there are no guessable defaults.
 
-See [../../deploy/helm/README.md](../../deploy/helm/README.md) for the full values reference, Ingress/TLS setup, what's bundled vs. external, and troubleshooting.
+See [Artifact Hub](https://artifacthub.io/packages/helm/paca/paca) for the full values reference, Ingress/TLS setup, what's bundled vs. external, and troubleshooting.
 
 ---
 


### PR DESCRIPTION
## Summary
- Point the Helm chart "full values reference" links in `README.md` and `docs/guides/getting-started.md` at the Artifact Hub package page instead of the local `deploy/helm/README.md`, so users land on the up-to-date, rendered values reference.

## Test plan
- [ ] Confirm both links resolve to https://artifacthub.io/packages/helm/paca/paca and render correctly on GitHub.