### PR TITLE
feat(mcp): add upload_task_attachment tool

### DIFF
--- a/apps/mcp/src/__tests__/api/views-client.test.ts
+++ b/apps/mcp/src/__tests__/api/views-client.test.ts
@@ -397,4 +397,145 @@ describe("PacaAPIViewsClient", () => {
 			).rejects.toThrow("413");
 		});
 	});
+
+	describe("uploadTaskAttachment", () => {
+		// A presigned-PUT response carrying (or omitting) an ETag header.
+		function putOk(etag: string | null) {
+			return {
+				ok: true,
+				status: 200,
+				headers: { get: (k: string) => (k.toLowerCase() === "etag" ? etag : null) },
+				text: async () => "",
+				json: async () => ({}),
+			};
+		}
+
+		it("single-part: PUTs the bytes, then completes with only the file_id", async () => {
+			const attachment = { id: "att1", file: { file_name: "a.txt" } };
+			const puts: string[] = [];
+			let completeBody: any;
+			fetchMock.mockImplementation((url: string, init: any) => {
+				if (url.endsWith("/initiate-upload")) {
+					return Promise.resolve(
+						okEnvelope({
+							file_id: "f1",
+							is_multipart: false,
+							upload_url: "https://store/put1",
+						}),
+					);
+				}
+				if (init?.method === "PUT") {
+					puts.push(url);
+					return Promise.resolve(putOk('"etag1"'));
+				}
+				if (url.endsWith("/complete-upload")) {
+					completeBody = JSON.parse(init.body);
+					return Promise.resolve(okEnvelope(attachment));
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			});
+
+			const client = new PacaAPIViewsClient(CONFIG);
+			const result = await client.uploadTaskAttachment("p1", "t1", {
+				fileName: "a.txt",
+				contentType: "text/plain",
+				data: new Uint8Array([1, 2, 3]),
+			});
+
+			expect(puts).toEqual(["https://store/put1"]);
+			expect(completeBody).toEqual({ file_id: "f1" });
+			expect(result).toEqual(attachment);
+		});
+
+		it("multipart: splits into 5 MiB parts, collects ETags, completes with upload_id + parts", async () => {
+			const attachment = { id: "att2" };
+			const puts: Array<{ url: string; size: number }> = [];
+			let completeBody: any;
+			fetchMock.mockImplementation((url: string, init: any) => {
+				if (url.endsWith("/initiate-upload")) {
+					return Promise.resolve(
+						okEnvelope({
+							file_id: "f2",
+							is_multipart: true,
+							multipart: {
+								upload_id: "u9",
+								parts: [
+									{ part_number: 1, upload_url: "https://store/p1" },
+									{ part_number: 2, upload_url: "https://store/p2" },
+								],
+							},
+						}),
+					);
+				}
+				if (init?.method === "PUT") {
+					puts.push({ url, size: (init.body as Uint8Array).byteLength });
+					return Promise.resolve(putOk(url.endsWith("/p1") ? '"e1"' : '"e2"'));
+				}
+				if (url.endsWith("/complete-upload")) {
+					completeBody = JSON.parse(init.body);
+					return Promise.resolve(okEnvelope(attachment));
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			});
+
+			const client = new PacaAPIViewsClient(CONFIG);
+			const FIVE_MB = 5 * 1024 * 1024;
+			const data = new Uint8Array(FIVE_MB + 100); // → 5 MiB + a 100-byte tail
+			const result = await client.uploadTaskAttachment("p1", "t1", {
+				fileName: "big.bin",
+				contentType: "application/octet-stream",
+				data,
+			});
+
+			expect(puts.map((p) => p.url)).toEqual([
+				"https://store/p1",
+				"https://store/p2",
+			]);
+			// Byte slicing: first part is exactly one PART_SIZE, second is the tail.
+			expect(puts.map((p) => p.size)).toEqual([FIVE_MB, 100]);
+			expect(completeBody).toEqual({
+				file_id: "f2",
+				upload_id: "u9",
+				parts: [
+					{ part_number: 1, etag: '"e1"' },
+					{ part_number: 2, etag: '"e2"' },
+				],
+			});
+			expect(result).toEqual(attachment);
+		});
+
+		it("fails fast (and never completes) when a part upload returns no ETag", async () => {
+			let completed = false;
+			fetchMock.mockImplementation((url: string, init: any) => {
+				if (url.endsWith("/initiate-upload")) {
+					return Promise.resolve(
+						okEnvelope({
+							file_id: "f3",
+							is_multipart: true,
+							multipart: {
+								upload_id: "u",
+								parts: [{ part_number: 1, upload_url: "https://store/x" }],
+							},
+						}),
+					);
+				}
+				if (init?.method === "PUT") return Promise.resolve(putOk(null));
+				if (url.endsWith("/complete-upload")) {
+					completed = true;
+					return Promise.resolve(okEnvelope({}));
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			});
+
+			const client = new PacaAPIViewsClient(CONFIG);
+			await expect(
+				client.uploadTaskAttachment("p1", "t1", {
+					fileName: "x.bin",
+					contentType: "application/octet-stream",
+					data: new Uint8Array(6 * 1024 * 1024),
+				}),
+			).rejects.toThrow(/no ETag/);
+			expect(completed).toBe(false);
+		});
+	});
 });

--- a/apps/mcp/src/__tests__/tools/attachment-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/attachment-tools.test.ts
@@ -5,6 +5,11 @@ vi.mock("../../utils/index.js", () => ({
 	formatFileSize: vi.fn((bytes: number) => `${bytes} bytes`),
 }));
 
+vi.mock("node:fs/promises", () => ({
+	readFile: vi.fn(),
+}));
+
+import { readFile } from "node:fs/promises";
 import {
 	getAttachmentTools,
 	handleAttachmentTool,
@@ -32,6 +37,7 @@ function makeClient(overrides: Record<string, any> = {}) {
 			contentType: "image/png",
 		}),
 		deleteTaskAttachment: vi.fn().mockResolvedValue(undefined),
+		uploadTaskAttachment: vi.fn().mockResolvedValue(attachment),
 		...overrides,
 	} as any;
 }
@@ -41,16 +47,97 @@ function makeClient(overrides: Record<string, any> = {}) {
 // ---------------------------------------------------------------------------
 
 describe("getAttachmentTools", () => {
-	it("returns 4 tools", () => {
-		expect(getAttachmentTools()).toHaveLength(4);
+	it("returns 5 tools", () => {
+		expect(getAttachmentTools()).toHaveLength(5);
 	});
 
-	it("includes list_task_attachments, get_attachment_download_url, read_task_attachment, delete_task_attachment", () => {
+	it("includes upload, list, download-url, read, and delete tools", () => {
 		const names = getAttachmentTools().map((t) => t.name);
+		expect(names).toContain("upload_task_attachment");
 		expect(names).toContain("list_task_attachments");
 		expect(names).toContain("get_attachment_download_url");
 		expect(names).toContain("read_task_attachment");
 		expect(names).toContain("delete_task_attachment");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// upload_task_attachment
+// ---------------------------------------------------------------------------
+
+describe("upload_task_attachment", () => {
+	it("reads the file and uploads it, inferring name and content type", async () => {
+		vi.mocked(readFile).mockResolvedValue(Buffer.from("PNGDATA") as any);
+		const client = makeClient();
+
+		const result = await handleAttachmentTool(
+			"upload_task_attachment",
+			{ projectId: "p1", taskId: "t1", filePath: "/tmp/photo.png" },
+			client,
+		);
+
+		expect(readFile).toHaveBeenCalledWith("/tmp/photo.png");
+		expect(client.uploadTaskAttachment).toHaveBeenCalledWith("p1", "t1", {
+			fileName: "photo.png",
+			contentType: "image/png",
+			data: expect.any(Buffer),
+		});
+		expect(result.isError).toBeFalsy();
+		expect(result.content[0].text).toContain("Uploaded");
+	});
+
+	it("honors explicit fileName and contentType overrides", async () => {
+		vi.mocked(readFile).mockResolvedValue(Buffer.from("data") as any);
+		const client = makeClient();
+
+		await handleAttachmentTool(
+			"upload_task_attachment",
+			{
+				projectId: "p1",
+				taskId: "t1",
+				filePath: "/tmp/x.bin",
+				fileName: "report.pdf",
+				contentType: "application/pdf",
+			},
+			client,
+		);
+
+		expect(client.uploadTaskAttachment).toHaveBeenCalledWith(
+			"p1",
+			"t1",
+			expect.objectContaining({
+				fileName: "report.pdf",
+				contentType: "application/pdf",
+			}),
+		);
+	});
+
+	it("returns an error when the file cannot be read", async () => {
+		vi.mocked(readFile).mockRejectedValue(new Error("ENOENT"));
+		const client = makeClient();
+
+		const result = await handleAttachmentTool(
+			"upload_task_attachment",
+			{ projectId: "p1", taskId: "t1", filePath: "/tmp/missing" },
+			client,
+		);
+
+		expect(result.isError).toBe(true);
+		expect(client.uploadTaskAttachment).not.toHaveBeenCalled();
+	});
+
+	it("rejects an empty file", async () => {
+		vi.mocked(readFile).mockResolvedValue(Buffer.alloc(0) as any);
+		const client = makeClient();
+
+		const result = await handleAttachmentTool(
+			"upload_task_attachment",
+			{ projectId: "p1", taskId: "t1", filePath: "/tmp/empty.txt" },
+			client,
+		);
+
+		expect(result.isError).toBe(true);
+		expect(client.uploadTaskAttachment).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/mcp/src/api/views-client.ts
+++ b/apps/mcp/src/api/views-client.ts
@@ -343,4 +343,108 @@ export class PacaAPIViewsClient {
 			contentType: response.headers.get("content-type") ?? undefined,
 		};
 	}
+
+	/**
+	 * Uploads a file as a task attachment via Paca's three-step flow:
+	 * initiate-upload (reserve a File row + presigned PUT URL[s]) → PUT the
+	 * bytes straight to object storage → complete-upload (mark uploaded +
+	 * create the task-attachment link). Handles both the single-part path
+	 * (< 5 MiB) and the multipart path the backend switches to for larger
+	 * files.
+	 *
+	 * The PUT goes to a presigned URL, which the backend rewrites to its
+	 * browser-facing public host (STORAGE_PUBLIC_URL) — the same host the web
+	 * client uploads through. An MCP server that can reach the Paca API's
+	 * public base URL (the usual setup for an external agent) can reach it
+	 * too; one confined to an internal Docker network that only resolves
+	 * `api`/`gateway` may not, and should surface the PUT error rather than
+	 * silently failing. (This mirrors downloadAttachmentContent's note, which
+	 * is why *reads* go through the API proxy instead — there is no equivalent
+	 * upload proxy endpoint to use here.)
+	 */
+	async uploadTaskAttachment(
+		projectId: string,
+		taskId: string,
+		input: { fileName: string; contentType: string; data: Uint8Array },
+	): Promise<Attachment> {
+		const { fileName, contentType, data } = input;
+		const session = await this.post(
+			`/api/v1/projects/${projectId}/tasks/${taskId}/attachments/initiate-upload`,
+			{
+				file_name: fileName,
+				content_type: contentType,
+				file_size: data.byteLength,
+			},
+		);
+
+		if (session.is_multipart && session.multipart) {
+			const parts = await this.putMultipart(
+				session.multipart.parts,
+				contentType,
+				data,
+			);
+			return this.post(
+				`/api/v1/projects/${projectId}/tasks/${taskId}/attachments/complete-upload`,
+				{
+					file_id: session.file_id,
+					upload_id: session.multipart.upload_id,
+					parts,
+				},
+			);
+		}
+
+		await this.putBytes(session.upload_url, contentType, data);
+		return this.post(
+			`/api/v1/projects/${projectId}/tasks/${taskId}/attachments/complete-upload`,
+			{ file_id: session.file_id },
+		);
+	}
+
+	/** PUTs raw bytes to a presigned object-store URL, returning its ETag. */
+	private async putBytes(
+		url: string,
+		contentType: string,
+		body: Uint8Array,
+	): Promise<string> {
+		const response = await fetch(url, {
+			method: "PUT",
+			headers: { "Content-Type": contentType },
+			// A Uint8Array is a valid fetch body at runtime (undici honors the
+			// view's byteOffset/byteLength, so a multipart subarray sends only its
+			// own bytes) but isn't in the DOM lib's BodyInit type — hence the cast.
+			body: body as unknown as BodyInit,
+		});
+		if (!response.ok) {
+			const errorText = await response.text().catch(() => "");
+			throw new Error(
+				`Uploading file bytes to object storage failed: ${formatApiRequestError(
+					response.status,
+					response.statusText,
+					errorText,
+				)}`,
+			);
+		}
+		return response.headers.get("etag") ?? "";
+	}
+
+	/**
+	 * Uploads each 5 MiB part to its presigned URL and returns the
+	 * {part_number, etag} list complete-upload needs to reassemble the object.
+	 */
+	private async putMultipart(
+		partURLs: Array<{ part_number: number; upload_url: string }>,
+		contentType: string,
+		data: Uint8Array,
+	): Promise<Array<{ part_number: number; etag: string }>> {
+		const PART_SIZE = 5 * 1024 * 1024; // matches the backend's DefaultPartSize
+		const ordered = [...partURLs].sort((a, b) => a.part_number - b.part_number);
+		const parts: Array<{ part_number: number; etag: string }> = [];
+		for (let i = 0; i < ordered.length; i++) {
+			const part = ordered[i];
+			const chunk = data.subarray(i * PART_SIZE, (i + 1) * PART_SIZE);
+			const etag = await this.putBytes(part.upload_url, contentType, chunk);
+			parts.push({ part_number: part.part_number, etag });
+		}
+		return parts;
+	}
 }

--- a/apps/mcp/src/api/views-client.ts
+++ b/apps/mcp/src/api/views-client.ts
@@ -443,6 +443,14 @@ export class PacaAPIViewsClient {
 			const part = ordered[i];
 			const chunk = data.subarray(i * PART_SIZE, (i + 1) * PART_SIZE);
 			const etag = await this.putBytes(part.upload_url, contentType, chunk);
+			if (!etag) {
+				// complete-upload requires an ETag per part; failing here names the
+				// offending part instead of surfacing a generic "etag is required"
+				// 400 from the backend a step later.
+				throw new Error(
+					`Part ${part.part_number} uploaded but the object store returned no ETag header; cannot complete the multipart upload.`,
+				);
+			}
 			parts.push({ part_number: part.part_number, etag });
 		}
 		return parts;

--- a/apps/mcp/src/permissions.ts
+++ b/apps/mcp/src/permissions.ts
@@ -278,6 +278,11 @@ export const TOOL_PERMISSIONS: ToolPermission[] = [
 
 	// Attachment tools
 	{
+		toolName: "upload_task_attachment",
+		permissionKey: "tasks.write",
+		requiresProject: true,
+	},
+	{
 		toolName: "list_task_attachments",
 		permissionKey: "tasks.read",
 		requiresProject: true,

--- a/apps/mcp/src/tools/attachment-tools.ts
+++ b/apps/mcp/src/tools/attachment-tools.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { PacaAPIViewsClient } from "../api/index.js";
@@ -7,6 +9,53 @@ const ListTaskAttachmentsSchema = z.object({
 	projectId: z.string(),
 	taskId: z.string(),
 });
+
+const UploadTaskAttachmentSchema = z.object({
+	projectId: z.string(),
+	taskId: z.string(),
+	filePath: z.string(),
+	fileName: z.string().optional(),
+	contentType: z.string().optional(),
+});
+
+// Minimal extension → MIME map for inferring content_type when the caller
+// doesn't pass one. Kept small and dependency-free; anything unknown falls back
+// to application/octet-stream (a valid, if generic, content type).
+const EXT_CONTENT_TYPES: Record<string, string> = {
+	txt: "text/plain",
+	md: "text/markdown",
+	csv: "text/csv",
+	log: "text/plain",
+	json: "application/json",
+	xml: "application/xml",
+	yml: "application/yaml",
+	yaml: "application/yaml",
+	html: "text/html",
+	htm: "text/html",
+	css: "text/css",
+	js: "text/javascript",
+	pdf: "application/pdf",
+	png: "image/png",
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	gif: "image/gif",
+	webp: "image/webp",
+	svg: "image/svg+xml",
+	zip: "application/zip",
+	gz: "application/gzip",
+	tar: "application/x-tar",
+	doc: "application/msword",
+	docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	xls: "application/vnd.ms-excel",
+	xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	ppt: "application/vnd.ms-powerpoint",
+	pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+};
+
+function guessContentType(fileName: string): string {
+	const ext = extname(fileName).slice(1).toLowerCase();
+	return EXT_CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
 
 const GetAttachmentDownloadURLSchema = z.object({
 	projectId: z.string(),
@@ -154,6 +203,46 @@ function classifyAttachment(
 export function getAttachmentTools(): Tool[] {
 	return [
 		{
+			name: "upload_task_attachment",
+			description:
+				"Upload a local file as an attachment on a task. Reads the file at " +
+				"filePath from the machine this MCP server runs on (e.g. a file the " +
+				"agent just created in its workspace) and attaches it to the task. " +
+				"The file name and content type are inferred from filePath unless " +
+				"given explicitly.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					projectId: {
+						type: "string",
+						description:
+							"The technical UUID of the project (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_projects to get the project ID. Do NOT use the project name.",
+					},
+					taskId: {
+						type: "string",
+						description:
+							"The technical UUID of the task (e.g., '550e8400-e29b-41d4-a716-446655440000'). Use list_tasks to get the task ID.",
+					},
+					filePath: {
+						type: "string",
+						description:
+							"Absolute or working-directory-relative path to the local file to upload.",
+					},
+					fileName: {
+						type: "string",
+						description:
+							"Optional name to store the attachment under. Defaults to the base name of filePath.",
+					},
+					contentType: {
+						type: "string",
+						description:
+							"Optional MIME type (e.g. 'application/pdf'). Defaults to a guess from the file extension.",
+					},
+				},
+				required: ["projectId", "taskId", "filePath"],
+			},
+		},
+		{
 			name: "list_task_attachments",
 			description: "List all attachments for a task",
 			inputSchema: {
@@ -274,6 +363,50 @@ export async function handleAttachmentTool(
 	viewsClient: PacaAPIViewsClient,
 ): Promise<any> {
 	switch (toolName) {
+		case "upload_task_attachment": {
+			const { projectId, taskId, filePath, fileName, contentType } =
+				UploadTaskAttachmentSchema.parse(args);
+
+			let data: Buffer;
+			try {
+				data = await readFile(filePath);
+			} catch (err) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Could not read file at "${filePath}": ${(err as Error).message}`,
+						},
+					],
+					isError: true,
+				};
+			}
+			if (data.byteLength === 0) {
+				return {
+					content: [
+						{ type: "text", text: `File "${filePath}" is empty; nothing to upload.` },
+					],
+					isError: true,
+				};
+			}
+
+			const name = fileName || basename(filePath);
+			const type = contentType || guessContentType(name);
+			const attachment = await viewsClient.uploadTaskAttachment(
+				projectId,
+				taskId,
+				{ fileName: name, contentType: type, data },
+			);
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Uploaded "${name}" (${formatFileSize(data.byteLength)}) to task ${taskId}.\n\n${formatAttachment(attachment)}`,
+					},
+				],
+			};
+		}
+
 		case "list_task_attachments": {
 			const { projectId, taskId } = ListTaskAttachmentsSchema.parse(args);
 			const attachments = await viewsClient.listTaskAttachments(

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -202,6 +202,7 @@ export async function handleToolCall(
 
 		// Attachment tools
 		if (
+			name === "upload_task_attachment" ||
 			name === "list_task_attachments" ||
 			name === "get_attachment_download_url" ||
 			name === "read_task_attachment" ||


### PR DESCRIPTION
The MCP server could list, read, download, and delete task attachments but not create them — there was no way for an agent to attach a file it produced (a report, a screenshot, a build artifact) to a task.

Add `upload_task_attachment(projectId, taskId, filePath, fileName?, contentType?)`. It reads a local file on the machine the MCP server runs on and drives Paca's three-step upload: initiate-upload (reserve a File row + presigned PUT URL[s]) → PUT the bytes to object storage → complete-upload (mark uploaded + create the task-attachment link). Both the single-part (< 5 MiB) and multipart paths are handled. File name and content type are inferred from the path when not given (small, dependency-free MIME map). Registered as a tasks.write tool.

The PUT targets a presigned URL, which the backend rewrites to its browser-facing public host — the same host the web client uploads through, reachable by an external agent that already talks to the Paca API over that URL. (Reads go through the API content proxy instead, for the sandbox case where that host isn't resolvable; there is no equivalent upload proxy to use here, so the tool surfaces the PUT error rather than failing silently.)

Adds upload coverage to attachment-tools.test.ts (name/type inference, explicit overrides, unreadable file, empty file); the suite passes.

## Summary

Describe the change in a few sentences.

## Type of Change

- Documentation
- Repository structure
- Architecture clarification
- Scaffolding
- Other

## Checklist

- The change is focused and scoped.
- Related documentation is updated.
- New structure or direction is explained clearly.
- I avoided unnecessary detail or premature abstraction.