### PR TITLE
feat: ensure last_active_at is updated on environment start and restart to prevent premature stopping

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -34,3 +34,4 @@ bun --bun run check
 - Routing uses TanStack file-based routes in `src/routes`.
 - Shared app shell is defined in `src/routes/__root.tsx`.
 - ShadCN primitives are in `src/components/ui`.
+- Keeping a page's data fresh: use `services/realtime` (Socket.IO), not `refetchInterval`/`setInterval` polling. See [`src/hooks/use-project-realtime.ts`](src/hooks/use-project-realtime.ts) for the pattern and [`docs/architecture/service-boundaries.md`](../../docs/architecture/service-boundaries.md#convention-real-time-events-over-polling) for the convention and its narrow exceptions (heartbeats, dropped-message safety nets).

--- a/apps/web/src/components/projects/environments/environment-detail.tsx
+++ b/apps/web/src/components/projects/environments/environment-detail.tsx
@@ -84,6 +84,7 @@ type Tab = "overview" | "folders" | "portForwards";
 
 const TRANSITIONAL_STATUSES: EnvironmentStatus[] = [
 	"creating",
+	"starting",
 	"stopping",
 	"deleting",
 ];

--- a/apps/web/src/components/projects/environments/environment-detail.tsx
+++ b/apps/web/src/components/projects/environments/environment-detail.tsx
@@ -957,6 +957,7 @@ export function EnvironmentDetailView({
 								<EnvironmentStatusLine
 									environment={environment}
 									hasActiveSshSession={usage.hasActiveSshSession}
+									showDot={environment.status === "running"}
 								/>
 							</div>
 						</div>

--- a/apps/web/src/components/projects/environments/environment-status-ring.tsx
+++ b/apps/web/src/components/projects/environments/environment-status-ring.tsx
@@ -170,10 +170,15 @@ export function EnvironmentStatusRing({
 export function EnvironmentStatusLine({
 	environment,
 	showBackendBadge = true,
+	showDot = true,
 	hasActiveSshSession = false,
 }: {
 	environment: Environment;
 	showBackendBadge?: boolean;
+	// When false, the dot is omitted entirely (not just hidden) so it
+	// leaves no gap behind — the row's own gap-1.5 only applies between
+	// rendered children, not around a hidden-but-present one.
+	showDot?: boolean;
 	// See EnvironmentStatusRing's identically-named prop doc comment.
 	hasActiveSshSession?: boolean;
 }) {
@@ -185,13 +190,18 @@ export function EnvironmentStatusLine({
 
 	return (
 		<div className="flex items-center gap-1.5 flex-wrap">
-			<span
-				className={cn(
-					"size-2 rounded-full",
-					isRunning && "animate-pulse",
-					ENVIRONMENT_STATUS_COLORS[environment.status].replace("text-", "bg-"),
-				)}
-			/>
+			{showDot && (
+				<span
+					className={cn(
+						"size-2 rounded-full",
+						isRunning && "animate-pulse",
+						ENVIRONMENT_STATUS_COLORS[environment.status].replace(
+							"text-",
+							"bg-",
+						),
+					)}
+				/>
+			)}
 			<span
 				className={cn(
 					"text-sm font-medium",

--- a/apps/web/src/components/projects/environments/environment-status-ring.tsx
+++ b/apps/web/src/components/projects/environments/environment-status-ring.tsx
@@ -29,12 +29,13 @@ const RADIUS = 21;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 // How often the ring/expiry text recomputes from the already-fetched
-// last_active_at — a local tick, not a refetch. environmentQueryOptions
-// only polls while a status is transitional (see that file's own doc
-// comment), so a long-sitting "running" environment's last_active_at is
-// otherwise never re-read; this just needs *something* to force a
-// re-render periodically so the ring/text visibly move over a session left
-// open, not to fetch fresher data.
+// last_active_at — a local tick, not a refetch. Nothing pushes a fresh
+// last_active_at for a long-sitting "running" environment on its own (no
+// realtime event fires just from time passing — only an actual heartbeat or
+// status change does, see environment-api.ts and use-project-realtime.ts),
+// so this just needs *something* to force a re-render periodically so the
+// ring/text visibly move over a session left open, not to fetch fresher
+// data.
 const TICK_MS = 30_000;
 
 // hasActiveSshSession comes from the live stats stream (see

--- a/apps/web/src/hooks/use-project-realtime.test.tsx
+++ b/apps/web/src/hooks/use-project-realtime.test.tsx
@@ -122,6 +122,21 @@ describe("useProjectRealtime", () => {
 		});
 	});
 
+	it("invalidates environments query key on environment.status_changed events", () => {
+		renderHook(() => useProjectRealtime("proj-abc"));
+
+		const [, listener] = mocks.socket.on.mock.calls[0] as [
+			string,
+			(event: { type: string; payload: Record<string, unknown> }) => void,
+		];
+
+		listener({ type: "environment.status_changed", payload: {} });
+
+		expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["projects", "proj-abc", "environments"],
+		});
+	});
+
 	it("invalidates workflows and tasks query keys on workflow.* events", () => {
 		renderHook(() => useProjectRealtime("proj-abc"));
 

--- a/apps/web/src/hooks/use-project-realtime.ts
+++ b/apps/web/src/hooks/use-project-realtime.ts
@@ -48,6 +48,12 @@
 //                  off "tasks" rather than "workflows", plus the
 //                  workflow.assigned bonus case — the automation engine
 //                  reassigning a task should refresh that task's data too).
+// environment.status_changed → invalidate ["projects", projectId,
+//                  "environments"] (covers both environmentsQueryOptions,
+//                  the list, and environmentQueryOptions, the per-id detail
+//                  query, since both hang off this shared prefix). Replaces
+//                  environment-api.ts's old fixed-interval polling while an
+//                  environment was creating/starting/stopping.
 //
 // More granular invalidations (e.g. specific taskId) are avoided intentionally:
 // the event payload fields are not yet stabilised and broad invalidation is
@@ -134,6 +140,13 @@ export function useProjectRealtime(projectId: string | undefined): void {
 				});
 				void queryClient.invalidateQueries({
 					queryKey: ["projects", currentProjectId, "tasks"],
+				});
+				return;
+			}
+
+			if (type.startsWith("environment.")) {
+				void queryClient.invalidateQueries({
+					queryKey: ["projects", currentProjectId, "environments"],
 				});
 				return;
 			}

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "Creating",
+			"starting": "Starting",
 			"running": "Running",
 			"stopping": "Stopping",
 			"stopped": "Stopped",

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "Creando",
+			"starting": "Iniciando",
 			"running": "En ejecución",
 			"stopping": "Deteniendo",
 			"stopped": "Detenido",

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "Création",
+			"starting": "Démarrage en cours",
 			"running": "En cours d'exécution",
 			"stopping": "Arrêt en cours",
 			"stopped": "Arrêté",

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "作成中",
+			"starting": "起動中",
 			"running": "実行中",
 			"stopping": "停止中",
 			"stopped": "停止済み",

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "생성 중",
+			"starting": "시작 중",
 			"running": "실행 중",
 			"stopping": "중지 중",
 			"stopped": "중지됨",

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "Criando",
+			"starting": "Iniciando",
 			"running": "Em execução",
 			"stopping": "Parando",
 			"stopped": "Parado",

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -352,6 +352,7 @@
 	"environments": {
 		"status": {
 			"creating": "Создание",
+			"starting": "Запуск",
 			"running": "Работает",
 			"stopping": "Остановка",
 			"stopped": "Остановлено",

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "Đang tạo",
+			"starting": "Đang khởi động",
 			"running": "Đang chạy",
 			"stopping": "Đang dừng",
 			"stopped": "Đã dừng",

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -342,6 +342,7 @@
 	"environments": {
 		"status": {
 			"creating": "创建中",
+			"starting": "启动中",
 			"running": "运行中",
 			"stopping": "停止中",
 			"stopped": "已停止",

--- a/apps/web/src/lib/environment-api.ts
+++ b/apps/web/src/lib/environment-api.ts
@@ -449,7 +449,9 @@ export const environmentsQueryOptions = (projectId: string) =>
 
 // No refetchInterval: kept live via useProjectRealtime's socket-driven
 // invalidation on "environment.status_changed" instead of polling while the
-// environment is in a transitional status (creating/starting/stopping).
+// environment is in a transitional status (creating/starting/stopping) —
+// same posture as every other socket-covered query in this app (tasks,
+// docs, sprints, ...), none of which keep a fallback poll either.
 export const environmentQueryOptions = (
 	projectId: string,
 	environmentId: string,

--- a/apps/web/src/lib/environment-api.ts
+++ b/apps/web/src/lib/environment-api.ts
@@ -11,6 +11,11 @@ import type { SuccessEnvelope } from "./api-error";
 
 export type EnvironmentStatus =
 	| "creating"
+	// Set immediately after StartEnvironment queues a start command,
+	// before the async consumer has actually asked agent-runner to start
+	// the backing container/Pod — see environmentdom.StatusStarting's own
+	// doc comment on the Go side.
+	| "starting"
 	| "running"
 	| "stopping"
 	| "stopped"
@@ -127,6 +132,7 @@ export interface EnvironmentPortForward {
 // realtime wiring exists for environments in Phase 1).
 const TRANSITIONAL_ENVIRONMENT_STATUSES = new Set<EnvironmentStatus>([
 	"creating",
+	"starting",
 	"stopping",
 	"deleting",
 ]);
@@ -543,6 +549,7 @@ export const environmentPortForwardsQueryOptions = (
 // shown to a user goes through translation instead of staying English-only.
 export const ENVIRONMENT_STATUS_COLORS: Record<EnvironmentStatus, string> = {
 	creating: "text-amber-500",
+	starting: "text-amber-500",
 	running: "text-emerald-500",
 	stopping: "text-amber-500",
 	stopped: "text-muted-foreground",

--- a/apps/web/src/lib/environment-api.ts
+++ b/apps/web/src/lib/environment-api.ts
@@ -1,4 +1,4 @@
-import { type Query, queryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { apiClient } from "./api-client";
 import type { SuccessEnvelope } from "./api-error";
 
@@ -125,19 +125,6 @@ export interface EnvironmentPortForward {
 	host_port: number | null;
 	created_at: string;
 }
-
-// Statuses an environment only passes through transiently on its way to a
-// stable state — while in one of these, environmentQueryOptions polls (see
-// below) instead of waiting for a manual refresh or a socket event (no
-// realtime wiring exists for environments in Phase 1).
-const TRANSITIONAL_ENVIRONMENT_STATUSES = new Set<EnvironmentStatus>([
-	"creating",
-	"starting",
-	"stopping",
-	"deleting",
-]);
-
-const ENVIRONMENT_POLL_INTERVAL_MS = 2_000;
 
 // ── Environments ──────────────────────────────────────────────────────────────
 
@@ -460,11 +447,9 @@ export const environmentsQueryOptions = (projectId: string) =>
 		queryFn: () => listEnvironments(projectId),
 	});
 
-// Polls every ENVIRONMENT_POLL_INTERVAL_MS while the environment is in a
-// transitional status (creating/stopping/deleting) — no realtime socket
-// wiring exists for environment status changes in Phase 1, so this is the
-// only way the UI learns a transition finished. Stops polling once the
-// status settles into a stable one (running/stopped/suspended/error).
+// No refetchInterval: kept live via useProjectRealtime's socket-driven
+// invalidation on "environment.status_changed" instead of polling while the
+// environment is in a transitional status (creating/starting/stopping).
 export const environmentQueryOptions = (
 	projectId: string,
 	environmentId: string,
@@ -472,12 +457,6 @@ export const environmentQueryOptions = (
 	queryOptions({
 		queryKey: ["projects", projectId, "environments", environmentId],
 		queryFn: () => getEnvironment(projectId, environmentId),
-		refetchInterval: (query: Query<Environment>) => {
-			const status = query.state.data?.status;
-			return status && TRANSITIONAL_ENVIRONMENT_STATUSES.has(status)
-				? ENVIRONMENT_POLL_INTERVAL_MS
-				: false;
-		},
 	});
 
 // environmentBrowseQueryOptions is keyed by path (undefined path collapses

--- a/apps/web/src/routes/_authenticated/projects/$projectId/environments/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/environments/index.tsx
@@ -148,15 +148,17 @@ function EnvironmentsPage() {
 									</Badge>
 								</div>
 								<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-									<span
-										className={cn(
-											"size-1.5 rounded-full",
-											ENVIRONMENT_STATUS_COLORS[env.status].replace(
-												"text-",
-												"bg-",
-											),
-										)}
-									/>
+									{env.status === "running" && (
+										<span
+											className={cn(
+												"size-1.5 rounded-full",
+												ENVIRONMENT_STATUS_COLORS[env.status].replace(
+													"text-",
+													"bg-",
+												),
+											)}
+										/>
+									)}
 									<span className={ENVIRONMENT_STATUS_COLORS[env.status]}>
 										{t(`environments.status.${env.status}`)}
 									</span>

--- a/docs/architecture/service-boundaries.md
+++ b/docs/architecture/service-boundaries.md
@@ -82,3 +82,20 @@ Concerns:
 ## Boundary Rule
 
 Keep ownership clear. `services/api` owns business rules and most durable state transitions. `services/realtime` only delivers live updates derived from API-owned events. `agent_conversations`/`agent_conversation_events` are a deliberate exception to "only `services/api` writes to the database": `services/api` creates the initial conversation row and publishes the trigger, then `services/agent-runner` writes status transitions and every event directly for the rest of that conversation's lifetime, rather than proxying each one through `services/api` — a round-trip per event would add latency with no ownership benefit, since `agent-runner` is the only thing that knows a given event happened as it happens. Shared code stays inside the owning runtime until duplication is real and proven.
+
+## Convention: real-time events over polling
+
+If a page needs to reflect state that can change from outside the current tab — another user's edit, an async worker finishing, a background job — wire a `services/realtime` event for it. Do not fall back to `refetchInterval` or a `setInterval` re-fetch loop as the way a page learns data changed; a fixed-interval poll wastes requests on every tick where nothing changed and still lags reality by up to the interval on the one tick where something did.
+
+The established pattern, followed throughout `apps/web`:
+
+1. `services/api` publishes a domain event to the `paca.events` Valkey Pub/Sub channel (`internal/platform/messaging.Publisher.Publish`) at the point a state transition is persisted — see `internal/events/topics.go` for the topic namespace convention (`<domain>.<verb>`, e.g. `sprint.updated`, `environment.status_changed`).
+2. `services/realtime` routes the event to a permission-gated, namespace-scoped Socket.IO room (`internal/permissions.ts`'s `NAMESPACE_PERMISSIONS`/`eventNamespace`, `internal/subscriber.ts`).
+3. `apps/web`'s `useProjectRealtime` hook (`src/hooks/use-project-realtime.ts`) listens on the shared project socket and invalidates the affected React Query cache keys — no bespoke socket listener per component.
+
+Adding a new event type touches all three layers; `environment.status_changed` (added alongside this convention note, replacing a 2-second `refetchInterval` that used to poll `GET .../environments/:id` while an environment was creating/starting/stopping) is a template to copy.
+
+Narrow exceptions that are *not* polling-for-data and should stay as-is:
+
+- **Heartbeats** — a client telling the server "I'm still here" to keep an idle timer from expiring (`heartbeatConversation`, `environment-terminal.tsx`'s `heartbeatTimer`). This is the client pushing liveness, not the client pulling for fresh data.
+- **Dropped-message safety nets** — a long-running, high-stakes view (an in-flight agent conversation) may keep a low-frequency reconciliation tick *in addition to* its real-time listener, purely to self-heal from an occasional missed socket message, not as the primary way it learns about changes (see `conversation-view.tsx`'s `CONVERSATION_RECONCILE_INTERVAL_MS`). If you add one of these, comment it as a safety net explicitly, and make sure a real-time listener already covers the common case first.

--- a/services/api/internal/bootstrap/app.go
+++ b/services/api/internal/bootstrap/app.go
@@ -67,6 +67,7 @@ type App struct {
 	docActivityConsumer  *worker.DocActivityConsumer
 	notificationConsumer *worker.NotificationConsumer
 	pluginEventConsumer  *worker.PluginEventConsumer
+	environmentConsumer  *worker.EnvironmentCommandConsumer
 	automationConsumer   *worker.AutomationConsumer
 	dueDateScheduler     *worker.DueDateScheduler
 	cronScheduler        *worker.CronScheduler
@@ -166,7 +167,8 @@ func New(cfg *config.Config) (*App, error) {
 	// surface. agentService.WithEnvironmentService below wires it into
 	// CreateAgent/UpdateAgent's default_environment_id validation and
 	// StartChatSession/StartGlobalChatSession's environment-attach flow.
-	environmentService := environmentsvc.New(environmentRepo, cfg.AIAgentURL, cfg.AIAgentInternalKey)
+	environmentService := environmentsvc.New(environmentRepo, cfg.AIAgentURL, cfg.AIAgentInternalKey).
+		WithPublisher(publisher)
 	agentService = agentService.WithEnvironmentService(environmentService)
 	settingsService := settingssvc.New(settingsRepo)
 	if cfg.Security.EncryptionKey != "" {
@@ -199,6 +201,7 @@ func New(cfg *config.Config) (*App, error) {
 	notificationConsumer := worker.NewNotificationConsumer(redisClient, notificationService, log, projectRepo, agentService).
 		WithActivityRecorder(activityService)
 	activityConsumer := worker.NewActivityConsumer(redisClient, activityRepo, projectRepo, log)
+	environmentConsumer := worker.NewEnvironmentCommandConsumer(redisClient, environmentService, log)
 	docService := docsvc.New(docRepo, projectRepo)
 	docActivityService := docsvc.NewActivityService(docRepo, projectRepo, publisher).
 		WithNotificationService(notificationService)
@@ -452,7 +455,7 @@ func New(cfg *config.Config) (*App, error) {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	return &App{server: srv, publisher: publisher, activityConsumer: activityConsumer, docActivityConsumer: docActivityConsumer, notificationConsumer: notificationConsumer, pluginEventConsumer: pluginEventConsumer, automationConsumer: automationConsumer, dueDateScheduler: dueDateScheduler, cronScheduler: cronScheduler, waitScheduler: waitScheduler, log: log}, nil
+	return &App{server: srv, publisher: publisher, activityConsumer: activityConsumer, docActivityConsumer: docActivityConsumer, notificationConsumer: notificationConsumer, pluginEventConsumer: pluginEventConsumer, environmentConsumer: environmentConsumer, automationConsumer: automationConsumer, dueDateScheduler: dueDateScheduler, cronScheduler: cronScheduler, waitScheduler: waitScheduler, log: log}, nil
 }
 
 // Run starts the activity consumers and the HTTP server.
@@ -463,6 +466,7 @@ func (a *App) Run() error {
 	a.docActivityConsumer.Start(context.Background())
 	a.notificationConsumer.Start(context.Background())
 	a.pluginEventConsumer.Start(context.Background())
+	a.environmentConsumer.Start(context.Background())
 	a.automationConsumer.Start(context.Background())
 	a.dueDateScheduler.Start(context.Background())
 	a.cronScheduler.Start(context.Background())
@@ -477,6 +481,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	a.docActivityConsumer.Stop()
 	a.notificationConsumer.Stop()
 	a.pluginEventConsumer.Stop()
+	a.environmentConsumer.Stop()
 	a.automationConsumer.Stop()
 	a.dueDateScheduler.Stop()
 	a.cronScheduler.Stop()

--- a/services/api/internal/domain/environment/entity.go
+++ b/services/api/internal/domain/environment/entity.go
@@ -13,7 +13,13 @@ import (
 // Status values an Environment can be in. Mirrors the environments.status
 // CHECK constraint (migration 000042_add_environments.sql) exactly.
 const (
-	StatusCreating  = "creating"
+	StatusCreating = "creating"
+	// StatusStarting is set immediately after StartEnvironment queues a
+	// start command onto StreamEnvironmentCommands, before
+	// worker.EnvironmentCommandConsumer has actually asked agent-runner to
+	// start the backing container/Pod — see StartEnvironment's own doc
+	// comment for why that call happens off the request path.
+	StatusStarting  = "starting"
 	StatusRunning   = "running"
 	StatusStopping  = "stopping"
 	StatusStopped   = "stopped"

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -210,10 +210,19 @@ const (
 	TopicAutomationAPITriggerFired = "automation.api_trigger.fired"
 
 	// --- Environment lifecycle events ---------------------------------------
+	// TopicEnvironmentCreate is StreamEnvironmentCommands' event type for a
+	// queued environmentsvc.Service.CreateEnvironment execution, consumed
+	// by worker.EnvironmentCommandConsumer.
+	TopicEnvironmentCreate = "environment.create"
 	// TopicEnvironmentStart is StreamEnvironmentCommands' event type for a
 	// queued environmentsvc.Service.StartEnvironment execution, consumed by
 	// worker.EnvironmentCommandConsumer.
 	TopicEnvironmentStart = "environment.start"
+	// TopicEnvironmentStop is StreamEnvironmentCommands' event type for a
+	// queued environmentsvc.Service.StopEnvironment execution — same
+	// deferred-execution shape as TopicEnvironmentStart, for the same
+	// reason (see StopEnvironment's own doc comment).
+	TopicEnvironmentStop = "environment.stop"
 )
 
 // Streams for AI Agent pipeline.

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -223,6 +223,15 @@ const (
 	// deferred-execution shape as TopicEnvironmentStart, for the same
 	// reason (see StopEnvironment's own doc comment).
 	TopicEnvironmentStop = "environment.stop"
+	// TopicEnvironmentStatusChanged is published directly to ChannelRealtime
+	// by environmentsvc.Service whenever an environment's status changes
+	// (e.g. creating -> running, running -> stopping -> stopped, or ->
+	// error) — consumed by services/realtime and fanned out to clients
+	// viewing that project's environments. Replaces the frontend's old
+	// fixed-interval polling of GET .../environments/:id while a
+	// transition was in flight (see environment-api.ts's
+	// TRANSITIONAL_ENVIRONMENT_STATUSES, now removed).
+	TopicEnvironmentStatusChanged = "environment.status_changed"
 )
 
 // Streams for AI Agent pipeline.

--- a/services/api/internal/events/topics.go
+++ b/services/api/internal/events/topics.go
@@ -67,6 +67,15 @@ const StreamPluginTriggerEvents = "paca.plugin_trigger_events"
 // worker.AutomationConsumer.handleSprintActivity.
 const StreamSprintActivities = "paca.sprint_activities"
 
+// StreamEnvironmentCommands is the Valkey Stream key environmentsvc.Service
+// appends to when queuing a static environment's own slow lifecycle
+// operations to run asynchronously instead of on the request path —
+// worker.EnvironmentCommandConsumer reads it and does the actual
+// agent-runner call. Added for StartEnvironment specifically: starting a
+// real container/Pod can take longer than an HTTP request from a browser
+// should have to stay open for.
+const StreamEnvironmentCommands = "paca.environment_commands"
+
 // Event type constants used in both Pub/Sub messages and Stream entries.
 const (
 	// --- Auth events --------------------------------------------------------
@@ -199,6 +208,12 @@ const (
 	// StreamAutomationExternalTriggers by the webhook receiver handler once
 	// a POST's token has been verified.
 	TopicAutomationAPITriggerFired = "automation.api_trigger.fired"
+
+	// --- Environment lifecycle events ---------------------------------------
+	// TopicEnvironmentStart is StreamEnvironmentCommands' event type for a
+	// queued environmentsvc.Service.StartEnvironment execution, consumed by
+	// worker.EnvironmentCommandConsumer.
+	TopicEnvironmentStart = "environment.start"
 )
 
 // Streams for AI Agent pipeline.

--- a/services/api/internal/service/environment/environment_service.go
+++ b/services/api/internal/service/environment/environment_service.go
@@ -319,6 +319,16 @@ func (s *Service) ExecuteCreate(ctx context.Context, environmentID uuid.UUID) er
 	if err != nil {
 		return err
 	}
+	if env.Status != environmentdom.StatusCreating {
+		// A stale replay of an already-superseded command — e.g. this
+		// message's ack failed and worker.EnvironmentCommandConsumer's
+		// processPending redelivered it from the PEL after a later action
+		// already moved the row past StatusCreating. Nothing to do: acting
+		// on it now would call agent-runner's create endpoint a second time
+		// against a row it (or a retry of CreateEnvironment) has already
+		// resolved one way or the other.
+		return nil
+	}
 
 	secretKeyPlain, err := s.decryptSecret(env.SecretKeyEncrypted)
 	if err != nil {
@@ -349,6 +359,19 @@ func (s *Service) ExecuteCreate(ctx context.Context, environmentID uuid.UUID) er
 
 	if err := s.repo.UpdateEnvironmentProvisioning(ctx, env.ID,
 		environmentdom.StatusRunning, respBody.Backend, respBody.BackendRef, respBody.VolumeRef); err != nil {
+		// agent-runner has already provisioned the container/Pod and volume
+		// by this point — leaving the row at StatusCreating here would
+		// strand it forever: StartEnvironment/StopEnvironment both reject
+		// anything that isn't Stopped/Suspended/Error/Running, and the idle
+		// reaper only ever looks at StatusRunning rows, so nothing would
+		// notice or recover it. Mark StatusError instead so it's at least
+		// visible: BackendRef/VolumeRef are still lost (this same write is
+		// what would have persisted them), so the freshly-provisioned
+		// container/Pod and volume are orphaned on agent-runner's side —
+		// a known gap, not solved here — but the row itself no longer sits
+		// invisibly stuck.
+		errMsg := fmt.Sprintf("persist environment provisioning: %s", err)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("persist environment provisioning: %w", err)
 	}
 	s.publishStatusChanged(ctx, env.ProjectID, env.ID, environmentdom.StatusRunning, nil)
@@ -416,13 +439,28 @@ func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID
 		return nil, fmt.Errorf("environment %s has never been provisioned (no volume_ref)", env.ID)
 	}
 
+	// Status set BEFORE queuing, not after: worker.EnvironmentCommandConsumer
+	// can pick up and finish the command as soon as it's queued — if the
+	// order were reversed, a fast enough worker could persist StatusRunning
+	// before this request's own StatusStarting write ran, and that write
+	// would then silently overwrite it back to StatusStarting, permanently
+	// (nothing else would ever move it off StatusStarting again). Queuing
+	// second means a failure there is reported as StatusError instead —
+	// see the fallback below — rather than corrupting a state a concurrent
+	// worker has already legitimately advanced past.
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStarting, nil, nil); err != nil {
+		return nil, err
+	}
 	if err := s.publisher.Append(ctx, events.StreamEnvironmentCommands, events.TopicEnvironmentStart, map[string]any{
 		"environment_id": env.ID.String(),
 	}); err != nil {
+		// Nothing will ever execute this start now — leaving the row at
+		// StatusStarting (just persisted above) would strand it there
+		// forever the same way an unhandled queue failure would elsewhere
+		// in this file (see CreateEnvironment's identical fallback).
+		errMsg := fmt.Sprintf("queue environment start: %s", err)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return nil, fmt.Errorf("queue environment start: %w", err)
-	}
-	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStarting, nil, nil); err != nil {
-		return nil, err
 	}
 	env.Status = environmentdom.StatusStarting
 	env.ErrorMessage = nil
@@ -451,6 +489,17 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 	env, err := s.repo.FindEnvironmentByID(ctx, environmentID)
 	if err != nil {
 		return err
+	}
+	if env.Status != environmentdom.StatusStarting {
+		// A stale replay of an already-superseded command (its ack failed
+		// and processPending redelivered it from the PEL after a later
+		// action already moved the row past StatusStarting) — most
+		// importantly, the user may have since stopped this environment on
+		// purpose; blindly calling agent-runner's /start here would start
+		// it back up out from under them. Whatever the current status is,
+		// it reflects a command that ran after this one queued, so this one
+		// has nothing left to do.
+		return nil
 	}
 	if env.BackendRef == nil {
 		errMsg := fmt.Sprintf("environment %s has never been provisioned (no backend_ref)", env.ID)
@@ -507,6 +556,16 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 		newBackendRef = &respBody.BackendRef
 	}
 	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
+		// agent-runner has already started the backend by this point —
+		// leaving the row at StatusStarting here would strand it forever
+		// (see StartEnvironment's identical reasoning for setting status
+		// before queuing). Mark StatusError instead: Error is one of
+		// StartEnvironment's accepted states, so the user can retry, and
+		// retrying is safe here specifically because agent-runner's /start
+		// against an already-running backend is a no-op, not a second
+		// start.
+		errMsg := fmt.Sprintf("persist running status: %s", err)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, newBackendRef, &errMsg)
 		return err
 	}
 	// Best-effort like the repo's other bookkeeping-only calls (e.g.
@@ -576,6 +635,14 @@ func (s *Service) restartEnvironmentPorts(ctx context.Context, env *environmentd
 		newBackendRef = &respBody.BackendRef
 	}
 	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
+		// agent-runner has already recreated the container/Pod with the new
+		// port bindings by this point — see ExecuteStart's identical
+		// reasoning for why a failure to persist that must not leave the
+		// row stuck on whatever transitional status it entered this
+		// function with (StatusStarting, when called from ExecuteStart's
+		// pending-restart branch).
+		errMsg := fmt.Sprintf("persist running status: %s", err)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, newBackendRef, &errMsg)
 		return nil, err
 	}
 	// Same reasoning as StartEnvironment's own call to this: best-effort,
@@ -624,13 +691,23 @@ func (s *Service) StopEnvironment(ctx context.Context, projectID, environmentID 
 		return nil, fmt.Errorf("environment %s has never been provisioned (no backend_ref)", env.ID)
 	}
 
+	// Status set BEFORE queuing — see StartEnvironment's identical reasoning
+	// for why: it closes the race where a fast worker finishes the command
+	// and persists StatusStopped before this request's own status write
+	// runs, which would otherwise silently regress it back to
+	// StatusStopping forever.
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStopping, nil, nil); err != nil {
+		return nil, err
+	}
 	if err := s.publisher.Append(ctx, events.StreamEnvironmentCommands, events.TopicEnvironmentStop, map[string]any{
 		"environment_id": env.ID.String(),
 	}); err != nil {
+		// Nothing will ever execute this stop now — see StartEnvironment's
+		// identical fallback for why this must not leave the row stranded
+		// at StatusStopping.
+		errMsg := fmt.Sprintf("queue environment stop: %s", err)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return nil, fmt.Errorf("queue environment stop: %w", err)
-	}
-	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStopping, nil, nil); err != nil {
-		return nil, err
 	}
 	env.Status = environmentdom.StatusStopping
 	env.ErrorMessage = nil
@@ -649,6 +726,14 @@ func (s *Service) ExecuteStop(ctx context.Context, environmentID uuid.UUID) erro
 	if err != nil {
 		return err
 	}
+	if env.Status != environmentdom.StatusStopping {
+		// A stale replay of an already-superseded command — see
+		// ExecuteStart's identical guard. Just as important here: the user
+		// may have since started this environment back up on purpose, and
+		// blindly calling agent-runner's /stop would kill it out from under
+		// them.
+		return nil
+	}
 	if env.BackendRef == nil {
 		errMsg := fmt.Sprintf("environment %s has never been provisioned (no backend_ref)", env.ID)
 		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
@@ -661,7 +746,21 @@ func (s *Service) ExecuteStop(ctx context.Context, environmentID uuid.UUID) erro
 		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("agent-runner: stop environment: %w", err)
 	}
-	return s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStopped, nil, nil)
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStopped, nil, nil); err != nil {
+		// agent-runner has already stopped the backend by this point — see
+		// ExecuteStart's identical reasoning for why a failure to persist
+		// that must not leave the row stuck at StatusStopping forever.
+		// StopEnvironment itself only accepts a StatusRunning row, so a
+		// stranded StatusStopping row couldn't be retried via Stop anyway
+		// (the backend isn't running to stop) — but StartEnvironment does
+		// accept StatusError, and starting an already-stopped backend is
+		// exactly what that action does, so marking Error still leaves the
+		// user a working recovery path.
+		errMsg := fmt.Sprintf("persist stopped status: %s", err)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
+		return err
+	}
+	return nil
 }
 
 // DeleteEnvironment asks agent-runner to permanently remove the

--- a/services/api/internal/service/environment/environment_service.go
+++ b/services/api/internal/service/environment/environment_service.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	"github.com/google/uuid"
 
 	environmentdom "github.com/Paca-AI/api/internal/domain/environment"
+	"github.com/Paca-AI/api/internal/events"
 	"github.com/Paca-AI/api/internal/platform/secret"
 )
 
@@ -64,6 +66,18 @@ type Service struct {
 	aiAgentURL         string
 	aiAgentInternalKey string
 	httpClient         *http.Client
+	// publisher queues StartEnvironment's own actual agent-runner call onto
+	// StreamEnvironmentCommands instead of making it on the request path —
+	// see WithPublisher and StartEnvironment's own doc comment.
+	publisher environmentPublisher
+}
+
+// environmentPublisher is the minimal messaging.Publisher surface
+// StartEnvironment needs, narrowed to keep it mockable in tests without a
+// real Valkey connection — *messaging.Publisher satisfies this directly,
+// no adapter needed.
+type environmentPublisher interface {
+	Append(ctx context.Context, stream, eventType string, payload any) error
 }
 
 // New returns a configured Environment service.
@@ -80,6 +94,15 @@ func New(repo environmentdom.Repository, aiAgentURL, aiAgentInternalKey string) 
 // persisted secret key, mirroring agentsvc.Service.WithEncryptor.
 func (s *Service) WithEncryptor(enc *secret.Encryptor) *Service {
 	s.encryptor = enc
+	return s
+}
+
+// WithPublisher wires the shared Valkey Streams publisher StartEnvironment
+// uses to queue its own execution — see StreamEnvironmentCommands' own doc
+// comment. Required for StartEnvironment to work; every other method on
+// Service functions without it.
+func (s *Service) WithPublisher(p environmentPublisher) *Service {
+	s.publisher = p
 	return s
 }
 
@@ -273,8 +296,16 @@ func (s *Service) UpdateEnvironment(ctx context.Context, projectID, environmentI
 	return env, nil
 }
 
-// StartEnvironment asks agent-runner to restart a stopped/suspended
-// environment's existing container/Pod. No-op if already running.
+// StartEnvironment validates that environmentID is eligible to start and
+// queues the actual agent-runner call onto StreamEnvironmentCommands for
+// worker.EnvironmentCommandConsumer to execute (via ExecuteStart below) —
+// this method itself never calls agent-runner, and returns as soon as the
+// command is durably queued. That work used to happen synchronously here,
+// which meant this call's latency was however long the real container/Pod
+// took to come up; a legitimately slow start could run past the HTTP
+// server's own WriteTimeout, which the gateway then reported to the
+// caller as a 502 for an operation that was actually still succeeding
+// server-side a few seconds later. No-op if already running.
 func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID uuid.UUID) (*environmentdom.Environment, error) {
 	env, err := s.repo.FindVisibleEnvironmentInProject(ctx, projectID, environmentID)
 	if err != nil {
@@ -289,25 +320,76 @@ func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID
 	if env.BackendRef == nil {
 		return nil, fmt.Errorf("environment %s has never been provisioned (no backend_ref)", env.ID)
 	}
+	// Cheap, already-loaded-row check — kept synchronous for immediate
+	// feedback since it costs no extra I/O, unlike the agent-runner call
+	// this same precondition used to gate inline (restartEnvironmentPorts
+	// is now only reached from ExecuteStart, which re-checks this too:
+	// see its own doc comment for why).
+	if env.PortsPendingRestart && env.VolumeRef == nil {
+		return nil, fmt.Errorf("environment %s has never been provisioned (no volume_ref)", env.ID)
+	}
+
+	if err := s.publisher.Append(ctx, events.StreamEnvironmentCommands, events.TopicEnvironmentStart, map[string]any{
+		"environment_id": env.ID.String(),
+	}); err != nil {
+		return nil, fmt.Errorf("queue environment start: %w", err)
+	}
+	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStarting, nil, nil); err != nil {
+		return nil, err
+	}
+	env.Status = environmentdom.StatusStarting
+	env.ErrorMessage = nil
+	return env, nil
+}
+
+// ExecuteStart performs the actual (potentially slow) work StartEnvironment
+// used to do inline: ask agent-runner to start environmentID's backing
+// container/Pod, or — if a port forward changed while it was stopped —
+// recreate it via restartEnvironmentPorts instead, the same branch
+// StartEnvironment used to take synchronously. Called only by
+// worker.EnvironmentCommandConsumer once it reads the command
+// StartEnvironment queued. Deliberately not part of environmentdom.Service:
+// it has no projectID scoping of its own (environmentID alone identifies a
+// globally unique row) and isn't a REST operation, just this service's own
+// deferred continuation of StartEnvironment.
+//
+// Re-reads environmentID fresh rather than trusting any state captured
+// when the command was queued, since an environment can be stopped,
+// deleted, or have its ports changed again in the time between queuing
+// and execution — and re-validates BackendRef/VolumeRef even though
+// StartEnvironment already checked them, since a nil pointer here would
+// otherwise panic this goroutine rather than fail the one environment
+// being started.
+func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) error {
+	env, err := s.repo.FindEnvironmentByID(ctx, environmentID)
+	if err != nil {
+		return err
+	}
+	if env.BackendRef == nil {
+		errMsg := fmt.Sprintf("environment %s has never been provisioned (no backend_ref)", env.ID)
+		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		return errors.New(errMsg)
+	}
 
 	if env.PortsPendingRestart {
-		// A port forward was added/removed since this environment's ports
-		// were last applied — a plain /start would leave the container's
-		// bindings stale (it never recreates anything), so this applies
-		// the current full set instead, the same call the explicit
-		// RestartEnvironment action makes. Safe to do here rather than
-		// just plain-starting: the environment isn't serving live traffic
-		// yet in any of the three states this branch is reachable from
-		// (stopped/suspended/error), so there's nothing to interrupt.
+		// See StartEnvironment's identical comment on this branch: applying
+		// the environment's current full port-mapping set is safe here
+		// rather than just plain-starting, since nothing is serving live
+		// traffic yet.
 		if env.VolumeRef == nil {
-			return nil, fmt.Errorf("environment %s has never been provisioned (no volume_ref)", env.ID)
+			errMsg := fmt.Sprintf("environment %s has never been provisioned (no volume_ref)", env.ID)
+			_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+			return errors.New(errMsg)
 		}
-		return s.restartEnvironmentPorts(ctx, env)
+		_, err := s.restartEnvironmentPorts(ctx, env)
+		return err
 	}
 
 	secretKeyPlain, err := s.decryptSecret(env.SecretKeyEncrypted)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt environment secret key: %w", err)
+		errMsg := fmt.Sprintf("decrypt environment secret key: %s", err)
+		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		return fmt.Errorf("decrypt environment secret key: %w", err)
 	}
 	reqBody := internalStartEnvironmentRequest{
 		BackendRef:    *env.BackendRef,
@@ -325,7 +407,7 @@ func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments/"+env.ID.String()+"/start", reqBody, &respBody); err != nil {
 		errMsg := err.Error()
 		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
-		return nil, fmt.Errorf("agent-runner: start environment: %w", err)
+		return fmt.Errorf("agent-runner: start environment: %w", err)
 	}
 
 	// respBody.BackendRef is only non-empty when agent-runner had to
@@ -338,26 +420,16 @@ func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID
 		newBackendRef = &respBody.BackendRef
 	}
 	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
-		return nil, err
+		return err
 	}
-	// Without this, a freshly-started environment can still have a stale
-	// last_active_at from long before it was stopped — the idle reaper's
-	// next tick (cmd/agent-runner/main.go's reapIdleEnvironments, up to a
-	// minute later) would then see status=running with an old
-	// last_active_at and immediately stop it again, seconds after the user
-	// started it.
-	if err := s.repo.TouchEnvironment(ctx, env.ID); err != nil {
-		return nil, err
-	}
-	env.Status = environmentdom.StatusRunning
-	env.ErrorMessage = nil
-	if newBackendRef != nil {
-		env.BackendRef = newBackendRef
-	}
-	if respBody.SSHPort != 0 {
-		env.SSHPort = &respBody.SSHPort
-	}
-	return env, nil
+	// Best-effort like the repo's other bookkeeping-only calls (e.g.
+	// InvalidateMembersCache) — see StartEnvironment's superseded version
+	// of this same comment for the idle-reaper reasoning. The backend is
+	// already started and status already persisted as running by this
+	// point, so a touch failure here must not be reported as this
+	// execution having failed.
+	_ = s.repo.TouchEnvironment(ctx, env.ID)
+	return nil
 }
 
 // RestartEnvironment applies any pending port-forward changes to a
@@ -419,12 +491,11 @@ func (s *Service) restartEnvironmentPorts(ctx context.Context, env *environmentd
 	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
 		return nil, err
 	}
-	// Same reasoning as StartEnvironment's own call to this: a stale
-	// last_active_at would otherwise let the idle reaper stop the
-	// environment again within its next tick.
-	if err := s.repo.TouchEnvironment(ctx, env.ID); err != nil {
-		return nil, err
-	}
+	// Same reasoning as StartEnvironment's own call to this: best-effort,
+	// must not stop this function from clearing ports_pending_restart below
+	// (the new port bindings are already live on the backend at this
+	// point regardless of whether this bookkeeping write succeeds).
+	_ = s.repo.TouchEnvironment(ctx, env.ID)
 	if err := s.repo.SetPortsPendingRestart(ctx, env.ID, false); err != nil {
 		return nil, err
 	}

--- a/services/api/internal/service/environment/environment_service.go
+++ b/services/api/internal/service/environment/environment_service.go
@@ -68,16 +68,22 @@ type Service struct {
 	httpClient         *http.Client
 	// publisher queues StartEnvironment's own actual agent-runner call onto
 	// StreamEnvironmentCommands instead of making it on the request path —
-	// see WithPublisher and StartEnvironment's own doc comment.
+	// see WithPublisher and StartEnvironment's own doc comment. Also used
+	// to publish environment.status_changed for services/realtime — see
+	// publishStatusChanged.
 	publisher environmentPublisher
 }
 
-// environmentPublisher is the minimal messaging.Publisher surface
-// StartEnvironment needs, narrowed to keep it mockable in tests without a
-// real Valkey connection — *messaging.Publisher satisfies this directly,
-// no adapter needed.
+// environmentPublisher is the minimal messaging.Publisher surface this
+// service needs, narrowed to keep it mockable in tests without a real
+// Valkey connection — *messaging.Publisher satisfies this directly, no
+// adapter needed. Append queues a slow agent-runner call onto
+// StreamEnvironmentCommands (see WithPublisher); Publish sends the
+// lightweight environment.status_changed notification to ChannelRealtime
+// (see publishStatusChanged).
 type environmentPublisher interface {
 	Append(ctx context.Context, stream, eventType string, payload any) error
+	Publish(ctx context.Context, channel string, payload any) error
 }
 
 // New returns a configured Environment service.
@@ -104,6 +110,47 @@ func (s *Service) WithEncryptor(enc *secret.Encryptor) *Service {
 func (s *Service) WithPublisher(p environmentPublisher) *Service {
 	s.publisher = p
 	return s
+}
+
+// setStatus persists an environment's status via UpdateEnvironmentStatus and
+// publishes environment.status_changed so services/realtime can notify
+// connected clients — see publishStatusChanged. Every status transition in
+// this file goes through here (or, for ExecuteCreate's success path,
+// UpdateEnvironmentProvisioning followed by a direct publishStatusChanged
+// call) instead of calling the repo directly, so no transition is silently
+// missed.
+func (s *Service) setStatus(ctx context.Context, projectID, environmentID uuid.UUID, status string, backendRef, errMsg *string) error {
+	if err := s.repo.UpdateEnvironmentStatus(ctx, environmentID, status, backendRef, errMsg); err != nil {
+		return err
+	}
+	s.publishStatusChanged(ctx, projectID, environmentID, status, errMsg)
+	return nil
+}
+
+// publishStatusChanged sends environment.status_changed to ChannelRealtime
+// so services/realtime can fan it out to clients viewing projectID's
+// environments — the socket-driven replacement for the frontend's old
+// fixed-interval polling of GET .../environments/:id while a transition was
+// in flight. Best-effort: a missed publish just means the affected client's
+// view goes stale until its next manual action, the same posture as every
+// other service's realtime notification in this codebase (e.g.
+// sprintsvc.Service.publish).
+func (s *Service) publishStatusChanged(ctx context.Context, projectID, environmentID uuid.UUID, status string, errMsg *string) {
+	if s.publisher == nil {
+		return
+	}
+	payload := map[string]any{
+		"project_id":     projectID.String(),
+		"environment_id": environmentID.String(),
+		"status":         status,
+	}
+	if errMsg != nil {
+		payload["error_message"] = *errMsg
+	}
+	_ = s.publisher.Publish(ctx, events.ChannelRealtime, map[string]any{
+		"type":    events.TopicEnvironmentStatusChanged,
+		"payload": payload,
+	})
 }
 
 // encryptSecret/decryptSecret fall back to plaintext when no encryptor is
@@ -161,11 +208,12 @@ func (s *Service) GetEnvironment(ctx context.Context, projectID, environmentID u
 // own doc comment: provisioning a real container/Pod and volume can take
 // longer than an HTTP request should stay open for, so this method itself
 // never calls agent-runner and returns as soon as the row exists and the
-// command is durably queued. The row stays StatusCreating (already
-// TRANSITIONAL_ENVIRONMENT_STATUSES-polled on the frontend) until
+// command is durably queued. The row stays StatusCreating until
 // ExecuteCreate updates it to StatusRunning (persisting the backend/
 // backend_ref/volume_ref agent-runner reports back) or StatusError (with
-// ErrorMessage set). See environmentdom.EnvironmentService's doc comment.
+// ErrorMessage set) — either transition publishes environment.status_changed
+// (see publishStatusChanged) so the frontend learns the outcome without
+// polling. See environmentdom.EnvironmentService's doc comment.
 func (s *Service) CreateEnvironment(ctx context.Context, projectID uuid.UUID, in environmentdom.CreateEnvironmentInput) (*environmentdom.Environment, error) {
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
@@ -245,7 +293,7 @@ func (s *Service) CreateEnvironment(ctx context.Context, projectID uuid.UUID, in
 		// of surfacing the failure, the same reasoning ExecuteStart/
 		// ExecuteStop apply to their own "can't proceed" cases.
 		errMsg := fmt.Sprintf("queue environment create: %s", err)
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return nil, fmt.Errorf("queue environment create: %w", err)
 	}
 	return env, nil
@@ -275,7 +323,7 @@ func (s *Service) ExecuteCreate(ctx context.Context, environmentID uuid.UUID) er
 	secretKeyPlain, err := s.decryptSecret(env.SecretKeyEncrypted)
 	if err != nil {
 		errMsg := fmt.Sprintf("decrypt environment secret key: %s", err)
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("decrypt environment secret key: %w", err)
 	}
 
@@ -295,7 +343,7 @@ func (s *Service) ExecuteCreate(ctx context.Context, environmentID uuid.UUID) er
 	var respBody internalCreateEnvironmentResponse
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments", reqBody, &respBody); err != nil {
 		errMsg := err.Error()
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("agent-runner: create environment: %w", err)
 	}
 
@@ -303,6 +351,7 @@ func (s *Service) ExecuteCreate(ctx context.Context, environmentID uuid.UUID) er
 		environmentdom.StatusRunning, respBody.Backend, respBody.BackendRef, respBody.VolumeRef); err != nil {
 		return fmt.Errorf("persist environment provisioning: %w", err)
 	}
+	s.publishStatusChanged(ctx, env.ProjectID, env.ID, environmentdom.StatusRunning, nil)
 	return nil
 }
 
@@ -372,7 +421,7 @@ func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID
 	}); err != nil {
 		return nil, fmt.Errorf("queue environment start: %w", err)
 	}
-	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStarting, nil, nil); err != nil {
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStarting, nil, nil); err != nil {
 		return nil, err
 	}
 	env.Status = environmentdom.StatusStarting
@@ -405,7 +454,7 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 	}
 	if env.BackendRef == nil {
 		errMsg := fmt.Sprintf("environment %s has never been provisioned (no backend_ref)", env.ID)
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return errors.New(errMsg)
 	}
 
@@ -416,7 +465,7 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 		// traffic yet.
 		if env.VolumeRef == nil {
 			errMsg := fmt.Sprintf("environment %s has never been provisioned (no volume_ref)", env.ID)
-			_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+			_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 			return errors.New(errMsg)
 		}
 		_, err := s.restartEnvironmentPorts(ctx, env)
@@ -426,7 +475,7 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 	secretKeyPlain, err := s.decryptSecret(env.SecretKeyEncrypted)
 	if err != nil {
 		errMsg := fmt.Sprintf("decrypt environment secret key: %s", err)
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("decrypt environment secret key: %w", err)
 	}
 	reqBody := internalStartEnvironmentRequest{
@@ -444,7 +493,7 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 	var respBody internalStartEnvironmentResponse
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments/"+env.ID.String()+"/start", reqBody, &respBody); err != nil {
 		errMsg := err.Error()
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("agent-runner: start environment: %w", err)
 	}
 
@@ -457,7 +506,7 @@ func (s *Service) ExecuteStart(ctx context.Context, environmentID uuid.UUID) err
 	if respBody.BackendRef != "" && respBody.BackendRef != *env.BackendRef {
 		newBackendRef = &respBody.BackendRef
 	}
-	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
 		return err
 	}
 	// Best-effort like the repo's other bookkeeping-only calls (e.g.
@@ -518,7 +567,7 @@ func (s *Service) restartEnvironmentPorts(ctx context.Context, env *environmentd
 	var respBody internalRestartPortsResponse
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments/"+env.ID.String()+"/restart-ports", reqBody, &respBody); err != nil {
 		errMsg := err.Error()
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return nil, fmt.Errorf("agent-runner: restart environment ports: %w", err)
 	}
 
@@ -526,7 +575,7 @@ func (s *Service) restartEnvironmentPorts(ctx context.Context, env *environmentd
 	if respBody.BackendRef != "" && respBody.BackendRef != *env.BackendRef {
 		newBackendRef = &respBody.BackendRef
 	}
-	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
 		return nil, err
 	}
 	// Same reasoning as StartEnvironment's own call to this: best-effort,
@@ -580,7 +629,7 @@ func (s *Service) StopEnvironment(ctx context.Context, projectID, environmentID 
 	}); err != nil {
 		return nil, fmt.Errorf("queue environment stop: %w", err)
 	}
-	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStopping, nil, nil); err != nil {
+	if err := s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStopping, nil, nil); err != nil {
 		return nil, err
 	}
 	env.Status = environmentdom.StatusStopping
@@ -602,17 +651,17 @@ func (s *Service) ExecuteStop(ctx context.Context, environmentID uuid.UUID) erro
 	}
 	if env.BackendRef == nil {
 		errMsg := fmt.Sprintf("environment %s has never been provisioned (no backend_ref)", env.ID)
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return errors.New(errMsg)
 	}
 
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments/"+env.ID.String()+"/stop",
 		internalBackendRefRequest{BackendRef: *env.BackendRef}, nil); err != nil {
 		errMsg := err.Error()
-		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 		return fmt.Errorf("agent-runner: stop environment: %w", err)
 	}
-	return s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStopped, nil, nil)
+	return s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusStopped, nil, nil)
 }
 
 // DeleteEnvironment asks agent-runner to permanently remove the
@@ -634,7 +683,7 @@ func (s *Service) DeleteEnvironment(ctx context.Context, projectID, environmentI
 		if err := s.callInternal(ctx, http.MethodDelete, "/internal/environments/"+env.ID.String(),
 			internalDeleteEnvironmentRequest{BackendRef: *env.BackendRef, VolumeRef: volumeRef}, nil); err != nil {
 			errMsg := err.Error()
-			_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+			_ = s.setStatus(ctx, env.ProjectID, env.ID, environmentdom.StatusError, nil, &errMsg)
 			return fmt.Errorf("agent-runner: delete environment: %w", err)
 		}
 	}

--- a/services/api/internal/service/environment/environment_service.go
+++ b/services/api/internal/service/environment/environment_service.go
@@ -340,6 +340,15 @@ func (s *Service) StartEnvironment(ctx context.Context, projectID, environmentID
 	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
 		return nil, err
 	}
+	// Without this, a freshly-started environment can still have a stale
+	// last_active_at from long before it was stopped — the idle reaper's
+	// next tick (cmd/agent-runner/main.go's reapIdleEnvironments, up to a
+	// minute later) would then see status=running with an old
+	// last_active_at and immediately stop it again, seconds after the user
+	// started it.
+	if err := s.repo.TouchEnvironment(ctx, env.ID); err != nil {
+		return nil, err
+	}
 	env.Status = environmentdom.StatusRunning
 	env.ErrorMessage = nil
 	if newBackendRef != nil {
@@ -408,6 +417,12 @@ func (s *Service) restartEnvironmentPorts(ctx context.Context, env *environmentd
 		newBackendRef = &respBody.BackendRef
 	}
 	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusRunning, newBackendRef, nil); err != nil {
+		return nil, err
+	}
+	// Same reasoning as StartEnvironment's own call to this: a stale
+	// last_active_at would otherwise let the idle reaper stop the
+	// environment again within its next tick.
+	if err := s.repo.TouchEnvironment(ctx, env.ID); err != nil {
 		return nil, err
 	}
 	if err := s.repo.SetPortsPendingRestart(ctx, env.ID, false); err != nil {

--- a/services/api/internal/service/environment/environment_service.go
+++ b/services/api/internal/service/environment/environment_service.go
@@ -154,12 +154,18 @@ func (s *Service) GetEnvironment(ctx context.Context, projectID, environmentID u
 	return env, nil
 }
 
-// CreateEnvironment writes the environment row (status StatusCreating),
-// asks agent-runner to provision its backing container/Pod and volume, then
-// updates status to StatusRunning (persisting the backend/backend_ref/
-// volume_ref agent-runner reports back) or StatusError (with ErrorMessage
-// set) before returning. See environmentdom.EnvironmentService's doc
-// comment.
+// CreateEnvironment writes the environment row (status StatusCreating) and
+// queues the actual agent-runner provisioning call onto
+// StreamEnvironmentCommands for worker.EnvironmentCommandConsumer to
+// execute (via ExecuteCreate below) — same reasoning as StartEnvironment's
+// own doc comment: provisioning a real container/Pod and volume can take
+// longer than an HTTP request should stay open for, so this method itself
+// never calls agent-runner and returns as soon as the row exists and the
+// command is durably queued. The row stays StatusCreating (already
+// TRANSITIONAL_ENVIRONMENT_STATUSES-polled on the frontend) until
+// ExecuteCreate updates it to StatusRunning (persisting the backend/
+// backend_ref/volume_ref agent-runner reports back) or StatusError (with
+// ErrorMessage set). See environmentdom.EnvironmentService's doc comment.
 func (s *Service) CreateEnvironment(ctx context.Context, projectID uuid.UUID, in environmentdom.CreateEnvironmentInput) (*environmentdom.Environment, error) {
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
@@ -231,41 +237,73 @@ func (s *Service) CreateEnvironment(ctx context.Context, projectID uuid.UUID, in
 		return nil, fmt.Errorf("create environment row: %w", err)
 	}
 
+	if err := s.publisher.Append(ctx, events.StreamEnvironmentCommands, events.TopicEnvironmentCreate, map[string]any{
+		"environment_id": env.ID.String(),
+	}); err != nil {
+		// The row already exists but nothing will ever provision it now —
+		// leaving it StatusCreating would strand it there forever instead
+		// of surfacing the failure, the same reasoning ExecuteStart/
+		// ExecuteStop apply to their own "can't proceed" cases.
+		errMsg := fmt.Sprintf("queue environment create: %s", err)
+		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		return nil, fmt.Errorf("queue environment create: %w", err)
+	}
+	return env, nil
+}
+
+// ExecuteCreate performs the actual (potentially slow) work CreateEnvironment
+// used to do inline: ask agent-runner to provision environmentID's backing
+// container/Pod and volume, then persist the resulting backend/backend_ref/
+// volume_ref. Called only by worker.EnvironmentCommandConsumer once it
+// reads the command CreateEnvironment queued — see ExecuteStart's own doc
+// comment for why this isn't part of environmentdom.Service.
+//
+// Re-reads environmentID fresh rather than threading its input through the
+// queued command: every field CreateEnvironment resolved (name, limits,
+// image, the encrypted secret key) is already persisted on the row by the
+// time this runs, the same "the row is the source of truth, not the
+// message" approach ExecuteStart/ExecuteStop already take — notably this
+// also means the plaintext secret key never has to pass through Valkey at
+// all, only its encrypted form (already on the row) and the decryption
+// key this process already holds.
+func (s *Service) ExecuteCreate(ctx context.Context, environmentID uuid.UUID) error {
+	env, err := s.repo.FindEnvironmentByID(ctx, environmentID)
+	if err != nil {
+		return err
+	}
+
+	secretKeyPlain, err := s.decryptSecret(env.SecretKeyEncrypted)
+	if err != nil {
+		errMsg := fmt.Sprintf("decrypt environment secret key: %s", err)
+		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		return fmt.Errorf("decrypt environment secret key: %w", err)
+	}
+
 	reqBody := internalCreateEnvironmentRequest{
 		EnvironmentID: env.ID.String(),
-		ProjectID:     projectID.String(),
-		CPULimit:      cpuLimit,
-		MemoryLimit:   memoryLimit,
-		DiskLimitGB:   diskLimitGB,
-		DockerEnabled: in.DockerEnabled,
+		ProjectID:     env.ProjectID.String(),
+		CPULimit:      env.CPULimit,
+		MemoryLimit:   env.MemoryLimit,
+		DiskLimitGB:   env.DiskLimitGB,
+		DockerEnabled: env.DockerEnabled,
 		SecretKey:     secretKeyPlain,
 	}
-	if in.Image != nil {
-		reqBody.Image = *in.Image
+	if env.Image != nil {
+		reqBody.Image = *env.Image
 	}
 
 	var respBody internalCreateEnvironmentResponse
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments", reqBody, &respBody); err != nil {
 		errMsg := err.Error()
 		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
-		// The user needs to see why creation failed — not swallowed here;
-		// the row itself (now StatusError) is still visible via a
-		// subsequent GetEnvironment/ListEnvironments call.
-		return nil, fmt.Errorf("agent-runner: create environment: %w", err)
+		return fmt.Errorf("agent-runner: create environment: %w", err)
 	}
 
 	if err := s.repo.UpdateEnvironmentProvisioning(ctx, env.ID,
 		environmentdom.StatusRunning, respBody.Backend, respBody.BackendRef, respBody.VolumeRef); err != nil {
-		return nil, fmt.Errorf("persist environment provisioning: %w", err)
+		return fmt.Errorf("persist environment provisioning: %w", err)
 	}
-	env.Status = environmentdom.StatusRunning
-	env.Backend = respBody.Backend
-	env.BackendRef = &respBody.BackendRef
-	env.VolumeRef = &respBody.VolumeRef
-	if respBody.SSHPort != 0 {
-		env.SSHPort = &respBody.SSHPort
-	}
-	return env, nil
+	return nil
 }
 
 // UpdateEnvironment patches mutable environment fields (name,
@@ -514,6 +552,14 @@ func (s *Service) restartEnvironmentPorts(ctx context.Context, env *environmentd
 
 // StopEnvironment asks agent-runner to stop the environment's container/Pod
 // without deleting it or its volume. No-op if already stopped/suspended.
+// StopEnvironment validates that environmentID is eligible to stop and
+// queues the actual agent-runner call onto StreamEnvironmentCommands for
+// worker.EnvironmentCommandConsumer to execute (via ExecuteStop below) —
+// same reasoning as StartEnvironment's own doc comment: this method never
+// calls agent-runner itself, and returns as soon as the command is
+// durably queued, rather than holding the request open for however long
+// the backing container/Pod actually takes to stop. No-op if already
+// stopped/suspended.
 func (s *Service) StopEnvironment(ctx context.Context, projectID, environmentID uuid.UUID) (*environmentdom.Environment, error) {
 	env, err := s.repo.FindVisibleEnvironmentInProject(ctx, projectID, environmentID)
 	if err != nil {
@@ -529,18 +575,44 @@ func (s *Service) StopEnvironment(ctx context.Context, projectID, environmentID 
 		return nil, fmt.Errorf("environment %s has never been provisioned (no backend_ref)", env.ID)
 	}
 
+	if err := s.publisher.Append(ctx, events.StreamEnvironmentCommands, events.TopicEnvironmentStop, map[string]any{
+		"environment_id": env.ID.String(),
+	}); err != nil {
+		return nil, fmt.Errorf("queue environment stop: %w", err)
+	}
+	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStopping, nil, nil); err != nil {
+		return nil, err
+	}
+	env.Status = environmentdom.StatusStopping
+	env.ErrorMessage = nil
+	return env, nil
+}
+
+// ExecuteStop performs the actual (potentially slow) work StopEnvironment
+// used to do inline: ask agent-runner to stop environmentID's backing
+// container/Pod. Called only by worker.EnvironmentCommandConsumer once it
+// reads the command StopEnvironment queued — see ExecuteStart's own doc
+// comment for why this isn't part of environmentdom.Service, and why it
+// re-reads environmentID fresh and re-validates BackendRef rather than
+// trusting state captured when the command was queued.
+func (s *Service) ExecuteStop(ctx context.Context, environmentID uuid.UUID) error {
+	env, err := s.repo.FindEnvironmentByID(ctx, environmentID)
+	if err != nil {
+		return err
+	}
+	if env.BackendRef == nil {
+		errMsg := fmt.Sprintf("environment %s has never been provisioned (no backend_ref)", env.ID)
+		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
+		return errors.New(errMsg)
+	}
+
 	if err := s.callInternal(ctx, http.MethodPost, "/internal/environments/"+env.ID.String()+"/stop",
 		internalBackendRefRequest{BackendRef: *env.BackendRef}, nil); err != nil {
 		errMsg := err.Error()
 		_ = s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusError, nil, &errMsg)
-		return nil, fmt.Errorf("agent-runner: stop environment: %w", err)
+		return fmt.Errorf("agent-runner: stop environment: %w", err)
 	}
-	if err := s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStopped, nil, nil); err != nil {
-		return nil, err
-	}
-	env.Status = environmentdom.StatusStopped
-	env.ErrorMessage = nil
-	return env, nil
+	return s.repo.UpdateEnvironmentStatus(ctx, env.ID, environmentdom.StatusStopped, nil, nil)
 }
 
 // DeleteEnvironment asks agent-runner to permanently remove the

--- a/services/api/internal/service/environment/environment_service_test.go
+++ b/services/api/internal/service/environment/environment_service_test.go
@@ -198,12 +198,20 @@ func (m *mockRepo) FindPortForwardByID(ctx context.Context, id uuid.UUID) (*envi
 // mockPublisher is a function-field-based mock of environmentPublisher,
 // mirroring mockRepo's own style.
 type mockPublisher struct {
-	appendFn func(ctx context.Context, stream, eventType string, payload any) error
+	appendFn  func(ctx context.Context, stream, eventType string, payload any) error
+	publishFn func(ctx context.Context, channel string, payload any) error
 }
 
 func (m *mockPublisher) Append(ctx context.Context, stream, eventType string, payload any) error {
 	if m.appendFn != nil {
 		return m.appendFn(ctx, stream, eventType, payload)
+	}
+	return nil
+}
+
+func (m *mockPublisher) Publish(ctx context.Context, channel string, payload any) error {
+	if m.publishFn != nil {
+		return m.publishFn(ctx, channel, payload)
 	}
 	return nil
 }

--- a/services/api/internal/service/environment/environment_service_test.go
+++ b/services/api/internal/service/environment/environment_service_test.go
@@ -504,6 +504,82 @@ func TestExecuteCreate_AgentRunnerFailure(t *testing.T) {
 	assert.Equal(t, []string{environmentdom.StatusError}, statusUpdates)
 }
 
+// TestExecuteCreate_SkipsStaleReplay verifies ExecuteCreate does nothing —
+// no agent-runner call, no status write — when the row has already moved
+// past StatusCreating by the time it runs, e.g. a redelivered PEL entry
+// whose original ack failed after a prior run already resolved it.
+func TestExecuteCreate_SkipsStaleReplay(t *testing.T) {
+	envID := uuid.New()
+	var calledAgentRunner bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calledAgentRunner = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalCreateEnvironmentResponse{})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{ID: envID, Status: environmentdom.StatusRunning}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteCreate(context.Background(), envID)
+
+	require.NoError(t, err)
+	assert.False(t, calledAgentRunner)
+	assert.Empty(t, statusUpdates)
+}
+
+// TestExecuteCreate_ProvisioningPersistFailureMarksError verifies that when
+// agent-runner successfully provisions the environment but persisting the
+// result fails, the row is marked StatusError rather than stranded at
+// StatusCreating — which StartEnvironment/StopEnvironment would both reject
+// and the idle reaper would never select.
+func TestExecuteCreate_ProvisioningPersistFailureMarksError(t *testing.T) {
+	envID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalCreateEnvironmentResponse{
+			Backend: "docker", BackendRef: "container-123", VolumeRef: "paca-env-abc",
+		})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	var errMsgs []*string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusCreating,
+				CPULimit: "2", MemoryLimit: "4Gi", DiskLimitGB: 20,
+			}, nil
+		},
+		updateEnvironmentProvisioning: func(_ context.Context, _ uuid.UUID, _, _, _, _ string) error {
+			return errors.New("db unavailable")
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, errMsg *string) error {
+			statusUpdates = append(statusUpdates, status)
+			errMsgs = append(errMsgs, errMsg)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteCreate(context.Background(), envID)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{environmentdom.StatusError}, statusUpdates)
+	require.Len(t, errMsgs, 1)
+	require.NotNil(t, errMsgs[0])
+}
+
 // TestCreateEnvironment_CPULimitTooSmall verifies a cpu_limit override that
 // parses but falls below minCPULimitMillicores is rejected before ever
 // reaching agent-runner — no repo write, no HTTP call — rather than
@@ -780,9 +856,12 @@ func TestStartEnvironment_QueuesCommandAndSetsStarting(t *testing.T) {
 }
 
 // TestStartEnvironment_ReturnsErrorWhenPublishFails verifies a failure to
-// queue the command is reported to the caller, and never marks the
-// environment "starting" — if nothing is going to execute the start,
-// telling the user it's starting would be a lie.
+// queue the command is reported to the caller and, since status is now set
+// BEFORE queuing (closing the race where a fast worker's own StatusRunning
+// write could otherwise be regressed back to StatusStarting by this
+// request — see StartEnvironment's doc comment), marks the row StatusError
+// rather than stranding it at StatusStarting with nothing left to move it
+// forward.
 func TestStartEnvironment_ReturnsErrorWhenPublishFails(t *testing.T) {
 	envID := uuid.New()
 	backendRef := "container-1"
@@ -810,7 +889,7 @@ func TestStartEnvironment_ReturnsErrorWhenPublishFails(t *testing.T) {
 	_, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
 
 	require.Error(t, err)
-	assert.Empty(t, statusUpdates)
+	assert.Equal(t, []string{environmentdom.StatusStarting, environmentdom.StatusError}, statusUpdates)
 }
 
 // TestStartEnvironment_RejectsPendingRestartWithNoVolumeRef verifies the
@@ -1025,6 +1104,89 @@ func TestExecuteStart_RestartsPortsWhenPending_ClearsPendingWhenTouchFails(t *te
 	assert.False(t, *pendingSet)
 }
 
+// TestExecuteStart_SkipsStaleReplay verifies ExecuteStart does nothing —
+// no agent-runner call, no status write — when the row is no longer
+// StatusStarting by the time it runs. This is the case that matters most:
+// a redelivered "start" command must not restart an environment the user
+// has since deliberately stopped (status would be StatusStopped/
+// StatusStopping by then, not StatusStarting).
+func TestExecuteStart_SkipsStaleReplay(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	var calledAgentRunner bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calledAgentRunner = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalStartEnvironmentResponse{})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopped,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStart(context.Background(), envID)
+
+	require.NoError(t, err)
+	assert.False(t, calledAgentRunner)
+	assert.Empty(t, statusUpdates)
+}
+
+// TestExecuteStart_RunningPersistFailureMarksError verifies that when
+// agent-runner successfully starts the backend but persisting StatusRunning
+// fails, the row is marked StatusError rather than stranded at
+// StatusStarting — Error is one of StartEnvironment's accepted states, and
+// retrying is safe since agent-runner's /start against an already-running
+// backend is a no-op.
+func TestExecuteStart_RunningPersistFailureMarksError(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalStartEnvironmentResponse{BaseURL: "http://sandbox:8080"})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	var errMsgs []*string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStarting,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, errMsg *string) error {
+			statusUpdates = append(statusUpdates, status)
+			errMsgs = append(errMsgs, errMsg)
+			if status == environmentdom.StatusRunning {
+				return errors.New("db unavailable")
+			}
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStart(context.Background(), envID)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{environmentdom.StatusRunning, environmentdom.StatusError}, statusUpdates)
+	require.Len(t, errMsgs, 2)
+	assert.Nil(t, errMsgs[0])
+	require.NotNil(t, errMsgs[1])
+}
+
 // TestStopEnvironment_QueuesCommandAndSetsStopping mirrors
 // TestStartEnvironment_QueuesCommandAndSetsStarting: StopEnvironment makes
 // no agent-runner call at all, just queues a command onto
@@ -1097,7 +1259,7 @@ func TestStopEnvironment_ReturnsErrorWhenPublishFails(t *testing.T) {
 	_, err := svc.StopEnvironment(context.Background(), uuid.New(), envID)
 
 	require.Error(t, err)
-	assert.Empty(t, statusUpdates)
+	assert.Equal(t, []string{environmentdom.StatusStopping, environmentdom.StatusError}, statusUpdates)
 }
 
 // TestExecuteStop_Success verifies ExecuteStop —
@@ -1173,6 +1335,86 @@ func TestExecuteStop_AgentRunnerFailure(t *testing.T) {
 	require.Len(t, errMsgs, 1)
 	require.NotNil(t, errMsgs[0])
 	assert.Contains(t, *errMsgs[0], "boom")
+}
+
+// TestExecuteStop_SkipsStaleReplay verifies ExecuteStop does nothing — no
+// agent-runner call, no status write — when the row is no longer
+// StatusStopping by the time it runs, e.g. the user has since started the
+// environment back up and a redelivered "stop" command must not kill it
+// out from under them.
+func TestExecuteStop_SkipsStaleReplay(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	var calledAgentRunner bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calledAgentRunner = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusRunning,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStop(context.Background(), envID)
+
+	require.NoError(t, err)
+	assert.False(t, calledAgentRunner)
+	assert.Empty(t, statusUpdates)
+}
+
+// TestExecuteStop_StoppedPersistFailureMarksError verifies that when
+// agent-runner successfully stops the backend but persisting StatusStopped
+// fails, the row is marked StatusError rather than stranded at
+// StatusStopping.
+func TestExecuteStop_StoppedPersistFailureMarksError(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	var errMsgs []*string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopping,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, errMsg *string) error {
+			statusUpdates = append(statusUpdates, status)
+			errMsgs = append(errMsgs, errMsg)
+			if status == environmentdom.StatusStopped {
+				return errors.New("db unavailable")
+			}
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStop(context.Background(), envID)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{environmentdom.StatusStopped, environmentdom.StatusError}, statusUpdates)
+	require.Len(t, errMsgs, 2)
+	assert.Nil(t, errMsgs[0])
+	require.NotNil(t, errMsgs[1])
 }
 
 // TestRestartEnvironment_RequiresRunning verifies the explicit restart

--- a/services/api/internal/service/environment/environment_service_test.go
+++ b/services/api/internal/service/environment/environment_service_test.go
@@ -643,6 +643,7 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 
 	var statusUpdates []string
 	var pendingSet *bool
+	var touched []uuid.UUID
 	repo := &mockRepo{
 		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
 			return &environmentdom.Environment{
@@ -655,6 +656,10 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 			statusUpdates = append(statusUpdates, status)
 			require.NotNil(t, backendRef)
 			assert.Equal(t, "container-new", *backendRef)
+			return nil
+		},
+		touchEnvironment: func(_ context.Context, id uuid.UUID) error {
+			touched = append(touched, id)
 			return nil
 		},
 		setPortsPendingRestart: func(_ context.Context, id uuid.UUID, pending bool) error {
@@ -670,6 +675,7 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "/internal/environments/"+envID.String()+"/restart-ports", calledPath)
 	assert.Equal(t, []string{environmentdom.StatusRunning}, statusUpdates)
+	assert.Equal(t, []uuid.UUID{envID}, touched)
 	require.NotNil(t, pendingSet)
 	assert.False(t, *pendingSet)
 	assert.Equal(t, environmentdom.StatusRunning, env.Status)
@@ -677,6 +683,44 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 	assert.Equal(t, "container-new", *env.BackendRef)
 	require.NotNil(t, env.SSHPort)
 	assert.Equal(t, 22001, *env.SSHPort)
+}
+
+// TestStartEnvironment_TouchesLastActiveAt verifies the plain (no pending
+// port changes) start path bumps last_active_at, not just status — without
+// this, a freshly-started environment keeps whatever last_active_at it had
+// from before it was stopped, and the idle reaper (agent-runner's
+// reapIdleEnvironments, which only reads the DB column) stops it again
+// within its next tick, seconds after the user started it.
+func TestStartEnvironment_TouchesLastActiveAt(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalStartEnvironmentResponse{
+			BaseURL: "http://sandbox:8080",
+		})
+	}))
+	defer srv.Close()
+
+	var touched []uuid.UUID
+	repo := &mockRepo{
+		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopped,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		touchEnvironment: func(_ context.Context, id uuid.UUID) error {
+			touched = append(touched, id)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	_, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
+
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{envID}, touched)
 }
 
 // TestRestartEnvironment_RequiresRunning verifies the explicit restart

--- a/services/api/internal/service/environment/environment_service_test.go
+++ b/services/api/internal/service/environment/environment_service_test.go
@@ -336,15 +336,92 @@ func TestResolveConversationWorkdir_FolderBelongsToDifferentEnvironment(t *testi
 // path against a stub agent-runner HTTP server, verifying the row is
 // written StatusCreating first, then StatusRunning with the backend/
 // backend_ref/volume_ref agent-runner reported.
-func TestCreateEnvironment_Success(t *testing.T) {
+// TestCreateEnvironment_QueuesCommand verifies the request path
+// CreateEnvironment now takes: it writes the row (StatusCreating) and
+// queues a command onto StreamEnvironmentCommands, making no agent-runner
+// call at all (no HTTP test server is even set up for this test). The
+// actual agent-runner provisioning call moved to ExecuteCreate — see
+// TestExecuteCreate_Success and TestExecuteCreate_AgentRunnerFailure below
+// — which worker.EnvironmentCommandConsumer invokes once it reads the
+// queued command.
+func TestCreateEnvironment_QueuesCommand(t *testing.T) {
 	var created *environmentdom.Environment
-	var provisioned struct {
-		status, backend, backendRef, volumeRef string
+	var publishedStream, publishedType string
+	var publishedPayload any
+	repo := &mockRepo{
+		createEnvironment: func(_ context.Context, e *environmentdom.Environment) error {
+			assert.Equal(t, environmentdom.StatusCreating, e.Status)
+			created = e
+			return nil
+		},
 	}
+	pub := &mockPublisher{
+		appendFn: func(_ context.Context, stream, eventType string, payload any) error {
+			publishedStream, publishedType, publishedPayload = stream, eventType, payload
+			return nil
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(pub)
 
+	projectID := uuid.New()
+	env, err := svc.CreateEnvironment(context.Background(), projectID, environmentdom.CreateEnvironmentInput{Name: "My Env"})
+
+	require.NoError(t, err)
+	require.NotNil(t, env)
+	assert.Equal(t, "my-env", env.Slug)
+	assert.Equal(t, environmentdom.StatusCreating, env.Status)
+	require.NotNil(t, created)
+	assert.Equal(t, events.StreamEnvironmentCommands, publishedStream)
+	assert.Equal(t, events.TopicEnvironmentCreate, publishedType)
+	assert.Equal(t, map[string]any{"environment_id": created.ID.String()}, publishedPayload)
+}
+
+// TestCreateEnvironment_ReturnsErrorWhenPublishFails verifies a failure to
+// queue the command is reported to the caller and marks the
+// already-written row StatusError — nothing will ever provision it now,
+// so leaving it StatusCreating would strand it there forever.
+func TestCreateEnvironment_ReturnsErrorWhenPublishFails(t *testing.T) {
+	var created *environmentdom.Environment
+	var statusUpdates []string
+	repo := &mockRepo{
+		createEnvironment: func(_ context.Context, e *environmentdom.Environment) error {
+			created = e
+			return nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, id uuid.UUID, status string, _, _ *string) error {
+			assert.Equal(t, created.ID, id)
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	pub := &mockPublisher{
+		appendFn: func(context.Context, string, string, any) error {
+			return errors.New("valkey unavailable")
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(pub)
+
+	env, err := svc.CreateEnvironment(context.Background(), uuid.New(), environmentdom.CreateEnvironmentInput{Name: "My Env"})
+
+	require.Error(t, err)
+	assert.Nil(t, env)
+	assert.Equal(t, []string{environmentdom.StatusError}, statusUpdates)
+}
+
+// TestExecuteCreate_Success verifies ExecuteCreate —
+// worker.EnvironmentCommandConsumer's entry point once it reads a queued
+// create command — provisions via agent-runner using fields already
+// persisted on the row (not threaded through the queued command itself;
+// see ExecuteCreate's own doc comment for why, including the secret key)
+// and persists the resulting backend/backend_ref/volume_ref.
+func TestExecuteCreate_Success(t *testing.T) {
+	envID := uuid.New()
+	projectID := uuid.New()
+	var gotReq internalCreateEnvironmentRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/internal/environments", r.URL.Path)
 		assert.Equal(t, "test-internal-key", r.Header.Get("X-Internal-Token"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotReq))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(internalCreateEnvironmentResponse{
 			Backend:    "docker",
@@ -355,38 +432,42 @@ func TestCreateEnvironment_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	var provisioned struct {
+		status, backend, backendRef, volumeRef string
+	}
 	repo := &mockRepo{
-		createEnvironment: func(_ context.Context, e *environmentdom.Environment) error {
-			assert.Equal(t, environmentdom.StatusCreating, e.Status)
-			created = e
-			return nil
+		findEnvironmentByID: func(_ context.Context, id uuid.UUID) (*environmentdom.Environment, error) {
+			assert.Equal(t, envID, id)
+			return &environmentdom.Environment{
+				ID: envID, ProjectID: projectID, Status: environmentdom.StatusCreating,
+				CPULimit: "2", MemoryLimit: "4Gi", DiskLimitGB: 20,
+				SecretKeyEncrypted: "plaintext-secret",
+			}, nil
 		},
 		updateEnvironmentProvisioning: func(_ context.Context, id uuid.UUID, status, backend, backendRef, volumeRef string) error {
-			assert.Equal(t, created.ID, id)
+			assert.Equal(t, envID, id)
 			provisioned.status, provisioned.backend, provisioned.backendRef, provisioned.volumeRef = status, backend, backendRef, volumeRef
 			return nil
 		},
 	}
 	svc := New(repo, srv.URL, "test-internal-key")
 
-	projectID := uuid.New()
-	env, err := svc.CreateEnvironment(context.Background(), projectID, environmentdom.CreateEnvironmentInput{Name: "My Env"})
+	err := svc.ExecuteCreate(context.Background(), envID)
 
 	require.NoError(t, err)
-	require.NotNil(t, env)
-	assert.Equal(t, "my-env", env.Slug)
-	assert.Equal(t, environmentdom.StatusRunning, env.Status)
-	assert.Equal(t, "docker", env.Backend)
-	require.NotNil(t, env.BackendRef)
-	assert.Equal(t, "container-123", *env.BackendRef)
+	assert.Equal(t, envID.String(), gotReq.EnvironmentID)
+	assert.Equal(t, projectID.String(), gotReq.ProjectID)
+	assert.Equal(t, "plaintext-secret", gotReq.SecretKey)
 	assert.Equal(t, environmentdom.StatusRunning, provisioned.status)
+	assert.Equal(t, "docker", provisioned.backend)
 	assert.Equal(t, "container-123", provisioned.backendRef)
 	assert.Equal(t, "paca-env-abc", provisioned.volumeRef)
 }
 
-// TestCreateEnvironment_AgentRunnerFailure verifies a failing agent-runner
-// call surfaces as an error (not swallowed) and marks the row StatusError.
-func TestCreateEnvironment_AgentRunnerFailure(t *testing.T) {
+// TestExecuteCreate_AgentRunnerFailure verifies a failing agent-runner call
+// surfaces as an error (not swallowed) and marks the row StatusError.
+func TestExecuteCreate_AgentRunnerFailure(t *testing.T) {
+	envID := uuid.New()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("boom"))
@@ -395,6 +476,12 @@ func TestCreateEnvironment_AgentRunnerFailure(t *testing.T) {
 
 	var statusUpdates []string
 	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, ProjectID: uuid.New(), Status: environmentdom.StatusCreating,
+				CPULimit: "2", MemoryLimit: "4Gi", DiskLimitGB: 20,
+			}, nil
+		},
 		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, errMsg *string) error {
 			statusUpdates = append(statusUpdates, status)
 			assert.NotNil(t, errMsg)
@@ -403,10 +490,9 @@ func TestCreateEnvironment_AgentRunnerFailure(t *testing.T) {
 	}
 	svc := New(repo, srv.URL, "test-internal-key")
 
-	env, err := svc.CreateEnvironment(context.Background(), uuid.New(), environmentdom.CreateEnvironmentInput{Name: "My Env"})
+	err := svc.ExecuteCreate(context.Background(), envID)
 
 	assert.Error(t, err)
-	assert.Nil(t, env)
 	assert.Equal(t, []string{environmentdom.StatusError}, statusUpdates)
 }
 
@@ -929,6 +1015,156 @@ func TestExecuteStart_RestartsPortsWhenPending_ClearsPendingWhenTouchFails(t *te
 	require.NoError(t, err)
 	require.NotNil(t, pendingSet)
 	assert.False(t, *pendingSet)
+}
+
+// TestStopEnvironment_QueuesCommandAndSetsStopping mirrors
+// TestStartEnvironment_QueuesCommandAndSetsStarting: StopEnvironment makes
+// no agent-runner call at all, just queues a command onto
+// StreamEnvironmentCommands and marks the row "stopping". The actual
+// agent-runner call moved to ExecuteStop — see
+// TestExecuteStop_Success/TestExecuteStop_AgentRunnerFailure below.
+func TestStopEnvironment_QueuesCommandAndSetsStopping(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+
+	var statusUpdates []string
+	var publishedStream, publishedType string
+	var publishedPayload any
+	repo := &mockRepo{
+		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusRunning,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	pub := &mockPublisher{
+		appendFn: func(_ context.Context, stream, eventType string, payload any) error {
+			publishedStream, publishedType, publishedPayload = stream, eventType, payload
+			return nil
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(pub)
+
+	env, err := svc.StopEnvironment(context.Background(), uuid.New(), envID)
+
+	require.NoError(t, err)
+	assert.Equal(t, events.StreamEnvironmentCommands, publishedStream)
+	assert.Equal(t, events.TopicEnvironmentStop, publishedType)
+	assert.Equal(t, map[string]any{"environment_id": envID.String()}, publishedPayload)
+	assert.Equal(t, []string{environmentdom.StatusStopping}, statusUpdates)
+	assert.Equal(t, environmentdom.StatusStopping, env.Status)
+}
+
+// TestStopEnvironment_ReturnsErrorWhenPublishFails mirrors
+// TestStartEnvironment_ReturnsErrorWhenPublishFails.
+func TestStopEnvironment_ReturnsErrorWhenPublishFails(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusRunning,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	pub := &mockPublisher{
+		appendFn: func(context.Context, string, string, any) error {
+			return errors.New("valkey unavailable")
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(pub)
+
+	_, err := svc.StopEnvironment(context.Background(), uuid.New(), envID)
+
+	require.Error(t, err)
+	assert.Empty(t, statusUpdates)
+}
+
+// TestExecuteStop_Success verifies ExecuteStop —
+// worker.EnvironmentCommandConsumer's entry point once it reads a queued
+// stop command — calls agent-runner's /stop endpoint and marks the row
+// stopped.
+func TestExecuteStop_Success(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	var calledPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calledPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopping,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStop(context.Background(), envID)
+
+	require.NoError(t, err)
+	assert.Equal(t, "/internal/environments/"+envID.String()+"/stop", calledPath)
+	assert.Equal(t, []string{environmentdom.StatusStopped}, statusUpdates)
+}
+
+// TestExecuteStop_AgentRunnerFailure verifies a failed agent-runner call
+// records StatusError with the failure reason, rather than leaving the row
+// stuck "stopping" forever.
+func TestExecuteStop_AgentRunnerFailure(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	var errMsgs []*string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopping,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, errMsg *string) error {
+			statusUpdates = append(statusUpdates, status)
+			errMsgs = append(errMsgs, errMsg)
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStop(context.Background(), envID)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{environmentdom.StatusError}, statusUpdates)
+	require.Len(t, errMsgs, 1)
+	require.NotNil(t, errMsgs[0])
+	assert.Contains(t, *errMsgs[0], "boom")
 }
 
 // TestRestartEnvironment_RequiresRunning verifies the explicit restart

--- a/services/api/internal/service/environment/environment_service_test.go
+++ b/services/api/internal/service/environment/environment_service_test.go
@@ -3,6 +3,7 @@ package environmentsvc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	environmentdom "github.com/Paca-AI/api/internal/domain/environment"
+	"github.com/Paca-AI/api/internal/events"
 )
 
 // mockRepo is a function-field-based mock of environmentdom.Repository —
@@ -191,6 +193,19 @@ func (m *mockRepo) FindPortForwardByID(ctx context.Context, id uuid.UUID) (*envi
 		return m.findPortForwardByID(ctx, id)
 	}
 	return nil, environmentdom.ErrPortForwardNotFound
+}
+
+// mockPublisher is a function-field-based mock of environmentPublisher,
+// mirroring mockRepo's own style.
+type mockPublisher struct {
+	appendFn func(ctx context.Context, stream, eventType string, payload any) error
+}
+
+func (m *mockPublisher) Append(ctx context.Context, stream, eventType string, payload any) error {
+	if m.appendFn != nil {
+		return m.appendFn(ctx, stream, eventType, payload)
+	}
+	return nil
 }
 
 var _ environmentdom.Repository = (*mockRepo)(nil)
@@ -625,7 +640,114 @@ func TestDeletePortForward_MarksPortsPendingRestart(t *testing.T) {
 // environment with PortsPendingRestart set calls /restart-ports (not
 // /start) and clears the flag on success — the "apply pending port
 // changes transparently on the next Start" path.
-func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
+// TestStartEnvironment_QueuesCommandAndSetsStarting verifies the request
+// path StartEnvironment now takes: it makes no agent-runner call at all
+// (no HTTP test server is even set up for this test), just queues a
+// command onto StreamEnvironmentCommands and marks the row "starting".
+// The actual agent-runner call moved to ExecuteStart — see
+// TestExecuteStart_PlainStart and friends below — which
+// worker.EnvironmentCommandConsumer invokes once it reads the queued
+// command.
+func TestStartEnvironment_QueuesCommandAndSetsStarting(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+
+	var statusUpdates []string
+	var publishedStream, publishedType string
+	var publishedPayload any
+	repo := &mockRepo{
+		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopped,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	pub := &mockPublisher{
+		appendFn: func(_ context.Context, stream, eventType string, payload any) error {
+			publishedStream, publishedType, publishedPayload = stream, eventType, payload
+			return nil
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(pub)
+
+	env, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
+
+	require.NoError(t, err)
+	assert.Equal(t, events.StreamEnvironmentCommands, publishedStream)
+	assert.Equal(t, events.TopicEnvironmentStart, publishedType)
+	assert.Equal(t, map[string]any{"environment_id": envID.String()}, publishedPayload)
+	assert.Equal(t, []string{environmentdom.StatusStarting}, statusUpdates)
+	assert.Equal(t, environmentdom.StatusStarting, env.Status)
+}
+
+// TestStartEnvironment_ReturnsErrorWhenPublishFails verifies a failure to
+// queue the command is reported to the caller, and never marks the
+// environment "starting" — if nothing is going to execute the start,
+// telling the user it's starting would be a lie.
+func TestStartEnvironment_ReturnsErrorWhenPublishFails(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopped,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+	}
+	pub := &mockPublisher{
+		appendFn: func(context.Context, string, string, any) error {
+			return errors.New("valkey unavailable")
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(pub)
+
+	_, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
+
+	require.Error(t, err)
+	assert.Empty(t, statusUpdates)
+}
+
+// TestStartEnvironment_RejectsPendingRestartWithNoVolumeRef verifies the
+// one precondition check StartEnvironment still does synchronously — it
+// costs no extra I/O (env is already loaded) unlike the agent-runner call
+// this same check used to gate, which moved to ExecuteStart.
+func TestStartEnvironment_RejectsPendingRestartWithNoVolumeRef(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	repo := &mockRepo{
+		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStopped,
+				BackendRef: &backendRef, VolumeRef: nil,
+				PortsPendingRestart: true,
+			}, nil
+		},
+	}
+	svc := New(repo, "", "").WithPublisher(&mockPublisher{})
+
+	_, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
+
+	assert.Error(t, err)
+}
+
+// TestExecuteStart_RestartsPortsWhenPending verifies ExecuteStart —
+// worker.EnvironmentCommandConsumer's entry point once it reads a queued
+// start command — takes the restart-ports branch when the environment has
+// a pending port change, the same branch StartEnvironment used to take
+// synchronously before this became asynchronous.
+func TestExecuteStart_RestartsPortsWhenPending(t *testing.T) {
 	envID := uuid.New()
 	backendRef := "container-old"
 	volumeRef := "paca-env-abc"
@@ -645,9 +767,9 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 	var pendingSet *bool
 	var touched []uuid.UUID
 	repo := &mockRepo{
-		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
 			return &environmentdom.Environment{
-				ID: envID, Status: environmentdom.StatusStopped,
+				ID: envID, Status: environmentdom.StatusStarting,
 				BackendRef: &backendRef, VolumeRef: &volumeRef,
 				PortsPendingRestart: true,
 			}, nil
@@ -670,7 +792,7 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 	}
 	svc := New(repo, srv.URL, "test-internal-key")
 
-	env, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
+	err := svc.ExecuteStart(context.Background(), envID)
 
 	require.NoError(t, err)
 	assert.Equal(t, "/internal/environments/"+envID.String()+"/restart-ports", calledPath)
@@ -678,20 +800,15 @@ func TestStartEnvironment_RestartsPortsWhenPending(t *testing.T) {
 	assert.Equal(t, []uuid.UUID{envID}, touched)
 	require.NotNil(t, pendingSet)
 	assert.False(t, *pendingSet)
-	assert.Equal(t, environmentdom.StatusRunning, env.Status)
-	require.NotNil(t, env.BackendRef)
-	assert.Equal(t, "container-new", *env.BackendRef)
-	require.NotNil(t, env.SSHPort)
-	assert.Equal(t, 22001, *env.SSHPort)
 }
 
-// TestStartEnvironment_TouchesLastActiveAt verifies the plain (no pending
-// port changes) start path bumps last_active_at, not just status — without
-// this, a freshly-started environment keeps whatever last_active_at it had
-// from before it was stopped, and the idle reaper (agent-runner's
-// reapIdleEnvironments, which only reads the DB column) stops it again
-// within its next tick, seconds after the user started it.
-func TestStartEnvironment_TouchesLastActiveAt(t *testing.T) {
+// TestExecuteStart_PlainStart verifies the plain (no pending port changes)
+// path bumps last_active_at, not just status — without this, a freshly
+// started environment keeps whatever last_active_at it had from before it
+// was stopped, and the idle reaper (agent-runner's reapIdleEnvironments,
+// which only reads the DB column) stops it again within its next tick,
+// seconds after the user started it.
+func TestExecuteStart_PlainStart(t *testing.T) {
 	envID := uuid.New()
 	backendRef := "container-1"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -702,13 +819,18 @@ func TestStartEnvironment_TouchesLastActiveAt(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	var statusUpdates []string
 	var touched []uuid.UUID
 	repo := &mockRepo{
-		findVisibleEnvironmentInProject: func(_ context.Context, _, _ uuid.UUID) (*environmentdom.Environment, error) {
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
 			return &environmentdom.Environment{
-				ID: envID, Status: environmentdom.StatusStopped,
+				ID: envID, Status: environmentdom.StatusStarting,
 				BackendRef: &backendRef,
 			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
 		},
 		touchEnvironment: func(_ context.Context, id uuid.UUID) error {
 			touched = append(touched, id)
@@ -717,10 +839,96 @@ func TestStartEnvironment_TouchesLastActiveAt(t *testing.T) {
 	}
 	svc := New(repo, srv.URL, "test-internal-key")
 
-	_, err := svc.StartEnvironment(context.Background(), uuid.New(), envID)
+	err := svc.ExecuteStart(context.Background(), envID)
 
 	require.NoError(t, err)
+	assert.Equal(t, []string{environmentdom.StatusRunning}, statusUpdates)
 	assert.Equal(t, []uuid.UUID{envID}, touched)
+}
+
+// TestExecuteStart_SucceedsWhenTouchFails verifies a TouchEnvironment
+// failure doesn't turn an otherwise-successful start into a reported
+// error: by the time it's called, the backend is already started and
+// status is already persisted as running, so failing the whole call here
+// would report a start that, in fact, succeeded (and leave the row with a
+// stale last_active_at on top).
+func TestExecuteStart_SucceedsWhenTouchFails(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalStartEnvironmentResponse{
+			BaseURL: "http://sandbox:8080",
+		})
+	}))
+	defer srv.Close()
+
+	var statusUpdates []string
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStarting,
+				BackendRef: &backendRef,
+			}, nil
+		},
+		updateEnvironmentStatus: func(_ context.Context, _ uuid.UUID, status string, _, _ *string) error {
+			statusUpdates = append(statusUpdates, status)
+			return nil
+		},
+		touchEnvironment: func(_ context.Context, _ uuid.UUID) error {
+			return errors.New("valkey unavailable")
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStart(context.Background(), envID)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{environmentdom.StatusRunning}, statusUpdates)
+}
+
+// TestExecuteStart_RestartsPortsWhenPending_ClearsPendingWhenTouchFails is
+// the restart-ports-path counterpart to
+// TestExecuteStart_SucceedsWhenTouchFails: a TouchEnvironment failure must
+// not skip clearing ports_pending_restart, since the new port bindings are
+// already live on the backend by the time TouchEnvironment is called.
+func TestExecuteStart_RestartsPortsWhenPending_ClearsPendingWhenTouchFails(t *testing.T) {
+	envID := uuid.New()
+	backendRef := "container-old"
+	volumeRef := "paca-env-abc"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(internalRestartPortsResponse{
+			BackendRef: "container-new",
+			BaseURL:    "http://sandbox:8080",
+		})
+	}))
+	defer srv.Close()
+
+	var pendingSet *bool
+	repo := &mockRepo{
+		findEnvironmentByID: func(_ context.Context, _ uuid.UUID) (*environmentdom.Environment, error) {
+			return &environmentdom.Environment{
+				ID: envID, Status: environmentdom.StatusStarting,
+				BackendRef: &backendRef, VolumeRef: &volumeRef,
+				PortsPendingRestart: true,
+			}, nil
+		},
+		touchEnvironment: func(_ context.Context, _ uuid.UUID) error {
+			return errors.New("valkey unavailable")
+		},
+		setPortsPendingRestart: func(_ context.Context, _ uuid.UUID, pending bool) error {
+			pendingSet = &pending
+			return nil
+		},
+	}
+	svc := New(repo, srv.URL, "test-internal-key")
+
+	err := svc.ExecuteStart(context.Background(), envID)
+
+	require.NoError(t, err)
+	require.NotNil(t, pendingSet)
+	assert.False(t, *pendingSet)
 }
 
 // TestRestartEnvironment_RequiresRunning verifies the explicit restart

--- a/services/api/internal/worker/activity_consumer.go
+++ b/services/api/internal/worker/activity_consumer.go
@@ -69,19 +69,26 @@ func NewActivityConsumer(client *redis.Client, repo taskdom.ActivityRepository, 
 // Start creates the consumer group if needed, then begins reading from the
 // stream in a background goroutine.  Call Stop to drain and exit cleanly.
 func (c *ActivityConsumer) Start(ctx context.Context) {
-	if err := c.ensureGroup(ctx); err != nil {
+	// "0" means start from the very beginning of the stream so this
+	// first-ever creation processes any messages that arrived before the
+	// group existed.
+	if err := c.ensureGroup(ctx, "0"); err != nil {
 		c.log.Warn("activity consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
 }
 
-// ensureGroup creates the consumer group if it doesn't already exist.
-// MKSTREAM ensures the stream key is created if it doesn't exist yet.  "0"
-// means start from the very beginning of the stream so we process any
-// messages that arrived before the group was created.
-func (c *ActivityConsumer) ensureGroup(ctx context.Context) error {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskActivities, activityConsumerGroup, "0").Err()
+// ensureGroup creates the consumer group at startID if it doesn't already
+// exist. MKSTREAM ensures the stream key is created if it doesn't exist
+// yet. startID is "0" only for Start's own first-ever creation (see doc
+// comment there) — the NOGROUP recovery path in run() below passes "$"
+// instead, since recreating at "0" there would redeliver the stream's
+// entire retained history (including entries already processed and acked
+// before the group vanished) through handlers with no event-level
+// deduplication.
+func (c *ActivityConsumer) ensureGroup(ctx context.Context, startID string) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskActivities, activityConsumerGroup, startID).Err()
 	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
 		return err
 	}
@@ -134,7 +141,16 @@ func (c *ActivityConsumer) run() {
 				// Start failing transiently) — without this, every
 				// subsequent XReadGroup call keeps failing the exact same
 				// way forever, since nothing else recreates the group.
-				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+				// Recreate at "$" (from now), not "0": unlike Start's own
+				// first-ever creation, the stream itself may still hold
+				// this consumer's own already-processed history (e.g. a
+				// manual XGROUP DESTROY that left the stream intact), and
+				// this handler has no event-level dedup to make replaying
+				// that safe.
+				recoverCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				geErr := c.ensureGroup(recoverCtx, "$")
+				cancel()
+				if geErr != nil {
 					c.log.Warn("activity consumer: failed to recreate consumer group", "err", geErr)
 				}
 			}

--- a/services/api/internal/worker/activity_consumer.go
+++ b/services/api/internal/worker/activity_consumer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,16 +69,23 @@ func NewActivityConsumer(client *redis.Client, repo taskdom.ActivityRepository, 
 // Start creates the consumer group if needed, then begins reading from the
 // stream in a background goroutine.  Call Stop to drain and exit cleanly.
 func (c *ActivityConsumer) Start(ctx context.Context) {
-	// Create consumer group; MKSTREAM ensures the stream key is created if it
-	// doesn't exist yet.  "0" means start from the very beginning of the stream
-	// so we process any messages that arrived before the group was created.
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskActivities, activityConsumerGroup, "0").Err()
-	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-		c.log.Warn("activity consumer: could not create consumer group", "err", err)
-		// Non-fatal — we still attempt to read below.
+	if err := c.ensureGroup(ctx); err != nil {
+		c.log.Warn("activity consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
+}
+
+// ensureGroup creates the consumer group if it doesn't already exist.
+// MKSTREAM ensures the stream key is created if it doesn't exist yet.  "0"
+// means start from the very beginning of the stream so we process any
+// messages that arrived before the group was created.
+func (c *ActivityConsumer) ensureGroup(ctx context.Context) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskActivities, activityConsumerGroup, "0").Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return err
+	}
+	return nil
 }
 
 // Stop signals the consumer to stop and waits for the goroutine to exit.
@@ -119,6 +127,17 @@ func (c *ActivityConsumer) run() {
 				continue
 			}
 			c.log.Error("activity consumer: xreadgroup error", "err", err)
+			if strings.Contains(err.Error(), "NOGROUP") {
+				// The stream and/or consumer group vanished out from under
+				// an already-running consumer (e.g. a Valkey restart
+				// without persistence, or the group's initial creation at
+				// Start failing transiently) — without this, every
+				// subsequent XReadGroup call keeps failing the exact same
+				// way forever, since nothing else recreates the group.
+				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+					c.log.Warn("activity consumer: failed to recreate consumer group", "err", geErr)
+				}
+			}
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/services/api/internal/worker/doc_activity_consumer.go
+++ b/services/api/internal/worker/doc_activity_consumer.go
@@ -65,16 +65,20 @@ func NewDocActivityConsumer(client *redis.Client, repo docdom.ActivityRepository
 // Start creates the consumer group if needed, then begins reading from the
 // stream in a background goroutine.  Call Stop to drain and exit cleanly.
 func (c *DocActivityConsumer) Start(ctx context.Context) {
-	if err := c.ensureGroup(ctx); err != nil {
+	// "0": see ActivityConsumer.Start's identical comment.
+	if err := c.ensureGroup(ctx, "0"); err != nil {
 		c.log.Warn("doc activity consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
 }
 
-// ensureGroup creates the consumer group if it doesn't already exist.
-func (c *DocActivityConsumer) ensureGroup(ctx context.Context) error {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamDocActivities, docActivityConsumerGroup, "0").Err()
+// ensureGroup creates the consumer group at startID if it doesn't already
+// exist — see ActivityConsumer.ensureGroup's doc comment for why startID
+// differs between Start's first-ever creation ("0") and the NOGROUP
+// recovery path in run() below ("$").
+func (c *DocActivityConsumer) ensureGroup(ctx context.Context, startID string) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamDocActivities, docActivityConsumerGroup, startID).Err()
 	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
 		return err
 	}
@@ -118,7 +122,12 @@ func (c *DocActivityConsumer) run() {
 			}
 			c.log.Error("doc activity consumer: xreadgroup error", "err", err)
 			if strings.Contains(err.Error(), "NOGROUP") {
-				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+				// "$", not "0": see ActivityConsumer's identical recovery
+				// comment — this handler has no event-level dedup either.
+				recoverCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				geErr := c.ensureGroup(recoverCtx, "$")
+				cancel()
+				if geErr != nil {
 					c.log.Warn("doc activity consumer: failed to recreate consumer group", "err", geErr)
 				}
 			}

--- a/services/api/internal/worker/doc_activity_consumer.go
+++ b/services/api/internal/worker/doc_activity_consumer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -64,12 +65,20 @@ func NewDocActivityConsumer(client *redis.Client, repo docdom.ActivityRepository
 // Start creates the consumer group if needed, then begins reading from the
 // stream in a background goroutine.  Call Stop to drain and exit cleanly.
 func (c *DocActivityConsumer) Start(ctx context.Context) {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamDocActivities, docActivityConsumerGroup, "0").Err()
-	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-		c.log.Warn("doc activity consumer: could not create consumer group", "err", err)
+	if err := c.ensureGroup(ctx); err != nil {
+		c.log.Warn("doc activity consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
+}
+
+// ensureGroup creates the consumer group if it doesn't already exist.
+func (c *DocActivityConsumer) ensureGroup(ctx context.Context) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamDocActivities, docActivityConsumerGroup, "0").Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return err
+	}
+	return nil
 }
 
 // Stop signals the consumer to stop and waits for the goroutine to exit.
@@ -108,6 +117,11 @@ func (c *DocActivityConsumer) run() {
 				continue
 			}
 			c.log.Error("doc activity consumer: xreadgroup error", "err", err)
+			if strings.Contains(err.Error(), "NOGROUP") {
+				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+					c.log.Warn("doc activity consumer: failed to recreate consumer group", "err", geErr)
+				}
+			}
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/services/api/internal/worker/environment_command_consumer.go
+++ b/services/api/internal/worker/environment_command_consumer.go
@@ -1,0 +1,230 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/Paca-AI/api/internal/events"
+)
+
+const (
+	environmentCommandConsumerGroup = "api.environment_commands"
+	environmentCommandReadBlock     = 5 * time.Second
+	environmentCommandReadCount     = 10
+)
+
+// environmentStarter is the minimal environmentsvc.Service surface this
+// consumer needs to actually execute a previously-queued start command —
+// see environmentsvc.Service.ExecuteStart's own doc comment for why that
+// method isn't part of environmentdom.Service (and so isn't reachable
+// through the notificationdom.Service-style full-domain-interface pattern
+// other consumers in this package use).
+type environmentStarter interface {
+	ExecuteStart(ctx context.Context, environmentID uuid.UUID) error
+}
+
+// EnvironmentCommandConsumer reads queued environment lifecycle commands —
+// currently just "start" — from StreamEnvironmentCommands and executes
+// them. This is the asynchronous counterpart to
+// environmentsvc.Service.StartEnvironment, which only validates and
+// queues: moving the actual (potentially slow) agent-runner call here
+// means the HTTP request that triggered it returns immediately regardless
+// of how long starting the backing container/Pod takes, instead of
+// holding the connection open for it — which, past the server's own
+// WriteTimeout, showed up to callers as a 502 for a start that was
+// actually still succeeding server-side a few seconds later.
+type EnvironmentCommandConsumer struct {
+	client       *redis.Client
+	svc          environmentStarter
+	log          *slog.Logger
+	consumerName string // unique per instance, derived from hostname
+	stopCh       chan struct{}
+	doneCh       chan struct{}
+}
+
+// NewEnvironmentCommandConsumer creates a consumer that is ready to be
+// started. The consumer name is derived from the hostname so it is unique
+// per pod/instance.
+func NewEnvironmentCommandConsumer(client *redis.Client, svc environmentStarter, log *slog.Logger) *EnvironmentCommandConsumer {
+	hostname, err := os.Hostname()
+	if err != nil || hostname == "" {
+		hostname = uuid.New().String()
+	}
+	return &EnvironmentCommandConsumer{
+		client:       client,
+		svc:          svc,
+		log:          log,
+		consumerName: fmt.Sprintf("%s.%s", environmentCommandConsumerGroup, hostname),
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+	}
+}
+
+// Start creates the consumer group if needed, then begins reading from the
+// stream in a background goroutine. Call Stop to drain and exit cleanly.
+func (c *EnvironmentCommandConsumer) Start(ctx context.Context) {
+	// "0": first-ever creation processes any command that arrived before
+	// the group existed (see ensureGroup's own doc comment on the
+	// distinction from the NOGROUP recovery path in run() below).
+	if err := c.ensureGroup(ctx, "0"); err != nil {
+		c.log.Warn("environment command consumer: could not create consumer group, will retry on first read", "err", err)
+	}
+
+	go c.run()
+}
+
+// ensureGroup creates the consumer group at startID if it doesn't already
+// exist. MKSTREAM ensures the stream key is created if it doesn't exist
+// yet. startID is "0" only for Start's own first-ever creation — the
+// NOGROUP recovery path in run() passes "$" instead, since recreating at
+// "0" there would redeliver every command still retained on the stream
+// (including ones already executed before the group vanished) with no
+// idempotency guard: re-executing an old "start" is at worst a harmless
+// no-op against an already-running environment, but there's no reason to
+// pay for the replay when "$" (from now) is available.
+func (c *EnvironmentCommandConsumer) ensureGroup(ctx context.Context, startID string) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamEnvironmentCommands, environmentCommandConsumerGroup, startID).Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return err
+	}
+	return nil
+}
+
+// Stop signals the consumer to stop and waits for the goroutine to exit.
+func (c *EnvironmentCommandConsumer) Stop() {
+	close(c.stopCh)
+	<-c.doneCh
+}
+
+// run is the main loop executed in a goroutine by Start.
+func (c *EnvironmentCommandConsumer) run() {
+	defer close(c.doneCh)
+	c.log.Info("environment command consumer: started", "stream", events.StreamEnvironmentCommands)
+
+	// On startup, replay any pending messages (PEL) that were delivered but
+	// never acknowledged (e.g. after a crash mid-execution). "0" fetches
+	// the backlog.
+	c.processPending(context.Background())
+
+	for {
+		select {
+		case <-c.stopCh:
+			c.log.Info("environment command consumer: stopping")
+			return
+		default:
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), environmentCommandReadBlock+time.Second)
+		msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    environmentCommandConsumerGroup,
+			Consumer: c.consumerName,
+			Streams:  []string{events.StreamEnvironmentCommands, ">"},
+			Count:    environmentCommandReadCount,
+			Block:    environmentCommandReadBlock,
+		}).Result()
+		cancel()
+
+		if err != nil {
+			if err == redis.Nil {
+				continue
+			}
+			c.log.Error("environment command consumer: xreadgroup error", "err", err)
+			if strings.Contains(err.Error(), "NOGROUP") {
+				recoverCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				geErr := c.ensureGroup(recoverCtx, "$")
+				cancel()
+				if geErr != nil {
+					c.log.Warn("environment command consumer: failed to recreate consumer group", "err", geErr)
+				}
+			}
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		for _, stream := range msgs {
+			for _, msg := range stream.Messages {
+				c.handle(msg)
+			}
+		}
+	}
+}
+
+// processPending re-delivers and acknowledges any messages in the PEL that
+// were not acked during a previous run.
+func (c *EnvironmentCommandConsumer) processPending(ctx context.Context) {
+	msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    environmentCommandConsumerGroup,
+		Consumer: c.consumerName,
+		Streams:  []string{events.StreamEnvironmentCommands, "0"},
+		Count:    environmentCommandReadCount,
+	}).Result()
+	if err != nil && err != redis.Nil {
+		c.log.Warn("environment command consumer: could not read pending messages", "err", err)
+		return
+	}
+	for _, stream := range msgs {
+		for _, msg := range stream.Messages {
+			c.handle(msg)
+		}
+	}
+}
+
+// handle deserialises one stream message and executes the command it
+// carries. Always acks, regardless of outcome: ExecuteStart already
+// persists StatusError with the failure reason directly onto the
+// environment row on failure, so there is nothing left in the PEL worth
+// retrying automatically — a user sees the error status and retries
+// explicitly, which queues a fresh command.
+func (c *EnvironmentCommandConsumer) handle(msg redis.XMessage) {
+	ctx := context.Background()
+
+	eventType, _ := msg.Values["type"].(string)
+	raw, ok := msg.Values["payload"].(string)
+	if !ok {
+		c.log.Warn("environment command consumer: message has no payload field", "id", msg.ID)
+		c.ack(ctx, msg.ID)
+		return
+	}
+
+	switch eventType {
+	case events.TopicEnvironmentStart:
+		var p environmentStartCommandPayload
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			c.log.Warn("environment command consumer: failed to decode payload", "id", msg.ID, "err", err)
+			break
+		}
+		environmentID, err := uuid.Parse(p.EnvironmentID)
+		if err != nil {
+			c.log.Warn("environment command consumer: invalid environment_id", "id", msg.ID, "environment_id", p.EnvironmentID)
+			break
+		}
+		if err := c.svc.ExecuteStart(ctx, environmentID); err != nil {
+			c.log.Error("environment command consumer: start failed", "environment_id", environmentID, "err", err)
+		}
+	default:
+		c.log.Warn("environment command consumer: unknown event type", "id", msg.ID, "type", eventType)
+	}
+
+	c.ack(ctx, msg.ID)
+}
+
+func (c *EnvironmentCommandConsumer) ack(ctx context.Context, id string) {
+	if err := c.client.XAck(ctx, events.StreamEnvironmentCommands, environmentCommandConsumerGroup, id).Err(); err != nil {
+		c.log.Warn("environment command consumer: xack failed", "id", id, "err", err)
+	}
+}
+
+// environmentStartCommandPayload mirrors the JSON shape
+// environmentsvc.Service.StartEnvironment publishes to
+// StreamEnvironmentCommands.
+type environmentStartCommandPayload struct {
+	EnvironmentID string `json:"environment_id"`
+}

--- a/services/api/internal/worker/environment_command_consumer.go
+++ b/services/api/internal/worker/environment_command_consumer.go
@@ -164,21 +164,35 @@ func (c *EnvironmentCommandConsumer) run() {
 }
 
 // processPending re-delivers and acknowledges any messages in the PEL that
-// were not acked during a previous run.
+// were not acked during a previous run. Loops in batches of
+// environmentCommandReadCount rather than reading once: each XReadGroup
+// call from ID "0" starts at the head of the PEL, so once a batch is
+// handled (and acked — see handle's own doc comment) the next call
+// naturally advances to whatever's left. Without the loop, a backlog of
+// more than one batch would leave the excess pending indefinitely — run()
+// switches to reading only new messages (">") right after this returns, so
+// nothing else would ever revisit them until the next process restart.
 func (c *EnvironmentCommandConsumer) processPending(ctx context.Context) {
-	msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
-		Group:    environmentCommandConsumerGroup,
-		Consumer: c.consumerName,
-		Streams:  []string{events.StreamEnvironmentCommands, "0"},
-		Count:    environmentCommandReadCount,
-	}).Result()
-	if err != nil && err != redis.Nil {
-		c.log.Warn("environment command consumer: could not read pending messages", "err", err)
-		return
-	}
-	for _, stream := range msgs {
-		for _, msg := range stream.Messages {
-			c.handle(msg)
+	for {
+		msgs, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    environmentCommandConsumerGroup,
+			Consumer: c.consumerName,
+			Streams:  []string{events.StreamEnvironmentCommands, "0"},
+			Count:    environmentCommandReadCount,
+		}).Result()
+		if err != nil && err != redis.Nil {
+			c.log.Warn("environment command consumer: could not read pending messages", "err", err)
+			return
+		}
+		delivered := 0
+		for _, stream := range msgs {
+			for _, msg := range stream.Messages {
+				c.handle(msg)
+				delivered++
+			}
+		}
+		if delivered < environmentCommandReadCount {
+			return
 		}
 	}
 }

--- a/services/api/internal/worker/environment_command_consumer.go
+++ b/services/api/internal/worker/environment_command_consumer.go
@@ -21,29 +21,33 @@ const (
 	environmentCommandReadCount     = 10
 )
 
-// environmentStarter is the minimal environmentsvc.Service surface this
-// consumer needs to actually execute a previously-queued start command —
-// see environmentsvc.Service.ExecuteStart's own doc comment for why that
-// method isn't part of environmentdom.Service (and so isn't reachable
-// through the notificationdom.Service-style full-domain-interface pattern
-// other consumers in this package use).
-type environmentStarter interface {
+// environmentLifecycleExecutor is the minimal environmentsvc.Service
+// surface this consumer needs to actually execute a previously-queued
+// create/start/stop command — see environmentsvc.Service.ExecuteStart's
+// own doc comment for why these methods aren't part of
+// environmentdom.Service (and so aren't reachable through the
+// notificationdom.Service-style full-domain-interface pattern other
+// consumers in this package use).
+type environmentLifecycleExecutor interface {
+	ExecuteCreate(ctx context.Context, environmentID uuid.UUID) error
 	ExecuteStart(ctx context.Context, environmentID uuid.UUID) error
+	ExecuteStop(ctx context.Context, environmentID uuid.UUID) error
 }
 
 // EnvironmentCommandConsumer reads queued environment lifecycle commands —
-// currently just "start" — from StreamEnvironmentCommands and executes
-// them. This is the asynchronous counterpart to
-// environmentsvc.Service.StartEnvironment, which only validates and
-// queues: moving the actual (potentially slow) agent-runner call here
-// means the HTTP request that triggered it returns immediately regardless
-// of how long starting the backing container/Pod takes, instead of
-// holding the connection open for it — which, past the server's own
-// WriteTimeout, showed up to callers as a 502 for a start that was
-// actually still succeeding server-side a few seconds later.
+// "create", "start", and "stop" — from StreamEnvironmentCommands and
+// executes them. This is the asynchronous counterpart to
+// environmentsvc.Service.CreateEnvironment/StartEnvironment/
+// StopEnvironment, which only validate and queue: moving the actual
+// (potentially slow) agent-runner call here means the HTTP request that
+// triggered it returns immediately regardless of how long provisioning/
+// starting/stopping the backing container/Pod takes, instead of holding
+// the connection open for it — which, past the server's own WriteTimeout,
+// showed up to callers as a 502 for a start that was actually still
+// succeeding server-side a few seconds later.
 type EnvironmentCommandConsumer struct {
 	client       *redis.Client
-	svc          environmentStarter
+	svc          environmentLifecycleExecutor
 	log          *slog.Logger
 	consumerName string // unique per instance, derived from hostname
 	stopCh       chan struct{}
@@ -53,7 +57,7 @@ type EnvironmentCommandConsumer struct {
 // NewEnvironmentCommandConsumer creates a consumer that is ready to be
 // started. The consumer name is derived from the hostname so it is unique
 // per pod/instance.
-func NewEnvironmentCommandConsumer(client *redis.Client, svc environmentStarter, log *slog.Logger) *EnvironmentCommandConsumer {
+func NewEnvironmentCommandConsumer(client *redis.Client, svc environmentLifecycleExecutor, log *slog.Logger) *EnvironmentCommandConsumer {
 	hostname, err := os.Hostname()
 	if err != nil || hostname == "" {
 		hostname = uuid.New().String()
@@ -88,8 +92,10 @@ func (c *EnvironmentCommandConsumer) Start(ctx context.Context) {
 // "0" there would redeliver every command still retained on the stream
 // (including ones already executed before the group vanished) with no
 // idempotency guard: re-executing an old "start" is at worst a harmless
-// no-op against an already-running environment, but there's no reason to
-// pay for the replay when "$" (from now) is available.
+// no-op against an already-running environment, but re-executing an old
+// "stop" is not — the environment could have been legitimately restarted
+// in the meantime, and a stale replay would stop it again out from under
+// whoever just started it. "$" (from now) avoids both concerns.
 func (c *EnvironmentCommandConsumer) ensureGroup(ctx context.Context, startID string) error {
 	err := c.client.XGroupCreateMkStream(ctx, events.StreamEnvironmentCommands, environmentCommandConsumerGroup, startID).Err()
 	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
@@ -178,10 +184,11 @@ func (c *EnvironmentCommandConsumer) processPending(ctx context.Context) {
 }
 
 // handle deserialises one stream message and executes the command it
-// carries. Always acks, regardless of outcome: ExecuteStart already
-// persists StatusError with the failure reason directly onto the
-// environment row on failure, so there is nothing left in the PEL worth
-// retrying automatically — a user sees the error status and retries
+// carries. Always acks, regardless of outcome: ExecuteCreate/ExecuteStart/
+// ExecuteStop already persist StatusError with the failure reason
+// directly onto the environment row on failure, so there is nothing left
+// in the PEL worth retrying automatically — a user sees the error status
+// and retries
 // explicitly, which queues a fresh command.
 func (c *EnvironmentCommandConsumer) handle(msg redis.XMessage) {
 	ctx := context.Background()
@@ -194,20 +201,31 @@ func (c *EnvironmentCommandConsumer) handle(msg redis.XMessage) {
 		return
 	}
 
+	var p environmentCommandPayload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		c.log.Warn("environment command consumer: failed to decode payload", "id", msg.ID, "err", err)
+		c.ack(ctx, msg.ID)
+		return
+	}
+	environmentID, err := uuid.Parse(p.EnvironmentID)
+	if err != nil {
+		c.log.Warn("environment command consumer: invalid environment_id", "id", msg.ID, "environment_id", p.EnvironmentID)
+		c.ack(ctx, msg.ID)
+		return
+	}
+
 	switch eventType {
+	case events.TopicEnvironmentCreate:
+		if err := c.svc.ExecuteCreate(ctx, environmentID); err != nil {
+			c.log.Error("environment command consumer: create failed", "environment_id", environmentID, "err", err)
+		}
 	case events.TopicEnvironmentStart:
-		var p environmentStartCommandPayload
-		if err := json.Unmarshal([]byte(raw), &p); err != nil {
-			c.log.Warn("environment command consumer: failed to decode payload", "id", msg.ID, "err", err)
-			break
-		}
-		environmentID, err := uuid.Parse(p.EnvironmentID)
-		if err != nil {
-			c.log.Warn("environment command consumer: invalid environment_id", "id", msg.ID, "environment_id", p.EnvironmentID)
-			break
-		}
 		if err := c.svc.ExecuteStart(ctx, environmentID); err != nil {
 			c.log.Error("environment command consumer: start failed", "environment_id", environmentID, "err", err)
+		}
+	case events.TopicEnvironmentStop:
+		if err := c.svc.ExecuteStop(ctx, environmentID); err != nil {
+			c.log.Error("environment command consumer: stop failed", "environment_id", environmentID, "err", err)
 		}
 	default:
 		c.log.Warn("environment command consumer: unknown event type", "id", msg.ID, "type", eventType)
@@ -222,9 +240,10 @@ func (c *EnvironmentCommandConsumer) ack(ctx context.Context, id string) {
 	}
 }
 
-// environmentStartCommandPayload mirrors the JSON shape
-// environmentsvc.Service.StartEnvironment publishes to
-// StreamEnvironmentCommands.
-type environmentStartCommandPayload struct {
+// environmentCommandPayload mirrors the JSON shape both
+// environmentsvc.Service.StartEnvironment and StopEnvironment publish to
+// StreamEnvironmentCommands — every command here concerns exactly one
+// environment, so environment_id is all either one carries.
+type environmentCommandPayload struct {
 	EnvironmentID string `json:"environment_id"`
 }

--- a/services/api/internal/worker/environment_command_consumer_test.go
+++ b/services/api/internal/worker/environment_command_consumer_test.go
@@ -1,0 +1,97 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Paca-AI/api/internal/events"
+)
+
+// fakeLifecycleExecutor is a function-field-based mock of
+// environmentLifecycleExecutor, counting how many times ExecuteStart runs.
+type fakeLifecycleExecutor struct {
+	startCalls int
+}
+
+func (f *fakeLifecycleExecutor) ExecuteCreate(context.Context, uuid.UUID) error { return nil }
+func (f *fakeLifecycleExecutor) ExecuteStart(context.Context, uuid.UUID) error {
+	f.startCalls++
+	return nil
+}
+func (f *fakeLifecycleExecutor) ExecuteStop(context.Context, uuid.UUID) error { return nil }
+
+// TestProcessPending_DrainsMoreThanOneBatch verifies processPending loops
+// until the PEL is empty rather than reading a single
+// environmentCommandReadCount-sized batch — a backlog larger than one batch
+// must not leave its excess stranded until another process restart (see
+// processPending's own doc comment).
+func TestProcessPending_DrainsMoreThanOneBatch(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+
+	svc := &fakeLifecycleExecutor{}
+	c := NewEnvironmentCommandConsumer(client, svc, discardLogger())
+	ctx := context.Background()
+
+	require.NoError(t, c.ensureGroup(ctx, "0"))
+
+	// More than one batch (environmentCommandReadCount == 10).
+	const totalCommands = 25
+	for i := 0; i < totalCommands; i++ {
+		payload, err := json.Marshal(environmentCommandPayload{EnvironmentID: uuid.New().String()})
+		require.NoError(t, err)
+		require.NoError(t, client.XAdd(ctx, &redis.XAddArgs{
+			Stream: events.StreamEnvironmentCommands,
+			Values: map[string]any{"type": events.TopicEnvironmentStart, "payload": string(payload)},
+		}).Err())
+	}
+
+	// Deliver every message into this consumer's own PEL without acking —
+	// simulates a prior run that read them but crashed (or failed to ack)
+	// before finishing.
+	_, err := client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    environmentCommandConsumerGroup,
+		Consumer: c.consumerName,
+		Streams:  []string{events.StreamEnvironmentCommands, ">"},
+		Count:    totalCommands,
+	}).Result()
+	require.NoError(t, err)
+
+	streamLen, err := client.XLen(ctx, events.StreamEnvironmentCommands).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, totalCommands, streamLen)
+
+	c.processPending(ctx)
+
+	require.Equal(t, totalCommands, svc.startCalls, "expected every pending command to be processed, not just the first batch")
+
+	pending, err := client.XPending(ctx, events.StreamEnvironmentCommands, environmentCommandConsumerGroup).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 0, pending.Count, "expected every processed command to be acked")
+}
+
+// TestProcessPending_EmptyPELIsANoOp verifies processPending returns
+// promptly (a single empty read) rather than looping when there's nothing
+// pending.
+func TestProcessPending_EmptyPELIsANoOp(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+
+	svc := &fakeLifecycleExecutor{}
+	c := NewEnvironmentCommandConsumer(client, svc, discardLogger())
+	ctx := context.Background()
+
+	require.NoError(t, c.ensureGroup(ctx, "0"))
+
+	c.processPending(ctx)
+
+	require.Equal(t, 0, svc.startCalls)
+}

--- a/services/api/internal/worker/notification_consumer.go
+++ b/services/api/internal/worker/notification_consumer.go
@@ -97,16 +97,20 @@ func (c *NotificationConsumer) WithActivityRecorder(r agentActivityRecorder) *No
 // Start creates the consumer group if needed and begins processing in a
 // background goroutine. Call Stop to drain and exit cleanly.
 func (c *NotificationConsumer) Start(ctx context.Context) {
-	if err := c.ensureGroup(ctx); err != nil {
+	// "0": see ActivityConsumer.Start's identical comment.
+	if err := c.ensureGroup(ctx, "0"); err != nil {
 		c.log.Warn("notification consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
 }
 
-// ensureGroup creates the consumer group if it doesn't already exist.
-func (c *NotificationConsumer) ensureGroup(ctx context.Context) error {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskAssignments, notificationConsumerGroup, "0").Err()
+// ensureGroup creates the consumer group at startID if it doesn't already
+// exist — see ActivityConsumer.ensureGroup's doc comment for why startID
+// differs between Start's first-ever creation ("0") and the NOGROUP
+// recovery path in run() below ("$").
+func (c *NotificationConsumer) ensureGroup(ctx context.Context, startID string) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskAssignments, notificationConsumerGroup, startID).Err()
 	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
 		return err
 	}
@@ -149,7 +153,15 @@ func (c *NotificationConsumer) run() {
 			}
 			c.log.Error("notification consumer: xreadgroup error", "err", err)
 			if strings.Contains(err.Error(), "NOGROUP") {
-				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+				// "$", not "0": recreating from the beginning here would
+				// redeliver the stream's retained history, and this
+				// handler generates fresh notification IDs with no
+				// event-level dedup — a replay would send duplicate
+				// notifications for assignments already handled.
+				recoverCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				geErr := c.ensureGroup(recoverCtx, "$")
+				cancel()
+				if geErr != nil {
 					c.log.Warn("notification consumer: failed to recreate consumer group", "err", geErr)
 				}
 			}

--- a/services/api/internal/worker/notification_consumer.go
+++ b/services/api/internal/worker/notification_consumer.go
@@ -97,12 +97,20 @@ func (c *NotificationConsumer) WithActivityRecorder(r agentActivityRecorder) *No
 // Start creates the consumer group if needed and begins processing in a
 // background goroutine. Call Stop to drain and exit cleanly.
 func (c *NotificationConsumer) Start(ctx context.Context) {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskAssignments, notificationConsumerGroup, "0").Err()
-	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-		c.log.Warn("notification consumer: could not create consumer group", "err", err)
+	if err := c.ensureGroup(ctx); err != nil {
+		c.log.Warn("notification consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
+}
+
+// ensureGroup creates the consumer group if it doesn't already exist.
+func (c *NotificationConsumer) ensureGroup(ctx context.Context) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamTaskAssignments, notificationConsumerGroup, "0").Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return err
+	}
+	return nil
 }
 
 // Stop signals the consumer to stop and waits for the goroutine to exit.
@@ -140,6 +148,11 @@ func (c *NotificationConsumer) run() {
 				continue
 			}
 			c.log.Error("notification consumer: xreadgroup error", "err", err)
+			if strings.Contains(err.Error(), "NOGROUP") {
+				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+					c.log.Warn("notification consumer: failed to recreate consumer group", "err", geErr)
+				}
+			}
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/services/api/internal/worker/plugin_event_consumer.go
+++ b/services/api/internal/worker/plugin_event_consumer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -66,13 +67,20 @@ func NewPluginEventConsumer(client *redis.Client, emitter PluginEventEmitter, lo
 // Start creates the consumer group if needed, then begins reading from the
 // stream in a background goroutine. Call Stop to drain and exit cleanly.
 func (c *PluginEventConsumer) Start(ctx context.Context) {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamPluginEvents, pluginEventConsumerGroup, "0").Err()
-	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-		c.log.Warn("plugin event consumer: could not create consumer group", "err", err)
-		// Non-fatal — we still attempt to read below.
+	if err := c.ensureGroup(ctx); err != nil {
+		c.log.Warn("plugin event consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
+}
+
+// ensureGroup creates the consumer group if it doesn't already exist.
+func (c *PluginEventConsumer) ensureGroup(ctx context.Context) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamPluginEvents, pluginEventConsumerGroup, "0").Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return err
+	}
+	return nil
 }
 
 // Stop signals the consumer to stop and waits for the goroutine to exit.
@@ -114,6 +122,11 @@ func (c *PluginEventConsumer) run() {
 				continue
 			}
 			c.log.Error("plugin event consumer: xreadgroup error", "err", err)
+			if strings.Contains(err.Error(), "NOGROUP") {
+				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+					c.log.Warn("plugin event consumer: failed to recreate consumer group", "err", geErr)
+				}
+			}
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/services/api/internal/worker/plugin_event_consumer.go
+++ b/services/api/internal/worker/plugin_event_consumer.go
@@ -67,16 +67,20 @@ func NewPluginEventConsumer(client *redis.Client, emitter PluginEventEmitter, lo
 // Start creates the consumer group if needed, then begins reading from the
 // stream in a background goroutine. Call Stop to drain and exit cleanly.
 func (c *PluginEventConsumer) Start(ctx context.Context) {
-	if err := c.ensureGroup(ctx); err != nil {
+	// "0": see ActivityConsumer.Start's identical comment.
+	if err := c.ensureGroup(ctx, "0"); err != nil {
 		c.log.Warn("plugin event consumer: could not create consumer group, will retry on first read", "err", err)
 	}
 
 	go c.run()
 }
 
-// ensureGroup creates the consumer group if it doesn't already exist.
-func (c *PluginEventConsumer) ensureGroup(ctx context.Context) error {
-	err := c.client.XGroupCreateMkStream(ctx, events.StreamPluginEvents, pluginEventConsumerGroup, "0").Err()
+// ensureGroup creates the consumer group at startID if it doesn't already
+// exist — see ActivityConsumer.ensureGroup's doc comment for why startID
+// differs between Start's first-ever creation ("0") and the NOGROUP
+// recovery path in run() below ("$").
+func (c *PluginEventConsumer) ensureGroup(ctx context.Context, startID string) error {
+	err := c.client.XGroupCreateMkStream(ctx, events.StreamPluginEvents, pluginEventConsumerGroup, startID).Err()
 	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
 		return err
 	}
@@ -123,7 +127,12 @@ func (c *PluginEventConsumer) run() {
 			}
 			c.log.Error("plugin event consumer: xreadgroup error", "err", err)
 			if strings.Contains(err.Error(), "NOGROUP") {
-				if geErr := c.ensureGroup(context.Background()); geErr != nil {
+				// "$", not "0": see ActivityConsumer's identical recovery
+				// comment — this handler has no event-level dedup either.
+				recoverCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				geErr := c.ensureGroup(recoverCtx, "$")
+				cancel()
+				if geErr != nil {
 					c.log.Warn("plugin event consumer: failed to recreate consumer group", "err", geErr)
 				}
 			}

--- a/services/api/migrations/000047_add_environment_starting_status.sql
+++ b/services/api/migrations/000047_add_environment_starting_status.sql
@@ -1,0 +1,26 @@
+-- 000047_add_environment_starting_status.sql
+-- Adds "starting" to environments.status' CHECK constraint —
+-- environmentdom.StatusStarting, the transitional status
+-- environmentsvc.Service.StartEnvironment now sets immediately after
+-- queuing a start command onto StreamEnvironmentCommands, before
+-- worker.EnvironmentCommandConsumer has actually asked agent-runner to
+-- start the backing container/Pod. Needed because that agent-runner call
+-- can legitimately take longer than an HTTP request should stay open (see
+-- StartEnvironment's own doc comment) — moving it off the request path
+-- means the environment sits in a distinct "queued, not yet running"
+-- state in the meantime, not "running" (not true yet) and not "stopped"
+-- (would look like nothing happened).
+--
+-- The constraint has no explicit name in 000042_add_environments.sql, so
+-- Postgres assigned it the default "environments_status_check" — dropped
+-- and recreated here, IF EXISTS, so this migration is safe to re-run
+-- (see database.RunMigrationsFS's own doc comment: there is no
+-- migration-tracking table, every file here re-runs on every startup).
+
+BEGIN;
+
+ALTER TABLE environments DROP CONSTRAINT IF EXISTS environments_status_check;
+ALTER TABLE environments ADD CONSTRAINT environments_status_check
+    CHECK (status IN ('creating', 'starting', 'running', 'stopping', 'stopped', 'suspended', 'error', 'deleting'));
+
+COMMIT;

--- a/services/realtime/src/permissions.ts
+++ b/services/realtime/src/permissions.ts
@@ -3,10 +3,11 @@
 // Instead of checking permissions on every received message, sockets are placed
 // into namespace-scoped rooms at join time:
 //
-//   project:<projectId>:tasks      — receives all task.* events
-//   project:<projectId>:docs       — receives all doc.* events
-//   project:<projectId>:workflows  — receives all workflow.* graph events
-//   project:<projectId>:sprints    — receives all sprint.* and view.* events
+//   project:<projectId>:tasks        — receives all task.* events
+//   project:<projectId>:docs         — receives all doc.* events
+//   project:<projectId>:workflows    — receives all workflow.* graph events
+//   project:<projectId>:sprints      — receives all sprint.* and view.* events
+//   project:<projectId>:environments — receives all environment.* events
 //
 // Room membership is determined once when the client emits "join": the server
 // fetches the user's project permissions, then joins only the rooms the user is
@@ -14,7 +15,12 @@
 // room with a plain io.to(room).emit() — no per-socket checks needed.
 
 // EventNamespace identifies the permission-gated sub-domains.
-export type EventNamespace = "tasks" | "docs" | "workflows" | "sprints";
+export type EventNamespace =
+	| "tasks"
+	| "docs"
+	| "workflows"
+	| "sprints"
+	| "environments";
 
 // NAMESPACE_PERMISSIONS maps each namespace to the project permission required
 // to receive events in that namespace.
@@ -23,6 +29,7 @@ export const NAMESPACE_PERMISSIONS: Record<EventNamespace, string> = {
 	docs: "docs.read",
 	workflows: "workflows.read",
 	sprints: "sprints.read",
+	environments: "environments.read",
 };
 
 // projectRoomName returns the Socket.IO room name for a project + namespace pair.
@@ -70,6 +77,10 @@ export function eventNamespace(type: string): EventNamespace | undefined {
 	// require the same sprints.read permission as sprint.* (see
 	// view_handler.go's route registration), so they share the room.
 	if (type.startsWith("view.")) return "sprints";
+	// environment.* events (currently just environment.status_changed)
+	// require environments.read, the same permission GET
+	// .../environments/:id is gated on.
+	if (type.startsWith("environment.")) return "environments";
 	return undefined;
 }
 

--- a/services/realtime/src/server.ts
+++ b/services/realtime/src/server.ts
@@ -20,10 +20,11 @@
 // ---------------
 // Events are routed through namespace-scoped rooms per project:
 //
-//   project:<projectId>:tasks      — all task.* events
-//   project:<projectId>:docs       — all doc.* events
-//   project:<projectId>:workflows  — all workflow.* graph events
-//   project:<projectId>:sprints    — all sprint.* events
+//   project:<projectId>:tasks        — all task.* events
+//   project:<projectId>:docs         — all doc.* events
+//   project:<projectId>:workflows    — all workflow.* graph events
+//   project:<projectId>:sprints      — all sprint.* events
+//   project:<projectId>:environments — all environment.* events
 //
 // When a client emits "join" with { projectId }, the server fetches the user's
 // project permissions via the API, then joins only the namespace rooms the user

--- a/services/realtime/src/subscriber.ts
+++ b/services/realtime/src/subscriber.ts
@@ -14,6 +14,7 @@
 //   workflow.* events  →  project:<projectId>:workflows (except
 //                          workflow.assigned, which is task-scoped)
 //   sprint.*   events  →  project:<projectId>:sprints
+//   environment.* events → project:<projectId>:environments
 //   agent.*    events  →  project:<projectId>:tasks, OR — when the event has
 //                          no project_id (a global agent's home-page / admin
 //                          chat, see services/ai-agent's


### PR DESCRIPTION
## Summary

- Fix static environments getting stopped by the idle reaper seconds after being (re)started, because `last_active_at` was never bumped on the start/restart path.
- Fix four Redis Streams consumer workers that could get permanently stuck on `NOGROUP` errors if their consumer group's creation failed once at startup, with no self-heal.

## Root cause 1: idle reaper stopping freshly-started environments

`StartEnvironment` and `restartEnvironmentPorts` in `services/api/internal/service/environment/environment_service.go` transitioned an environment to `running` via `UpdateEnvironmentStatus`, but never called the already-existing `TouchEnvironment` to refresh `last_active_at`.

agent-runner's `reapIdleEnvironments` ticks every minute and stops any environment where `status='running' AND last_active_at < now() - idle_timeout_minutes`. A long-stopped environment's `last_active_at` is typically far older than its own idle timeout, so starting it could get it reaped again on the very next tick. Observed directly in local dev: an environment was force-killed (`docker stop`, exit 137) 23 seconds after being started.

**Fix:** call `TouchEnvironment` right after `UpdateEnvironmentStatus(..., StatusRunning, ...)` in both `StartEnvironment` and `restartEnvironmentPorts`. Added `TestStartEnvironment_TouchesLastActiveAt` and extended `TestStartEnvironment_RestartsPortsWhenPending` to assert the touch happens.

## Root cause 2: Redis consumer groups never self-healed

`ActivityConsumer`, `PluginEventConsumer`, `NotificationConsumer`, and `DocActivityConsumer` each created their consumer group once, in `Start()`, treating a creation failure as non-fatal ("we still attempt to read below"). If that single attempt failed, every subsequent `XReadGroup` call failed with `NOGROUP` forever, since nothing ever recreated the group. `AutomationConsumer` already handled this correctly — on a `NOGROUP` read error it recreates the group inline — but the other four consumers didn't, and were observed spinning on `NOGROUP` errors for hours in local dev.

**Fix:** refactored each consumer's inline `XGroupCreateMkStream` call into an `ensureGroup(ctx)` method, and call it again whenever a read fails with `NOGROUP`, mirroring `AutomationConsumer`'s existing behavior.

## Testing

- `go build ./...` and `go test ./internal/service/environment/... ./internal/worker/...` pass.
- Verified live against local dev (`docker compose`): restarted a static environment through the real API path and confirmed it survives the idle reaper's next tick; confirmed all four consumer groups (`api.activity_writer`, `api.plugin_dispatcher`, `api.notification_writer`, `api.doc_activity_writer`) exist in Valkey and the `NOGROUP` error spam stopped.