### PR TITLE
feat: add GOOSE_PATH_ROOT to environment configuration for persistent…

### DIFF
--- a/services/agent-runner/internal/executor/executor.go
+++ b/services/agent-runner/internal/executor/executor.go
@@ -48,6 +48,32 @@ const defaultTimeoutMinutes = 30
 // the same spike. /home/goose is that user's home directory.
 const sandboxWorkdir = "/home/goose"
 
+// environmentGooseDataDir is where coldStartEnvironment points GOOSE_PATH_ROOT
+// for every static-environment container — a dot-prefixed subdirectory of
+// the same persisted workspace mount internal/sandbox/environmentssh.go's
+// environmentWorkspaceRoot names (mirrored, not imported, the same way the
+// docker/k8s sandbox packages each keep their own copy of that literal), so
+// it survives recreateGoneEnvironmentContainer/recreateEnvironmentContainer
+// exactly like environmentSSHHostKeyDir already does.
+//
+// Without this, goose serve's default session store lives under
+// /home/goose/.local/share/goose (or /root/... — see conversation
+// 8b325e33-567f-46d5-8224-8df899429036: verified directly against a live
+// environment container's filesystem, not assumed), which is NOT under the
+// persisted volume — only /home/paca/workspaces itself is. Every
+// environment container is disposable (idle-reaped, then recreated fresh
+// against the same volume on the next attach — see
+// docker.Manager.recreateGoneEnvironmentContainer's doc comment), so a
+// session store outside that volume is wiped every time that happens,
+// leaving attachEnvironmentSession's LoadSession call with nothing to
+// resume: it fails "Session not found", and the fallback it documents (a
+// brand-new, context-free session) silently takes over — exactly what
+// happened in that conversation. Relocating the store onto the volume via
+// GOOSE_PATH_ROOT (confirmed empirically: it relocates goose's config/data/
+// state dirs, sessions.db included, wholesale) makes LoadSession actually
+// have something to find after a recreate.
+const environmentGooseDataDir = "/home/paca/workspaces/.goose"
+
 // Options holds service-level settings shared across every conversation
 // this process runs — the Go analog of services/ai-agent's config.Settings,
 // scoped to just the fields the executor itself needs.
@@ -536,6 +562,14 @@ func (e *Executor) coldStartEnvironment(ctx, turnCtx context.Context, cfg agent.
 	if err != nil {
 		return nil, "", err
 	}
+
+	// See environmentGooseDataDir's own doc comment. Set unconditionally
+	// (not just on first create) so ensureEnvironmentInfraEnv's
+	// pacaInfraEnvKeys staleness check (docker/k8s sandbox packages) can
+	// detect a container created before this existed and recreate it once
+	// to backfill this, the same way it already does for
+	// PACA_API_KEY/PACA_WORKDIR/etc.
+	containerEnv["GOOSE_PATH_ROOT"] = environmentGooseDataDir
 
 	// Git identity has no dedicated EnvironmentConfig field (unlike
 	// sandbox.Config.GitCommitterName/Email) — folded into the generic Env

--- a/services/agent-runner/internal/sandbox/docker/environment.go
+++ b/services/agent-runner/internal/sandbox/docker/environment.go
@@ -586,6 +586,21 @@ var pacaInfraEnvKeys = []string{
 // this can never silently reassign this environment's frozen LLM/agent
 // identity to whichever conversation happens to trigger the sync.
 func (m *Manager) ensureEnvironmentInfraEnv(ctx context.Context, backendRef string, cfg sandbox.EnvironmentConfig) (*sandbox.EnvironmentHandle, error) {
+	if len(cfg.Env) == 0 {
+		// A caller with no infra-env context at all — e.g.
+		// handleStartEnvironment's plain restart, whose EnvironmentConfig
+		// never sets Env (see its own doc comment: "restarts ... without
+		// touching" what it doesn't own) — has nothing to reconcile
+		// pacaInfraEnvKeys against. Every real attach path (coldStartEnvironment)
+		// always populates cfg.Env with at least GOOSE_PROVIDER/GOOSE_MODEL/the
+		// API key, so this only ever fires for that kind of context-free
+		// caller; treating a nil/empty cfg.Env as "clear every key" instead
+		// would strip PACA_API_KEY, GOOSE_PATH_ROOT, etc. from an
+		// already-correctly-configured container on every such call. Mirrors
+		// recreateEnvironmentIfMissingEnv's own cfg.Env["GOOSE_PROVIDER"] == ""
+		// guard just above.
+		return nil, nil
+	}
 	inspect, err := m.docker.ContainerInspect(ctx, backendRef, client.ContainerInspectOptions{})
 	if err != nil || inspect.Container.Config == nil {
 		return nil, nil

--- a/services/agent-runner/internal/sandbox/docker/environment.go
+++ b/services/agent-runner/internal/sandbox/docker/environment.go
@@ -543,6 +543,14 @@ func (m *Manager) recreateEnvironmentIfMissingEnv(ctx context.Context, backendRe
 var pacaInfraEnvKeys = []string{
 	"PACA_API_KEY", "PACA_API_URL", "PACA_GATEWAY_URL",
 	"PACA_WORKDIR", "PACA_ACTOR_USER_ID", "PACA_REPO_PLUGIN_IDS",
+	// GOOSE_PATH_ROOT is deployment-level fixed, like the PACA_API_* trio
+	// above, not conversation-scoped — included here (rather than getting
+	// its own GOOSE_PROVIDER-style one-time backfill) purely so a container
+	// created before executor.environmentGooseDataDir existed picks it up
+	// on its very next StartEnvironment call instead of staying stuck with
+	// goose's default, unpersisted session store forever. See that
+	// constant's own doc comment for the full story.
+	"GOOSE_PATH_ROOT",
 }
 
 // ensureEnvironmentInfraEnv keeps pacaInfraEnvKeys in sync with this

--- a/services/agent-runner/internal/sandbox/docker/environment_test.go
+++ b/services/agent-runner/internal/sandbox/docker/environment_test.go
@@ -204,3 +204,24 @@ func TestRecreateEnvironmentIfMissingEnv_NoopWhenCfgHasNoProvider(t *testing.T) 
 		t.Errorf("recreateEnvironmentIfMissingEnv with no cfg.Env = %+v, want nil handle", handle)
 	}
 }
+
+// TestEnsureEnvironmentInfraEnv_NoopWhenCfgHasNoEnv guards against
+// handleStartEnvironment's plain restart (whose EnvironmentConfig never
+// sets Env at all — see its own doc comment) silently wiping
+// pacaInfraEnvKeys (PACA_API_KEY, GOOSE_PATH_ROOT, etc.) from an
+// already-configured container: a nil/empty cfg.Env must be treated as
+// "nothing to reconcile", not "clear every key". Same zero-value-Manager
+// technique as TestRecreateEnvironmentIfMissingEnv_NoopWhenCfgHasNoProvider
+// just above — the guard must return before ever touching the Docker
+// client, which a nil client would panic on otherwise.
+func TestEnsureEnvironmentInfraEnv_NoopWhenCfgHasNoEnv(t *testing.T) {
+	m := &Manager{}
+
+	handle, err := m.ensureEnvironmentInfraEnv(context.Background(), "some-container-id", sandbox.EnvironmentConfig{})
+	if err != nil {
+		t.Fatalf("ensureEnvironmentInfraEnv: %v", err)
+	}
+	if handle != nil {
+		t.Errorf("ensureEnvironmentInfraEnv with no cfg.Env = %+v, want nil handle", handle)
+	}
+}

--- a/services/agent-runner/internal/sandbox/k8s/environment.go
+++ b/services/agent-runner/internal/sandbox/k8s/environment.go
@@ -503,6 +503,10 @@ func (m *Manager) ensureEnvironmentEnv(ctx context.Context, backendRef string, c
 var pacaInfraEnvKeys = []string{
 	"PACA_API_KEY", "PACA_API_URL", "PACA_GATEWAY_URL",
 	"PACA_WORKDIR", "PACA_ACTOR_USER_ID", "PACA_REPO_PLUGIN_IDS",
+	// GOOSE_PATH_ROOT — see docker/environment.go's copy of this list for
+	// why it's included here rather than getting its own GOOSE_PROVIDER-
+	// style one-time backfill.
+	"GOOSE_PATH_ROOT",
 }
 
 // ensureEnvironmentInfraEnv keeps pacaInfraEnvKeys in sync with cfg.Env on

--- a/services/agent-runner/internal/sandbox/k8s/environment.go
+++ b/services/agent-runner/internal/sandbox/k8s/environment.go
@@ -534,6 +534,20 @@ var pacaInfraEnvKeys = []string{
 // this can never silently reassign this environment's frozen LLM/agent
 // identity to whichever conversation happens to trigger the sync.
 func (m *Manager) ensureEnvironmentInfraEnv(ctx context.Context, backendRef string, cfg sandbox.EnvironmentConfig) error {
+	if len(cfg.Env) == 0 {
+		// A caller with no infra-env context at all — e.g.
+		// handleStartEnvironment's plain restart, whose EnvironmentConfig
+		// never sets Env (see its own doc comment: "restarts ... without
+		// touching" what it doesn't own) — has nothing to reconcile
+		// pacaInfraEnvKeys against. Every real attach path (coldStartEnvironment)
+		// always populates cfg.Env with at least GOOSE_PROVIDER/GOOSE_MODEL/the
+		// API key, so this only ever fires for that kind of context-free
+		// caller; treating a nil/empty cfg.Env as "clear every key" instead
+		// would strip PACA_API_KEY, GOOSE_PATH_ROOT, etc. from an
+		// already-correctly-configured Deployment on every such call. Mirrors
+		// ensureEnvironmentEnv's own cfg.Env["GOOSE_PROVIDER"] == "" guard.
+		return nil
+	}
 	depClient := m.clientset.AppsV1().Deployments(m.namespace)
 	dep, err := depClient.Get(ctx, backendRef, metav1.GetOptions{})
 	if err != nil {

--- a/services/agent-runner/internal/sandbox/k8s/environment_test.go
+++ b/services/agent-runner/internal/sandbox/k8s/environment_test.go
@@ -617,3 +617,40 @@ func TestEnsureEnvironmentEnv_NoopWhenCfgHasNoProvider(t *testing.T) {
 		t.Errorf("deployment env after ensureEnvironmentEnv with no cfg.Env = %+v, want empty", got.Spec.Template.Spec.Containers[0].Env)
 	}
 }
+
+// TestEnsureEnvironmentInfraEnv_NoopWhenCfgHasNoEnv guards against
+// handleStartEnvironment's plain restart (whose EnvironmentConfig never
+// sets Env at all — see its own doc comment) silently wiping
+// pacaInfraEnvKeys (PACA_API_KEY, GOOSE_PATH_ROOT, etc.) off an
+// already-configured Deployment: a nil/empty cfg.Env must be treated as
+// "nothing to reconcile", not "clear every key" (the staleness diff's
+// cfg.Env[key] != existing[key] would otherwise see every key as newly
+// stale and delete it). The Deployment here already carries
+// GOOSE_PATH_ROOT and PACA_API_KEY, mirroring a container this PR already
+// backfilled once; it must come back unchanged.
+func TestEnsureEnvironmentInfraEnv_NoopWhenCfgHasNoEnv(t *testing.T) {
+	const name = "paca-env-env4"
+	existing := []corev1.EnvVar{
+		{Name: "PACA_API_KEY", Value: "secret"},
+		{Name: "GOOSE_PATH_ROOT", Value: "/home/paca/workspaces/.goose"},
+	}
+	m := managerWithDeployment("paca", deploymentFixtureWithEnv(name, existing))
+
+	if err := m.ensureEnvironmentInfraEnv(context.Background(), name, sandbox.EnvironmentConfig{}); err != nil {
+		t.Fatalf("ensureEnvironmentInfraEnv: %v", err)
+	}
+
+	got, err := m.clientset.AppsV1().Deployments("paca").Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	gotEnv := got.Spec.Template.Spec.Containers[0].Env
+	if len(gotEnv) != len(existing) {
+		t.Fatalf("deployment env after ensureEnvironmentInfraEnv with no cfg.Env = %+v, want unchanged %+v", gotEnv, existing)
+	}
+	for i, ev := range existing {
+		if gotEnv[i] != ev {
+			t.Errorf("deployment env[%d] after ensureEnvironmentInfraEnv with no cfg.Env = %+v, want unchanged %+v", i, gotEnv[i], ev)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replies to an environment-backed agent conversation were silently losing all prior context. Root cause: Goose's own session database (`~/.local/share/goose/sessions/sessions.db`) lives outside the environment's persisted `/home/paca/workspaces` volume, so whenever the idle reaper stopped an environment and it got recreated on the next attach, `session/load` 404'd ("Session not found") and the code's documented fallback silently minted a brand-new, context-free Goose session instead.

Reproduced directly against conversation `8b325e33-567f-46d5-8224-8df899429036`:

```
12:35:06 reaping idle environment environment_id=8c2fc6d5-...
13:03:15 WARN failed to resume stored acp session, starting a fresh session
         error="acp: session/load: Resource not found: Session not found: 20260826_2"
```

## Fix

Point `GOOSE_PATH_ROOT` (verified empirically — it relocates Goose's entire config/data/state tree, including `sessions.db`) at a dot-folder inside the already-persisted `/home/paca/workspaces` volume for every environment container, so Goose's session history now survives container recreation:

- `executor.go`: new `environmentGooseDataDir` constant, set into every environment container's env in `coldStartEnvironment`
- `docker/environment.go`, `k8s/environment.go`: added `GOOSE_PATH_ROOT` to `pacaInfraEnvKeys`, the existing mechanism that recreates an already-running environment container once to backfill a newly-required env var — so environments created before this fix pick it up automatically on their next attach, no manual recreation needed

Note: the first attach after this ships still triggers one backfill recreate, so that one transition loses history same as before — after that, resumes survive idle-reap cycles correctly.

## Type of Change

- Bug fix

## Checklist

- The change is focused and scoped.
- Related documentation is updated.
- New structure or direction is explained clearly.
- I avoided unnecessary detail or premature abstraction.
