### PR TITLE
fix(web): custom-field/sprint dates show correct day in negative UTC offsets

### DIFF
--- a/apps/web/src/components/projects/interactions/task-detail/property-field/helpers.test.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/helpers.test.ts
@@ -1,0 +1,47 @@
+// Regression tests for the custom-field / sprint date off-by-one bug: a
+// date-only value is stored as "YYYY-MM-DDT00:00:00Z" (UTC midnight), so
+// parsing/formatting it in a negative-offset timezone (e.g. America/Sao_Paulo,
+// UTC-3) used to render the *previous* calendar day. These helpers must treat
+// the value as a plain calendar date, independent of the viewer's timezone.
+//
+// TZ must be set before any Date is constructed (V8 reads it lazily but caches
+// it once used), so it is forced here at module load — before the test bodies
+// run. Done via globalThis so it type-checks without @types/node in the app's
+// build tsconfig (tsc -b), where the bare `process` global is not declared.
+(
+	globalThis as unknown as { process: { env: Record<string, string> } }
+).process.env.TZ = "America/Sao_Paulo";
+
+import { describe, expect, it } from "vitest";
+import { displayDate, toDateObject, toISODate } from "./helpers";
+
+describe("date helpers (timezone-safe, calendar-date semantics)", () => {
+	it("displayDate shows the stored calendar day, not the day before", () => {
+		expect(displayDate("2026-09-04T00:00:00Z")).toContain("4");
+		expect(displayDate("2026-01-01T00:00:00Z")).toContain("1");
+	});
+
+	it("toDateObject resolves to the stored calendar day locally", () => {
+		const d = toDateObject("2026-09-04T00:00:00Z");
+		expect(d?.getFullYear()).toBe(2026);
+		expect(d?.getMonth()).toBe(8); // September (0-based)
+		expect(d?.getDate()).toBe(4);
+	});
+
+	it("round-trips a picked date without drifting", () => {
+		// Calendar hands back a Date at LOCAL midnight for the picked day.
+		const picked = new Date(2026, 8, 4); // 4 Sep 2026, local
+		const iso = toISODate(picked);
+		expect(iso).toBe("2026-09-04T00:00:00Z");
+		expect(toDateObject(iso)?.getDate()).toBe(4);
+		expect(displayDate(iso)).toContain("4");
+	});
+
+	it("handles empty / invalid input", () => {
+		expect(displayDate(null)).toBeNull();
+		expect(displayDate("")).toBeNull();
+		expect(displayDate("not-a-date")).toBeNull();
+		expect(toDateObject(null)).toBeUndefined();
+		expect(toDateObject("")).toBeUndefined();
+	});
+});

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/helpers.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/helpers.ts
@@ -1,5 +1,17 @@
+// Date-only custom fields (and sprint start/due dates) are stored as
+// "YYYY-MM-DDT00:00:00Z" — a calendar date pinned to UTC midnight, NOT an
+// instant. Parsing/formatting it via the local timezone shifts the day back
+// for any negative UTC offset (e.g. America/Sao_Paulo, UTC-3), which showed
+// the previous day. So we read the Y-M-D parts directly and format in UTC.
+
 export function toDateObject(iso?: string | null): Date | undefined {
 	if (!iso) return undefined;
+	const parts = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+	if (parts) {
+		// Build a LOCAL date on that calendar day so the calendar highlights
+		// the same day the user picked, regardless of timezone.
+		return new Date(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]));
+	}
 	const d = new Date(iso);
 	return Number.isNaN(d.getTime()) ? undefined : d;
 }
@@ -14,9 +26,11 @@ export function toISODate(date: Date): string {
 export function displayDate(iso?: string | null) {
 	if (!iso) return null;
 	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return null;
 	return d.toLocaleDateString(undefined, {
 		month: "short",
 		day: "numeric",
 		year: "numeric",
+		timeZone: "UTC",
 	});
 }


### PR DESCRIPTION
## Problem

Date-only values — **custom fields of type `Date`**, and **sprint start/due dates** — are stored as `"YYYY-MM-DDT00:00:00Z"`: a calendar date pinned to UTC midnight, not an instant in time.

`displayDate` and `toDateObject` (`apps/web/src/components/projects/interactions/task-detail/property-field/helpers.ts`) interpreted that value in the **viewer's local timezone** via `new Date(iso)`. For any negative UTC offset (e.g. `America/Sao_Paulo`, UTC−3), UTC midnight is 21:00 the previous day locally, so:

- picking **the 4th** displayed **the 3rd**, and
- reopening the calendar re-highlighted **the 3rd**.

The stored value was actually correct — only the read/format path drifted — so every user west of UTC saw dates one day early.

### Reproduce
Set the browser/OS timezone to any negative offset (e.g. `America/Sao_Paulo`), add a custom field of type `Date` to a task, pick a day → the chip shows the day before, and the calendar highlights the day before on reopen.

## Fix (`helpers.ts`, frontend-only, storage format unchanged)

- **`displayDate`** — format with `timeZone: "UTC"` so it renders the stored calendar day regardless of the viewer's timezone; also return `null` for invalid input instead of the literal string `"Invalid Date"`.
- **`toDateObject`** — parse the `Y-M-D` parts and build a **local** `Date` on that calendar day, so the calendar highlights the day the user picked in any timezone.
- **`toISODate`** — unchanged; it already extracts the local `Y-M-D` correctly.

Because the fix is on the read/format side and keeps the `"…T00:00:00Z"` storage format, **existing data is not migrated and not corrupted** — previously-saved dates simply start displaying on the correct day.

## Tests

Adds `helpers.test.ts` with the timezone forced to `America/Sao_Paulo`, covering `displayDate`, `toDateObject`, a pick→store→read round-trip, and invalid/empty input. Fails on `master`, passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)