### PR TITLE
Feature/improve environments feature

### DIFF
--- a/apps/web/src/components/projects/environments/environment-detail.tsx
+++ b/apps/web/src/components/projects/environments/environment-detail.tsx
@@ -764,7 +764,7 @@ function PortForwardsTab({
 							</div>
 							<div className="flex items-center gap-2 shrink-0">
 								{pf.host_port !== null ? (
-									<div className="w-56">
+									<div className="w-80">
 										<CommandBox
 											command={`${host ?? "<host>"}:${pf.host_port}`}
 										/>

--- a/services/agent-runner/internal/handler/handler.go
+++ b/services/agent-runner/internal/handler/handler.go
@@ -436,11 +436,17 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 				reason = registry.ReasonStop
 			}
 
-			if isChat && reason == registry.ReasonPause {
+			if isChat && trigger.EnvironmentID == nil && reason == registry.ReasonPause {
 				// Interrupt-only pause — mirrors _keep_sandbox_alive's
 				// is_chat && !errored && !shutdown case (a pause is never
 				// "errored" or "shutdown"): keep the sandbox alive for the
 				// conversation's next reply instead of tearing it down.
+				//
+				// Scoped to EnvironmentID == nil like the natural-finish
+				// branch below: a chat conversation attached to a static
+				// environment must still end this turn in a terminal status
+				// (see that branch's own doc comment), so an interrupt for
+				// one of these falls through to the full stop below instead.
 				h.keepSandboxAlive(trigger, result)
 				if err := h.ConvRepo.UpdateStatus(ctx, trigger.ConversationID, "paused", nil); err != nil {
 					h.Log.Warn("agent-runner: failed to record paused status",
@@ -489,7 +495,14 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 		// canReply are chat-specific concepts (see the natural-finish
 		// branch below) — a task-triggered conversation has no retry path
 		// through the UI regardless of status.
-		if classified && isChat {
+		//
+		// Also scoped to EnvironmentID == nil, same as the natural-finish
+		// branch below: canReplyToConversation already treats every
+		// environment-attached conversation as always replyable regardless
+		// of status (see its own doc comment), so "paused" buys nothing
+		// there and would only break the "ends every turn in a terminal
+		// status" invariant those conversations otherwise hold.
+		if classified && isChat && trigger.EnvironmentID == nil {
 			if err := h.ConvRepo.UpdateStatus(ctx, trigger.ConversationID, "paused", &errMsg); err != nil {
 				h.Log.Warn("agent-runner: failed to record paused-after-provider-error status",
 					"conversation_id", trigger.ConversationID, "error", err)


### PR DESCRIPTION
## Summary

- Widen the port-forward URL box in the environment detail page's Port Forwards tab from `w-56` (224px) to `w-80` (320px) so the `host:port` address has enough room to display without truncating/scrolling.
- Fix a bug where a chat conversation attached to a static environment could end a turn on status `paused` ("waiting for reply") instead of a terminal status. `paused` is meant only for an ephemeral chat sandbox waiting to be resumed; a conversation attached to a static environment must always end its turn in a terminal status, since the environment's container outlives the conversation and `canReplyToConversation` already treats it as always-replyable regardless of status. Two `agent-runner` branches were missing the `EnvironmentID == nil` guard the natural-finish path already had:
  - An interrupted turn (composer stop/pause) now falls through to `stopped` instead of `paused` when an environment is attached.
  - A classified, retryable provider error (rate limit/out of credits) now falls through to `failed` instead of `paused` when an environment is attached.

## Test plan

- [x] `go build ./...` and `go test ./internal/handler/...` pass in `services/agent-runner`.
- [ ] Manually verify the Port Forwards tab shows the full `host:port` value without truncation.
- [ ] Manually verify stopping a chat turn on a static-environment conversation now leaves it in a terminal status (not "waiting for reply").
