### PR TITLE
feat: optimize plugin ram usage

### DIFF
--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -148,7 +148,7 @@ PLUGINS_MARKETPLACE_TIMEOUT=20s
 # Resource limits enforced on plugin WASM execution.
 PLUGINS_MAX_CALL_DURATION=5s
 PLUGINS_MAX_MEMORY_PAGES=1024
-PLUGINS_MAX_REQUEST_BODY_BYTES=10485760
+PLUGINS_MAX_REQUEST_BODY_BYTES=1048576
 
 # Service topology. Not read by any service at runtime — upgrade.sh reads
 # these back so it can keep the web/agent-runner containers scaled to 0 on

--- a/docs/plugins/backend-plugin-system.md
+++ b/docs/plugins/backend-plugin-system.md
@@ -279,7 +279,7 @@ Limits are configurable via environment variables (see `services/api/.env.exampl
 |---|---|---|
 | `PLUGINS_MAX_CALL_DURATION` | `5s` | Max time for a single plugin function call |
 | `PLUGINS_MAX_MEMORY_PAGES` | `1024` (64 MiB) | Max WASM linear-memory pages per module instance |
-| `PLUGINS_MAX_REQUEST_BODY_BYTES` | `10485760` (10 MiB) | Max inbound HTTP request body / event payload size |
+| `PLUGINS_MAX_REQUEST_BODY_BYTES` | `1048576` (1 MiB) | Max inbound HTTP request body / event payload size |
 
 ## Plugin Storage Location
 

--- a/docs/plugins/developer-guide.md
+++ b/docs/plugins/developer-guide.md
@@ -217,14 +217,42 @@ CREATE INDEX ON my_items (task_id);
 
 ### Building the WASM Binary
 
+Use TinyGo — it produces a dramatically smaller binary than the standard Go
+compiler, because it doesn't statically link Go's full runtime (GC,
+goroutine scheduler, reflection). This matters a lot in production: every
+loaded plugin gets its own independent copy of that runtime, so a plugin
+built with standard Go can cost tens of MiB of *host* memory once loaded,
+versus a few MiB for the same plugin built with TinyGo.
+
 ```sh
 cd backend
-GOOS=wasip1 GOARCH=wasm tinygo build -o ../dist/my-plugin.wasm -target wasip1 .
+tinygo build -target=wasip1 -buildmode=c-shared -o ../dist/my-plugin.wasm .
 ```
 
-Or with standard Go (larger binary):
+`-buildmode=c-shared` is required, not optional: without it, TinyGo doesn't
+wire up the WASI reactor entry point (`_initialize`) that the runtime
+depends on to set up before any `//go:wasmexport` function runs. The plugin
+will still compile without it, but every call into it will panic at runtime
+with `"//go:wasmexport function called before runtime initialization"`.
+
+If your plugin declares its own `//go:wasmimport` host functions beyond
+what this SDK provides, TinyGo requires them to be called directly by name —
+never passed around as a function value. If you use
+[`plugin.CallHostFunction`](https://pkg.go.dev/github.com/Paca-AI/plugin-sdk-go#CallHostFunction),
+wrap your import in a small closure instead of passing it directly:
+
+```go
+// Works under both standard Go and TinyGo:
+err := plugin.CallHostFunction(func(a, b, c, d int64) { hostMyImport(a, b, c, d) }, req, &res)
+
+// Compiles under standard Go, but fails to build under TinyGo:
+err := plugin.CallHostFunction(hostMyImport, req, &res)
+```
+
+Or with standard Go (only if you hit a TinyGo compatibility issue — TinyGo
+supports a subset of the stdlib, notably around `reflect`):
 ```sh
-GOOS=wasip1 GOARCH=wasm go build -o ../dist/my-plugin.wasm .
+GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o ../dist/my-plugin.wasm .
 ```
 
 ---

--- a/docs/plugins/sdk-reference.md
+++ b/docs/plugins/sdk-reference.md
@@ -326,7 +326,7 @@ Go's full runtime (GC, scheduler, reflection) — every loaded plugin gets
 its own independent copy of that runtime on the host, so this is a real
 difference in production memory use, not just download size.
 
-Standard Go 1.21+ (`GOARCH=wasm GOOS=wasip1 go build -buildmode=c-shared`)
+Standard Go 1.24+ (`GOARCH=wasm GOOS=wasip1 go build -buildmode=c-shared`)
 is also supported, and is the right fallback if your plugin hits a TinyGo
 compatibility limitation (TinyGo implements a subset of the stdlib, notably
 around `reflect`). If your plugin declares its own `//go:wasmimport` host

--- a/docs/plugins/sdk-reference.md
+++ b/docs/plugins/sdk-reference.md
@@ -311,7 +311,28 @@ function afterMutation(pluginId: string) {
 go get github.com/Paca-AI/plugin-sdk-go
 ```
 
-Build target must be `GOARCH=wasm GOOS=wasip1`. Standard Go 1.21+ WASI preview 1 is supported; TinyGo produces smaller binaries.
+Build with TinyGo, targeting `wasip1`:
+
+```sh
+tinygo build -target=wasip1 -buildmode=c-shared -o plugin.wasm .
+```
+
+`-buildmode=c-shared` is required — without it, TinyGo skips the WASI
+reactor entry point (`_initialize`) that the runtime depends on, and every
+call into the plugin panics at runtime with "//go:wasmexport function
+called before runtime initialization". TinyGo produces a much smaller
+binary than the standard Go compiler, because it doesn't statically link
+Go's full runtime (GC, scheduler, reflection) — every loaded plugin gets
+its own independent copy of that runtime on the host, so this is a real
+difference in production memory use, not just download size.
+
+Standard Go 1.21+ (`GOARCH=wasm GOOS=wasip1 go build -buildmode=c-shared`)
+is also supported, and is the right fallback if your plugin hits a TinyGo
+compatibility limitation (TinyGo implements a subset of the stdlib, notably
+around `reflect`). If your plugin declares its own `//go:wasmimport` host
+function, call it directly by name rather than passing it as a value (e.g.
+into a generic helper) — TinyGo doesn't support taking the address of a
+`go:wasmimport` function, only calling it.
 
 ---
 

--- a/scripts/QUICK_START.md
+++ b/scripts/QUICK_START.md
@@ -35,7 +35,7 @@ PACA_DIR="/Volumes/HaiSSD/Projects/paca"
 
 # 1. Build backend WASM
 cd "$PLUGIN_DIR/backend"
-GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o backend.wasm .
+tinygo build -target=wasip1 -buildmode=c-shared -o backend.wasm .
 
 # 2. Populate backend store
 BACKEND_DIR="$PACA_DIR/plugins/local/backend/$PLUGIN_ID"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,7 +115,7 @@ source ~/.bashrc
 
 1. **Validates the plugin directory** - Checks for `plugin.json`, `backend/`, and `frontend/`
 2. **Extracts plugin metadata** - Reads plugin ID and version from `plugin.json`
-3. **Builds backend WASM** - Compiles Go backend to WASM using `GOOS=wasip1 GOARCH=wasm`
+3. **Builds backend WASM** - Compiles Go backend to WASM using TinyGo (`tinygo build -target=wasip1 -buildmode=c-shared`) — requires TinyGo to be installed
 4. **Populates backend store** - Copies WASM binary, migrations, and manifest to `plugins/local/backend/<plugin-id>/`
 5. **Builds frontend** - Runs `bun run build` to create frontend bundles
 6. **Populates frontend store** - Copies built assets to `plugins/local/frontend/<plugin-id>/`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,12 +53,14 @@ export API_KEY=your-api-key-here
 - `--api-key KEY`: API key for authentication (required)
 - `--skip-build`: Skip building (only install via API)
 - `--skip-install`: Skip API installation (only build)
+- `--go-toolchain TOOL`: `tinygo` (default) or `go` — use `go` only if your plugin hits a TinyGo stdlib limitation
 
 ### Environment Variables
 
 - `PACA_DIR`: Path to Paca project directory
 - `API_URL`: API base URL
 - `API_KEY`: API key for authentication (required)
+- `GO_TOOLCHAIN`: Same as `--go-toolchain`
 
 ## Examples
 
@@ -176,7 +178,7 @@ Do you want to update the existing plugin? (y/N)
 
 ### Build Fails
 
-- Ensure Go and Bun are installed and in your PATH
+- Ensure TinyGo (or Go, if using `--go-toolchain go`) and Bun are installed and in your PATH
 - Check that `go.mod` exists in the `backend/` directory
 - Check that `package.json` exists in the `frontend/` directory
 - Verify dependencies can be installed: `cd backend && go mod tidy`, `cd frontend && bun install`
@@ -193,7 +195,7 @@ The script needs write permissions to the `plugins/local/` directory and its sub
 
 ## Requirements
 
-- **Go** (for building WASM backend)
+- **TinyGo** (default, for building WASM backend — see [tinygo.org/getting-started/install](https://tinygo.org/getting-started/install/)), or **Go** if you pass `--go-toolchain go`
 - **Bun** (for building frontend)
 - **jq** (for JSON parsing, used when checking existing plugins)
 - **curl** (for API calls)

--- a/scripts/SUMMARY.md
+++ b/scripts/SUMMARY.md
@@ -43,7 +43,7 @@ export API_KEY=your-api-key
 The script automates the complete plugin installation process:
 
 1. ✅ **Validates plugin structure** - Checks for required files
-2. ✅ **Builds backend WASM** - Compiles Go backend using `GOOS=wasip1 GOARCH=wasm`
+2. ✅ **Builds backend WASM** - Compiles Go backend using TinyGo (`tinygo build -target=wasip1 -buildmode=c-shared`)
 3. ✅ **Populates backend store** - Copies artifacts to `plugins/local/backend/<plugin-id>/`
 4. ✅ **Builds frontend** - Runs `bun run build` to create bundles
 5. ✅ **Populates frontend store** - Copies assets to `plugins/local/frontend/<plugin-id>/`

--- a/scripts/install-local-plugin.sh
+++ b/scripts/install-local-plugin.sh
@@ -48,11 +48,20 @@ Options:
   --api-key KEY       API key for authentication (required)
   --skip-build        Skip building (only install)
   --skip-install      Skip installing (only build)
+  --go-toolchain TOOL "tinygo" (default) or "go" — most plugins build with
+                      TinyGo for a much smaller binary; use "go" (the
+                      standard compiler) only if your plugin hits a TinyGo
+                      stdlib limitation, e.g. it uses html/template or
+                      text/template — TinyGo's reflect package doesn't fully
+                      support what those need and the plugin will panic at
+                      runtime the first time it's actually invoked, not at
+                      build time.
 
 Environment Variables:
   PACA_DIR            Same as --paca-dir
   API_URL             Same as --api-url
   API_KEY             Same as --api-key (required)
+  GO_TOOLCHAIN        Same as --go-toolchain
 
 Examples:
   # Basic usage with API key
@@ -75,6 +84,7 @@ EOF
 # Parse arguments
 SKIP_BUILD=false
 SKIP_INSTALL=false
+GO_TOOLCHAIN="${GO_TOOLCHAIN:-tinygo}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -101,6 +111,10 @@ while [[ $# -gt 0 ]]; do
         --skip-install)
             SKIP_INSTALL=true
             shift
+            ;;
+        --go-toolchain)
+            GO_TOOLCHAIN="$2"
+            shift 2
             ;;
         -*)
             print_error "Unknown option: $1"
@@ -140,6 +154,11 @@ fi
 
 if ! command -v jq >/dev/null 2>&1; then
     print_error "jq is required but not installed"
+    exit 1
+fi
+
+if [[ "$GO_TOOLCHAIN" != "tinygo" && "$GO_TOOLCHAIN" != "go" ]]; then
+    print_error "--go-toolchain must be \"tinygo\" or \"go\", got: $GO_TOOLCHAIN"
     exit 1
 fi
 
@@ -185,8 +204,20 @@ if [[ "$SKIP_BUILD" = false ]]; then
         print_error "go.mod not found in backend directory"
         exit 1
     fi
-    
-    GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o backend.wasm .
+
+    if [[ "$GO_TOOLCHAIN" = "tinygo" ]]; then
+        if ! command -v tinygo >/dev/null 2>&1; then
+            print_error "tinygo is required but not installed (see https://tinygo.org/getting-started/install/), or pass --go-toolchain go"
+            exit 1
+        fi
+        tinygo build -target=wasip1 -buildmode=c-shared -o backend.wasm .
+    else
+        if ! command -v go >/dev/null 2>&1; then
+            print_error "go is required but not installed"
+            exit 1
+        fi
+        GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o backend.wasm .
+    fi
     
     if [[ ! -f "backend.wasm" ]]; then
         print_error "backend.wasm build failed"

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -59,7 +59,7 @@ PLUGINS_MARKETPLACE_TIMEOUT=20s
 # Resource limits enforced on plugin WASM execution.
 PLUGINS_MAX_CALL_DURATION=5s
 PLUGINS_MAX_MEMORY_PAGES=1024
-PLUGINS_MAX_REQUEST_BODY_BYTES=10485760
+PLUGINS_MAX_REQUEST_BODY_BYTES=1048576
 
 # Release / update check — powers the home update banner and the "What's New"
 # changelog page (public GET /api/v1/version and /api/v1/releases). All

--- a/services/api/internal/config/load.go
+++ b/services/api/internal/config/load.go
@@ -100,7 +100,7 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("config: PLUGINS_MAX_MEMORY_PAGES: %w", err)
 	}
-	pluginMaxRequestBodyBytes, err := parseInt64(env("PLUGINS_MAX_REQUEST_BODY_BYTES", "10485760"))
+	pluginMaxRequestBodyBytes, err := parseInt64(env("PLUGINS_MAX_REQUEST_BODY_BYTES", "1048576"))
 	if err != nil {
 		return nil, fmt.Errorf("config: PLUGINS_MAX_REQUEST_BODY_BYTES: %w", err)
 	}

--- a/services/api/internal/config/load_test.go
+++ b/services/api/internal/config/load_test.go
@@ -184,8 +184,8 @@ func TestLoad_PluginLimits_Defaults(t *testing.T) {
 	if cfg.Plugins.Limits.MaxMemoryPages != 1024 {
 		t.Fatalf("expected default MaxMemoryPages 1024, got %d", cfg.Plugins.Limits.MaxMemoryPages)
 	}
-	if cfg.Plugins.Limits.MaxRequestBodyBytes != 10*1024*1024 {
-		t.Fatalf("expected default MaxRequestBodyBytes 10MiB, got %d", cfg.Plugins.Limits.MaxRequestBodyBytes)
+	if cfg.Plugins.Limits.MaxRequestBodyBytes != 1*1024*1024 {
+		t.Fatalf("expected default MaxRequestBodyBytes 1MiB, got %d", cfg.Plugins.Limits.MaxRequestBodyBytes)
 	}
 }
 

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,6 +28,11 @@ import (
 	"github.com/Paca-AI/api/internal/platform/cache"
 	"github.com/Paca-AI/api/internal/platform/netguard"
 )
+
+// ErrPayloadTooLarge is wrapped into the error callExport returns when a
+// payload exceeds MaxRequestBodyBytes, so HTTP transport code can map it to
+// a proper "payload too large" response instead of a generic internal error.
+var ErrPayloadTooLarge = errors.New("plugin: payload exceeds limit")
 
 // ResourceLimits controls per-plugin execution constraints.
 type ResourceLimits struct {
@@ -213,6 +219,32 @@ func NewRuntime(store *Store, services HostServices, limits ResourceLimits, log 
 // plugin's WASM memory.  0 means "no limit".
 func (r *Runtime) MaxRequestBodyBytes() int64 {
 	return r.limits.MaxRequestBodyBytes
+}
+
+// httpEnvelopeOverheadBytes is slack reserved for the JSON envelope fields
+// (method, path, headers, query, etc.) that accompany the base64-encoded
+// body when computing MaxHTTPBodyBytes from MaxRequestBodyBytes.
+const httpEnvelopeOverheadBytes = 8 * 1024
+
+// MaxHTTPBodyBytes returns the largest raw HTTP request body that is
+// guaranteed to still fit under MaxRequestBodyBytes once base64-encoded and
+// wrapped in the JSON envelope passed to a plugin's HandleRequest export.
+// Base64 inflates the body by ~4/3, so this is strictly smaller than
+// MaxRequestBodyBytes: without the reduction, a raw body accepted by the
+// HTTP layer's cap could still be rejected downstream by callExport's
+// envelope-size check.  0 means "no limit".
+func (r *Runtime) MaxHTTPBodyBytes() int64 {
+	max := r.limits.MaxRequestBodyBytes
+	if max <= 0 {
+		return 0
+	}
+	// If the configured limit is too small to accommodate the overhead
+	// reservation, fall back to the unreduced limit rather than returning 0
+	// (which means "no limit" — the opposite of intent).
+	if raw := (max - httpEnvelopeOverheadBytes) * 3 / 4; raw > 0 {
+		return raw
+	}
+	return max
 }
 
 // LoadAll instantiates wazero modules for every enabled plugin in the list.
@@ -402,7 +434,7 @@ func (r *Runtime) callExport(ctx context.Context, pluginName, exportName string,
 	}
 
 	if maxBytes := r.limits.MaxRequestBodyBytes; maxBytes > 0 && int64(len(payload)) > maxBytes {
-		return nil, fmt.Errorf("plugin %q: %s payload of %d bytes exceeds limit of %d bytes", pluginName, exportName, len(payload), maxBytes)
+		return nil, fmt.Errorf("%w: plugin %q: %s payload of %d bytes exceeds limit of %d bytes", ErrPayloadTooLarge, pluginName, exportName, len(payload), maxBytes)
 	}
 
 	fn := inst.mod.ExportedFunction(exportName)
@@ -2202,13 +2234,21 @@ func writeToMemory(m api.Module, data []byte) ([]uint64, error) {
 	// plugin-sdk-go's exports use a name that can't collide with those.
 	malloc := m.ExportedFunction("paca_malloc")
 	if malloc == nil {
-		return nil, fmt.Errorf("plugin: paca_malloc not exported")
+		// Fall back to the pre-rename export so plugins built against the
+		// previous SDK keep working until they're rebuilt.
+		malloc = m.ExportedFunction("malloc")
+	}
+	if malloc == nil {
+		return nil, fmt.Errorf("plugin: paca_malloc or malloc not exported")
 	}
 	results, err := malloc.Call(context.Background(), uint64(len(data)))
 	if err != nil || len(results) == 0 {
 		return nil, fmt.Errorf("plugin: malloc failed: %w", err)
 	}
 	ptr := results[0]
+	if ptr == 0 {
+		return nil, fmt.Errorf("plugin: malloc returned 0 (buffer exhausted)")
+	}
 	if !m.Memory().Write(uint32(ptr), data) {
 		return nil, fmt.Errorf("plugin: memory write out of bounds")
 	}

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -221,30 +221,31 @@ func (r *Runtime) MaxRequestBodyBytes() int64 {
 	return r.limits.MaxRequestBodyBytes
 }
 
-// httpEnvelopeOverheadBytes is slack reserved for the JSON envelope fields
-// (method, path, headers, query, etc.) that accompany the base64-encoded
-// body when computing MaxHTTPBodyBytes from MaxRequestBodyBytes.
-const httpEnvelopeOverheadBytes = 8 * 1024
-
 // MaxHTTPBodyBytes returns the largest raw HTTP request body that is
 // guaranteed to still fit under MaxRequestBodyBytes once base64-encoded and
 // wrapped in the JSON envelope passed to a plugin's HandleRequest export.
-// Base64 inflates the body by ~4/3, so this is strictly smaller than
-// MaxRequestBodyBytes: without the reduction, a raw body accepted by the
-// HTTP layer's cap could still be rejected downstream by callExport's
-// envelope-size check.  0 means "no limit".
-func (r *Runtime) MaxHTTPBodyBytes() int64 {
+// knownOverheadBytes is the exact marshaled size of that envelope with an
+// empty body (method, path, query, headers, ids, and the JSON field syntax
+// itself) for this specific request — callers must measure it per-request
+// rather than guessing, since headers/query/path size varies a lot in
+// practice. Base64 inflates the body by ~4/3, so the result is strictly
+// smaller than MaxRequestBodyBytes-knownOverheadBytes.
+//
+// Returns 0 when the configured limit is disabled (<=0) — the only case
+// where 0 means "no limit". Returns -1 when knownOverheadBytes alone already
+// consumes the whole limit, meaning no body — not even an empty one — can
+// fit; callers must reject the request outright rather than treating -1 as
+// "no limit".
+func (r *Runtime) MaxHTTPBodyBytes(knownOverheadBytes int64) int64 {
 	max := r.limits.MaxRequestBodyBytes
 	if max <= 0 {
 		return 0
 	}
-	// If the configured limit is too small to accommodate the overhead
-	// reservation, fall back to the unreduced limit rather than returning 0
-	// (which means "no limit" — the opposite of intent).
-	if raw := (max - httpEnvelopeOverheadBytes) * 3 / 4; raw > 0 {
-		return raw
+	remaining := max - knownOverheadBytes
+	if remaining <= 0 {
+		return -1
 	}
-	return max
+	return remaining * 3 / 4
 }
 
 // LoadAll instantiates wazero modules for every enabled plugin in the list.

--- a/services/api/internal/platform/plugin/runtime.go
+++ b/services/api/internal/platform/plugin/runtime.go
@@ -52,8 +52,8 @@ type ResourceLimits struct {
 func DefaultResourceLimits() ResourceLimits {
 	return ResourceLimits{
 		MaxCallDuration:     5 * time.Second,
-		MaxMemoryPages:      1024,             // 64 MiB
-		MaxRequestBodyBytes: 10 * 1024 * 1024, // 10 MiB
+		MaxMemoryPages:      1024,            // 64 MiB
+		MaxRequestBodyBytes: 1 * 1024 * 1024, // 1 MiB — keep in sync with plugin-sdk-go's mallocBuffer size
 	}
 }
 
@@ -2197,9 +2197,12 @@ func writeToMemory(m api.Module, data []byte) ([]uint64, error) {
 	if len(data) == 0 {
 		return []uint64{0, 0}, nil
 	}
-	malloc := m.ExportedFunction("malloc")
+	// Exported as paca_malloc, not malloc: TinyGo-built plugins already
+	// export "malloc"/"free" from their own bundled wasi-libc allocator, so
+	// plugin-sdk-go's exports use a name that can't collide with those.
+	malloc := m.ExportedFunction("paca_malloc")
 	if malloc == nil {
-		return nil, fmt.Errorf("plugin: malloc not exported")
+		return nil, fmt.Errorf("plugin: paca_malloc not exported")
 	}
 	results, err := malloc.Call(context.Background(), uint64(len(data)))
 	if err != nil || len(results) == 0 {

--- a/services/api/internal/platform/plugin/runtime_test.go
+++ b/services/api/internal/platform/plugin/runtime_test.go
@@ -195,6 +195,131 @@ func TestDispatchEvent_OversizedPayload_RejectedWithoutTouchingPlugin(t *testing
 	}
 }
 
+const legacyMallocPluginName = "test.legacymalloc"
+
+var (
+	legacyMallocWasmOnce sync.Once
+	legacyMallocWasmPath string
+	legacyMallocWasmErr  error
+)
+
+// buildLegacyMallocFixture compiles testdata/legacymallocplugin, which
+// exports only "malloc" -- never "paca_malloc" -- the same shape as every
+// plugin binary built against the plugin-sdk-go version before the
+// allocator export was renamed.
+func buildLegacyMallocFixture(t *testing.T) string {
+	t.Helper()
+	legacyMallocWasmOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "legacymallocplugin-*")
+		if err != nil {
+			legacyMallocWasmErr = err
+			return
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			legacyMallocWasmErr = err
+			return
+		}
+		out := filepath.Join(dir, "legacymalloc.wasm")
+		cmd := exec.CommandContext(t.Context(), "go", "build", "-buildmode=c-shared", "-o", out, "./testdata/legacymallocplugin")
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
+		if output, buildErr := cmd.CombinedOutput(); buildErr != nil {
+			legacyMallocWasmErr = fmt.Errorf("build legacymalloc fixture: %w: %s", buildErr, output)
+			return
+		}
+		legacyMallocWasmPath = out
+	})
+	if legacyMallocWasmErr != nil {
+		t.Fatalf("build legacymalloc fixture: %v", legacyMallocWasmErr)
+	}
+	return legacyMallocWasmPath
+}
+
+// loadLegacyMallocPlugin compiles (see buildLegacyMallocFixture) and loads
+// the legacymalloc fixture into a fresh Runtime.
+func loadLegacyMallocPlugin(t *testing.T, limits ResourceLimits) *Runtime {
+	t.Helper()
+
+	wasmPath := buildLegacyMallocFixture(t)
+	wasmBytes, err := os.ReadFile(wasmPath)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, legacyMallocPluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "backend.wasm"), wasmBytes, 0o644); err != nil {
+		t.Fatalf("write fixture wasm: %v", err)
+	}
+
+	store := &Store{cfg: StoreConfig{Store: "local", WASMDir: dir}}
+	rt := NewRuntime(store, HostServices{}, limits, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	p := plugindom.Plugin{
+		Name:    legacyMallocPluginName,
+		Enabled: true,
+		Manifest: plugindom.PluginManifest{
+			Backend: &plugindom.BackendManifest{},
+		},
+	}
+	ctx := context.Background()
+	if err := rt.Load(ctx, p); err != nil {
+		t.Fatalf("load fixture plugin: %v", err)
+	}
+	t.Cleanup(func() { rt.Unload(ctx, legacyMallocPluginName) })
+	return rt
+}
+
+// TestHandleRequest_LegacyMallocExport_FallbackStillWorks pins
+// writeToMemory's backward-compatibility fallback: a plugin binary compiled
+// against the pre-rename SDK exports only "malloc", never "paca_malloc".
+// The host must still be able to write the request payload into such a
+// plugin's memory and call it successfully -- if the fallback ever
+// regresses, every already-deployed plugin of this shape breaks the moment
+// the host redeploys, silently, since callers of writeToMemory often ignore
+// its error.
+func TestHandleRequest_LegacyMallocExport_FallbackStillWorks(t *testing.T) {
+	rt := loadLegacyMallocPlugin(t, DefaultResourceLimits())
+	ctx := context.Background()
+
+	if _, err := rt.HandleRequest(ctx, legacyMallocPluginName, []byte("hello")); err != nil {
+		t.Fatalf("expected request to a legacy-malloc-only plugin to succeed via the fallback, got: %v", err)
+	}
+}
+
+// TestMaxHTTPBodyBytes covers the three cases callers of MaxHTTPBodyBytes
+// must distinguish: the limit disabled entirely (0, "no limit"), the known
+// envelope overhead alone already exceeding the limit (-1, "reject
+// outright, not even an empty body fits"), and the normal case where the
+// base64 expansion factor is applied to whatever room remains after
+// subtracting the caller-measured overhead.
+func TestMaxHTTPBodyBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxBytes int64
+		overhead int64
+		want     int64
+	}{
+		{name: "disabled limit means no limit", maxBytes: 0, overhead: 500, want: 0},
+		{name: "negative limit also means no limit", maxBytes: -1, overhead: 500, want: 0},
+		{name: "overhead equal to limit leaves no room", maxBytes: 1000, overhead: 1000, want: -1},
+		{name: "overhead exceeding limit leaves no room", maxBytes: 1000, overhead: 1500, want: -1},
+		{name: "remaining room is reduced by the base64 factor", maxBytes: 1000, overhead: 200, want: 600}, // (1000-200)*3/4
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &Runtime{limits: ResourceLimits{MaxRequestBodyBytes: tt.maxBytes}}
+			if got := rt.MaxHTTPBodyBytes(tt.overhead); got != tt.want {
+				t.Fatalf("MaxHTTPBodyBytes(%d) with MaxRequestBodyBytes=%d = %d, want %d", tt.overhead, tt.maxBytes, got, tt.want)
+			}
+		})
+	}
+}
+
 // callerPlugin builds a plugindom.Plugin for use as execQuery/execStatement's
 // caller argument, with an optional RequestedSensitiveFields declaration.
 func callerPlugin(name string, requested ...string) plugindom.Plugin {

--- a/services/api/internal/platform/plugin/testdata/cacheplugin/main.go
+++ b/services/api/internal/platform/plugin/testdata/cacheplugin/main.go
@@ -18,7 +18,7 @@ var mallocBuf [4096]byte
 var mallocOffset uint32
 var mallocBase uint32
 
-//go:wasmexport malloc
+//go:wasmexport paca_malloc
 func malloc(size uint32) uint32 {
 	if mallocBase == 0 {
 		mallocBase = uint32(uintptr(unsafe.Pointer(&mallocBuf[0])))

--- a/services/api/internal/platform/plugin/testdata/legacymallocplugin/main.go
+++ b/services/api/internal/platform/plugin/testdata/legacymallocplugin/main.go
@@ -1,0 +1,58 @@
+// Command legacymallocplugin is a minimal WASI-reactor fixture used by
+// runtime_test.go to pin writeToMemory's backward-compatibility fallback: it
+// exports only "malloc" (the pre-rename name), never "paca_malloc", the same
+// shape as every plugin binary compiled against the plugin-sdk-go version
+// before the allocator export was renamed. If the fallback in writeToMemory
+// ever regresses, every already-deployed plugin like this one stops working
+// the moment the host is redeployed — this fixture makes that failure show
+// up in CI instead of in production.
+//
+// Rebuild after editing with:
+//
+//	GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared \
+//	  -o ../legacymalloc.wasm .
+package main
+
+import "unsafe"
+
+// mallocBuf backs a simple bounds-checked bump allocator -- unlike
+// poisonplugin, this fixture isn't testing the host's out-of-bounds
+// recovery, so it protects itself normally the way a real SDK allocator
+// does.
+var mallocBuf [4096]byte
+var mallocOffset uint32
+var mallocBase uint32
+
+//go:wasmexport malloc
+func malloc(size uint32) uint32 {
+	if mallocBase == 0 {
+		mallocBase = uint32(uintptr(unsafe.Pointer(&mallocBuf[0])))
+	}
+	if mallocOffset+size > uint32(len(mallocBuf)) {
+		return 0
+	}
+	ptr := mallocBase + mallocOffset
+	mallocOffset += size
+	return ptr
+}
+
+//go:wasmexport ResetAllocator
+func resetAllocator() {
+	mallocOffset = 0
+}
+
+// HandleRequest ignores the request payload and reports an empty response
+// (outPtr=0, outLen=0). The test only cares whether the call into this
+// export succeeds at all -- i.e. whether the host could write the request
+// payload into this module's memory via its legacy "malloc" export.
+//
+//go:wasmexport HandleRequest
+func handleRequest(ptr uint32, length uint32) uint64 {
+	return 0
+}
+
+//go:wasmexport HandleEvent
+func handleEvent(topicPtr uint32, topicLen uint32, payloadPtr uint32, payloadLen uint32) {
+}
+
+func main() {}

--- a/services/api/internal/platform/plugin/testdata/poisonplugin/main.go
+++ b/services/api/internal/platform/plugin/testdata/poisonplugin/main.go
@@ -26,7 +26,7 @@ var offset uint32 = 4096
 // fixture intentionally does not protect itself, since the bug under test is
 // about the host's behavior when that happens.
 //
-//go:wasmexport malloc
+//go:wasmexport paca_malloc
 func malloc(size uint32) uint32 {
 	ptr := offset
 	offset += size

--- a/services/api/internal/transport/http/handler/plugin_handler.go
+++ b/services/api/internal/transport/http/handler/plugin_handler.go
@@ -655,27 +655,6 @@ func (h *PluginHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Read request body, capped so an oversized body can never reach the
-	// plugin's WASM memory (see Runtime.HandleRequest for why that matters).
-	// MaxHTTPBodyBytes (not MaxRequestBodyBytes) is used here because the raw
-	// body is base64-encoded and wrapped in a JSON envelope before it reaches
-	// the runtime's own size check — using the same limit for both would let
-	// a body the HTTP layer accepts still get rejected downstream.
-	if maxBody := h.runtime.MaxHTTPBodyBytes(); maxBody > 0 {
-		r.Body = http.MaxBytesReader(w, r.Body, maxBody)
-	}
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			presenter.Error(w, r, apierr.New(apierr.CodePayloadTooLarge,
-				fmt.Sprintf("request body exceeds the %d byte limit", maxBytesErr.Limit)))
-			return
-		}
-		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "failed to read request body"))
-		return
-	}
-
 	// Build flattened headers map (first value per header name).
 	headers := make(map[string]string, len(r.Header))
 	for k, vs := range r.Header {
@@ -692,6 +671,53 @@ func (h *PluginHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		if len(vs) > 0 {
 			query[k] = vs[0]
 		}
+	}
+
+	// Measure the envelope's exact overhead for this request (everything but
+	// the body) before reading the body, so the size cap accounts for the
+	// real headers/query/path instead of a guessed constant — those vary a
+	// lot in practice (large cookies, forwarded headers, long query strings).
+	envelopeProbe := &pluginrt.HTTPRequest{
+		Method:     r.Method,
+		Path:       subPath,
+		Query:      query,
+		ProjectID:  pathParams[projectParamName],
+		CallerID:   callerID,
+		UserID:     userIDStr,
+		CallerRole: callerRole,
+		Headers:    headers,
+	}
+	probeBytes, err := json.Marshal(envelopeProbe)
+	if err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "failed to serialise request"))
+		return
+	}
+
+	// Read request body, capped so an oversized body can never reach the
+	// plugin's WASM memory (see Runtime.HandleRequest for why that matters).
+	// MaxHTTPBodyBytes (not MaxRequestBodyBytes) is used here because the raw
+	// body is base64-encoded and wrapped in the JSON envelope above before it
+	// reaches the runtime's own size check — using the same limit for both
+	// would let a body the HTTP layer accepts still get rejected downstream.
+	maxBody := h.runtime.MaxHTTPBodyBytes(int64(len(probeBytes)))
+	if maxBody < 0 {
+		presenter.Error(w, r, apierr.New(apierr.CodePayloadTooLarge,
+			"request headers/path/query leave no room for a body under the plugin payload limit"))
+		return
+	}
+	if maxBody > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBody)
+	}
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			presenter.Error(w, r, apierr.New(apierr.CodePayloadTooLarge,
+				fmt.Sprintf("request body exceeds the %d byte limit", maxBytesErr.Limit)))
+			return
+		}
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "failed to read request body"))
+		return
 	}
 
 	req := &pluginrt.HTTPRequest{

--- a/services/api/internal/transport/http/handler/plugin_handler.go
+++ b/services/api/internal/transport/http/handler/plugin_handler.go
@@ -657,7 +657,11 @@ func (h *PluginHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Read request body, capped so an oversized body can never reach the
 	// plugin's WASM memory (see Runtime.HandleRequest for why that matters).
-	if maxBody := h.runtime.MaxRequestBodyBytes(); maxBody > 0 {
+	// MaxHTTPBodyBytes (not MaxRequestBodyBytes) is used here because the raw
+	// body is base64-encoded and wrapped in a JSON envelope before it reaches
+	// the runtime's own size check — using the same limit for both would let
+	// a body the HTTP layer accepts still get rejected downstream.
+	if maxBody := h.runtime.MaxHTTPBodyBytes(); maxBody > 0 {
 		r.Body = http.MaxBytesReader(w, r.Body, maxBody)
 	}
 	bodyBytes, err := io.ReadAll(r.Body)
@@ -713,6 +717,10 @@ func (h *PluginHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 
 	respBytes, err := h.runtime.HandleRequest(reqCtx, pluginID, reqBytes)
 	if err != nil {
+		if errors.Is(err, pluginrt.ErrPayloadTooLarge) {
+			presenter.Error(w, r, apierr.New(apierr.CodePayloadTooLarge, "request payload too large"))
+			return
+		}
 		presenter.Error(w, r, apierr.New(apierr.CodeInternalError, "plugin execution error: "+err.Error()))
 		return
 	}

--- a/services/api/internal/transport/http/handler/plugin_handler_test.go
+++ b/services/api/internal/transport/http/handler/plugin_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -182,8 +183,11 @@ func TestProxyRequest_OversizedBody_Returns413(t *testing.T) {
 		},
 	}
 	rt := pluginrt.NewRuntime(nil, pluginrt.HostServices{}, pluginrt.ResourceLimits{
-		MaxCallDuration:     time.Second,
-		MaxRequestBodyBytes: 16,
+		MaxCallDuration: time.Second,
+		// Comfortably above the ~130-byte envelope overhead this request
+		// carries (empty headers/query/ids), so this pins the body itself
+		// tripping the cap rather than the envelope alone exhausting it.
+		MaxRequestBodyBytes: 512,
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	r := newPluginProxyRouter(svc, rt)
 
@@ -194,6 +198,50 @@ func TestProxyRequest_OversizedBody_Returns413(t *testing.T) {
 
 	if w.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestProxyRequest_LargeHeaders_Returns413EvenWithTinyBody pins the fix for
+// a class of bug where a fixed, guessed reservation for the JSON envelope's
+// non-body fields (headers/query/path) let an oversized envelope slip past
+// the HTTP-layer size check because the *body* alone looked small enough --
+// only to fail downstream, or worse, not fail at all if the reservation
+// happened to be generous enough for that particular request. The cap must
+// account for this specific request's actual header size, not a guess, so
+// a request with tiny body but huge headers is rejected here at the
+// boundary -- before ever calling into the plugin runtime (none is loaded
+// in this test, so any call that reached HandleRequest would fail with a
+// 500 "plugin not loaded", not a 413).
+func TestProxyRequest_LargeHeaders_Returns413EvenWithTinyBody(t *testing.T) {
+	svc := &mockPluginSvc{
+		listPlugins: func(_ context.Context) ([]*plugindom.Plugin, error) {
+			return []*plugindom.Plugin{{
+				Name:    "test.plugin",
+				Enabled: true,
+				Manifest: plugindom.PluginManifest{
+					Backend: &plugindom.BackendManifest{
+						Routes: []plugindom.PluginRoute{
+							{Method: http.MethodPost, Path: "/echo", Middlewares: []plugindom.PluginRouteMiddleware{}},
+						},
+					},
+				},
+			}}, nil
+		},
+	}
+	rt := pluginrt.NewRuntime(nil, pluginrt.HostServices{}, pluginrt.ResourceLimits{
+		MaxCallDuration:     time.Second,
+		MaxRequestBodyBytes: 1024,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	r := newPluginProxyRouter(svc, rt)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/plugins/test.plugin/echo", bytes.NewReader(make([]byte, 4)))
+	req.Header.Set("X-Huge-Header", strings.Repeat("a", 2000))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 from oversized headers alone, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -214,8 +262,10 @@ func TestProxyRequest_BodyWithinLimit_PassesSizeCheck(t *testing.T) {
 		},
 	}
 	rt := pluginrt.NewRuntime(nil, pluginrt.HostServices{}, pluginrt.ResourceLimits{
-		MaxCallDuration:     time.Second,
-		MaxRequestBodyBytes: 16,
+		MaxCallDuration: time.Second,
+		// Large enough that a tiny body plus this request's small envelope
+		// overhead (~130 bytes for empty headers/query/ids) both fit.
+		MaxRequestBodyBytes: 4096,
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	r := newPluginProxyRouter(svc, rt)
 

--- a/services/api/test/e2e/testdata/echoplugin/main.go
+++ b/services/api/test/e2e/testdata/echoplugin/main.go
@@ -44,7 +44,7 @@ func arenaBase() uint32 {
 // malloc returns the current cursor and advances it by size with no check
 // against the arena's actual capacity. See the package doc above.
 //
-//go:wasmexport malloc
+//go:wasmexport paca_malloc
 func malloc(size uint32) uint32 {
 	ptr := arenaBase() + offset
 	offset += size


### PR DESCRIPTION
## Summary

Cuts plugin memory overhead by switching the recommended/default plugin build toolchain from standard Go to TinyGo, and tightens the request body limit to match.

- **Default to TinyGo for building plugin WASM binaries.** Standard Go statically links its full runtime (GC, goroutine scheduler, reflection) into every plugin binary, so each loaded plugin carries its own independent copy of that runtime in host memory — tens of MiB per plugin. TinyGo avoids this, cutting per-plugin memory to a few MiB. `install-local-plugin.sh` now defaults to TinyGo (`--go-toolchain`/`GO_TOOLCHAIN` lets you opt back into standard Go for plugins that hit a TinyGo stdlib limitation, e.g. `reflect`-heavy code like `html/template`).
- **Require `-buildmode=c-shared` for TinyGo builds.** Without it, TinyGo skips wiring up the WASI reactor entry point (`_initialize`), and every call into the plugin panics at runtime with `"//go:wasmexport function called before runtime initialization"`. Docs and scripts are updated accordingly.
- **Rename the SDK's exported allocator from `malloc` to `paca_malloc`.** TinyGo-built plugins already export their own `malloc`/`free` from wasi-libc, which collided with `plugin-sdk-go`'s export of the same name. `runtime.go`'s `writeToMemory` and all WASM test fixtures (`cacheplugin`, `poisonplugin`, `echoplugin`) are updated to use `paca_malloc`.
- **Lower `PLUGINS_MAX_REQUEST_BODY_BYTES` default from 10 MiB to 1 MiB**, matching `plugin-sdk-go`'s `mallocBuffer` size, to avoid over-allocating per-call buffers.
- Documented the `//go:wasmimport` host-function calling convention difference: TinyGo requires calling these by name directly rather than passing them as function values (e.g. via `plugin.CallHostFunction`), since it doesn't support taking their address.

## Why

Every loaded plugin previously paid for its own copy of the full Go runtime, which becomes expensive in aggregate as more plugins are installed. Building with TinyGo by default (with standard Go as an explicit opt-out) reduces per-plugin host memory footprint significantly.

## Test plan

- [ ] `go test ./services/api/internal/config/...` (default `MaxRequestBodyBytes` updated to 1 MiB)
- [ ] `go test ./services/api/internal/platform/plugin/...` (test fixtures rebuilt with `paca_malloc` export)
- [ ] `go test ./services/api/test/e2e/...`
- [ ] Manually build a plugin with `tinygo build -target=wasip1 -buildmode=c-shared` and confirm it loads and responds correctly
