### PR TITLE
fix(web): date off-by-one in list/board views + add Tags column to table

### DIFF
--- a/apps/web/src/components/projects/interactions/task-card.tsx
+++ b/apps/web/src/components/projects/interactions/task-card.tsx
@@ -541,6 +541,20 @@ export function TaskCard({
 					</span>
 				);
 
+			case "tags":
+				return task.tags && task.tags.length > 0 ? (
+					<span key="tags" className="inline-flex gap-0.5 flex-wrap">
+						{task.tags.map((tag) => (
+							<span
+								key={tag}
+								className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary/80"
+							>
+								{tag}
+							</span>
+						))}
+					</span>
+				) : null;
+
 			case "epic": {
 				const epic = task.parent_task_id
 					? epics.find((e) => e.id === task.parent_task_id)

--- a/apps/web/src/components/projects/interactions/task-card.tsx
+++ b/apps/web/src/components/projects/interactions/task-card.tsx
@@ -509,7 +509,11 @@ export function TaskCard({
 						key="start_date"
 						className="text-xs text-muted-foreground/70 shrink-0"
 					>
-						{formatDate(task.start_date, { month: "short", day: "numeric" })}
+						{formatDate(
+							task.start_date,
+							{ month: "short", day: "numeric" },
+							{ dateOnly: true },
+						)}
 					</span>
 				) : null;
 
@@ -519,7 +523,11 @@ export function TaskCard({
 						key="due_date"
 						className="text-xs text-muted-foreground/70 shrink-0"
 					>
-						{formatDate(task.due_date, { month: "short", day: "numeric" })}
+						{formatDate(
+							task.due_date,
+							{ month: "short", day: "numeric" },
+							{ dateOnly: true },
+						)}
 					</span>
 				) : null;
 
@@ -681,7 +689,11 @@ export function TaskCard({
 								key={fieldKey}
 								className="text-xs text-muted-foreground/70 shrink-0"
 							>
-								{formatDate(String(val), { month: "short", day: "numeric" })}
+								{formatDate(
+									String(val),
+									{ month: "short", day: "numeric" },
+									{ dateOnly: true },
+								)}
 							</span>
 						);
 					case "select":

--- a/apps/web/src/components/projects/interactions/task-row.tsx
+++ b/apps/web/src/components/projects/interactions/task-row.tsx
@@ -116,6 +116,12 @@ export function getRowColConfig(
 				headerLabel: t("board.taskRow.columnHeaders.epic"),
 				responsive: true,
 			};
+		case "tags":
+			return {
+				className: "w-40 shrink-0",
+				headerLabel: t("board.taskRow.columnHeaders.tags"),
+				responsive: true,
+			};
 		case "created":
 			return {
 				className: "w-24 shrink-0",
@@ -567,10 +573,11 @@ export function TaskRow({
 					>
 						<span className="text-xs text-muted-foreground/70 truncate">
 							{task.start_date
-								? formatDate(task.start_date, {
-										month: "short",
-										day: "numeric",
-									})
+								? formatDate(
+										task.start_date,
+										{ month: "short", day: "numeric" },
+										{ dateOnly: true },
+									)
 								: "—"}
 						</span>
 					</div>
@@ -584,7 +591,11 @@ export function TaskRow({
 					>
 						<span className="text-xs text-muted-foreground/70 truncate">
 							{task.due_date
-								? formatDate(task.due_date, { month: "short", day: "numeric" })
+								? formatDate(
+										task.due_date,
+										{ month: "short", day: "numeric" },
+										{ dateOnly: true },
+									)
 								: "—"}
 						</span>
 					</div>
@@ -619,6 +630,29 @@ export function TaskRow({
 						<span className="text-xs text-muted-foreground/50 truncate">
 							{formatDate(task.created_at, { month: "short", day: "numeric" })}
 						</span>
+					</div>
+				);
+
+			case "tags":
+				return (
+					<div
+						key="tags"
+						className={cn(col.className, responsiveClass, "items-center")}
+					>
+						{task.tags && task.tags.length > 0 ? (
+							<span className="inline-flex gap-1 flex-wrap">
+								{task.tags.map((tag) => (
+									<span
+										key={tag}
+										className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary/80"
+									>
+										{tag}
+									</span>
+								))}
+							</span>
+						) : (
+							<span className="text-xs text-muted-foreground/40">—</span>
+						)}
 					</div>
 				);
 
@@ -771,7 +805,11 @@ export function TaskRow({
 						case "date":
 							return (
 								<span className="text-xs text-muted-foreground/70">
-									{formatDate(String(val), { month: "short", day: "numeric" })}
+									{formatDate(
+										String(val),
+										{ month: "short", day: "numeric" },
+										{ dateOnly: true },
+									)}
 								</span>
 							);
 						case "select":

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -356,6 +356,7 @@ export const BUILTIN_FIELDS = [
 	{ key: "story_points", labelKey: "viewUtils.fields.storyPoints" },
 	{ key: "type", labelKey: "viewUtils.fields.type" },
 	{ key: "epic", labelKey: "viewUtils.fields.epic" },
+	{ key: "tags", labelKey: "viewUtils.fields.tags" },
 	{ key: "reporter", labelKey: "viewUtils.fields.reporter" },
 	{ key: "start_date", labelKey: "viewUtils.fields.startDate" },
 	{ key: "due_date", labelKey: "viewUtils.fields.dueDate" },

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "Start Date",
 				"dueDate": "Due Date",
 				"epic": "Epic",
-				"created": "Created"
+				"created": "Created",
+				"tags": "Tags"
 			},
 			"unassigned": "Unassigned",
 			"noEpic": "No Epic"
@@ -1321,7 +1322,8 @@
 			"reporter": "Reporter",
 			"startDate": "Start Date",
 			"dueDate": "Due Date",
-			"created": "Created"
+			"created": "Created",
+			"tags": "Tags"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "Fecha de inicio",
 				"dueDate": "Fecha de vencimiento",
 				"epic": "Épica",
-				"created": "Creada"
+				"created": "Creada",
+				"tags": "Etiquetas"
 			},
 			"unassigned": "Sin asignar",
 			"noEpic": "Sin épica"
@@ -1321,7 +1322,8 @@
 			"reporter": "Reportero",
 			"startDate": "Fecha de inicio",
 			"dueDate": "Fecha de vencimiento",
-			"created": "Creada"
+			"created": "Creada",
+			"tags": "Etiquetas"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "Date de début",
 				"dueDate": "Date d'échéance",
 				"epic": "Epic",
-				"created": "Créée"
+				"created": "Créée",
+				"tags": "Étiquettes"
 			},
 			"unassigned": "Non attribué",
 			"noEpic": "Aucun epic"
@@ -1321,7 +1322,8 @@
 			"reporter": "Rapporteur",
 			"startDate": "Date de début",
 			"dueDate": "Date d'échéance",
-			"created": "Créée"
+			"created": "Créée",
+			"tags": "Étiquettes"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "開始日",
 				"dueDate": "期日",
 				"epic": "エピック",
-				"created": "作成日"
+				"created": "作成日",
+				"tags": "タグ"
 			},
 			"unassigned": "未割り当て",
 			"noEpic": "エピックなし"
@@ -1321,7 +1322,8 @@
 			"reporter": "報告者",
 			"startDate": "開始日",
 			"dueDate": "期日",
-			"created": "作成日"
+			"created": "作成日",
+			"tags": "タグ"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "시작일",
 				"dueDate": "마감일",
 				"epic": "에픽",
-				"created": "생성일"
+				"created": "생성일",
+				"tags": "태그"
 			},
 			"unassigned": "담당자 없음",
 			"noEpic": "에픽 없음"
@@ -1321,7 +1322,8 @@
 			"reporter": "보고자",
 			"startDate": "시작일",
 			"dueDate": "마감일",
-			"created": "생성일"
+			"created": "생성일",
+			"tags": "태그"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "Data de início",
 				"dueDate": "Data de entrega",
 				"epic": "Épico",
-				"created": "Criada"
+				"created": "Criada",
+				"tags": "Tags"
 			},
 			"unassigned": "Sem responsável",
 			"noEpic": "Sem épico"
@@ -1321,7 +1322,8 @@
 			"reporter": "Relator",
 			"startDate": "Data de início",
 			"dueDate": "Data de entrega",
-			"created": "Criada"
+			"created": "Criada",
+			"tags": "Tags"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -1061,7 +1061,8 @@
 				"startDate": "Дата начала",
 				"dueDate": "Срок",
 				"epic": "Эпик",
-				"created": "Создана"
+				"created": "Создана",
+				"tags": "Теги"
 			},
 			"unassigned": "Не назначено",
 			"noEpic": "Без эпика"
@@ -1341,7 +1342,8 @@
 			"reporter": "Автор",
 			"startDate": "Дата начала",
 			"dueDate": "Срок",
-			"created": "Создана"
+			"created": "Создана",
+			"tags": "Теги"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "Ngày bắt đầu",
 				"dueDate": "Ngày đến hạn",
 				"epic": "Epic",
-				"created": "Đã tạo"
+				"created": "Đã tạo",
+				"tags": "Thẻ"
 			},
 			"unassigned": "Chưa giao",
 			"noEpic": "Không có Epic"
@@ -1321,7 +1322,8 @@
 			"reporter": "Người báo cáo",
 			"startDate": "Ngày bắt đầu",
 			"dueDate": "Ngày đến hạn",
-			"created": "Đã tạo"
+			"created": "Đã tạo",
+			"tags": "Thẻ"
 		}
 	},
 	"automation": {

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -1043,7 +1043,8 @@
 				"startDate": "开始日期",
 				"dueDate": "截止日期",
 				"epic": "史诗",
-				"created": "创建时间"
+				"created": "创建时间",
+				"tags": "标签"
 			},
 			"unassigned": "未分配",
 			"noEpic": "无史诗"
@@ -1321,7 +1322,8 @@
 			"reporter": "报告人",
 			"startDate": "开始日期",
 			"dueDate": "截止日期",
-			"created": "创建时间"
+			"created": "创建时间",
+			"tags": "标签"
 		}
 	},
 	"automation": {

--- a/apps/web/src/lib/format-date.test.ts
+++ b/apps/web/src/lib/format-date.test.ts
@@ -1,0 +1,38 @@
+// Regression tests for the date off-by-one in list/board views: date-only
+// values (custom Date fields, task start/due dates) are stored as
+// "YYYY-MM-DDT00:00:00Z" (UTC midnight). Formatting them in the viewer's local
+// timezone (negative UTC offset, e.g. America/Sao_Paulo, UTC-3) rendered the
+// previous day. formatDate must render date-only values in UTC, while keeping
+// real timestamps (created_at/updated_at) in local time.
+//
+// TZ must be set before any Date is constructed; done via globalThis so it
+// type-checks without @types/node under the app's build tsconfig (tsc -b).
+(
+	globalThis as unknown as { process: { env: Record<string, string> } }
+).process.env.TZ = "America/Sao_Paulo";
+
+import { describe, expect, it } from "vitest";
+import { formatDate } from "./format-date";
+
+describe("formatDate", () => {
+	it("dateOnly renders the stored calendar day regardless of timezone", () => {
+		expect(
+			formatDate(
+				"2026-08-14T00:00:00Z",
+				{ month: "short", day: "numeric" },
+				{ dateOnly: true },
+			),
+		).toContain("14");
+	});
+
+	it("keeps real timestamps in local time (no dateOnly)", () => {
+		// 2026-08-14T02:00:00Z is 2026-08-13 23:00 local (UTC-3) → day 13.
+		expect(
+			formatDate("2026-08-14T02:00:00Z", { month: "short", day: "numeric" }),
+		).toContain("13");
+	});
+
+	it("returns empty string for invalid input", () => {
+		expect(formatDate("not-a-date", { day: "numeric" })).toBe("");
+	});
+});

--- a/apps/web/src/lib/format-date.test.ts
+++ b/apps/web/src/lib/format-date.test.ts
@@ -15,6 +15,13 @@ import { describe, expect, it } from "vitest";
 import { formatDate } from "./format-date";
 
 describe("formatDate", () => {
+	it("runs under a negative UTC offset (guards the TZ setup)", () => {
+		// If process.env.TZ was silently ignored (can happen on ICU-backed Node),
+		// these tests would pass vacuously in UTC. America/Sao_Paulo is UTC-3, so
+		// getTimezoneOffset() must be positive; fail loudly otherwise.
+		expect(new Date(0).getTimezoneOffset()).toBeGreaterThan(0);
+	});
+
 	it("dateOnly renders the stored calendar day regardless of timezone", () => {
 		expect(
 			formatDate(

--- a/apps/web/src/lib/format-date.ts
+++ b/apps/web/src/lib/format-date.ts
@@ -7,6 +7,17 @@ export function formatDate(
 		month: "long",
 		day: "numeric",
 	},
+	// Date-only values (custom Date fields, task start/due dates) are stored as
+	// "YYYY-MM-DDT00:00:00Z" — a calendar date pinned to UTC midnight, not an
+	// instant. Rendering them in the viewer's local timezone shifts the day for
+	// negative UTC offsets. Pass dateOnly to format in UTC so the stored day is
+	// shown as-is. Real timestamps (created_at/updated_at) keep local time.
+	opts?: { dateOnly?: boolean },
 ): string {
-	return new Intl.DateTimeFormat(i18n.language, options).format(new Date(iso));
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return "";
+	const finalOptions = opts?.dateOnly
+		? { ...options, timeZone: "UTC" }
+		: options;
+	return new Intl.DateTimeFormat(i18n.language, finalOptions).format(d);
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectId/interactions/sprints/$sprintId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/interactions/sprints/$sprintId.tsx
@@ -203,7 +203,9 @@ function SprintPage() {
 						: sprint.start_date
 							? t("layout.sprintDetail.descriptionWithStartDate", {
 									status: statusBadge,
-									date: formatDate(sprint.start_date),
+									date: formatDate(sprint.start_date, undefined, {
+										dateOnly: true,
+									}),
 								})
 							: t("layout.sprintDetail.description", { status: statusBadge })
 				}


### PR DESCRIPTION
Two related fixes to the interactions table/board views.

## 1) Date off-by-one in the list (table) and board cards

Date-only values — **custom fields of type `Date`**, and **task `start_date`/`due_date`** — are stored as `"YYYY-MM-DDT00:00:00Z"`: a calendar date pinned to UTC midnight, not an instant.

`formatDate` (`apps/web/src/lib/format-date.ts`) rendered them via `new Date(iso)` in the **viewer's local timezone**, so for any negative UTC offset (e.g. `America/Sao_Paulo`, UTC−3) the list/table and the board cards showed the **previous day** (pick the 4th → the table shows the 3rd). The task-detail card was already correct, which is why the same task showed two different days.

**Fix (frontend-only, storage format unchanged):**
- `formatDate` gains a `dateOnly` option that formats with `timeZone: "UTC"`, so the stored calendar day is shown regardless of the viewer's timezone. It also now returns `""` for invalid input instead of the literal `"Invalid Date"`.
- Applied `dateOnly` at the date-only call sites in `task-row.tsx` (table) and `task-card.tsx` (board): custom `Date` fields, `start_date`, `due_date`.
- **`created_at`/`updated_at` are left in local time** — they are real timestamps, not calendar dates, so UTC would be wrong for them.

Existing data is not migrated or corrupted — the read/format path is what changed.

## 2) Tags column in the table view

`tags` was not offered in the table field picker. Adds it to `BUILTIN_FIELDS`, with a column header + chip rendering in `task-row.tsx`, and translations in all 9 locales.

## Tests

Adds `format-date.test.ts` (TZ forced to `America/Sao_Paulo`) covering `dateOnly` UTC rendering, local rendering for real timestamps, and invalid input. i18n parity holds (key added to all 9 locales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)