### PR TITLE
feat(acp-bridge): configurable session scope (default per-task)

### DIFF
--- a/apps/acp-bridge/internal/cli/cli.go
+++ b/apps/acp-bridge/internal/cli/cli.go
@@ -9,16 +9,36 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/Paca-AI/paca/apps/acp-bridge/internal/bridge"
 	"github.com/Paca-AI/paca/apps/acp-bridge/internal/runner"
 )
 
 const usage = "usage: paca-acp-bridge run --agent-id <id> --token <token> --server <url> " +
-	"[--workspace <path>] [--log-level <level>]\n" +
+	"[--workspace <path>] [--log-level <level>] [--session-scope <scope>] [--session-idle-minutes <n>]\n" +
 	"       paca-acp-bridge version"
+
+// envOr returns os.Getenv(key) if set and non-empty, else fallback.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// envIntOr returns the integer in env var key, or fallback if unset/invalid.
+func envIntOr(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
 
 // Main is the CLI's entrypoint, returning the process exit code. version is
 // this build's version string (see cmd/paca-acp-bridge/main.go), reported
@@ -44,6 +64,12 @@ func Main(argv []string, version string) int {
 	workspace := fs.String("workspace", cwd,
 		"Directory the ACP server operates on (default: current directory)")
 	logLevel := fs.String("log-level", "INFO", "Log level: DEBUG, INFO, WARN, or ERROR")
+	sessionScope := fs.String("session-scope", envOr("PACA_SESSION_SCOPE", runner.ScopeTask),
+		"How conversations map to Claude Code sessions: task (default; one session per task, "+
+			"context shared across a task's conversations), conversation (upstream; one per conversation), "+
+			"or agent (one per agent). Or PACA_SESSION_SCOPE.")
+	idleMinutes := fs.Int("session-idle-minutes", envIntOr("PACA_SESSION_IDLE_MINUTES", 30),
+		"Reclaim a session after this many idle minutes (0 disables). Or PACA_SESSION_IDLE_MINUTES.")
 
 	if err := fs.Parse(argv[1:]); err != nil {
 		return 2
@@ -70,9 +96,11 @@ func Main(argv []string, version string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	log.Info("paca-acp-bridge starting", "version", version, "workspace", *workspace)
+	cfg := runner.Config{Scope: *sessionScope, IdleTimeout: time.Duration(*idleMinutes) * time.Minute}
+	log.Info("paca-acp-bridge starting", "version", version, "workspace", *workspace,
+		"session_scope", cfg.Scope, "session_idle_minutes", *idleMinutes)
 
-	client := bridge.New(*server, *agentID, *token, *workspace, log, runner.New(*workspace, log))
+	client := bridge.New(*server, *agentID, *token, *workspace, log, runner.New(*workspace, cfg, log))
 	if err := client.RunForever(ctx); err != nil && ctx.Err() == nil {
 		log.Error("bridge exited with error", "error", err)
 		return 1

--- a/apps/acp-bridge/internal/runner/runner.go
+++ b/apps/acp-bridge/internal/runner/runner.go
@@ -65,6 +65,22 @@ type conversationState struct {
 	// always sleeping the full interruptGracePeriod.
 	turnDone chan struct{}
 
+	// currentConversationID/currentProjectID identify the conversation whose
+	// turn is running right now. With per-task (or per-agent) session scope a
+	// single conversationState — one ACP subprocess — is reused across MORE
+	// than one Paca conversation, so the conversation an event belongs to
+	// changes turn-to-turn and can no longer be captured once in the spawn
+	// closure. runTurn stamps these under mu before doing any work; the ACP
+	// stdout goroutine's onUpdate closure reads them (via currentIDs) so each
+	// event is attributed to the turn actually in flight. Guarded by mu.
+	currentConversationID string
+	currentProjectID      string
+
+	// lastActivity is refreshed whenever a turn starts or finishes; the idle
+	// sweeper (see Runner.sweepIdle) evicts a session that has been idle
+	// longer than the configured timeout. Guarded by mu.
+	lastActivity time.Time
+
 	// client/sessionID are set once the ACP session is established and
 	// reused across every later turn of this same conversation — a chat
 	// conversation reattaches to the same subprocess rather than spawning
@@ -97,30 +113,108 @@ type conversationState struct {
 	outbound     chan map[string]any
 }
 
+// Session scope names — how a start_turn is mapped to the ACP subprocess
+// ("session") that serves it. See Runner.sessionKeyFor.
+const (
+	// ScopeConversation is the upstream behavior: one ACP session per Paca
+	// conversation. Maximum isolation, but no shared memory even between two
+	// conversations on the same task.
+	ScopeConversation = "conversation"
+	// ScopeTask keys the session by task_id when the trigger carries one
+	// (falling back to chat_session_id, then conversation_id), so every
+	// conversation on one task — its task_assigned turn, later comment
+	// @mentions, task chat — shares a single Claude Code process and its
+	// accumulated context. This is the fork's default and reason for being.
+	ScopeTask = "task"
+	// ScopeAgent keys every conversation to a single session — one persistent
+	// process for the whole agent, matching the "channel" model. Maximum
+	// memory, zero isolation between tasks.
+	ScopeAgent = "agent"
+)
+
+// Config tunes how the Runner maps conversations to ACP sessions and when it
+// reclaims idle ones. The zero value is valid: Scope defaults to ScopeTask
+// and IdleTimeout to 0 (no eviction).
+type Config struct {
+	// Scope selects the session-keying strategy (see the Scope* constants).
+	// An unknown or empty value is normalized to ScopeTask.
+	Scope string
+	// IdleTimeout, when > 0, reclaims a session that has had no turn for at
+	// least this long. Zero disables eviction (upstream's behavior).
+	IdleTimeout time.Duration
+}
+
+func (c Config) scope() string {
+	switch c.Scope {
+	case ScopeConversation, ScopeTask, ScopeAgent:
+		return c.Scope
+	default:
+		return ScopeTask
+	}
+}
+
 // Runner implements bridge.Handler.
 type Runner struct {
-	workspace string
-	send      bridge.SendFunc
-	log       *slog.Logger
+	workspace   string
+	send        bridge.SendFunc
+	log         *slog.Logger
+	scope       string
+	idleTimeout time.Duration
 
-	mu            sync.Mutex
+	mu sync.Mutex
+	// conversations is keyed by session key (see sessionKeyFor), NOT by
+	// conversation_id — under ScopeTask several conversation_ids map to one
+	// entry.
 	conversations map[string]*conversationState
+	// convIndex maps a conversation_id to its session key, so Interrupt
+	// (which the bridge calls with a conversation_id) can find the session
+	// even when the map is keyed by task. Populated on every StartTurn.
+	convIndex map[string]string
 }
 
 // New builds a Runner rooted at workspace, using send to report events and
 // turn_status back over the bridge. Suitable as the newHandler argument to
 // bridge.New.
-func New(workspace string, log *slog.Logger) func(bridge.SendFunc) bridge.Handler {
+func New(workspace string, cfg Config, log *slog.Logger) func(bridge.SendFunc) bridge.Handler {
 	if log == nil {
 		log = slog.Default()
 	}
 	return func(send bridge.SendFunc) bridge.Handler {
-		return &Runner{
+		r := &Runner{
 			workspace:     workspace,
 			send:          send,
 			log:           log,
+			scope:         cfg.scope(),
+			idleTimeout:   cfg.IdleTimeout,
 			conversations: make(map[string]*conversationState),
+			convIndex:     make(map[string]string),
 		}
+		if r.idleTimeout > 0 {
+			go r.sweepIdle()
+		}
+		return r
+	}
+}
+
+// sessionKeyFor derives the session key for a start_turn message under the
+// configured scope. The task→chat_session→conversation fallback is what makes
+// the fork safe against an unpatched Paca: a server that doesn't send task_id
+// yet leaves ScopeTask degrading to exactly ScopeConversation, with no error.
+func (r *Runner) sessionKeyFor(msg map[string]any) string {
+	conversationID, _ := msg["conversation_id"].(string)
+	switch r.scope {
+	case ScopeAgent:
+		return "agent"
+	case ScopeTask:
+		if taskID, _ := msg["task_id"].(string); taskID != "" {
+			return "task:" + taskID
+		}
+		if chatID, _ := msg["chat_session_id"].(string); chatID != "" {
+			return "chat:" + chatID
+		}
+		return conversationID
+	default: // ScopeConversation
+		return conversationID
 	}
 }
 
@@ -136,32 +230,46 @@ func (r *Runner) StartTurn(ctx context.Context, msg map[string]any) {
 		return
 	}
 
+	key := r.sessionKeyFor(msg)
+
 	r.mu.Lock()
-	state, exists := r.conversations[conversationID]
+	state, exists := r.conversations[key]
 	if !exists {
 		state = &conversationState{chunks: newChunkBuffer()}
-		r.conversations[conversationID] = state
+		r.conversations[key] = state
 	}
+	// Index this conversation to its session so Interrupt (called by
+	// conversation_id) can find the shared session under task keying.
+	r.convIndex[conversationID] = key
 	r.mu.Unlock()
 
 	state.mu.Lock()
 	if state.turnRunning {
 		state.mu.Unlock()
+		// Under ScopeTask two conversations on the same task share one
+		// session's single turnRunning gate, so an @mention arriving mid-turn
+		// is rejected here rather than queued — the server's watchdog would
+		// otherwise fail a queued-and-delayed conversation out from under us.
 		r.log.Warn("runner: ignoring start_turn: a previous turn is still running",
-			"conversation_id", conversationID)
+			"conversation_id", conversationID, "session_key", key)
 		r.reportStatus(state, conversationID, projectID, "failed",
-			"A previous turn for this conversation is still running; please retry.")
+			"The agent is busy with another turn on this task; please retry.")
 		return
 	}
 
-	if !exists {
+	if state.client == nil && state.command == nil {
 		acpProvider, _ := msg["acp_provider"].(string)
 		command, err := provider.ResolveCommand(acpProvider, stringSlice(msg["acp_command"]))
 		if err != nil {
 			state.mu.Unlock()
 			r.log.Error("runner: cannot start conversation", "conversation_id", conversationID, "error", err)
 			r.mu.Lock()
-			delete(r.conversations, conversationID)
+			// Only drop the session if this failed first turn left it empty;
+			// never yank a session a sibling conversation is already using.
+			if s, ok := r.conversations[key]; ok && s == state && s.client == nil {
+				delete(r.conversations, key)
+			}
+			delete(r.convIndex, conversationID)
 			r.mu.Unlock()
 			r.reportStatus(state, conversationID, projectID, "failed", err.Error())
 			return
@@ -171,6 +279,9 @@ func (r *Runner) StartTurn(ctx context.Context, msg map[string]any) {
 	}
 
 	state.turnRunning = true
+	state.currentConversationID = conversationID
+	state.currentProjectID = projectID
+	state.lastActivity = time.Now()
 	turnCtx, cancel := context.WithCancel(context.Background())
 	state.turnCancel = cancel
 	state.turnDone = make(chan struct{})
@@ -188,9 +299,13 @@ func (r *Runner) Interrupt(conversationID string) {
 		return
 	}
 	r.mu.Lock()
-	state, ok := r.conversations[conversationID]
+	key, indexed := r.convIndex[conversationID]
+	var state *conversationState
+	if indexed {
+		state = r.conversations[key]
+	}
 	r.mu.Unlock()
-	if !ok {
+	if state == nil {
 		return
 	}
 
@@ -312,8 +427,14 @@ func (r *Runner) ensureSession(
 		return client, sessionID, nil
 	}
 
+	// The onUpdate closure must NOT capture conversationID/projectID: this
+	// subprocess outlives the turn that spawned it and, under task keying,
+	// serves later turns of other conversations. Read the conversation in
+	// flight from state at each callback instead, so every event is
+	// attributed to the right Paca conversation thread.
 	client, err := acpclient.Spawn(state.command, r.workspace, func(u acpclient.Update) {
-		r.handleUpdate(state, conversationID, projectID, u)
+		cid, pid := state.currentIDs()
+		r.handleUpdate(state, cid, pid, u)
 	}, r.log)
 	if err != nil {
 		return nil, "", fmt.Errorf("spawning %v: %w", state.command, err)
@@ -348,11 +469,79 @@ func (r *Runner) finishTurn(state *conversationState) {
 	state.mu.Lock()
 	state.turnRunning = false
 	state.turnCancel = nil
+	state.lastActivity = time.Now()
 	done := state.turnDone
 	state.turnDone = nil
 	state.mu.Unlock()
 	if done != nil {
 		close(done)
+	}
+}
+
+// currentIDs returns the conversation/project the session's turn is serving
+// right now, read under mu — see conversationState.currentConversationID.
+func (s *conversationState) currentIDs() (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.currentConversationID, s.currentProjectID
+}
+
+// sweepIdle periodically reclaims sessions with no turn for longer than
+// r.idleTimeout, closing the ACP subprocess and forgetting the session (and
+// every convIndex entry pointing at it). Upstream never evicts, which is why
+// abandoned sessions pile up as long-lived CC processes; per-task keying
+// reduces the count but doesn't bound it, so the fork closes the leak. A
+// revisited task simply spawns a fresh session — durable per-task memory
+// across an eviction is a later concern (Paca's persistence_dir + ACP
+// session/load), deliberately out of scope here.
+func (r *Runner) sweepIdle() {
+	interval := r.idleTimeout / 2
+	if interval < time.Minute {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		r.evictIdle(time.Now())
+	}
+}
+
+func (r *Runner) evictIdle(now time.Time) {
+	r.mu.Lock()
+	var victims []*conversationState
+	for key, state := range r.conversations {
+		state.mu.Lock()
+		idle := !state.turnRunning && !state.lastActivity.IsZero() &&
+			now.Sub(state.lastActivity) >= r.idleTimeout
+		client := state.client
+		state.mu.Unlock()
+		if !idle {
+			continue
+		}
+		delete(r.conversations, key)
+		for convID, k := range r.convIndex {
+			if k == key {
+				delete(r.convIndex, convID)
+			}
+		}
+		if client != nil {
+			victims = append(victims, state)
+		}
+	}
+	r.mu.Unlock()
+
+	// Close subprocesses outside r.mu — Close can block, and nothing else can
+	// reach these states now that they're unlinked from both maps.
+	for _, state := range victims {
+		state.mu.Lock()
+		client := state.client
+		state.client = nil
+		state.sessionID = ""
+		state.mu.Unlock()
+		if client != nil {
+			_ = client.Close()
+			r.log.Info("runner: evicted idle ACP session")
+		}
 	}
 }
 

--- a/apps/acp-bridge/internal/runner/runner.go
+++ b/apps/acp-bridge/internal/runner/runner.go
@@ -241,9 +241,15 @@ func (r *Runner) StartTurn(ctx context.Context, msg map[string]any) {
 	// Index this conversation to its session so Interrupt (called by
 	// conversation_id) can find the shared session under task keying.
 	r.convIndex[conversationID] = key
+	// Acquire state.mu while still holding r.mu (lock order: r.mu -> state.mu),
+	// then release r.mu. This closes the eviction race: the idle sweeper needs
+	// r.mu to reach this state and state.mu (TryLock) to act on it, so holding
+	// state.mu continuously from lookup through the turnRunning claim below
+	// makes it impossible for the sweeper to unlink and close a session between
+	// the moment StartTurn selects it and the moment it marks it busy.
+	state.mu.Lock()
 	r.mu.Unlock()
 
-	state.mu.Lock()
 	if state.turnRunning {
 		state.mu.Unlock()
 		// Under ScopeTask two conversations on the same task share one
@@ -508,40 +514,45 @@ func (r *Runner) sweepIdle() {
 
 func (r *Runner) evictIdle(now time.Time) {
 	r.mu.Lock()
-	var victims []*conversationState
+	var victims []*acpclient.Client
 	for key, state := range r.conversations {
-		state.mu.Lock()
-		idle := !state.turnRunning && !state.lastActivity.IsZero() &&
-			now.Sub(state.lastActivity) >= r.idleTimeout
-		client := state.client
-		state.mu.Unlock()
-		if !idle {
+		// TryLock, not Lock: a state whose mu is held is being claimed or used
+		// by StartTurn/runTurn right now (StartTurn holds it across its
+		// turnRunning claim). Skipping it — rather than blocking r.mu on it —
+		// both avoids the eviction-vs-startup race and keeps the sweep from
+		// stalling every other StartTurn behind r.mu.
+		if !state.mu.TryLock() {
 			continue
 		}
-		delete(r.conversations, key)
-		for convID, k := range r.convIndex {
-			if k == key {
-				delete(r.convIndex, convID)
+		idle := !state.turnRunning && !state.lastActivity.IsZero() &&
+			now.Sub(state.lastActivity) >= r.idleTimeout
+		if idle {
+			// Unlink and take ownership of the client atomically under both
+			// r.mu and state.mu. turnRunning is false and we hold state.mu, so
+			// no turn is using this client and none can start one on it — the
+			// captured client is ours alone to close.
+			client := state.client
+			state.client = nil
+			state.sessionID = ""
+			delete(r.conversations, key)
+			for convID, k := range r.convIndex {
+				if k == key {
+					delete(r.convIndex, convID)
+				}
+			}
+			if client != nil {
+				victims = append(victims, client)
 			}
 		}
-		if client != nil {
-			victims = append(victims, state)
-		}
+		state.mu.Unlock()
 	}
 	r.mu.Unlock()
 
-	// Close subprocesses outside r.mu — Close can block, and nothing else can
-	// reach these states now that they're unlinked from both maps.
-	for _, state := range victims {
-		state.mu.Lock()
-		client := state.client
-		state.client = nil
-		state.sessionID = ""
-		state.mu.Unlock()
-		if client != nil {
-			_ = client.Close()
-			r.log.Info("runner: evicted idle ACP session")
-		}
+	// Close subprocesses outside the locks — Close can block, and each victim
+	// client is already unlinked and owned solely by this goroutine.
+	for _, client := range victims {
+		_ = client.Close()
+		r.log.Info("runner: evicted idle ACP session")
 	}
 }
 

--- a/apps/acp-bridge/internal/runner/runner_test.go
+++ b/apps/acp-bridge/internal/runner/runner_test.go
@@ -62,7 +62,7 @@ func (c *capturedSends) all() []map[string]any {
 func newTestRunner(t *testing.T) (*Runner, *capturedSends) {
 	t.Helper()
 	sent := newCapturedSends()
-	handler := New(t.TempDir(), nil)(sent.send)
+	handler := New(t.TempDir(), Config{}, nil)(sent.send)
 	r, ok := handler.(*Runner)
 	if !ok {
 		t.Fatalf("New's handler is not *Runner (got %T)", handler)

--- a/apps/acp-bridge/internal/runner/session_scope_test.go
+++ b/apps/acp-bridge/internal/runner/session_scope_test.go
@@ -245,3 +245,38 @@ func TestEvictIdleReclaimsAndCleansIndex(t *testing.T) {
 		t.Fatal("running session was wrongly evicted")
 	}
 }
+
+// TestEvictIdleSkipsClaimedSession covers the race greptile flagged: while a
+// StartTurn holds a session's mu to claim it (before it has set turnRunning),
+// the sweeper must NOT unlink and close that session. evictIdle TryLocks and
+// skips a held state, so an idle-looking session that is mid-claim survives the
+// sweep and is only reclaimed once genuinely free.
+func TestEvictIdleSkipsClaimedSession(t *testing.T) {
+	r := &Runner{
+		conversations: make(map[string]*conversationState),
+		convIndex:     make(map[string]string),
+		idleTimeout:   30 * time.Minute,
+	}
+	now := time.Now()
+	st := &conversationState{chunks: newChunkBuffer(), lastActivity: now.Add(-time.Hour)}
+	r.conversations["task:X"] = st
+	r.convIndex["conv-x"] = "task:X"
+
+	// Simulate a StartTurn that has selected this session and holds its mu
+	// while it decides to claim it (turnRunning not yet set).
+	st.mu.Lock()
+	r.evictIdle(now)
+	if _, ok := r.conversations["task:X"]; !ok {
+		t.Fatal("sweeper evicted a session that was mid-claim (race not fixed)")
+	}
+	st.mu.Unlock()
+
+	// Once the claim is released and the session is genuinely idle, it goes.
+	r.evictIdle(now)
+	if _, ok := r.conversations["task:X"]; ok {
+		t.Fatal("idle session not evicted after claim released")
+	}
+	if _, ok := r.convIndex["conv-x"]; ok {
+		t.Fatal("convIndex not cleaned after eviction")
+	}
+}

--- a/apps/acp-bridge/internal/runner/session_scope_test.go
+++ b/apps/acp-bridge/internal/runner/session_scope_test.go
@@ -1,0 +1,247 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSessionKeyFor covers the scope→key mapping, including the
+// task→chat_session→conversation fallback that keeps ScopeTask working
+// (as ScopeConversation) against a server that doesn't send task_id yet.
+func TestSessionKeyFor(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope string
+		msg   map[string]any
+		want  string
+	}{
+		{"conversation scope ignores task", ScopeConversation,
+			map[string]any{"conversation_id": "c1", "task_id": "t1"}, "c1"},
+		{"agent scope collapses everything", ScopeAgent,
+			map[string]any{"conversation_id": "c1", "task_id": "t1"}, "agent"},
+		{"task scope keys by task", ScopeTask,
+			map[string]any{"conversation_id": "c1", "task_id": "t1"}, "task:t1"},
+		{"task scope falls back to chat session", ScopeTask,
+			map[string]any{"conversation_id": "c1", "chat_session_id": "s1"}, "chat:s1"},
+		{"task scope falls back to conversation (unpatched server)", ScopeTask,
+			map[string]any{"conversation_id": "c1"}, "c1"},
+		{"task prefers task over chat when both present", ScopeTask,
+			map[string]any{"conversation_id": "c1", "task_id": "t1", "chat_session_id": "s1"}, "task:t1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Runner{scope: tc.scope}
+			if got := r.sessionKeyFor(tc.msg); got != tc.want {
+				t.Fatalf("sessionKeyFor(%s) = %q, want %q", tc.scope, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfigScopeNormalizesUnknown proves an empty/unknown scope becomes the
+// fork's default (task), so a zero Config is a valid "per-task" runner.
+func TestConfigScopeNormalizesUnknown(t *testing.T) {
+	for _, in := range []string{"", "bogus"} {
+		if got := (Config{Scope: in}).scope(); got != ScopeTask {
+			t.Fatalf("Config{Scope:%q}.scope() = %q, want %q", in, got, ScopeTask)
+		}
+	}
+	for _, in := range []string{ScopeConversation, ScopeAgent, ScopeTask} {
+		if got := (Config{Scope: in}).scope(); got != in {
+			t.Fatalf("Config{Scope:%q}.scope() = %q, want it unchanged", in, got)
+		}
+	}
+}
+
+// TestPerTaskSessionReuseAndAttribution is the core acceptance test: two
+// conversations sharing a task_id run through ONE session (one subprocess,
+// reused), and each turn's events are attributed to the conversation actually
+// in flight — not the one that first spawned the subprocess.
+func TestPerTaskSessionReuseAndAttribution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real subprocess")
+	}
+	setFakeAgentEnv(t, "normal")
+
+	r, sent := newTestRunner(t) // Config{} → ScopeTask
+	// Pre-seed the task's session with the fake-agent command, exactly as the
+	// upstream E2E tests seed a conversation — avoids depending on provider
+	// resolution. Key is the task key, since both conversations share task T1.
+	r.mu.Lock()
+	r.conversations["task:T1"] = &conversationState{
+		chunks:      newChunkBuffer(),
+		acpProvider: "custom",
+		command:     []string{os.Args[0]},
+	}
+	r.mu.Unlock()
+
+	// Turn 1 — conversation conv-1 on task T1.
+	r.StartTurn(context.Background(), map[string]any{
+		"conversation_id": "conv-1",
+		"project_id":      "proj-1",
+		"task_id":         "T1",
+		"message":         "first",
+	})
+	waitForStatus(t, sent, "finished")
+
+	r.mu.Lock()
+	state := r.conversations["task:T1"]
+	r.mu.Unlock()
+	state.mu.Lock()
+	clientAfter1 := state.client
+	state.mu.Unlock()
+	if clientAfter1 == nil {
+		t.Fatal("expected a live ACP client after turn 1")
+	}
+
+	// Turn 2 — a DIFFERENT conversation conv-2 on the SAME task T1.
+	r.StartTurn(context.Background(), map[string]any{
+		"conversation_id": "conv-2",
+		"project_id":      "proj-1",
+		"task_id":         "T1",
+		"message":         "second",
+	})
+	waitForStatus(t, sent, "finished")
+
+	// Exactly one session for the task — conv-2 reused conv-1's subprocess.
+	r.mu.Lock()
+	nSessions := len(r.conversations)
+	k1, k2 := r.convIndex["conv-1"], r.convIndex["conv-2"]
+	r.mu.Unlock()
+	if nSessions != 1 {
+		t.Fatalf("expected 1 shared session for the task, got %d", nSessions)
+	}
+	if k1 != "task:T1" || k2 != "task:T1" {
+		t.Fatalf("convIndex = {conv-1:%q, conv-2:%q}, want both task:T1", k1, k2)
+	}
+	state.mu.Lock()
+	clientAfter2 := state.client
+	state.mu.Unlock()
+	if clientAfter2 != clientAfter1 {
+		t.Fatal("turn 2 spawned a new subprocess instead of reusing the task's session")
+	}
+
+	// Attribution: turn 2's events/status must carry conversation_id conv-2,
+	// and conv-2 must have produced its own user_message (proving the onUpdate
+	// closure read the in-flight conversation, not the spawn-time one).
+	var conv2UserMsg, conv2Finished bool
+	for _, m := range sent.all() {
+		if m["conversation_id"] != "conv-2" {
+			continue
+		}
+		if m["type"] == "event" && m["event_type"] == "user_message" {
+			conv2UserMsg = true
+		}
+		if m["type"] == "turn_status" && m["status"] == "finished" {
+			conv2Finished = true
+		}
+	}
+	if !conv2UserMsg {
+		t.Fatal("no user_message attributed to conv-2 (attribution bug)")
+	}
+	if !conv2Finished {
+		t.Fatal("no finished turn_status attributed to conv-2")
+	}
+}
+
+// TestInterruptResolvesSharedTaskSession proves Interrupt — which the bridge
+// calls with a conversation_id — still finds the session when the map is keyed
+// by task. Without the convIndex fix this is a silent no-op and the turn never
+// stops. Mirrors the upstream "interrupt suppresses turn_status" contract.
+func TestInterruptResolvesSharedTaskSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a real subprocess")
+	}
+	setFakeAgentEnv(t, "cancel")
+
+	r, sent := newTestRunner(t)
+	r.mu.Lock()
+	r.conversations["task:T1"] = &conversationState{
+		chunks:      newChunkBuffer(),
+		acpProvider: "custom",
+		command:     []string{os.Args[0]},
+	}
+	r.mu.Unlock()
+
+	r.StartTurn(context.Background(), map[string]any{
+		"conversation_id": "conv-9",
+		"project_id":      "proj-1",
+		"task_id":         "T1",
+		"message":         "work",
+	})
+	// Wait until the turn is actually in flight (user_message emitted) so the
+	// cancel isn't racing session setup.
+	waitForEventType(t, sent, "user_message")
+
+	// Interrupt by CONVERSATION id; the session is keyed by TASK.
+	r.Interrupt("conv-9")
+
+	// Cooperative cancel → no terminal turn_status (upstream contract). Give
+	// the turn a moment to unwind, then assert none was reported.
+	deadline := time.Now().Add(testTimeout)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		st := r.conversations["task:T1"]
+		r.mu.Unlock()
+		st.mu.Lock()
+		running := st.turnRunning
+		st.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	for _, m := range sent.all() {
+		if m["type"] == "turn_status" {
+			t.Fatalf("expected no turn_status after cooperative interrupt, got %v", m["status"])
+		}
+	}
+}
+
+// TestEvictIdleReclaimsAndCleansIndex proves the sweeper removes a session
+// idle past the timeout and forgets every convIndex entry pointing at it,
+// while leaving a recently-active session (and a running one) untouched.
+func TestEvictIdleReclaimsAndCleansIndex(t *testing.T) {
+	r := &Runner{
+		conversations: make(map[string]*conversationState),
+		convIndex:     make(map[string]string),
+		idleTimeout:   30 * time.Minute,
+	}
+	now := time.Now()
+
+	// Idle session shared by two conversations (nil client → no real Close).
+	idle := &conversationState{chunks: newChunkBuffer(), lastActivity: now.Add(-time.Hour)}
+	r.conversations["task:OLD"] = idle
+	r.convIndex["conv-a"] = "task:OLD"
+	r.convIndex["conv-b"] = "task:OLD"
+
+	// Recently active session — must survive.
+	fresh := &conversationState{chunks: newChunkBuffer(), lastActivity: now.Add(-time.Minute)}
+	r.conversations["task:NEW"] = fresh
+	r.convIndex["conv-c"] = "task:NEW"
+
+	// Running session, idle-looking timestamp but a turn in flight — must survive.
+	busy := &conversationState{chunks: newChunkBuffer(), lastActivity: now.Add(-time.Hour), turnRunning: true}
+	r.conversations["task:BUSY"] = busy
+	r.convIndex["conv-d"] = "task:BUSY"
+
+	r.evictIdle(now)
+
+	if _, ok := r.conversations["task:OLD"]; ok {
+		t.Fatal("idle session was not evicted")
+	}
+	if _, ok := r.convIndex["conv-a"]; ok {
+		t.Fatal("convIndex conv-a not cleaned after eviction")
+	}
+	if _, ok := r.convIndex["conv-b"]; ok {
+		t.Fatal("convIndex conv-b not cleaned after eviction")
+	}
+	if _, ok := r.conversations["task:NEW"]; !ok {
+		t.Fatal("recently-active session was wrongly evicted")
+	}
+	if _, ok := r.conversations["task:BUSY"]; !ok {
+		t.Fatal("running session was wrongly evicted")
+	}
+}

--- a/services/agent-runner/internal/acpbridge/dispatch.go
+++ b/services/agent-runner/internal/acpbridge/dispatch.go
@@ -61,6 +61,13 @@ func (d *Dispatcher) DispatchTrigger(ctx context.Context, trigger agent.Trigger,
 		"trigger_type":    string(trigger.TriggerType),
 		"acp_provider":    cfg.ACPProvider,
 		"acp_command":     cfg.ACPCommand,
+		// Task/comment/chat linkage the bridge uses to group conversations
+		// into per-task (or per-chat) sessions. Empty when the trigger has no
+		// such link (e.g. project-global chat, or an automation message with
+		// no task); an older bridge simply ignores these keys.
+		"task_id":         uuidPtrOrEmpty(trigger.TaskID),
+		"comment_id":      uuidPtrOrEmpty(trigger.CommentID),
+		"chat_session_id": uuidPtrOrEmpty(trigger.ChatSessionID),
 	})
 	if err != nil {
 		return err
@@ -130,6 +137,13 @@ func (d *Dispatcher) watchdog(conversationID, projectID uuid.UUID, timeout time.
 
 func projectIDOrEmpty(id uuid.UUID) string {
 	if id == uuid.Nil {
+		return ""
+	}
+	return id.String()
+}
+
+func uuidPtrOrEmpty(id *uuid.UUID) string {
+	if id == nil || *id == uuid.Nil {
 		return ""
 	}
 	return id.String()


### PR DESCRIPTION
The acp-bridge keys its ACP sessions by conversation_id, so every Paca conversation on a task spawns a fresh coding-agent process with no shared context — an @mention in a task comment can't recall what the agent did when the task was assigned.

Add a --session-scope flag (task | conversation | agent; default task):
- task: key the session by task_id (falling back to chat_session_id, then conversation_id) so every conversation on one task shares a single agent process and its accumulated context.
- conversation: the previous behavior.
- agent: one session for the whole agent.

The bridge learns the task/chat linkage from three new start_turn fields (task_id, comment_id, chat_session_id) added in services/agent-runner's dispatch — they're already on the Trigger, just weren't forwarded. The fallback keeps ScopeTask degrading to ScopeConversation against an older server, so the bridge stays compatible with an unpatched runner.

Also fixes two issues surfaced by session sharing:
- Interrupt is invoked by conversation_id but the session map is now keyed by task; a convIndex maps conversation_id -> session key so stop/pause still resolve the right session.
- Events are attributed to the conversation whose turn is in flight (read from state) rather than the one that first spawned the subprocess.

And adds idle session eviction (--session-idle-minutes, default 30), which the runner previously never did.

## Summary

Describe the change in a few sentences.

## Type of Change

- Documentation
- Repository structure
- Architecture clarification
- Scaffolding
- Other

## Checklist

- The change is focused and scoped.
- Related documentation is updated.
- New structure or direction is explained clearly.
- I avoided unnecessary detail or premature abstraction.