### PR TITLE
fix(mcp): load https plugin entries via fetch, not import() of the URL

### DIFF
--- a/apps/mcp/src/__tests__/plugin-loader.test.ts
+++ b/apps/mcp/src/__tests__/plugin-loader.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { PluginRegistry } from "../plugin-loader.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PluginRegistry, resolveImportUrl } from "../plugin-loader.js";
 import type { PacaConfig } from "../types/index.js";
 
 const config: PacaConfig = {
@@ -194,5 +194,82 @@ describe("PluginRegistry.getToolContext", () => {
 				apiKey: config.apiKey,
 			},
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resolveImportUrl — importable-form resolution + SSRF guard
+// ---------------------------------------------------------------------------
+
+describe("resolveImportUrl", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function decodeDataUrl(dataUrl: string): string {
+		const m = /^data:text\/javascript;base64,(.*)$/.exec(dataUrl);
+		if (!m) throw new Error(`not a js data: URL: ${dataUrl.slice(0, 40)}`);
+		return Buffer.from(m[1], "base64").toString("utf8");
+	}
+
+	it("fetches an https:// entry and returns it as a data: URL (Node can't import() https)", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			text: async () => "export default { hello: 1 }",
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		// Bare *public* IP host: passes the SSRF guard without any DNS lookup.
+		const out = await resolveImportUrl(
+			"https://8.8.8.8/plugins-mcp/x/mcp.js",
+			"https://paca.example.com",
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith("https://8.8.8.8/plugins-mcp/x/mcp.js");
+		expect(decodeDataUrl(out)).toBe("export default { hello: 1 }");
+	});
+
+	it("resolves a path-only entry against baseURL, then fetches it", async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			text: async () => "export default {}",
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const out = await resolveImportUrl(
+			"/plugins-mcp/x/mcp.js",
+			"https://8.8.8.8",
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith("https://8.8.8.8/plugins-mcp/x/mcp.js");
+		expect(out.startsWith("data:text/javascript;base64,")).toBe(true);
+	});
+
+	it("rejects an https:// host that is a private IP (SSRF) without fetching", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			resolveImportUrl("https://10.0.0.5/mcp.js", "https://paca.example.com"),
+		).rejects.toThrow(/private\/internal IP/);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("passes a file:// entry through unchanged (import()-able as-is)", async () => {
+		const out = await resolveImportUrl(
+			"file:///tmp/mcp.js",
+			"https://paca.example.com",
+		);
+		expect(out).toBe("file:///tmp/mcp.js");
+	});
+
+	it("throws when the fetch fails", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" }),
+		);
+		await expect(
+			resolveImportUrl("https://8.8.8.8/mcp.js", "https://paca.example.com"),
+		).rejects.toThrow(/Failed to fetch plugin module.*404/);
 	});
 });

--- a/apps/mcp/src/__tests__/plugin-loader.test.ts
+++ b/apps/mcp/src/__tests__/plugin-loader.test.ts
@@ -42,7 +42,9 @@ describe("PluginRegistry.getToolContext", () => {
 
 	it("only calls plugins that declared a hook for the requested toolId", async () => {
 		const taskHook = vi.fn().mockResolvedValue("## GitHub\nBranch: feat/t1");
-		const sprintOnlyHook = vi.fn().mockResolvedValue("should not run for get_task");
+		const sprintOnlyHook = vi
+			.fn()
+			.mockResolvedValue("should not run for get_task");
 		const registry = new PluginRegistry([
 			{
 				pluginId: "com.paca.github",
@@ -79,7 +81,9 @@ describe("PluginRegistry.getToolContext", () => {
 				entry: {
 					tools: [],
 					handleToolCall: vi.fn(),
-					getToolContext: vi.fn().mockResolvedValue("## GitHub\nBranch: feat/t1"),
+					getToolContext: vi
+						.fn()
+						.mockResolvedValue("## GitHub\nBranch: feat/t1"),
 				},
 				toolContextHooks: ["get_task"],
 			},
@@ -225,7 +229,14 @@ describe("resolveImportUrl", () => {
 			"https://paca.example.com",
 		);
 
-		expect(fetchMock).toHaveBeenCalledWith("https://8.8.8.8/plugins-mcp/x/mcp.js");
+		// redirect: "error" is required — following a redirect would skip the
+		// private-IP guard and reopen the SSRF hole.
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://8.8.8.8/plugins-mcp/x/mcp.js",
+			{
+				redirect: "error",
+			},
+		);
 		expect(decodeDataUrl(out)).toBe("export default { hello: 1 }");
 	});
 
@@ -241,7 +252,12 @@ describe("resolveImportUrl", () => {
 			"https://8.8.8.8",
 		);
 
-		expect(fetchMock).toHaveBeenCalledWith("https://8.8.8.8/plugins-mcp/x/mcp.js");
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://8.8.8.8/plugins-mcp/x/mcp.js",
+			{
+				redirect: "error",
+			},
+		);
 		expect(out.startsWith("data:text/javascript;base64,")).toBe(true);
 	});
 
@@ -266,7 +282,9 @@ describe("resolveImportUrl", () => {
 	it("throws when the fetch fails", async () => {
 		vi.stubGlobal(
 			"fetch",
-			vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" }),
+			vi
+				.fn()
+				.mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" }),
 		);
 		await expect(
 			resolveImportUrl("https://8.8.8.8/mcp.js", "https://paca.example.com"),

--- a/apps/mcp/src/plugin-loader.ts
+++ b/apps/mcp/src/plugin-loader.ts
@@ -342,9 +342,10 @@ async function loadPluginEntry(
 	url: string,
 	baseURL: string,
 ): Promise<PluginMCPEntry> {
-	// Dynamic import works for both file:// and https:// URLs in Node 18+.
-	// For http:// URLs (common in local dev), we fetch the source first and
-	// evaluate it via a data: URL import.
+	// resolveImportUrl returns something Node's default ESM loader can
+	// actually import(): a file:// URL as-is, or a data: URL carrying the
+	// fetched source for http(s):// entries — Node can't import() remote URLs
+	// (network imports were experimental and removed in Node 22).
 	const importUrl = await resolveImportUrl(url, baseURL);
 	const mod = await import(importUrl);
 
@@ -364,13 +365,18 @@ async function loadPluginEntry(
  *   URLs are accepted.  Any other scheme is rejected.
  * - For `https://` URLs the hostname is resolved via DNS and the function
  *   throws if any resolved address falls inside a private / internal IP range
- *   (SSRF protection, similar to the API marketplace URL validator).
+ *   (SSRF protection, similar to the API marketplace URL validator). The
+ *   source is then fetched and re-exposed as a `data:` URL, because Node's
+ *   default ESM loader cannot `import()` a remote URL of any scheme (network
+ *   imports were experimental and removed in Node 22).
  * - For `http://` URLs the hostname must be localhost, a loopback address, or
  *   the same hostname as `baseURL` (trusted operator-configured gateway).
- *   The source is fetched and re-exposed as a `data:` URL because Node.js
- *   cannot `import()` plain `http://` URLs.
+ *   The source is fetched and re-exposed as a `data:` URL for the same reason.
  */
-async function resolveImportUrl(url: string, baseURL: string): Promise<string> {
+export async function resolveImportUrl(
+	url: string,
+	baseURL: string,
+): Promise<string> {
 	// Always resolve against baseURL so the URL constructor handles absolute,
 	// relative, and protocol-relative URLs correctly without fragile heuristics:
 	//   "/plugins-mcp/id/mcp.js" → "<baseURL>/plugins-mcp/id/mcp.js"
@@ -392,7 +398,10 @@ async function resolveImportUrl(url: string, baseURL: string): Promise<string> {
 	if (scheme === "https:") {
 		// Guard against SSRF: reject hostnames that resolve to private IPs.
 		await assertNotPrivateHost(resolved.hostname);
-		return resolved.href;
+		// Node's default ESM loader can't import() an https:// URL either —
+		// network imports were experimental and removed in Node 22 — so fetch
+		// the source and evaluate it via a data: URL, same as http:// below.
+		return fetchAsDataUrl(resolved.href);
 	}
 
 	if (scheme === "http:") {
@@ -416,22 +425,32 @@ async function resolveImportUrl(url: string, baseURL: string): Promise<string> {
 
 		// Node.js cannot import() http:// URLs — fetch source and wrap in a
 		// data: URL so import() can evaluate it without network restrictions.
-		const response = await fetch(resolved.href);
-		if (!response.ok) {
-			throw new Error(
-				`Failed to fetch plugin module from ${resolved.href}: ${response.status} ${response.statusText}`,
-			);
-		}
-		const source = await response.text();
-		// Use base64 to avoid issues with special characters in the source
-		const b64 = Buffer.from(source, "utf8").toString("base64");
-		return `data:text/javascript;base64,${b64}`;
+		return fetchAsDataUrl(resolved.href);
 	}
 
 	throw new Error(
 		`Plugin entry URL scheme "${scheme.replace(":", "")}" is not allowed. ` +
 			`Only https://, http:// (localhost only), and file:// are permitted.`,
 	);
+}
+
+/**
+ * Fetches JavaScript source over http(s) and returns it as a base64 `data:`
+ * URL that Node's default ESM loader can import(). Neither http:// nor
+ * https:// URLs are importable directly — network imports were experimental
+ * and removed in Node 22 — so both schemes route through here.
+ */
+async function fetchAsDataUrl(url: string): Promise<string> {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch plugin module from ${url}: ${response.status} ${response.statusText}`,
+		);
+	}
+	const source = await response.text();
+	// base64 to avoid issues with special characters in the source
+	const b64 = Buffer.from(source, "utf8").toString("base64");
+	return `data:text/javascript;base64,${b64}`;
 }
 
 /** Returns true if the hostname is a loopback / localhost address. */

--- a/apps/mcp/src/plugin-loader.ts
+++ b/apps/mcp/src/plugin-loader.ts
@@ -441,7 +441,13 @@ export async function resolveImportUrl(
  * and removed in Node 22 — so both schemes route through here.
  */
 async function fetchAsDataUrl(url: string): Promise<string> {
-	const response = await fetch(url);
+	// redirect: "error" is load-bearing for SSRF safety: assertNotPrivateHost
+	// only validated the *initial* URL's host, so following a redirect could
+	// land on an internal address (cloud metadata 169.254.169.254, RFC-1918,
+	// …) that the guard never re-checked. Plugin modules are served directly
+	// from the operator's gateway and shouldn't redirect, so reject any
+	// redirect outright rather than re-validating each hop.
+	const response = await fetch(url, { redirect: "error" });
 	if (!response.ok) {
 		throw new Error(
 			`Failed to fetch plugin module from ${url}: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
resolveImportUrl returned an https:// plugin entry URL for loadPluginEntry to import() directly, on the assumption (per an outdated comment) that Node can import() remote https URLs. It can't by default — network imports were experimental and were removed in Node 22 — so loading any plugin whose MCP module is served over https fails at startup with:

    ERR_UNSUPPORTED_ESM_URL_SCHEME: Only URLs with a scheme in: file, data,
    and node are supported by the default ESM loader. Received protocol 'https:'

which knocks out that plugin's tools for every deployment addressed by an https PACA_API_URL (the http:// branch already worked, so LAN deployments using an internal http gateway were unaffected — masking the bug).

Route https:// through the same fetch-source-and-wrap-in-a-data:-URL path the http:// branch already used (factored into a shared fetchAsDataUrl helper), keeping the existing SSRF guard that rejects private/internal hosts before fetching. Also correct the stale "import works for https in Node 18+" comments.

Exports resolveImportUrl and adds tests: https is fetched into a data: URL, a path-only entry resolves against baseURL first, a private-IP https host is rejected without fetching, file:// passes through unchanged, and a failed fetch surfaces a clear error.

## Summary

Describe the change in a few sentences.

## Type of Change

- Documentation
- Repository structure
- Architecture clarification
- Scaffolding
- Other

## Checklist

- The change is focused and scoped.
- Related documentation is updated.
- New structure or direction is explained clearly.
- I avoided unnecessary detail or premature abstraction.