### PR TITLE
feat: add context injection for chat conversations

### DIFF
--- a/apps/mcp/src/__tests__/api/conversation-client.test.ts
+++ b/apps/mcp/src/__tests__/api/conversation-client.test.ts
@@ -85,6 +85,40 @@ describe("PacaAPIConversationClient", () => {
 		).toBeUndefined();
 	});
 
+	it("sends X-Conversation-ID header only alongside agentId", async () => {
+		const client = new PacaAPIConversationClient({
+			...CONFIG,
+			agentId: "agent-1",
+			conversationId: "conv-current",
+		});
+		await client.getConversation("c1");
+		expect(fetchMock.mock.calls[0][1].headers["X-Conversation-ID"]).toBe(
+			"conv-current",
+		);
+	});
+
+	it("omits X-Conversation-ID when conversationId is configured without agentId", async () => {
+		const client = new PacaAPIConversationClient({
+			...CONFIG,
+			conversationId: "conv-current",
+		});
+		await client.getConversation("c1");
+		expect(
+			fetchMock.mock.calls[0][1].headers["X-Conversation-ID"],
+		).toBeUndefined();
+	});
+
+	it("omits X-Conversation-ID when conversationId is not configured", async () => {
+		const client = new PacaAPIConversationClient({
+			...CONFIG,
+			agentId: "agent-1",
+		});
+		await client.getConversation("c1");
+		expect(
+			fetchMock.mock.calls[0][1].headers["X-Conversation-ID"],
+		).toBeUndefined();
+	});
+
 	it("throws on non-OK response", async () => {
 		fetchMock.mockResolvedValue(errorResponse(503, "Service Unavailable"));
 		const client = new PacaAPIConversationClient(CONFIG);

--- a/apps/mcp/src/__tests__/api/conversation-client.test.ts
+++ b/apps/mcp/src/__tests__/api/conversation-client.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PacaAPIConversationClient } from "../../api/conversation-client.js";
+
+const CONFIG = { baseURL: "https://api.example.com", apiKey: "key123" };
+
+function okEnvelope(data: any) {
+	return {
+		ok: true,
+		json: async () => ({ success: true, data }),
+		text: async () => "",
+	};
+}
+
+function rawOk(data: any) {
+	return { ok: true, json: async () => data, text: async () => "" };
+}
+
+function errorResponse(status = 400, body = "Bad Request") {
+	return {
+		ok: false,
+		status,
+		statusText: body,
+		text: async () => body,
+		json: async () => ({}),
+	};
+}
+
+describe("PacaAPIConversationClient", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn().mockResolvedValue(okEnvelope({}));
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	// ---------------------------------------------------------------------------
+	// Basic request behaviour
+	// ---------------------------------------------------------------------------
+
+	it("includes X-API-Key header", async () => {
+		const client = new PacaAPIConversationClient(CONFIG);
+		await client.getConversation("c1");
+		expect(fetchMock.mock.calls[0][1].headers["X-API-Key"]).toBe("key123");
+	});
+
+	it("sends X-Agent-ID header when agentId is configured", async () => {
+		const client = new PacaAPIConversationClient({
+			...CONFIG,
+			agentId: "agent-1",
+		});
+		await client.getConversation("c1");
+		expect(fetchMock.mock.calls[0][1].headers["X-Agent-ID"]).toBe("agent-1");
+	});
+
+	it("omits X-Agent-ID when agentId is not configured", async () => {
+		const client = new PacaAPIConversationClient(CONFIG);
+		await client.getConversation("c1");
+		expect(fetchMock.mock.calls[0][1].headers["X-Agent-ID"]).toBeUndefined();
+	});
+
+	it("sends X-Actor-User-ID header only alongside agentId", async () => {
+		const client = new PacaAPIConversationClient({
+			...CONFIG,
+			agentId: "agent-1",
+			actorUserId: "user-7",
+		});
+		await client.getConversation("c1");
+		expect(fetchMock.mock.calls[0][1].headers["X-Actor-User-ID"]).toBe(
+			"user-7",
+		);
+	});
+
+	it("omits X-Actor-User-ID when actorUserId is configured without agentId", async () => {
+		const client = new PacaAPIConversationClient({
+			...CONFIG,
+			actorUserId: "user-7",
+		});
+		await client.getConversation("c1");
+		expect(
+			fetchMock.mock.calls[0][1].headers["X-Actor-User-ID"],
+		).toBeUndefined();
+	});
+
+	it("throws on non-OK response", async () => {
+		fetchMock.mockResolvedValue(errorResponse(503, "Service Unavailable"));
+		const client = new PacaAPIConversationClient(CONFIG);
+		await expect(client.getConversation("c1")).rejects.toThrow("503");
+	});
+
+	it("returns raw JSON when not a SuccessEnvelope", async () => {
+		fetchMock.mockResolvedValue(rawOk({ id: "c1", status: "running" }));
+		const client = new PacaAPIConversationClient(CONFIG);
+		const result = await client.getConversation("c1");
+		expect(result).toEqual({ id: "c1", status: "running" });
+	});
+
+	it("sends only GET requests (no body)", async () => {
+		const client = new PacaAPIConversationClient(CONFIG);
+		await client.getConversation("c1");
+		expect(fetchMock.mock.calls[0][1].method).toBe("GET");
+		expect(fetchMock.mock.calls[0][1].body).toBeUndefined();
+	});
+
+	// ---------------------------------------------------------------------------
+	// Agent self-service conversation reads — GET /agents/me/conversations/:id.
+	// No projectId: this path authorizes by the conversation's own agent_id
+	// matching the caller (see agentdom.Service.GetConversationForAgent), not
+	// by project or human membership, so it works identically for a
+	// project-scoped or global conversation.
+	// ---------------------------------------------------------------------------
+
+	describe("getConversation", () => {
+		it("calls GET /api/v1/agents/me/conversations/:conversationId", async () => {
+			const client = new PacaAPIConversationClient(CONFIG);
+			fetchMock.mockResolvedValue(okEnvelope({ id: "c1", status: "running" }));
+			const result = await client.getConversation("c1");
+			expect(fetchMock.mock.calls[0][0]).toBe(
+				"https://api.example.com/api/v1/agents/me/conversations/c1",
+			);
+			expect(result).toEqual({ id: "c1", status: "running" });
+		});
+	});
+
+	describe("listConversationEvents", () => {
+		it("calls GET /api/v1/agents/me/conversations/:conversationId/events with no query string by default", async () => {
+			const client = new PacaAPIConversationClient(CONFIG);
+			fetchMock.mockResolvedValue(
+				okEnvelope({
+					items: [],
+					total: 0,
+					next_cursor: null,
+					prev_cursor: null,
+				}),
+			);
+			await client.listConversationEvents("c1");
+			expect(fetchMock.mock.calls[0][0]).toBe(
+				"https://api.example.com/api/v1/agents/me/conversations/c1/events",
+			);
+		});
+
+		it("builds after/before/limit query params", async () => {
+			const client = new PacaAPIConversationClient(CONFIG);
+			fetchMock.mockResolvedValue(
+				okEnvelope({
+					items: [],
+					total: 0,
+					next_cursor: null,
+					prev_cursor: null,
+				}),
+			);
+			await client.listConversationEvents("c1", { after: "cur1", limit: 25 });
+			const url = fetchMock.mock.calls[0][0] as string;
+			expect(url).toContain("after=cur1");
+			expect(url).toContain("limit=25");
+			expect(url).not.toContain("before=");
+		});
+
+		it("URL-encodes cursor values", async () => {
+			const client = new PacaAPIConversationClient(CONFIG);
+			fetchMock.mockResolvedValue(
+				okEnvelope({
+					items: [],
+					total: 0,
+					next_cursor: null,
+					prev_cursor: null,
+				}),
+			);
+			await client.listConversationEvents("c1", { before: "a b&c" });
+			const url = fetchMock.mock.calls[0][0] as string;
+			expect(url).toContain(`before=${encodeURIComponent("a b&c")}`);
+		});
+
+		it("normalizes the items/total/cursor response shape", async () => {
+			const client = new PacaAPIConversationClient(CONFIG);
+			const events = [
+				{
+					id: "e1",
+					conversation_id: "c1",
+					event_index: 0,
+					event_type: "user_message",
+					event_source: "user",
+					payload: {},
+					created_at: "2024-01-01T00:00:00Z",
+				},
+			];
+			fetchMock.mockResolvedValue(
+				okEnvelope({
+					items: events,
+					total: 5,
+					next_cursor: "n1",
+					prev_cursor: null,
+				}),
+			);
+			const result = await client.listConversationEvents("c1");
+			expect(result).toEqual({
+				items: events,
+				total: 5,
+				next_cursor: "n1",
+				prev_cursor: null,
+			});
+		});
+
+		it("defaults missing fields when the response omits them", async () => {
+			const client = new PacaAPIConversationClient(CONFIG);
+			fetchMock.mockResolvedValue(okEnvelope({}));
+			const result = await client.listConversationEvents("c1");
+			expect(result).toEqual({
+				items: [],
+				total: 0,
+				next_cursor: null,
+				prev_cursor: null,
+			});
+		});
+	});
+});

--- a/apps/mcp/src/__tests__/permissions.test.ts
+++ b/apps/mcp/src/__tests__/permissions.test.ts
@@ -164,6 +164,12 @@ describe("getToolPermission", () => {
 		expect(perm?.permissionKey).toBe("tasks.read");
 		expect(perm?.requiresProject).toBe(true);
 	});
+
+	it("returns the correct permission for read_conversation", () => {
+		const perm = getToolPermission("read_conversation");
+		expect(perm?.permissionKey).toBe("agents.read");
+		expect(perm?.requiresProject).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -188,6 +194,7 @@ describe("TOOL_PERMISSIONS", () => {
 			"create_custom_field",
 			"list_task_attachments",
 			"add_task_comment",
+			"read_conversation",
 		];
 		for (const name of expected) {
 			expect(names, `missing tool: ${name}`).toContain(name);

--- a/apps/mcp/src/__tests__/permissions.test.ts
+++ b/apps/mcp/src/__tests__/permissions.test.ts
@@ -165,10 +165,9 @@ describe("getToolPermission", () => {
 		expect(perm?.requiresProject).toBe(true);
 	});
 
-	it("returns the correct permission for read_conversation", () => {
+	it("has no permission mapping for read_conversation — it's always listed, since its real authorization is unconditional and self-scoped (see TOOL_PERMISSIONS' comment)", () => {
 		const perm = getToolPermission("read_conversation");
-		expect(perm?.permissionKey).toBe("agents.read");
-		expect(perm?.requiresProject).toBe(true);
+		expect(perm).toBeNull();
 	});
 });
 
@@ -194,7 +193,6 @@ describe("TOOL_PERMISSIONS", () => {
 			"create_custom_field",
 			"list_task_attachments",
 			"add_task_comment",
-			"read_conversation",
 		];
 		for (const name of expected) {
 			expect(names, `missing tool: ${name}`).toContain(name);

--- a/apps/mcp/src/__tests__/tools/conversation-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/conversation-tools.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	formatConversationTranscript,
+	formatTranscriptLines,
+	getConversationTools,
+	handleConversationTool,
+} from "../../tools/conversation-tools.js";
+import type {
+	AgentConversation,
+	AgentConversationEvent,
+	ConversationEventPage,
+} from "../../types/index.js";
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const CONVERSATION: AgentConversation = {
+	id: "conv-1",
+	agent_id: "agent-1",
+	project_id: "p1",
+	trigger_type: "chat_message",
+	status: "running",
+	iteration_count: 1,
+	input_tokens: 10,
+	output_tokens: 20,
+	total_tokens: 30,
+	created_at: "2024-01-01T00:00:00Z",
+	started_at: "2024-01-01T00:00:01Z",
+	agent_name: "Ada",
+	agent_handle: "ada-bot",
+};
+
+function makeClient(
+	opts: {
+		conversation?: AgentConversation;
+		page?: Partial<ConversationEventPage>;
+	} = {},
+) {
+	const page: ConversationEventPage = {
+		items: [],
+		total: 0,
+		next_cursor: null,
+		prev_cursor: null,
+		...opts.page,
+	};
+	return {
+		getConversation: vi
+			.fn()
+			.mockResolvedValue(opts.conversation ?? CONVERSATION),
+		listConversationEvents: vi.fn().mockResolvedValue(page),
+	} as any;
+}
+
+function ev(
+	overrides: Partial<AgentConversationEvent> & { event_type: string },
+): AgentConversationEvent {
+	return {
+		id: `ev-${Math.random()}`,
+		conversation_id: "conv-1",
+		event_index: 0,
+		event_source: "agent",
+		payload: {},
+		created_at: "2024-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+// ── getConversationTools ─────────────────────────────────────────────────────
+
+describe("getConversationTools", () => {
+	it("returns exactly one tool: read_conversation", () => {
+		const tools = getConversationTools();
+		expect(tools).toHaveLength(1);
+		expect(tools[0].name).toBe("read_conversation");
+	});
+
+	it("only requires conversationId", () => {
+		const tools = getConversationTools();
+		expect(tools[0].inputSchema.required).toEqual(["conversationId"]);
+	});
+});
+
+// ── handleConversationTool ────────────────────────────────────────────────────
+
+describe("handleConversationTool – read_conversation", () => {
+	it("fetches the conversation and its events by ID alone — no projectId needed", async () => {
+		const client = makeClient();
+		await handleConversationTool(
+			"read_conversation",
+			{ conversationId: "conv-1" },
+			client,
+		);
+		expect(client.getConversation).toHaveBeenCalledWith("conv-1");
+		expect(client.listConversationEvents).toHaveBeenCalledWith("conv-1", {
+			after: undefined,
+			before: undefined,
+			limit: undefined,
+		});
+	});
+
+	it("passes after/before/limit through to the events call", async () => {
+		const client = makeClient();
+		await handleConversationTool(
+			"read_conversation",
+			{ conversationId: "conv-1", after: "cur1", limit: 25 },
+			client,
+		);
+		expect(client.listConversationEvents).toHaveBeenCalledWith("conv-1", {
+			after: "cur1",
+			before: undefined,
+			limit: 25,
+		});
+	});
+
+	it("rejects when both after and before are provided", async () => {
+		const client = makeClient();
+		await expect(
+			handleConversationTool(
+				"read_conversation",
+				{ conversationId: "conv-1", after: "a", before: "b" },
+				client,
+			),
+		).rejects.toThrow();
+	});
+
+	it("returns the rendered transcript as text content", async () => {
+		const client = makeClient({
+			page: {
+				items: [
+					ev({
+						event_type: "user_message",
+						event_source: "user",
+						payload: { content: { type: "text", text: "hello" } },
+					}),
+				],
+				total: 1,
+			},
+		});
+		const result = await handleConversationTool(
+			"read_conversation",
+			{ conversationId: "conv-1" },
+			client,
+		);
+		expect(result.content[0].type).toBe("text");
+		expect(result.content[0].text).toContain("User: hello");
+		expect(result.content[0].text).toContain("Ada");
+	});
+
+	it("throws for an unknown tool name", async () => {
+		const client = makeClient();
+		await expect(handleConversationTool("unknown", {}, client)).rejects.toThrow(
+			"Unknown conversation tool",
+		);
+	});
+});
+
+// ── formatTranscriptLines ──────────────────────────────────────────────────────
+
+describe("formatTranscriptLines", () => {
+	it("renders a user_message event", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "user_message",
+				event_source: "user",
+				payload: { content: { type: "text", text: "Hi there" } },
+			}),
+		]);
+		expect(lines).toEqual(["User: Hi there"]);
+	});
+
+	it("merges consecutive agent_message_chunk events into one Agent line", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "agent_message_chunk",
+				payload: { content: { text: "Hel" } },
+			}),
+			ev({
+				event_type: "agent_message_chunk",
+				payload: { content: { text: "lo!" } },
+			}),
+		]);
+		expect(lines).toEqual(["Agent: Hello!"]);
+	});
+
+	it("renders agent_thought_chunk as a distinct thinking line", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "agent_thought_chunk",
+				payload: { content: { text: "considering options" } },
+			}),
+		]);
+		expect(lines).toEqual(["Agent (thinking): considering options"]);
+	});
+
+	it("flushes the agent buffer before a new user_message", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "agent_message_chunk",
+				payload: { content: { text: "Reply" } },
+			}),
+			ev({
+				event_type: "user_message",
+				event_source: "user",
+				payload: { content: { text: "Follow-up" } },
+			}),
+		]);
+		expect(lines).toEqual(["Agent: Reply", "User: Follow-up"]);
+	});
+
+	it("skips non-user-visible bookkeeping events", () => {
+		for (const type of [
+			"ConversationStateUpdateEvent",
+			"SystemPromptEvent",
+			"StreamingDeltaEvent",
+			"environment_ready",
+			"turn_end",
+			"turn_usage",
+		]) {
+			expect(formatTranscriptLines([ev({ event_type: type })])).toEqual([]);
+		}
+	});
+
+	it("renders a tool_call then merges its tool_call_update result onto the same line", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "tool_call",
+				payload: { toolCallId: "tc1", title: "get_task" },
+			}),
+			ev({
+				event_type: "tool_call_update",
+				payload: {
+					toolCallId: "tc1",
+					status: "completed",
+					content: [{ content: { text: "Task #1" } }],
+				},
+			}),
+		]);
+		expect(lines).toEqual(["[tool: get_task] called -> Task #1"]);
+	});
+
+	it("marks a failed tool_call_update as an error", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "tool_call",
+				payload: { toolCallId: "tc1", title: "read_doc" },
+			}),
+			ev({
+				event_type: "tool_call_update",
+				payload: { toolCallId: "tc1", status: "failed" },
+			}),
+		]);
+		expect(lines).toEqual(["[tool: read_doc] called -> ERROR: failed"]);
+	});
+
+	it("renders a legacy MessageEvent from the user and from the agent", () => {
+		const userLines = formatTranscriptLines([
+			ev({
+				event_type: "MessageEvent",
+				event_source: "user",
+				payload: { content: [{ text: "hi" }] },
+			}),
+		]);
+		expect(userLines).toEqual(["User: hi"]);
+
+		const agentLines = formatTranscriptLines([
+			ev({
+				event_type: "MessageEvent",
+				event_source: "agent",
+				payload: { llm_message: { content: [{ text: "hello back" }] } },
+			}),
+		]);
+		expect(agentLines).toEqual(["Agent: hello back"]);
+	});
+
+	it("renders a legacy ActionEvent/ObservationEvent tool-call pair", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "ActionEvent",
+				payload: { tool_call_id: "tc1", tool_name: "read_doc" },
+			}),
+			ev({
+				event_type: "ObservationEvent",
+				payload: {
+					tool_call_id: "tc1",
+					tool_name: "read_doc",
+					observation: { message: "Doc content" },
+				},
+			}),
+		]);
+		expect(lines).toEqual(["[tool: read_doc] called -> Doc content"]);
+	});
+
+	it("renders the synthetic 'finish' ActionEvent as the agent's reply, skipping its ObservationEvent", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "ActionEvent",
+				payload: {
+					tool_call_id: "tc1",
+					tool_name: "finish",
+					action: { message: "All done!" },
+				},
+			}),
+			ev({
+				event_type: "ObservationEvent",
+				payload: { tool_call_id: "tc1", tool_name: "finish" },
+			}),
+		]);
+		expect(lines).toEqual(["Agent: All done!"]);
+	});
+
+	it("marks AgentErrorEvent and UserRejectObservation as errors", () => {
+		const errorLines = formatTranscriptLines([
+			ev({
+				event_type: "ActionEvent",
+				payload: { tool_call_id: "tc1", tool_name: "run" },
+			}),
+			ev({
+				event_type: "AgentErrorEvent",
+				payload: { tool_call_id: "tc1", error: "boom" },
+			}),
+		]);
+		expect(errorLines).toEqual(["[tool: run] called -> ERROR: boom"]);
+
+		const rejectLines = formatTranscriptLines([
+			ev({
+				event_type: "ActionEvent",
+				payload: { tool_call_id: "tc2", tool_name: "run" },
+			}),
+			ev({
+				event_type: "UserRejectObservation",
+				payload: { tool_call_id: "tc2", rejection_reason: "not allowed" },
+			}),
+		]);
+		expect(rejectLines).toEqual(["[tool: run] called -> ERROR: not allowed"]);
+	});
+
+	it("renders an ACPToolCallEvent, updating the same line once completed", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "ACPToolCallEvent",
+				payload: { tool_call_id: "tc1", title: "bash", status: "pending" },
+			}),
+			ev({
+				event_type: "ACPToolCallEvent",
+				payload: {
+					tool_call_id: "tc1",
+					title: "bash",
+					status: "completed",
+					raw_output: "done",
+				},
+			}),
+		]);
+		expect(lines).toEqual(["[tool: bash] -> done"]);
+	});
+
+	it("marks a failed ACPToolCallEvent as an error", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "ACPToolCallEvent",
+				payload: {
+					tool_call_id: "tc1",
+					title: "bash",
+					status: "failed",
+					is_error: true,
+				},
+			}),
+		]);
+		expect(lines).toEqual(["[tool: bash] ERROR: -> failed"]);
+	});
+
+	it("falls back to plain text for an unrecognized event type", () => {
+		const lines = formatTranscriptLines([
+			ev({
+				event_type: "SomeFutureEvent",
+				event_source: "agent",
+				payload: { message: "note" },
+			}),
+		]);
+		expect(lines).toEqual(["Agent: note"]);
+	});
+
+	it("returns an empty array for no events", () => {
+		expect(formatTranscriptLines([])).toEqual([]);
+	});
+});
+
+// ── formatConversationTranscript ───────────────────────────────────────────────
+
+describe("formatConversationTranscript", () => {
+	it("includes agent name/handle, status, and trigger type in the header", () => {
+		const text = formatConversationTranscript(CONVERSATION, {
+			items: [],
+			total: 0,
+			next_cursor: null,
+			prev_cursor: null,
+		});
+		expect(text).toContain("Ada (@ada-bot)");
+		expect(text).toContain("Status: running");
+		expect(text).toContain("Trigger: chat_message");
+	});
+
+	it("shows a placeholder when the event window is empty", () => {
+		const text = formatConversationTranscript(CONVERSATION, {
+			items: [],
+			total: 0,
+			next_cursor: null,
+			prev_cursor: null,
+		});
+		expect(text).toContain("(no events in this window)");
+	});
+
+	it("reports the shown/total event counts", () => {
+		const items = [
+			ev({ event_type: "user_message", payload: { content: { text: "hi" } } }),
+		];
+		const text = formatConversationTranscript(CONVERSATION, {
+			items,
+			total: 42,
+			next_cursor: null,
+			prev_cursor: null,
+		});
+		expect(text).toContain("Showing 1 of 42 total event(s)");
+	});
+
+	it("mentions the after cursor when next_cursor is present", () => {
+		const text = formatConversationTranscript(CONVERSATION, {
+			items: [],
+			total: 0,
+			next_cursor: "next-abc",
+			prev_cursor: null,
+		});
+		expect(text).toContain('after: "next-abc"');
+	});
+
+	it("mentions the before cursor when prev_cursor is present", () => {
+		const text = formatConversationTranscript(CONVERSATION, {
+			items: [],
+			total: 0,
+			next_cursor: null,
+			prev_cursor: "prev-abc",
+		});
+		expect(text).toContain('before: "prev-abc"');
+	});
+
+	it("omits cursor hints entirely when both cursors are null", () => {
+		const text = formatConversationTranscript(CONVERSATION, {
+			items: [],
+			total: 0,
+			next_cursor: null,
+			prev_cursor: null,
+		});
+		expect(text).not.toContain("Call read_conversation again");
+		expect(text).not.toContain("Older events exist");
+	});
+});

--- a/apps/mcp/src/__tests__/tools/filesystem-doc-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/filesystem-doc-tools.test.ts
@@ -220,6 +220,64 @@ describe("handleFilesystemDocTool – read_doc", () => {
 	});
 });
 
+// ── read_doc – docId ───────────────────────────────────────────────────────────
+// A doc "injected" as chat context only carries a raw ID, never a virtual
+// folder path — docId must skip buildDocTree/resolvePath entirely and call
+// apiClient.getDocument directly (see filesystem-doc-tools.ts's read_doc case).
+
+describe("handleFilesystemDocTool – read_doc with docId", () => {
+	it("calls apiClient.getDocument directly, bypassing path resolution", async () => {
+		const apiClient = makeApiClient();
+		const docClient = makeDocClient();
+		const result = await handleFilesystemDocTool(
+			"read_doc",
+			{ projectId: "p1", docId: "d1" },
+			apiClient,
+			docClient,
+		);
+		expect(apiClient.getDocument).toHaveBeenCalledWith("p1", "d1");
+		// The tree-walk helpers are never consulted for a docId lookup.
+		expect(apiClient.listDocuments).not.toHaveBeenCalled();
+		expect(docClient.listFolders).not.toHaveBeenCalled();
+		expect(result.content[0].text).toContain("mocked markdown");
+		expect(result.content[0].text).toContain("README");
+	});
+
+	it("works for a docId that has no corresponding path (e.g. a doc from another folder tree)", async () => {
+		const apiClient = makeApiClient({ documents: [] });
+		const result = await handleFilesystemDocTool(
+			"read_doc",
+			{ projectId: "p1", docId: "not-in-tree" },
+			apiClient,
+			makeDocClient({ folders: [] }),
+		);
+		expect(apiClient.getDocument).toHaveBeenCalledWith("p1", "not-in-tree");
+		expect(result.isError).toBeUndefined();
+	});
+
+	it("prefers docId over path when both are provided", async () => {
+		const apiClient = makeApiClient();
+		const _result = await handleFilesystemDocTool(
+			"read_doc",
+			{ projectId: "p1", path: "Architecture/Overview", docId: "d1" },
+			apiClient,
+			makeDocClient(),
+		);
+		expect(apiClient.getDocument).toHaveBeenCalledWith("p1", "d1");
+	});
+
+	it("returns isError when neither path nor docId is provided", async () => {
+		await expect(
+			handleFilesystemDocTool(
+				"read_doc",
+				{ projectId: "p1" },
+				makeApiClient(),
+				makeDocClient(),
+			),
+		).rejects.toThrow();
+	});
+});
+
 // ── write_doc ──────────────────────────────────────────────────────────────────
 
 describe("handleFilesystemDocTool – write_doc", () => {

--- a/apps/mcp/src/__tests__/tools/index.test.ts
+++ b/apps/mcp/src/__tests__/tools/index.test.ts
@@ -83,6 +83,12 @@ vi.mock("../../tools/automation-tools.js", () => ({
 		.fn()
 		.mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
 }));
+vi.mock("../../tools/conversation-tools.js", () => ({
+	getConversationTools: vi.fn(() => [{ name: "read_conversation" }]),
+	handleConversationTool: vi
+		.fn()
+		.mockResolvedValue({ content: [{ type: "text", text: "ok" }] }),
+}));
 vi.mock("../../tools/doc-activity-tools.js", () => ({
 	getDocActivityTools: vi.fn(() => [
 		{ name: "list_doc_activities" },
@@ -105,6 +111,7 @@ vi.mock("../../tools/repo-tools.js", () => ({
 
 import { handleAttachmentTool } from "../../tools/attachment-tools.js";
 import { handleAutomationTool } from "../../tools/automation-tools.js";
+import { handleConversationTool } from "../../tools/conversation-tools.js";
 import { handleDocActivityTool } from "../../tools/doc-activity-tools.js";
 import { handleFilesystemDocTool } from "../../tools/filesystem-doc-tools.js";
 import { getAllTools, handleToolCall } from "../../tools/index.js";
@@ -125,6 +132,7 @@ const stubClients = {
 	taskExtendedClient: {} as any,
 	docClient: {} as any,
 	automationClient: {} as any,
+	conversationClient: {} as any,
 };
 
 function makeRequest(name: string, args: Record<string, unknown> = {}) {
@@ -156,6 +164,7 @@ describe("getAllTools", () => {
 		expect(names).toContain("get_automation");
 		expect(names).toContain("list_doc_activities");
 		expect(names).toContain("list_repositories");
+		expect(names).toContain("read_conversation");
 	});
 });
 
@@ -390,6 +399,20 @@ describe("handleToolCall – doc activity routing", () => {
 			"add_doc_comment",
 			{},
 			stubClients.docClient,
+		);
+	});
+});
+
+describe("handleToolCall – conversation tool routing", () => {
+	it("routes read_conversation to handleConversationTool", async () => {
+		await handleToolCall(
+			makeRequest("read_conversation", { conversationId: "c1" }),
+			stubClients,
+		);
+		expect(handleConversationTool).toHaveBeenCalledWith(
+			"read_conversation",
+			{ conversationId: "c1" },
+			stubClients.conversationClient,
 		);
 	});
 });

--- a/apps/mcp/src/api/conversation-client.ts
+++ b/apps/mcp/src/api/conversation-client.ts
@@ -1,0 +1,137 @@
+import type {
+	AgentConversation,
+	ConversationEventPage,
+	ConversationEventWindow,
+	PacaConfig,
+	SuccessEnvelope,
+} from "../types/index.js";
+import { formatApiRequestError } from "../utils/index.js";
+
+/**
+ * Read-only API client for another conversation's transcript. Backs the
+ * read_conversation MCP tool, which lets an agent pull in a Conversation
+ * attached as chat context (or otherwise referenced by ID) the same way
+ * get_task/read_doc already do for a Task/Document.
+ *
+ * Calls GET /agents/me/conversations/:id(/events) — an agent-authenticated
+ * self-service path, deliberately distinct from the human-facing
+ * GET /projects/:projectId/conversations/:id and GET /agents/conversations/:id
+ * endpoints the frontend uses. Both of those require a human member/actor
+ * identity (project_members.id or actor_user_id) to authorize against; a
+ * bare agent calling via its own X-Agent-ID has neither (agents aren't
+ * project members, and a plain project-scoped chat trigger never carries an
+ * actor_user_id), so calling them here always failed — with "member not
+ * found" (404) on the project-scoped path, or a mis-scoped lookup on the
+ * global path, regardless of which one this tool guessed at based on
+ * whether the caller happened to pass a projectId. The /agents/me path
+ * sidesteps this entirely: it authorizes by the server's own verified
+ * X-Agent-ID against the conversation's own agent_id (see
+ * agentdom.Service.GetConversationForAgent's doc comment for the exact
+ * rule), so there's no project/global split — and no projectId parameter —
+ * for the caller to get wrong.
+ *
+ * Only covers GET .../conversations/:id and GET .../conversations/:id/events
+ * — every other conversation endpoint (send message, stop, pause,
+ * heartbeat) belongs to the conversation the calling agent is actually
+ * running inside, not one it's reading for context, so there's no need to
+ * mirror those here.
+ */
+export class PacaAPIConversationClient {
+	private config: PacaConfig;
+
+	constructor(config: PacaConfig) {
+		this.config = config;
+	}
+
+	private async request(method: string, path: string): Promise<any> {
+		const url = `${this.config.baseURL}${path}`;
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+			"X-API-Key": this.config.apiKey,
+		};
+		if (this.config.agentId) {
+			headers["X-Agent-ID"] = this.config.agentId;
+		}
+		// Only ever meaningful alongside X-Agent-ID (see PacaConfig.actorUserId's
+		// doc comment: "unset for a personal API key"). Gating on agentId here
+		// too — not just trusting actorUserId's own truthiness — means a stray
+		// or misconfigured PACA_ACTOR_USER_ID can never reach the server
+		// without an agent identity attached to it. Mirrors client.ts's
+		// PacaAPIClient exactly. Unused by the /agents/me path itself (it
+		// authorizes on X-Agent-ID alone), kept for parity with the other
+		// clients and in case a future agents/me route needs it.
+		if (this.config.agentId && this.config.actorUserId) {
+			headers["X-Actor-User-ID"] = this.config.actorUserId;
+		}
+
+		const response = await fetch(url, { method, headers });
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			throw new Error(
+				formatApiRequestError(response.status, response.statusText, errorText),
+			);
+		}
+
+		if (response.status === 204) {
+			return undefined;
+		}
+
+		const jsonResponse = await response.json();
+
+		// Handle SuccessEnvelope wrapper
+		if (
+			jsonResponse &&
+			typeof jsonResponse === "object" &&
+			"success" in jsonResponse
+		) {
+			const envelope = jsonResponse as SuccessEnvelope<any>;
+			if (envelope.success) {
+				return envelope.data;
+			}
+		}
+
+		// Fallback for responses not wrapped in SuccessEnvelope
+		return jsonResponse;
+	}
+
+	private async get(path: string): Promise<any> {
+		return this.request("GET", path);
+	}
+
+	/** Builds the shared after/before/limit query string for an events window. */
+	private buildEventWindowQuery(window: ConversationEventWindow): string {
+		const params: string[] = [];
+		if (window.after) params.push(`after=${encodeURIComponent(window.after)}`);
+		if (window.before)
+			params.push(`before=${encodeURIComponent(window.before)}`);
+		if (window.limit !== undefined) params.push(`limit=${window.limit}`);
+		return params.length > 0 ? `?${params.join("&")}` : "";
+	}
+
+	/** Normalizes the {items, total, next_cursor, prev_cursor} envelope shared
+	 * by both events endpoints (see writeConversationEventWindowResponse). */
+	private toEventPage(response: any): ConversationEventPage {
+		return {
+			items: response?.items ?? [],
+			total: response?.total ?? 0,
+			next_cursor: response?.next_cursor ?? null,
+			prev_cursor: response?.prev_cursor ?? null,
+		};
+	}
+
+	async getConversation(conversationId: string): Promise<AgentConversation> {
+		return this.get(`/api/v1/agents/me/conversations/${conversationId}`);
+	}
+
+	async listConversationEvents(
+		conversationId: string,
+		window: ConversationEventWindow = {},
+	): Promise<ConversationEventPage> {
+		const query = this.buildEventWindowQuery(window);
+		const response = await this.get(
+			`/api/v1/agents/me/conversations/${conversationId}/events${query}`,
+		);
+		return this.toEventPage(response);
+	}
+}

--- a/apps/mcp/src/api/conversation-client.ts
+++ b/apps/mcp/src/api/conversation-client.ts
@@ -57,11 +57,19 @@ export class PacaAPIConversationClient {
 		// too — not just trusting actorUserId's own truthiness — means a stray
 		// or misconfigured PACA_ACTOR_USER_ID can never reach the server
 		// without an agent identity attached to it. Mirrors client.ts's
-		// PacaAPIClient exactly. Unused by the /agents/me path itself (it
-		// authorizes on X-Agent-ID alone), kept for parity with the other
-		// clients and in case a future agents/me route needs it.
+		// PacaAPIClient exactly.
 		if (this.config.agentId && this.config.actorUserId) {
 			headers["X-Actor-User-ID"] = this.config.actorUserId;
+		}
+		// The conversation this MCP server instance is running as part of —
+		// load-bearing for the /agents/me path specifically: GetConversationForAgent
+		// authorizes a cross-conversation read (getConversation/
+		// listConversationEvents for a *different* conversationId than this
+		// one) against this header's conversation's own project/actor/owning
+		// member, not against X-Agent-ID alone. See PacaConfig.conversationId's
+		// doc comment.
+		if (this.config.agentId && this.config.conversationId) {
+			headers["X-Conversation-ID"] = this.config.conversationId;
 		}
 
 		const response = await fetch(url, { method, headers });

--- a/apps/mcp/src/api/index.ts
+++ b/apps/mcp/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from "./automation-client.js";
 export * from "./client.js";
+export * from "./conversation-client.js";
 export * from "./doc-client.js";
 export * from "./extended-client.js";
 export * from "./task-extended-client.js";

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -26,6 +26,7 @@ async function main() {
 	const agentId = process.env.PACA_AGENT_ID || undefined;
 	const projectId = process.env.PACA_PROJECT_ID || undefined;
 	const actorUserId = process.env.PACA_ACTOR_USER_ID || undefined;
+	const conversationId = process.env.PACA_CONVERSATION_ID || undefined;
 	// Comma-separated plugin names — see agent-runner's executor.go
 	// buildMCPServers, which sets this from trigger.RepoPluginIDs (itself
 	// decoded from the paca:agent:triggers stream's repo_plugin_ids field).
@@ -62,6 +63,7 @@ async function main() {
 		agentId,
 		projectId,
 		actorUserId,
+		conversationId,
 		repoPluginIds,
 	};
 

--- a/apps/mcp/src/permissions.ts
+++ b/apps/mcp/src/permissions.ts
@@ -348,22 +348,6 @@ export const TOOL_PERMISSIONS: ToolPermission[] = [
 		permissionKey: "workflows.write",
 		requiresProject: true,
 	},
-
-	// Conversation tools — read_conversation takes no projectId; it always
-	// calls the agent-self-service GET /agents/me/conversations/:id path,
-	// which authorizes by the conversation's own agent_id matching the
-	// caller (see agentdom.Service.GetConversationForAgent's doc comment),
-	// not by project or human membership. requiresProject here just means
-	// "check agents.read against any project this agent belongs to" (true
-	// for both a project-scoped agent's one project and a global agent's
-	// invited projects) — real enforcement of which conversation the caller
-	// may actually read still happens server-side regardless; this table
-	// only gates whether the tool is *listed* at all (see server.ts).
-	{
-		toolName: "read_conversation",
-		permissionKey: "agents.read",
-		requiresProject: true,
-	},
 ];
 
 /** Parses a permissions object/array response body into a flat boolean map. */

--- a/apps/mcp/src/permissions.ts
+++ b/apps/mcp/src/permissions.ts
@@ -348,6 +348,22 @@ export const TOOL_PERMISSIONS: ToolPermission[] = [
 		permissionKey: "workflows.write",
 		requiresProject: true,
 	},
+
+	// Conversation tools — read_conversation takes no projectId; it always
+	// calls the agent-self-service GET /agents/me/conversations/:id path,
+	// which authorizes by the conversation's own agent_id matching the
+	// caller (see agentdom.Service.GetConversationForAgent's doc comment),
+	// not by project or human membership. requiresProject here just means
+	// "check agents.read against any project this agent belongs to" (true
+	// for both a project-scoped agent's one project and a global agent's
+	// invited projects) — real enforcement of which conversation the caller
+	// may actually read still happens server-side regardless; this table
+	// only gates whether the tool is *listed* at all (see server.ts).
+	{
+		toolName: "read_conversation",
+		permissionKey: "agents.read",
+		requiresProject: true,
+	},
 ];
 
 /** Parses a permissions object/array response body into a flat boolean map. */
@@ -478,7 +494,12 @@ export async function fetchAgentPermissions(
 		}
 
 		if (config.projectId) {
-			await fetchProjectPermissions(config, headers, config.projectId, projects);
+			await fetchProjectPermissions(
+				config,
+				headers,
+				config.projectId,
+				projects,
+			);
 			const entityType = config.agentId ? "agent" : "user";
 			console.error(
 				`[permissions] Loaded permissions for ${entityType} in project ${config.projectId}`,
@@ -497,7 +518,9 @@ export async function fetchAgentPermissions(
 				if (projectsResponse.ok) {
 					const projectsJson = await projectsResponse.json();
 					const body =
-						projectsJson && typeof projectsJson === "object" && "data" in projectsJson
+						projectsJson &&
+						typeof projectsJson === "object" &&
+						"data" in projectsJson
 							? projectsJson.data
 							: projectsJson;
 					const projectIds: string[] = Array.isArray(body?.project_ids)

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -6,6 +6,7 @@ import {
 import {
 	PacaAPIAutomationClient,
 	PacaAPIClient,
+	PacaAPIConversationClient,
 	PacaAPIDocClient,
 	PacaAPIExtendedClient,
 	PacaAPITaskExtendedClient,
@@ -42,6 +43,7 @@ export async function createServer(config: PacaConfig): Promise<Server> {
 	const taskExtendedClient = new PacaAPITaskExtendedClient(config);
 	const docClient = new PacaAPIDocClient(config);
 	const automationClient = new PacaAPIAutomationClient(config);
+	const conversationClient = new PacaAPIConversationClient(config);
 
 	// Load plugin MCP modules from the Paca API.
 	// Failures for individual plugins are logged and skipped.
@@ -54,6 +56,7 @@ export async function createServer(config: PacaConfig): Promise<Server> {
 		taskExtendedClient,
 		docClient,
 		automationClient,
+		conversationClient,
 	};
 
 	// Fetch agent permissions at startup

--- a/apps/mcp/src/tools/conversation-tools.ts
+++ b/apps/mcp/src/tools/conversation-tools.ts
@@ -1,0 +1,439 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { PacaAPIConversationClient } from "../api/index.js";
+import type {
+	AgentConversation,
+	AgentConversationEvent,
+	ConversationEventPage,
+	ConversationEventWindow,
+} from "../types/index.js";
+
+// ── Zod schema ────────────────────────────────────────────────────────────────
+
+const ReadConversationSchema = z
+	.object({
+		conversationId: z.string(),
+		after: z.string().optional(),
+		before: z.string().optional(),
+		limit: z.number().int().min(1).max(200).optional(),
+	})
+	.refine((data) => !(data.after && data.before), {
+		message: "after and before are mutually exclusive",
+		path: ["before"],
+	});
+
+// ── Tool definition ────────────────────────────────────────────────────────────
+
+export function getConversationTools(): Tool[] {
+	return [
+		{
+			name: "read_conversation",
+			description:
+				"Read another conversation's transcript — for example one attached as chat context (an '## Attached Context' section naming a Conversation ID). " +
+				"Works for any conversation you (this agent) participated in, whether it happened in a project or as a global chat — you don't need to know or specify which. " +
+				"Returns a condensed, skimmable transcript ('User: ...' / 'Agent: ...' lines, plus one-line '[tool: name] ...' summaries for tool calls — not full arguments or results) rather than a pixel-perfect replay of the UI. " +
+				"Events are paginated: the response reports how many of the conversation's total events are shown, and — if more exist — which cursor to pass back (after/before) on a follow-up call to read further.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					conversationId: {
+						type: "string",
+						description: "The technical UUID of the conversation to read.",
+					},
+					after: {
+						type: "string",
+						description:
+							"Opaque cursor from a previous call's response — resumes forward toward newer events from that point. Mutually exclusive with before. Omit both to start at the most recent events.",
+					},
+					before: {
+						type: "string",
+						description:
+							"Opaque cursor from a previous call's response — resumes backward toward older events from that point. Mutually exclusive with after.",
+					},
+					limit: {
+						type: "number",
+						description:
+							"Max events to return in this page (1-200, default 50).",
+					},
+				},
+				required: ["conversationId"],
+			},
+		},
+	];
+}
+
+// ── Event → text rendering ──────────────────────────────────────────────────────
+//
+// A simplified re-derivation of apps/web's
+// components/projects/agents/conversation-to-thread-messages.ts for plain-text
+// output: that file groups a turn's parts into rich ThreadMessageLike objects
+// for the UI (with diff artifacts, streaming state, etc.); this just needs
+// flat lines of text an LLM can skim, so tool calls are condensed to one-line
+// summaries instead of full args/results. Covers the current ACP-based event
+// vocabulary (user_message/agent_message_chunk/agent_thought_chunk/tool_call/
+// tool_call_update) plus the legacy OpenHands-style shapes
+// (MessageEvent/ActionEvent/ObservationEvent/AgentErrorEvent/
+// UserRejectObservation/ACPToolCallEvent) older conversation history may
+// still contain.
+
+function oneLine(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function truncate(text: string, max = 200): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function condense(text: string, max = 200): string {
+	return truncate(oneLine(text), max);
+}
+
+function extractBlockText(block: unknown): string | null {
+	if (typeof block !== "object" || block === null) return null;
+	const text = (block as Record<string, unknown>).text;
+	return typeof text === "string" && text.length > 0 ? text : null;
+}
+
+function extractContentText(content: unknown): string | null {
+	if (Array.isArray(content)) {
+		const parts = content
+			.map((c) => {
+				if (typeof c === "object" && c !== null && "text" in c) {
+					const t = (c as { text: unknown }).text;
+					return typeof t === "string" ? t : null;
+				}
+				return null;
+			})
+			.filter((t): t is string => t !== null && t.trim().length > 0);
+		return parts.length > 0 ? parts.join(" ").trim() : null;
+	}
+	if (typeof content === "string" && content.trim().length > 0) {
+		return content.trim();
+	}
+	return null;
+}
+
+function extractToolCallUpdateText(content: unknown): string | null {
+	if (!Array.isArray(content)) return null;
+	const parts = content
+		.map((c) => {
+			if (typeof c !== "object" || c === null) return null;
+			return extractBlockText((c as Record<string, unknown>).content);
+		})
+		.filter((t): t is string => t !== null);
+	return parts.length > 0 ? parts.join("") : null;
+}
+
+// Non-user-visible bookkeeping events, never rendered as a transcript line.
+const SKIPPED_EVENT_TYPES = new Set([
+	"ConversationStateUpdateEvent",
+	"SystemPromptEvent",
+	"StreamingDeltaEvent",
+	"environment_ready",
+	"turn_end",
+	"turn_usage",
+]);
+
+/**
+ * Renders a page of conversation events into flat transcript lines, oldest
+ * first. Exported for testing.
+ */
+export function formatTranscriptLines(
+	events: AgentConversationEvent[],
+): string[] {
+	const lines: string[] = [];
+	let agentBuf = "";
+	let thoughtBuf = "";
+	// Maps an open tool call's id to the line it's rendered on, so a later
+	// update/observation event can append its result to that same line
+	// instead of appearing as an unrelated entry further down.
+	const openToolCalls = new Map<string, number>();
+
+	const flushAgent = () => {
+		if (agentBuf) {
+			lines.push(`Agent: ${oneLine(agentBuf)}`);
+			agentBuf = "";
+		}
+	};
+	const flushThought = () => {
+		if (thoughtBuf) {
+			lines.push(`Agent (thinking): ${condense(thoughtBuf)}`);
+			thoughtBuf = "";
+		}
+	};
+	const flushAll = () => {
+		flushAgent();
+		flushThought();
+	};
+
+	for (const ev of events) {
+		const p = ev.payload ?? {};
+		const t = ev.event_type;
+
+		if (SKIPPED_EVENT_TYPES.has(t)) continue;
+
+		// user_message is written once per turn with the user's actual message
+		// (see services/agent-runner's handler.go) — ACP itself has no
+		// equivalent event.
+		if (t === "user_message") {
+			const text = extractBlockText(p.content);
+			if (!text) continue;
+			flushAll();
+			lines.push(`User: ${oneLine(text)}`);
+			continue;
+		}
+
+		// Chunks stream one reply/thought piece by piece — buffered and only
+		// flushed once a different kind of event interrupts the run, so a
+		// streamed reply renders as one line instead of dozens of fragments.
+		if (t === "agent_message_chunk") {
+			const text = extractBlockText(p.content);
+			if (text) agentBuf += text;
+			continue;
+		}
+		if (t === "agent_thought_chunk") {
+			const text = extractBlockText(p.content);
+			if (text) thoughtBuf += text;
+			continue;
+		}
+
+		if (t === "tool_call") {
+			flushAll();
+			const toolCallId =
+				typeof p.toolCallId === "string" ? p.toolCallId : ev.id;
+			const toolName = typeof p.title === "string" ? p.title : "tool";
+			lines.push(`[tool: ${toolName}] called`);
+			openToolCalls.set(toolCallId, lines.length - 1);
+			continue;
+		}
+
+		if (t === "tool_call_update") {
+			const toolCallId =
+				typeof p.toolCallId === "string" ? p.toolCallId : undefined;
+			const status = typeof p.status === "string" ? p.status : null;
+			const resultText = extractToolCallUpdateText(p.content);
+			const idx = toolCallId ? openToolCalls.get(toolCallId) : undefined;
+			const failed = status === "failed";
+			const summary = resultText
+				? condense(resultText, 160)
+				: (status ?? "done");
+			if (idx !== undefined) {
+				lines[idx] = `${lines[idx]} -> ${failed ? "ERROR: " : ""}${summary}`;
+			} else {
+				lines.push(`[tool] ${failed ? "ERROR: " : ""}${summary}`);
+			}
+			continue;
+		}
+
+		// --- Legacy (pre-ACP) OpenHands-style events -----------------------
+
+		if (t === "MessageEvent") {
+			const llmMsg = p.llm_message as { content?: unknown } | undefined;
+			const text =
+				extractContentText(llmMsg?.content) ?? extractContentText(p.content);
+			if (!text) continue;
+			flushAll();
+			lines.push(
+				ev.event_source === "user"
+					? `User: ${oneLine(text)}`
+					: `Agent: ${oneLine(text)}`,
+			);
+			continue;
+		}
+
+		if (t === "ActionEvent") {
+			const toolCall = p.tool_call as { name?: string } | undefined;
+			const toolCallId =
+				typeof p.tool_call_id === "string" ? p.tool_call_id : ev.id;
+			const toolName =
+				(typeof p.tool_name === "string" ? p.tool_name : undefined) ??
+				toolCall?.name ??
+				"tool";
+
+			// Every turn ends with a synthetic "finish" tool call whose action
+			// carries the agent's actual natural-language reply — render it as
+			// reply text, not a tool-call line.
+			if (toolName === "finish") {
+				const action = p.action as { message?: unknown } | undefined;
+				const finishText =
+					typeof action?.message === "string" ? action.message : null;
+				flushAll();
+				if (finishText) lines.push(`Agent: ${oneLine(finishText)}`);
+				continue;
+			}
+
+			flushAll();
+			lines.push(`[tool: ${toolName}] called`);
+			openToolCalls.set(toolCallId, lines.length - 1);
+			continue;
+		}
+
+		if (
+			t === "ObservationEvent" ||
+			t === "AgentErrorEvent" ||
+			t === "UserRejectObservation"
+		) {
+			// The matching ActionEvent already rendered the "finish" call's
+			// message as reply text; its observation just repeats it.
+			if (p.tool_name === "finish") continue;
+
+			const isError = t !== "ObservationEvent";
+			const obs = p.observation as Record<string, unknown> | undefined;
+			const resultText =
+				(obs &&
+					(extractContentText(obs.content) ??
+						(typeof obs.message === "string" ? obs.message : null))) ??
+				extractContentText(p.content) ??
+				(typeof p.error === "string" ? p.error : null) ??
+				(typeof p.rejection_reason === "string" ? p.rejection_reason : null) ??
+				(typeof p.message === "string" ? p.message : null) ??
+				(typeof p.output === "string" ? p.output : null) ??
+				"";
+			const toolCallId =
+				typeof p.tool_call_id === "string" ? p.tool_call_id : undefined;
+			const idx = toolCallId ? openToolCalls.get(toolCallId) : undefined;
+			const summary =
+				condense(resultText, 160) || (isError ? "failed" : "done");
+			if (idx !== undefined) {
+				lines[idx] = `${lines[idx]} -> ${isError ? "ERROR: " : ""}${summary}`;
+			} else {
+				const toolName = typeof p.tool_name === "string" ? p.tool_name : "tool";
+				lines.push(`[tool: ${toolName}] ${isError ? "ERROR: " : ""}${summary}`);
+			}
+			continue;
+		}
+
+		// ACPToolCallEvent — emitted by ACP-type agents (Claude Code/Codex/
+		// Gemini CLI local bridge) in place of the ActionEvent/ObservationEvent
+		// pair. Streams multiple updates for the same tool_call_id, so the
+		// line is created once and updated in place.
+		if (t === "ACPToolCallEvent") {
+			const toolCallId =
+				typeof p.tool_call_id === "string" ? p.tool_call_id : ev.id;
+			const toolName =
+				(typeof p.title === "string" ? p.title : null) ??
+				(typeof p.tool_kind === "string" ? p.tool_kind : null) ??
+				"tool";
+			let idx = openToolCalls.get(toolCallId);
+			if (idx === undefined) {
+				flushAll();
+				lines.push(`[tool: ${toolName}] called`);
+				idx = lines.length - 1;
+				openToolCalls.set(toolCallId, idx);
+			}
+			const status = typeof p.status === "string" ? p.status : null;
+			if (status === "completed" || status === "failed") {
+				const rawOutput = p.raw_output;
+				const resultText =
+					extractContentText(p.content) ??
+					(typeof rawOutput === "string"
+						? rawOutput
+						: rawOutput !== undefined && rawOutput !== null
+							? JSON.stringify(rawOutput)
+							: "");
+				const summary = condense(resultText, 160) || status;
+				const failed = status === "failed" || p.is_error === true;
+				lines[idx] =
+					`[tool: ${toolName}] ${failed ? "ERROR: " : ""}-> ${summary}`;
+			}
+			continue;
+		}
+
+		// Fallback for any other/unrecognized event type: surface as plain
+		// text so nothing silently disappears from the transcript.
+		const fallbackText =
+			extractContentText(p.content) ??
+			extractContentText(p.thought) ??
+			(typeof p.message === "string" ? p.message : null);
+		if (fallbackText) {
+			flushAll();
+			lines.push(
+				ev.event_source === "user"
+					? `User: ${oneLine(fallbackText)}`
+					: `Agent: ${oneLine(fallbackText)}`,
+			);
+		}
+	}
+
+	flushAll();
+	return lines;
+}
+
+function formatHeader(conversation: AgentConversation): string {
+	const who = conversation.agent_name
+		? `${conversation.agent_name}${conversation.agent_handle ? ` (@${conversation.agent_handle})` : ""}`
+		: conversation.agent_id;
+	return (
+		`Conversation ${conversation.id} with ${who}\n` +
+		`Status: ${conversation.status} | Trigger: ${conversation.trigger_type} | Started: ${conversation.started_at ?? conversation.created_at}`
+	);
+}
+
+function formatPaginationFooter(page: ConversationEventPage): string {
+	const lines = [
+		`--- Showing ${page.items.length} of ${page.total} total event(s) ---`,
+	];
+	if (page.prev_cursor) {
+		lines.push(
+			`Older events exist. Call read_conversation again with before: "${page.prev_cursor}" to read further back.`,
+		);
+	}
+	if (page.next_cursor) {
+		lines.push(
+			`Call read_conversation again with after: "${page.next_cursor}" to continue reading forward (useful if this conversation is still running).`,
+		);
+	}
+	return lines.join("\n");
+}
+
+/** Exported for testing. */
+export function formatConversationTranscript(
+	conversation: AgentConversation,
+	page: ConversationEventPage,
+): string {
+	const transcriptLines = formatTranscriptLines(page.items);
+	const body =
+		transcriptLines.length > 0
+			? transcriptLines.join("\n")
+			: "(no events in this window)";
+	return [
+		formatHeader(conversation),
+		"",
+		body,
+		"",
+		formatPaginationFooter(page),
+	].join("\n");
+}
+
+// ── Tool handler ──────────────────────────────────────────────────────────────
+
+export async function handleConversationTool(
+	toolName: string,
+	args: unknown,
+	client: PacaAPIConversationClient,
+): Promise<any> {
+	switch (toolName) {
+		case "read_conversation": {
+			const { conversationId, after, before, limit } =
+				ReadConversationSchema.parse(args);
+			const window: ConversationEventWindow = { after, before, limit };
+
+			const [conversation, page] = await Promise.all([
+				client.getConversation(conversationId),
+				client.listConversationEvents(conversationId, window),
+			]);
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: formatConversationTranscript(conversation, page),
+					},
+				],
+			};
+		}
+
+		default:
+			throw new Error(`Unknown conversation tool: ${toolName}`);
+	}
+}

--- a/apps/mcp/src/tools/filesystem-doc-tools.ts
+++ b/apps/mcp/src/tools/filesystem-doc-tools.ts
@@ -11,10 +11,20 @@ const ListDocsSchema = z.object({
 	path: z.string().optional(),
 });
 
-const ReadDocSchema = z.object({
-	projectId: z.string(),
-	path: z.string(),
-});
+const ReadDocSchema = z
+	.object({
+		projectId: z.string(),
+		path: z.string().optional(),
+		// Lets a caller that already has a raw document ID (e.g. one attached
+		// as chat context, which only carries an ID, never a virtual folder
+		// path) skip path resolution entirely and go straight to
+		// apiClient.getDocument. See the read_doc handler below.
+		docId: z.string().optional(),
+	})
+	.refine((data) => !!data.path || !!data.docId, {
+		message: "Either path or docId must be provided",
+		path: ["path"],
+	});
 
 const WriteDocSchema = z.object({
 	projectId: z.string(),
@@ -221,8 +231,9 @@ export function getFilesystemDocTools(): Tool[] {
 		{
 			name: "read_doc",
 			description:
-				"Read the Markdown content of a document by its path (e.g. 'Architecture/API Design'). " +
-				"Use list_docs first to discover available paths.",
+				"Read the Markdown content of a document, either by its path (e.g. 'Architecture/API Design') or directly by its technical UUID via docId. " +
+				"Use list_docs first to discover available paths, or pass docId directly when you already have a document's ID (e.g. one attached as chat context) rather than its folder path — docId skips path resolution entirely. " +
+				"Provide exactly one of path or docId.",
 			inputSchema: {
 				type: "object",
 				properties: {
@@ -235,10 +246,15 @@ export function getFilesystemDocTools(): Tool[] {
 						type: "string",
 						description:
 							"Path to the document (e.g. 'Architecture/API Design' or just 'README'). " +
-							"Folder and document names are separated by '/'.",
+							"Folder and document names are separated by '/'. Omit if docId is provided.",
+					},
+					docId: {
+						type: "string",
+						description:
+							"The technical UUID of the document to read directly, bypassing path resolution. Use this when you already have a document's ID (e.g. from context attached to this conversation) rather than its folder path. Omit if path is provided.",
 					},
 				},
-				required: ["projectId", "path"],
+				required: ["projectId"],
 			},
 		},
 		{
@@ -367,7 +383,34 @@ export async function handleFilesystemDocTool(
 		}
 
 		case "read_doc": {
-			const { projectId, path } = ReadDocSchema.parse(args);
+			const { projectId, path, docId } = ReadDocSchema.parse(args);
+
+			// docId short-circuits straight to the API, skipping the
+			// buildDocTree/resolvePath walk below entirely — needed for a
+			// caller that only has a raw document ID (e.g. a doc injected as
+			// chat context), which has no virtual folder path to resolve.
+			if (docId) {
+				const doc = await apiClient.getDocument(projectId, docId);
+				const content = doc.content ? blocknoteToMarkdown(doc.content) : "";
+				return {
+					content: [
+						{
+							type: "text",
+							text: `📄 ${doc.title}\nID: ${doc.id}\nUpdated: ${doc.updated_at}\n\n---\n\n${content}`,
+						},
+					],
+				};
+			}
+
+			if (!path) {
+				return {
+					content: [
+						{ type: "text", text: "Either path or docId must be provided." },
+					],
+					isError: true,
+				};
+			}
+
 			const tree = await buildDocTree(projectId, apiClient, docClient);
 			const resolved = resolvePath(path, tree);
 

--- a/apps/mcp/src/tools/index.ts
+++ b/apps/mcp/src/tools/index.ts
@@ -2,6 +2,7 @@ import type { CallToolRequest, Tool } from "@modelcontextprotocol/sdk/types.js";
 import type {
 	PacaAPIAutomationClient,
 	PacaAPIClient,
+	PacaAPIConversationClient,
 	PacaAPIDocClient,
 	PacaAPIExtendedClient,
 	PacaAPITaskExtendedClient,
@@ -16,6 +17,10 @@ import {
 	getAutomationTools,
 	handleAutomationTool,
 } from "./automation-tools.js";
+import {
+	getConversationTools,
+	handleConversationTool,
+} from "./conversation-tools.js";
 import {
 	getDocActivityTools,
 	handleDocActivityTool,
@@ -70,6 +75,7 @@ export function getAllTools(): Tool[] {
 		...getAutomationTools(),
 		...getDocActivityTools(),
 		...getRepoTools(),
+		...getConversationTools(),
 	];
 }
 
@@ -86,6 +92,7 @@ export async function handleToolCall(
 		taskExtendedClient: PacaAPITaskExtendedClient;
 		docClient: PacaAPIDocClient;
 		automationClient: PacaAPIAutomationClient;
+		conversationClient: PacaAPIConversationClient;
 	},
 	repoPluginIds: string[] = [],
 ): Promise<any> {
@@ -257,6 +264,11 @@ export async function handleToolCall(
 			name === "push_branch"
 		) {
 			return handleRepoTool(name, args, clients.apiClient, repoPluginIds);
+		}
+
+		// Conversation tools
+		if (name === "read_conversation") {
+			return handleConversationTool(name, args, clients.conversationClient);
 		}
 
 		throw new Error(`Unknown tool: ${name}`);

--- a/apps/mcp/src/types/index.ts
+++ b/apps/mcp/src/types/index.ts
@@ -853,6 +853,85 @@ export interface AddAutomationEdgeInput {
 	target_node_id: string;
 }
 
+// ==================== Agent Conversations (conversation-tools) ====================
+// Read-only view used by the read_conversation tool to let one agent read
+// another conversation's transcript (e.g. one attached as chat context).
+// Field-for-field mirror of services/api's dto.AgentConversationResponse /
+// dto.AgentConversationEventResponse. ProjectID/TriggeredByMemberID are unset
+// for a global-chat conversation, which carries ActorUserID instead — see
+// that DTO's doc comment.
+
+export type ConversationStatus =
+	| "queued"
+	| "running"
+	| "paused"
+	| "finished"
+	| "failed"
+	| "stopped";
+
+export type ConversationTriggerType =
+	| "task_assigned"
+	| "comment_mention"
+	| "chat_message"
+	| "description_write"
+	| "automation_message";
+
+export interface AgentConversation {
+	id: string;
+	agent_id: string;
+	project_id?: string | null;
+	trigger_type: ConversationTriggerType;
+	task_id?: string | null;
+	chat_session_id?: string | null;
+	triggered_by_member_id?: string | null;
+	actor_user_id?: string | null;
+	status: ConversationStatus;
+	iteration_count: number;
+	input_tokens: number;
+	output_tokens: number;
+	total_tokens: number;
+	cost_usd?: number | null;
+	error_message?: string | null;
+	pr_url?: string | null;
+	started_at?: string | null;
+	finished_at?: string | null;
+	created_at: string;
+	agent_name?: string;
+	agent_handle?: string;
+	environment_id?: string | null;
+}
+
+export interface AgentConversationEvent {
+	id: string;
+	conversation_id: string;
+	event_index: number;
+	event_type: string;
+	event_source: "agent" | "user" | "system";
+	payload: Record<string, unknown>;
+	created_at: string;
+}
+
+/**
+ * Query params for one page of a conversation's events — see
+ * conversation_handler.go's parseConversationEventWindowQuery. `after` and
+ * `before` are mutually exclusive; leaving both unset opens on the newest
+ * `limit` events.
+ */
+export interface ConversationEventWindow {
+	after?: string;
+	before?: string;
+	limit?: number;
+}
+
+export interface ConversationEventPage {
+	items: AgentConversationEvent[];
+	total: number;
+	/** Opaque cursor to resume forward toward newer events (pass as `after`), or null. */
+	next_cursor: string | null;
+	/** Opaque cursor to resume backward toward older events (pass as `before`), or null when this page already starts at event_index 0. */
+	prev_cursor: string | null;
+}
+
 // ==================== Repository (repo-tools) ====================
 
 /**

--- a/apps/mcp/src/types/index.ts
+++ b/apps/mcp/src/types/index.ts
@@ -31,6 +31,19 @@ export interface PacaConfig {
 	 */
 	actorUserId?: string;
 	/**
+	 * UUID of the conversation this MCP server instance is running as part
+	 * of, forwarded as X-Conversation-ID on every API request — set
+	 * unconditionally by agent-runner's buildMCPServers (PACA_CONVERSATION_ID),
+	 * unlike projectId/actorUserId. Lets services/api's
+	 * GetConversationForAgent (the read_conversation tool's backing
+	 * endpoint) authorize a cross-conversation read against *this*
+	 * conversation's own project/actor/owning member, instead of trusting
+	 * agentId alone — see that method's doc comment for why bare agent
+	 * identity isn't sufficient. Unset only for a personal API key running
+	 * outside any conversation.
+	 */
+	conversationId?: string;
+	/**
 	 * Names (e.g. "com.paca.github") of the repository plugins installed on
 	 * this conversation's project, forwarded from the agent-runner trigger's
 	 * repo_plugin_ids field as PACA_REPO_PLUGIN_IDS (comma-separated). Empty

--- a/apps/web/src/components/assistant-ui/context-injection.tsx
+++ b/apps/web/src/components/assistant-ui/context-injection.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useParams } from "@tanstack/react-router";
+import {
+	FileText,
+	Hash,
+	Loader2,
+	MessageSquare,
+	Plus,
+	Search,
+	Workflow,
+} from "lucide-react";
+import { type ComponentType, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChipField } from "@/components/projects/interactions/task-detail/property-field/chip-field";
+import { useContextItemSearch } from "@/hooks/use-context-item-search";
+import { useContextInjectionStore } from "@/lib/context-injection-store";
+import type { ContextItem, ContextItemType } from "@/lib/context-items";
+import { createLoadMoreScrollHandler } from "@/lib/scroll-pagination";
+import { useCurrentContextStore } from "@/lib/shortcuts/current-context-store";
+import { cn } from "@/lib/utils";
+
+// Per-type icon/color, scoped locally to this file only. task/doc match the
+// palette blocknote-inline-contents.tsx already uses for its rich-text
+// mention chips (emerald/Hash, purple/FileText) for visual continuity;
+// conversation (amber/MessageSquare) and automation (sky/Workflow) are new.
+// Intentionally not shared with/imported from blocknote-inline-contents.tsx —
+// that file is a separate system (rich-text body mentions), out of scope
+// here.
+const CONTEXT_TYPE_ICON: Record<
+	ContextItemType,
+	ComponentType<{ className?: string }>
+> = {
+	task: Hash,
+	doc: FileText,
+	conversation: MessageSquare,
+	automation: Workflow,
+};
+
+const CONTEXT_TYPE_TEXT_CLASS: Record<ContextItemType, string> = {
+	task: "text-emerald-700 dark:text-emerald-400",
+	doc: "text-purple-700 dark:text-purple-400",
+	conversation: "text-amber-700 dark:text-amber-400",
+	automation: "text-sky-700 dark:text-sky-400",
+};
+
+// No `Record<ContextItemType, string>` annotation here on purpose — it would
+// widen every value to `string`, which the project's typed-i18next `t()`
+// rejects (it only accepts literal known keys). `as const` keeps each value
+// a literal type instead.
+const CONTEXT_TYPE_LABEL_KEY = {
+	task: "agents.thread.contextInjection.contextTypeTask",
+	doc: "agents.thread.contextInjection.contextTypeDoc",
+	conversation: "agents.thread.contextInjection.contextTypeConversation",
+	automation: "agents.thread.contextInjection.contextTypeAutomation",
+} as const satisfies Record<ContextItemType, string>;
+
+function contextItemKey(type: ContextItemType, id: string): string {
+	return `${type}:${id}`;
+}
+
+function ContextItemLabel({ item }: { item: ContextItem }) {
+	const Icon = CONTEXT_TYPE_ICON[item.type];
+	return (
+		<span
+			className={cn(
+				"inline-flex min-w-0 items-center gap-1",
+				CONTEXT_TYPE_TEXT_CLASS[item.type],
+			)}
+		>
+			<Icon className="size-3 shrink-0" />
+			<span className="max-w-32 truncate text-foreground/80">{item.title}</span>
+		</span>
+	);
+}
+
+/** Same label, plus a hover tooltip explaining the adjacent X removes it —
+ *  only used for the editable chip row (ChipField's remove button has no
+ *  accessible name of its own and can't be customized without modifying
+ *  that shared component, so this tooltip lives on the label content
+ *  ChipField renders right next to it instead). Not used by
+ *  ContextItemReadOnlyRow, which has no remove action to describe. */
+function RemovableContextItemLabel({ item }: { item: ContextItem }) {
+	const { t } = useTranslation("projects");
+	return (
+		<span
+			title={t("agents.thread.contextInjection.removeContextItem", {
+				title: item.title,
+			})}
+		>
+			<ContextItemLabel item={item} />
+		</span>
+	);
+}
+
+/**
+ * Read-only badge row for a historical message's attached context — see
+ * thread.tsx's UserMessage, which reads metadata.custom.contextItems off the
+ * message and renders this. No remove buttons, no "+" trigger.
+ */
+export function ContextItemReadOnlyRow({ items }: { items: ContextItem[] }) {
+	if (items.length === 0) return null;
+	return (
+		<div className="col-span-full col-start-1 row-start-1 flex w-full flex-wrap items-center justify-end gap-1.5">
+			{items.map((item) => (
+				<span
+					key={contextItemKey(item.type, item.id)}
+					className="inline-flex items-center gap-1 rounded-md border border-border/20 bg-muted/50 px-2 py-0.5 text-xs font-medium"
+				>
+					<ContextItemLabel item={item} />
+				</span>
+			))}
+		</div>
+	);
+}
+
+// ── Search popover body ──────────────────────────────────────────────────────
+
+function ContextSearchPanel({
+	projectId,
+	availableTypes,
+	onSelect,
+}: {
+	projectId: string | undefined;
+	availableTypes: readonly ContextItemType[];
+	onSelect: (item: ContextItem) => void;
+}) {
+	const { t } = useTranslation("projects");
+	const [type, setType] = useState<ContextItemType>(
+		availableTypes[0] ?? "conversation",
+	);
+	const activeType = availableTypes.includes(type) ? type : availableTypes[0];
+
+	const { search, setSearch, queryTooShort, results, isLoading, pagination } =
+		useContextItemSearch(activeType ?? "conversation", projectId, true);
+
+	if (!activeType) return null;
+
+	return (
+		<div className="flex flex-col gap-2">
+			{availableTypes.length > 1 && (
+				<div className="flex items-center gap-0.5 rounded-lg bg-muted/40 p-0.5">
+					{availableTypes.map((tabType) => {
+						const Icon = CONTEXT_TYPE_ICON[tabType];
+						return (
+							<button
+								key={tabType}
+								type="button"
+								onClick={() => setType(tabType)}
+								className={cn(
+									// min-w-0 overrides a flex item's default min-width:auto,
+									// which otherwise ignores flex-1's shrinking and grows the
+									// button (and the whole row) to fit the untruncated label —
+									// exactly what was pushing this row past the popover's box.
+									"flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1 text-xs font-medium transition-colors",
+									activeType === tabType
+										? "bg-background text-foreground shadow-sm"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+							>
+								<Icon className="size-3" />
+								<span className="truncate">
+									{t(CONTEXT_TYPE_LABEL_KEY[tabType])}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+			)}
+
+			<div className="relative">
+				<Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/50" />
+				<input
+					// biome-ignore lint/a11y/noAutofocus: intentional for popover
+					autoFocus
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					placeholder={t(
+						"agents.thread.contextInjection.contextSearchPlaceholder",
+					)}
+					className="w-full rounded-md border border-border/30 bg-muted/20 py-1.5 pr-2 pl-8 text-xs outline-none focus:border-primary/40 focus:ring-2 focus:ring-primary/15"
+				/>
+			</div>
+
+			<div
+				onScroll={createLoadMoreScrollHandler(pagination)}
+				className="max-h-96 min-h-10 overflow-y-auto [scrollbar-gutter:stable]"
+			>
+				{queryTooShort ? (
+					<p className="px-2 py-3 text-center text-xs text-muted-foreground/60">
+						{t("agents.thread.contextInjection.contextSearchMinChars")}
+					</p>
+				) : isLoading ? (
+					<div className="flex justify-center py-3">
+						<Loader2 className="size-4 animate-spin text-muted-foreground/50" />
+					</div>
+				) : results.length === 0 ? (
+					<p className="px-2 py-3 text-center text-xs text-muted-foreground/60">
+						{t("agents.thread.contextInjection.noContextResults")}
+					</p>
+				) : (
+					<>
+						{results.map((result) => (
+							<button
+								key={result.id}
+								type="button"
+								onClick={() =>
+									onSelect({
+										type: activeType,
+										id: result.id,
+										title: result.title,
+										...(projectId ? { projectId } : {}),
+									})
+								}
+								className="flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/50"
+							>
+								<span className="w-full truncate text-xs font-medium">
+									{result.title}
+								</span>
+								{result.subtitle && (
+									<span className="w-full truncate text-[11px] text-muted-foreground/60">
+										{result.subtitle}
+									</span>
+								)}
+							</button>
+						))}
+						{pagination.isLoadingMore && (
+							<div className="flex justify-center py-2">
+								<Loader2 className="size-3.5 animate-spin text-muted-foreground/50" />
+							</div>
+						)}
+					</>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ── Composer row ──────────────────────────────────────────────────────────────
+
+/**
+ * The interactive badge row + "+" search popover + one-click quick-add,
+ * mounted inside Composer (thread.tsx) above the message textarea. Reads its
+ * project scope from the current route (rather than a prop threaded through
+ * Thread/Composer, which take none) — exactly one Composer is ever mounted
+ * at a time, and it always lives under whichever route (project-scoped or
+ * global) is currently active, so useParams here reflects the right scope
+ * without any plumbing changes to Thread itself.
+ */
+export function ContextInjectionRow() {
+	const { t } = useTranslation("projects");
+	const { projectId } = useParams({ strict: false });
+	const items = useContextInjectionStore((s) => s.items);
+	const remove = useContextInjectionStore((s) => s.remove);
+	const add = useContextInjectionStore((s) => s.add);
+	const active = useCurrentContextStore((s) => s.active);
+
+	// Task/Doc/Automation search is project-scoped only — hide those tabs
+	// entirely on the global (no-project) chat surfaces, where only
+	// Conversation search applies.
+	const availableTypes: readonly ContextItemType[] = projectId
+		? ["task", "doc", "conversation", "automation"]
+		: ["conversation"];
+
+	const showQuickAdd =
+		!!active &&
+		!items.some((i) => i.type === active.type && i.id === active.id);
+
+	return (
+		<div className="flex flex-wrap items-center gap-1.5 empty:hidden">
+			<ChipField
+				chips={items.map((item) => ({
+					key: contextItemKey(item.type, item.id),
+					label: <RemovableContextItemLabel item={item} />,
+				}))}
+				onRemoveChip={(key) => {
+					const sep = key.indexOf(":");
+					remove(key.slice(0, sep) as ContextItemType, key.slice(sep + 1));
+				}}
+				canEdit
+				addLabel={t("agents.thread.contextInjection.attachContext")}
+				// ChipField's default popover box (w-52) is sized for its other
+				// callers' short tag/user lists — too narrow for this panel's
+				// type tabs + search input + result list. Widened to fit, and
+				// overflow-hidden clips the box to its own rounded border as a
+				// backstop so no child content (e.g. an unexpectedly long
+				// result title) can ever visually spill past it again.
+				popoverContentClassName="w-96 overflow-hidden p-2.5 rounded-xl border border-border/40 shadow-lg"
+			>
+				<ContextSearchPanel
+					projectId={projectId}
+					availableTypes={availableTypes}
+					onSelect={add}
+				/>
+			</ChipField>
+			{showQuickAdd && active && (
+				<button
+					type="button"
+					onClick={() => add(active)}
+					title={t("agents.thread.contextInjection.addCurrent", {
+						title: active.title,
+					})}
+					className="inline-flex max-w-48 items-center gap-1 rounded-md border border-dashed border-border/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors duration-150 hover:border-primary/50 hover:text-primary"
+				>
+					<Plus className="size-2.5 shrink-0" />
+					<span className="truncate">
+						{t("agents.thread.contextInjection.addCurrent", {
+							title: active.title,
+						})}
+					</span>
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/assistant-ui/context-injection.tsx
+++ b/apps/web/src/components/assistant-ui/context-injection.tsx
@@ -10,7 +10,7 @@ import {
 	Search,
 	Workflow,
 } from "lucide-react";
-import { type ComponentType, useState } from "react";
+import { type ComponentType, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChipField } from "@/components/projects/interactions/task-detail/property-field/chip-field";
 import { useContextItemSearch } from "@/hooks/use-context-item-search";
@@ -254,6 +254,24 @@ export function ContextInjectionRow() {
 	const remove = useContextInjectionStore((s) => s.remove);
 	const add = useContextInjectionStore((s) => s.add);
 	const active = useCurrentContextStore((s) => s.active);
+
+	// useContextInjectionStore is a single global store (see its own doc
+	// comment for why that's safe — only one Composer is ever mounted at a
+	// time), but that means it never unmounts along with any one composer
+	// on its own. Without this, staging a badge in one project's chat, then
+	// closing the panel without sending and opening a different project's
+	// (or the global) chat instead, would carry that stale badge along into
+	// an unrelated conversation. Clearing on unmount handles the floating
+	// widgets' open/close toggle (their panel contents genuinely unmount);
+	// clearing on a projectId change additionally handles a route
+	// transition that preserves this component's instance instead of
+	// remounting it.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: projectId is a deliberate trigger-only dep, unread in the body — clear on unmount *and* on change.
+	useEffect(() => {
+		return () => {
+			useContextInjectionStore.getState().clear();
+		};
+	}, [projectId]);
 
 	// Task/Doc/Automation search is project-scoped only — hide those tabs
 	// entirely on the global (no-project) chat surfaces, where only

--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -36,9 +36,14 @@ import {
 	type PropsWithChildren,
 	type ReactNode,
 	useContext,
+	useMemo,
 } from "react";
 import { useTranslation } from "react-i18next";
 import { UserMessageAttachments } from "@/components/assistant-ui/attachment";
+import {
+	ContextInjectionRow,
+	ContextItemReadOnlyRow,
+} from "@/components/assistant-ui/context-injection";
 import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
@@ -56,6 +61,7 @@ import {
 } from "@/components/assistant-ui/tool-group";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
+import { parseContextItems } from "@/lib/context-items";
 import { cn } from "@/lib/utils";
 
 export type ThreadGroupPart = MessagePrimitive.GroupedParts.GroupPart;
@@ -310,6 +316,7 @@ const Composer: FC = () => {
 				data-slot="aui_composer-shell"
 				className="border-border/60 focus-within:border-border dark:border-muted-foreground/15 dark:focus-within:border-muted-foreground/30 flex w-full flex-col gap-2 rounded-(--composer-radius) border bg-(--composer-bg) p-(--composer-padding) shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)] dark:shadow-none"
 			>
+				<ContextInjectionRow />
 				<ComposerPrimitive.Input
 					placeholder={t("agents.thread.composerPlaceholder")}
 					className="aui-composer-input caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-sm outline-none"
@@ -576,7 +583,7 @@ const AssistantActionBar: FC = () => {
 					side="bottom"
 					align="start"
 					sideOffset={6}
-					className="aui-action-bar-more-content bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
+					className="aui-action-bar-more-content bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-80 min-w-32 overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
 				>
 					<ActionBarPrimitive.ExportMarkdown
 						render={
@@ -593,6 +600,26 @@ const AssistantActionBar: FC = () => {
 };
 
 const UserMessage: FC = () => {
+	// ThreadMessageLike.metadata.custom is a real, otherwise-unused
+	// assistant-ui escape hatch for arbitrary app data — set by
+	// conversation-to-thread-messages.ts's user_message branch when a
+	// historical message carried attached context.
+	//
+	// useAuiState compares its selector's return value with Object.is —
+	// parseContextItems builds a brand-new array on every call, so calling
+	// it *inside* the selector returned a fresh reference on every store
+	// snapshot check, which useSyncExternalStore always read as "changed,"
+	// forcing a re-render, which called the selector again, forever
+	// ("Maximum update depth exceeded"). Selecting the raw, referentially
+	// stable field and doing the array-producing work in a separate
+	// useMemo (keyed on that same stable reference) breaks the loop.
+	const rawContextItems = useAuiState(
+		(s) => s.message.metadata.custom.contextItems,
+	);
+	const contextItems = useMemo(
+		() => parseContextItems(rawContextItems),
+		[rawContextItems],
+	);
 	return (
 		<MessagePrimitive.Root
 			data-slot="aui_user-message-root"
@@ -600,6 +627,7 @@ const UserMessage: FC = () => {
 			data-role="user"
 		>
 			<UserMessageAttachments />
+			<ContextItemReadOnlyRow items={contextItems} />
 
 			<div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
 				<div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.test.ts
@@ -1096,6 +1096,55 @@ describe("eventsToThreadMessages", () => {
 			});
 		});
 	});
+
+	describe("context_items on a user_message event", () => {
+		it("maps payload.context_items (snake_case) into metadata.custom.contextItems (camelCase)", () => {
+			const events: AgentConversationEvent[] = [
+				{
+					id: "evt-ctx-1",
+					conversation_id: "conv-1",
+					event_index: 0,
+					event_type: "user_message",
+					event_source: "user",
+					payload: {
+						content: { type: "text", text: "look at this" },
+						context_items: [
+							{
+								type: "task",
+								id: "task-1",
+								project_id: "proj-1",
+								title: "Fix login bug",
+							},
+							{ type: "doc", id: "doc-1", title: "Runbook" },
+						],
+					},
+					created_at: "2026-01-01T00:00:00.000Z",
+				},
+			];
+
+			const messages = eventsToThreadMessages(events, false);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]?.metadata?.custom?.contextItems).toEqual([
+				{
+					type: "task",
+					id: "task-1",
+					projectId: "proj-1",
+					title: "Fix login bug",
+				},
+				{ type: "doc", id: "doc-1", title: "Runbook" },
+			]);
+		});
+
+		it("adds no metadata.custom when a user_message event carries no context_items", () => {
+			const events = [acpUserMessage("hi")];
+
+			const messages = eventsToThreadMessages(events, false);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]?.metadata).toBeUndefined();
+		});
+	});
 });
 
 describe("hasEnvironmentReadyEvent", () => {

--- a/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
+++ b/apps/web/src/components/projects/agents/conversation-to-thread-messages.ts
@@ -3,6 +3,7 @@ import type {
 	AgentConversation,
 	AgentConversationEvent,
 } from "@/lib/agent-api";
+import { parseContextItems } from "@/lib/context-items";
 
 // Our chat runtimes (conversation-view.tsx / ai-chat-float.tsx / the
 // Conversations page's new-conversation composer) only ever send a single
@@ -333,11 +334,19 @@ export function eventsToThreadMessages(
 			const text = extractAcpBlockText(p.content);
 			if (!text) continue;
 			flushCurrent();
+			// context_items (snake_case, as persisted by
+			// services/agent-runner's handler.go) round-trips back into the
+			// camelCase ContextItem[] shape here so thread.tsx's UserMessage
+			// can render a read-only badge row via metadata.custom.contextItems.
+			const contextItems = parseContextItems(p.context_items);
 			messages.push({
 				id: ev.id,
 				role: "user",
 				createdAt: new Date(ev.created_at),
 				content: [{ type: "text", text }],
+				...(contextItems.length > 0
+					? { metadata: { custom: { contextItems } } }
+					: {}),
 			});
 			continue;
 		}

--- a/apps/web/src/components/projects/agents/conversation-view.tsx
+++ b/apps/web/src/components/projects/agents/conversation-view.tsx
@@ -42,6 +42,7 @@ import {
 	stopConversation,
 	stopGlobalConversation,
 } from "@/lib/agent-api";
+import { useContextInjectionStore } from "@/lib/context-injection-store";
 import { cn } from "@/lib/utils";
 import { ConversationErrorBox } from "./conversation-error-box";
 import {
@@ -248,6 +249,9 @@ export function ConversationView({
 		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
+		// Snapshot now (not read again after any await) so a badge staged
+		// mid-send can't sneak into this message or get cleared under it.
+		const contextItems = useContextInjectionStore.getState().items;
 
 		if (!conversation.chat_session_id) {
 			// A conversation of a non-chat trigger type (task_assigned,
@@ -256,10 +260,20 @@ export function ConversationView({
 			// comment) — reply in place on the same conversation_id rather
 			// than through a chat session.
 			if (projectId) {
-				await sendConversationMessage(projectId, conversation.id, text);
+				await sendConversationMessage(
+					projectId,
+					conversation.id,
+					text,
+					contextItems,
+				);
 			} else {
-				await sendGlobalConversationMessage(conversation.id, text);
+				await sendGlobalConversationMessage(
+					conversation.id,
+					text,
+					contextItems,
+				);
 			}
+			useContextInjectionStore.getState().clear();
 			invalidate();
 			return;
 		}
@@ -269,11 +283,13 @@ export function ConversationView({
 					projectId,
 					conversation.agent_id,
 					conversation.chat_session_id,
-					{ message: text },
+					{ message: text, contextItems },
 				)
 			: await sendGlobalChatMessage(conversation.chat_session_id, {
 					message: text,
+					contextItems,
 				});
+		useContextInjectionStore.getState().clear();
 		// The previous conversation may have already ended (explicitly
 		// stopped, or reaped after 3 minutes with no heartbeat) — replying
 		// then silently starts a fresh conversation server-side. Follow it,

--- a/apps/web/src/components/projects/agents/conversations-layout.tsx
+++ b/apps/web/src/components/projects/agents/conversations-layout.tsx
@@ -1,5 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Link, Outlet, useParams } from "@tanstack/react-router";
+import type { TFunction } from "i18next";
 import { Clock, Coins, MessageSquare, Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,6 +33,36 @@ import { ConversationFilters } from "./conversation-filters";
 // from. See conversation-view.tsx for the equivalent generalization of the
 // detail pane rendered in the Outlet.
 
+/**
+ * Human-readable label for a conversation's trigger — shared with
+ * hooks/use-context-item-search.ts's conversation search results, so the
+ * "why did this conversation start" synthesis lives in exactly one place
+ * rather than two independently-maintained copies.
+ *
+ * A conversation with no human actor was fired by the automation-workflow
+ * engine (see agent_service.go's TriggerTaskAssigned/TriggerDirectMessage:
+ * triggeredByMemberID is nil for automation-triggered runs), not by someone
+ * assigning a task or messaging the agent by hand. Global conversations are
+ * never automation-triggered — they always carry actor_user_id instead.
+ */
+export function conversationTriggerLabel(
+	conv: AgentConversation,
+	t: TFunction<"projects">,
+): string {
+	const isAutomationTriggered =
+		!conv.triggered_by_member_id &&
+		!conv.actor_user_id &&
+		(conv.trigger_type === "task_assigned" ||
+			conv.trigger_type === "automation_message");
+	return isAutomationTriggered
+		? t("conversationsPage.triggerAutomation")
+		: conv.trigger_type === "chat_message"
+			? t("conversationsPage.triggerChat")
+			: conv.trigger_type === "description_write"
+				? t("conversationsPage.triggerWriteDescription")
+				: t("conversationsPage.triggerTask");
+}
+
 // ── List item ─────────────────────────────────────────────────────────────────
 
 function ConversationListItem({
@@ -49,24 +80,7 @@ function ConversationListItem({
 	const { t } = useTranslation("projects");
 	const statusColor = CONVERSATION_STATUS_COLORS[conv.status];
 	const statusLabel = CONVERSATION_STATUS_LABELS[conv.status];
-	// A conversation with no human actor was fired by the automation-workflow
-	// engine (see agent_service.go's TriggerTaskAssigned/TriggerDirectMessage:
-	// triggeredByMemberID is nil for automation-triggered runs), not by
-	// someone assigning a task or messaging the agent by hand. Global
-	// conversations are never automation-triggered — they always carry
-	// actor_user_id instead.
-	const isAutomationTriggered =
-		!conv.triggered_by_member_id &&
-		!conv.actor_user_id &&
-		(conv.trigger_type === "task_assigned" ||
-			conv.trigger_type === "automation_message");
-	const triggerLabel = isAutomationTriggered
-		? t("conversationsPage.triggerAutomation")
-		: conv.trigger_type === "chat_message"
-			? t("conversationsPage.triggerChat")
-			: conv.trigger_type === "description_write"
-				? t("conversationsPage.triggerWriteDescription")
-				: t("conversationsPage.triggerTask");
+	const triggerLabel = conversationTriggerLabel(conv, t);
 	const initials = (agent?.name ?? "?")
 		.split(" ")
 		.map((w) => w[0])

--- a/apps/web/src/components/projects/agents/new-conversation-thread.tsx
+++ b/apps/web/src/components/projects/agents/new-conversation-thread.tsx
@@ -15,6 +15,7 @@ import {
 	startChatSession,
 	startGlobalChatSession,
 } from "@/lib/agent-api";
+import { useContextInjectionStore } from "@/lib/context-injection-store";
 import {
 	AgentPickerContext,
 	AgentPickerInline,
@@ -76,6 +77,9 @@ export function NewConversationThread({
 		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
+		// Snapshot now (not read again after any await) so a badge staged
+		// mid-send can't sneak into this message or get cleared under it.
+		const contextItems = useContextInjectionStore.getState().items;
 
 		// Guards against a fast double-Enter firing two chat sessions before
 		// the first request resolves and this component navigates away.
@@ -86,7 +90,9 @@ export function NewConversationThread({
 					message: text,
 					...(environmentId ? { environment_id: environmentId } : {}),
 					...(folderId ? { folder_id: folderId } : {}),
+					contextItems,
 				});
+				useContextInjectionStore.getState().clear();
 				qc.setQueryData(
 					conversationQueryOptions(projectId, result.conversation.id).queryKey,
 					result.conversation,
@@ -101,7 +107,9 @@ export function NewConversationThread({
 			} else {
 				const result = await startGlobalChatSession(agentId, {
 					message: text,
+					contextItems,
 				});
+				useContextInjectionStore.getState().clear();
 				qc.setQueryData(
 					globalConversationQueryOptions(result.conversation.id).queryKey,
 					result.conversation,

--- a/apps/web/src/components/projects/ai-chat-float-global.tsx
+++ b/apps/web/src/components/projects/ai-chat-float-global.tsx
@@ -28,6 +28,7 @@ import {
 	startGlobalChatSession,
 	stopGlobalConversation,
 } from "@/lib/agent-api";
+import { useContextInjectionStore } from "@/lib/context-injection-store";
 import { cn } from "@/lib/utils";
 import { ConversationErrorBox } from "./agents/conversation-error-box";
 import {
@@ -135,6 +136,9 @@ export function GlobalAIChatFloat() {
 		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
+		// Snapshot now (not read again after any await) so a badge staged
+		// mid-send can't sneak into this message or get cleared under it.
+		const contextItems = useContextInjectionStore.getState().items;
 
 		setIsSubmitting(true);
 		try {
@@ -142,7 +146,9 @@ export function GlobalAIChatFloat() {
 				if (!agentId) throw new Error(t("aiChat.selectAgentFirst"));
 				const result = await startGlobalChatSession(agentId, {
 					message: text,
+					contextItems,
 				});
+				useContextInjectionStore.getState().clear();
 				qc.setQueryData(
 					globalConversationQueryOptions(result.conversation.id).queryKey,
 					result.conversation,
@@ -161,13 +167,20 @@ export function GlobalAIChatFloat() {
 				// ACP (see canReplyToConversation's own doc comment) — reply in
 				// place on the same conversation_id rather than through a chat
 				// session.
-				await sendGlobalConversationMessage(conversation.id, text);
+				await sendGlobalConversationMessage(
+					conversation.id,
+					text,
+					contextItems,
+				);
+				useContextInjectionStore.getState().clear();
 				invalidate();
 				return;
 			}
 			const result = await sendGlobalChatMessage(conversation.chat_session_id, {
 				message: text,
+				contextItems,
 			});
+			useContextInjectionStore.getState().clear();
 			if (result.id !== conversationId) {
 				qc.setQueryData(
 					globalConversationQueryOptions(result.id).queryKey,
@@ -248,7 +261,11 @@ export function GlobalAIChatFloat() {
 				aria-label={t("aiChat.chatWithAgent")}
 				onClick={handleToggleOpen}
 				className={cn(
-					"fixed bottom-6 right-6 z-40 flex size-12 items-center justify-center rounded-full shadow-lg transition-all hover:scale-105",
+					// z-70: must stay above the task-detail dialog (z-50, with its
+					// own backdrop-blur) so the float stays clickable and unblurred
+					// while that dialog is open, and above its nested field dialog
+					// (z-60) too.
+					"fixed bottom-6 right-6 z-70 flex size-12 items-center justify-center rounded-full shadow-lg transition-all hover:scale-105",
 					open
 						? "bg-muted text-foreground border border-border"
 						: "bg-primary text-primary-foreground hover:bg-primary/90",
@@ -261,7 +278,7 @@ export function GlobalAIChatFloat() {
 			{open && (
 				<div
 					className={cn(
-						"fixed bottom-20 right-6 z-40 flex w-95 flex-col overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl",
+						"fixed bottom-20 right-6 z-70 flex w-95 flex-col overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl",
 						conversationId ? "h-150" : "max-h-150",
 					)}
 				>

--- a/apps/web/src/components/projects/ai-chat-float.tsx
+++ b/apps/web/src/components/projects/ai-chat-float.tsx
@@ -27,6 +27,7 @@ import {
 	startChatSession,
 	stopConversation,
 } from "@/lib/agent-api";
+import { useContextInjectionStore } from "@/lib/context-injection-store";
 import { cn } from "@/lib/utils";
 import { ConversationErrorBox } from "./agents/conversation-error-box";
 import {
@@ -136,6 +137,9 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 		if (text === null) {
 			throw new Error(t("agents.conversationView.textOnlyMessage"));
 		}
+		// Snapshot now (not read again after any await) so a badge staged
+		// mid-send can't sneak into this message or get cleared under it.
+		const contextItems = useContextInjectionStore.getState().items;
 
 		// Guards against a fast double-Enter firing two requests (e.g. two
 		// chat sessions) before the first one resolves and flips isRunning.
@@ -145,7 +149,9 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 				if (!agentId) throw new Error(t("aiChat.selectAgentFirst"));
 				const result = await startChatSession(projectId, agentId, {
 					message: text,
+					contextItems,
 				});
+				useContextInjectionStore.getState().clear();
 				// Seed the cache before flipping conversationId so the Thread
 				// doesn't flash a "can't reply" state while the query resolves.
 				qc.setQueryData(
@@ -167,7 +173,13 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 				// (see canReplyToConversation's own doc comment) — reply in
 				// place on the same conversation_id rather than through a chat
 				// session.
-				await sendConversationMessage(projectId, conversation.id, text);
+				await sendConversationMessage(
+					projectId,
+					conversation.id,
+					text,
+					contextItems,
+				);
+				useContextInjectionStore.getState().clear();
 				invalidate();
 				return;
 			}
@@ -175,8 +187,9 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 				projectId,
 				conversation.agent_id,
 				conversation.chat_session_id,
-				{ message: text },
+				{ message: text, contextItems },
 			);
+			useContextInjectionStore.getState().clear();
 			// The previous conversation may have already ended (explicitly
 			// stopped, or reaped after 3 minutes with no heartbeat) — replying
 			// then silently starts a fresh conversation server-side. Follow it,
@@ -291,7 +304,11 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 				aria-label={t("aiChat.chatWithAgent")}
 				onClick={handleToggleOpen}
 				className={cn(
-					"fixed bottom-6 right-6 z-40 flex size-12 items-center justify-center rounded-full shadow-lg transition-all hover:scale-105",
+					// z-70: must stay above the task-detail dialog (z-50, with its
+					// own backdrop-blur) so the float stays clickable and unblurred
+					// while that dialog is open, and above its nested field dialog
+					// (z-60) too.
+					"fixed bottom-6 right-6 z-70 flex size-12 items-center justify-center rounded-full shadow-lg transition-all hover:scale-105",
 					open
 						? "bg-muted text-foreground border border-border"
 						: "bg-primary text-primary-foreground hover:bg-primary/90",
@@ -304,7 +321,7 @@ export function AIChatFloat({ projectId }: AIChatFloatProps) {
 			{open && (
 				<div
 					className={cn(
-						"fixed bottom-20 right-6 z-40 flex w-95 flex-col overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl",
+						"fixed bottom-20 right-6 z-70 flex w-95 flex-col overflow-hidden rounded-2xl border border-border/60 bg-background shadow-2xl",
 						conversationId ? "h-150" : "max-h-150",
 					)}
 				>

--- a/apps/web/src/components/projects/interactions/task-detail/index.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/index.tsx
@@ -24,6 +24,7 @@ import {
 	isEpicType,
 	projectQueryOptions,
 } from "@/lib/project-api";
+import { useCurrentContextStore } from "@/lib/shortcuts/current-context-store";
 import { cleanBlocks, cn } from "@/lib/utils";
 import { getTaskTypeIconComponent } from "../../task-types/task-type-icons";
 import { getPriority } from "../priority";
@@ -243,6 +244,25 @@ export function TaskDetailModal({
 	});
 
 	const handleUpdate = canEdit ? updateMutation.mutate : undefined;
+
+	// Register this task as "currently on screen" for the chat composer's
+	// quick-add affordance — same shown/loaded guard every other query above
+	// uses (open in modal mode, or always in page mode), so a closed modal
+	// (still mounted with open=false, per the mode==="modal" && !open early
+	// return below) doesn't stay registered.
+	useEffect(() => {
+		const shown = open || mode === "page";
+		if (!shown || !task) return;
+		useCurrentContextStore.getState().setActive({
+			type: "task",
+			id: task.id,
+			projectId,
+			title: task.title,
+		});
+		return () => {
+			useCurrentContextStore.getState().clearActive("task", task.id);
+		};
+	}, [open, mode, task, projectId]);
 
 	// Close on Escape (modal mode only)
 	useEffect(() => {

--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -25,7 +25,7 @@ function ContextMenuContent({
 }: ContextMenuPrimitive.Popup.Props) {
 	return (
 		<ContextMenuPrimitive.Portal>
-			<ContextMenuPrimitive.Positioner className="isolate z-50 outline-none">
+			<ContextMenuPrimitive.Positioner className="isolate z-80 outline-none">
 				<ContextMenuPrimitive.Popup
 					data-slot="context-menu-content"
 					className={cn(

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -30,7 +30,7 @@ function DropdownMenuContent({
 	return (
 		<MenuPrimitive.Portal>
 			<MenuPrimitive.Positioner
-				className="isolate z-50 outline-none"
+				className="isolate z-80 outline-none"
 				align={align}
 				alignOffset={alignOffset}
 				side={side}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
 				alignOffset={alignOffset}
 				side={side}
 				sideOffset={sideOffset}
-				className="isolate z-50"
+				className="isolate z-80"
 			>
 				<PopoverPrimitive.Popup
 					data-slot="popover-content"

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -75,7 +75,7 @@ function SelectContent({
 				align={align}
 				alignOffset={alignOffset}
 				alignItemWithTrigger={alignItemWithTrigger}
-				className="isolate z-50"
+				className="isolate z-80"
 			>
 				<SelectPrimitive.Popup
 					data-slot="select-content"

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -43,7 +43,7 @@ function TooltipContent({
 				alignOffset={alignOffset}
 				side={side}
 				sideOffset={sideOffset}
-				className="isolate z-50"
+				className="isolate z-80"
 			>
 				<TooltipPrimitive.Popup
 					data-slot="tooltip-content"

--- a/apps/web/src/hooks/use-context-item-search.ts
+++ b/apps/web/src/hooks/use-context-item-search.ts
@@ -1,0 +1,254 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { conversationTriggerLabel } from "@/components/projects/agents/conversations-layout";
+import {
+	type AgentConversation,
+	agentsQueryOptions,
+	chattableAgentsQueryOptions,
+	listConversations,
+	listGlobalConversations,
+} from "@/lib/agent-api";
+import { listAutomationsPage } from "@/lib/automation-api";
+import type { ContextItemType } from "@/lib/context-items";
+import { listDocumentsPage } from "@/lib/doc-api";
+import { searchTasksForPicker } from "@/lib/interaction-api";
+import type { LoadMorePagination } from "@/lib/scroll-pagination";
+import { useDebouncedCallback } from "./use-debounced-callback";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+// Below this length, `search` does a leading-wildcard ILIKE scan server-side
+// (no trigram index backs it) — cheap enough per-project at 2+ chars, but a
+// single character is broad enough to be worth avoiding. Mirrors
+// use-task-picker-search.ts's own MIN_SEARCH_LENGTH. Doesn't apply to an
+// *empty* query — that's "browse everything," not "search," and every
+// backend list endpoint already treats a missing/blank search param as
+// "no filter" for exactly this reason.
+export const MIN_SEARCH_LENGTH = 2;
+
+const PAGE_SIZE = 20;
+
+/** One search result, normalized across all 4 context-item types so the
+ *  popover's result list can render them uniformly. */
+export interface ContextSearchResult {
+	id: string;
+	title: string;
+	subtitle?: string;
+}
+
+// "conversation" pages carry raw AgentConversation[] instead of an
+// already-normalized ContextSearchResult[] — see the `results` useMemo below
+// for why the agent-name/trigger-label synthesis has to happen there instead
+// of inside queryFn.
+interface RawPage {
+	items: readonly (ContextSearchResult | AgentConversation)[];
+	nextCursor: string | undefined;
+}
+
+interface UseContextItemSearchResult {
+	search: string;
+	setSearch: (value: string) => void;
+	/** True only for a 1-character (or otherwise sub-minimum) non-empty
+	 *  query — too short to search, but not empty either. `results` is
+	 *  always empty while this holds; callers should show a "type more"
+	 *  hint instead. An empty query is *not* "too short" — see
+	 *  MIN_SEARCH_LENGTH's doc comment. */
+	queryTooShort: boolean;
+	/** The current query's results — either everything (browsing, query
+	 *  empty) or a filtered page (query at least MIN_SEARCH_LENGTH chars).
+	 *  Always empty while queryTooShort holds. */
+	results: ContextSearchResult[];
+	/** True while a debounce or in-flight initial fetch means `results` may
+	 *  be stale/incomplete. */
+	isLoading: boolean;
+	pagination: LoadMorePagination;
+}
+
+/**
+ * Backs the context-injection popover's search box (see
+ * components/assistant-ui/context-injection.tsx), dispatching per
+ * ContextItemType to whichever backend search already exists for that type:
+ *   - task: the same searchTasksForPicker use-task-picker-search.ts uses.
+ *   - doc / automation: listDocumentsPage/listAutomationsPage — cursor-
+ *     paginated, same as task/conversation.
+ *   - conversation: listConversations (project-scoped) or
+ *     listGlobalConversations (no projectId — global chat).
+ *
+ * All four already treat an empty/omitted `search` param as "no filter," so
+ * leaving the query box empty browses the full (paginated) list rather than
+ * showing nothing — only a *non-empty* query shorter than MIN_SEARCH_LENGTH
+ * is rejected client-side (queryTooShort), to avoid firing an expensive
+ * leading-wildcard scan per keystroke on 1 character.
+ *
+ * Conversations have no title field, so their label is synthesized from the
+ * triggering agent's name + conversationTriggerLabel (shared with
+ * conversations-layout.tsx's ConversationListItem) + created_at date —
+ * recomputed in a useMemo below (not inside the query itself) so it always
+ * reflects the latest agents list/translations even if those resolve after
+ * the conversation page itself has already loaded.
+ */
+export function useContextItemSearch(
+	type: ContextItemType,
+	projectId: string | undefined,
+	enabled: boolean,
+): UseContextItemSearchResult {
+	const { t } = useTranslation("projects");
+	const [search, setSearch] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const applyDebounced = useDebouncedCallback(
+		setDebouncedSearch,
+		SEARCH_DEBOUNCE_MS,
+	);
+
+	const updateSearch = (value: string) => {
+		setSearch(value);
+		applyDebounced(value.trim());
+	};
+
+	useEffect(() => {
+		if (!enabled) {
+			setSearch("");
+			setDebouncedSearch("");
+		}
+	}, [enabled]);
+
+	const queryTooShort =
+		search.trim().length > 0 && search.trim().length < MIN_SEARCH_LENGTH;
+	const debouncedTooShort =
+		debouncedSearch.length > 0 && debouncedSearch.length < MIN_SEARCH_LENGTH;
+	// Fires for an empty query (browse everything) or one long enough to
+	// search — never for the 1-character in-between state.
+	const queryEnabled = enabled && !debouncedTooShort;
+
+	// Only fetched for the "conversation" tab — used to resolve each
+	// conversation's agent_id into a display name. Cheap/deduped by
+	// react-query when already fetched elsewhere (e.g. the agent picker).
+	const agentsBaseOptions = projectId
+		? agentsQueryOptions(projectId)
+		: chattableAgentsQueryOptions;
+	const { data: agents = [] } = useQuery({
+		...agentsBaseOptions,
+		enabled: queryEnabled && type === "conversation",
+	});
+	const agentsById = useMemo(
+		() => new Map(agents.map((a) => [a.id, a])),
+		[agents],
+	);
+
+	const { data, isFetching, isFetchingNextPage, hasNextPage, fetchNextPage } =
+		useInfiniteQuery({
+			queryKey: ["context-item-search", type, projectId, debouncedSearch],
+			queryFn: async ({
+				pageParam,
+			}: {
+				pageParam: string | undefined;
+			}): Promise<RawPage> => {
+				switch (type) {
+					case "task": {
+						if (!projectId) return { items: [], nextCursor: undefined };
+						const page = await searchTasksForPicker(
+							projectId,
+							debouncedSearch,
+							{
+								cursor: pageParam,
+							},
+						);
+						return {
+							items: page.items.map((task) => ({
+								id: task.id,
+								title: task.title,
+							})),
+							nextCursor: page.next_cursor ?? undefined,
+						};
+					}
+					case "doc": {
+						if (!projectId) return { items: [], nextCursor: undefined };
+						const page = await listDocumentsPage(projectId, {
+							search: debouncedSearch,
+							cursor: pageParam,
+							pageSize: PAGE_SIZE,
+						});
+						return {
+							items: page.items.map((doc) => ({
+								id: doc.id,
+								title: doc.title,
+							})),
+							nextCursor: page.next_cursor ?? undefined,
+						};
+					}
+					case "automation": {
+						if (!projectId) return { items: [], nextCursor: undefined };
+						const page = await listAutomationsPage(projectId, {
+							search: debouncedSearch,
+							cursor: pageParam,
+							pageSize: PAGE_SIZE,
+						});
+						return {
+							items: page.items.map((automation) => ({
+								id: automation.id,
+								title: automation.name,
+							})),
+							nextCursor: page.next_cursor ?? undefined,
+						};
+					}
+					case "conversation": {
+						const page = projectId
+							? await listConversations(projectId, {
+									search: debouncedSearch,
+									cursor: pageParam,
+								})
+							: await listGlobalConversations({
+									search: debouncedSearch,
+									cursor: pageParam,
+								});
+						// Kept as raw AgentConversation[] here — labeling needs
+						// `t` and the agents-by-id map, which aren't available
+						// inside queryFn; see the `results` useMemo below.
+						return {
+							items: page.items,
+							nextCursor: page.next_cursor ?? undefined,
+						};
+					}
+					default:
+						return { items: [], nextCursor: undefined };
+				}
+			},
+			initialPageParam: undefined as string | undefined,
+			getNextPageParam: (lastPage) => lastPage.nextCursor,
+			enabled: queryEnabled,
+			staleTime: 15_000,
+		});
+
+	const results = useMemo((): ContextSearchResult[] => {
+		if (!queryEnabled) return [];
+		const rawItems = data?.pages.flatMap((page) => page.items) ?? [];
+		if (type !== "conversation") return rawItems as ContextSearchResult[];
+		return (rawItems as AgentConversation[]).map((conv) => {
+			const agentName = agentsById.get(conv.agent_id)?.name;
+			return {
+				id: conv.id,
+				title: agentName ?? conv.agent_id.slice(0, 8),
+				subtitle: `${conversationTriggerLabel(conv, t)} · ${new Date(
+					conv.created_at,
+				).toLocaleDateString()}`,
+			};
+		});
+	}, [data, queryEnabled, type, agentsById, t]);
+
+	const isInitialFetch = isFetching && !isFetchingNextPage;
+	const debouncePending = search.trim() !== debouncedSearch;
+
+	return {
+		search,
+		setSearch: updateSearch,
+		queryTooShort,
+		results,
+		isLoading: queryEnabled && (debouncePending || isInitialFetch),
+		pagination: {
+			hasMore: queryEnabled && !!hasNextPage,
+			isLoadingMore: isFetchingNextPage,
+			onLoadMore: () => void fetchNextPage(),
+		},
+	};
+}

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "Image Attachment Preview",
 			"attachmentAriaLabel": "{{type}} attachment",
 			"attachmentAriaLabelError": "{{type}} attachment, upload failed",
-			"attachmentAriaLabelUploading": "{{type}} attachment, uploading"
+			"attachmentAriaLabelUploading": "{{type}} attachment, uploading",
+			"contextInjection": {
+				"attachContext": "Attach context",
+				"contextSearchPlaceholder": "Search tasks, docs, conversations, automations…",
+				"removeContextItem": "Remove {{title}}",
+				"addCurrent": "Attach {{title}}",
+				"contextTypeTask": "Task",
+				"contextTypeDoc": "Doc",
+				"contextTypeConversation": "Conversation",
+				"contextTypeAutomation": "Automation",
+				"noContextResults": "No results found",
+				"contextSearchMinChars": "Type at least 2 characters to search"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "Vista previa de la imagen adjunta",
 			"attachmentAriaLabel": "Adjunto de {{type}}",
 			"attachmentAriaLabelError": "Adjunto de {{type}}, error al subir",
-			"attachmentAriaLabelUploading": "Adjunto de {{type}}, subiendo"
+			"attachmentAriaLabelUploading": "Adjunto de {{type}}, subiendo",
+			"contextInjection": {
+				"attachContext": "Adjuntar contexto",
+				"contextSearchPlaceholder": "Buscar tareas, documentos, conversaciones, automatizaciones…",
+				"removeContextItem": "Quitar {{title}}",
+				"addCurrent": "Adjuntar {{title}}",
+				"contextTypeTask": "Tarea",
+				"contextTypeDoc": "Documento",
+				"contextTypeConversation": "Conversación",
+				"contextTypeAutomation": "Automatización",
+				"noContextResults": "No se encontraron resultados",
+				"contextSearchMinChars": "Escribe al menos 2 caracteres para buscar"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "Aperçu de l'image jointe",
 			"attachmentAriaLabel": "Pièce jointe {{type}}",
 			"attachmentAriaLabelError": "Pièce jointe {{type}}, échec du téléversement",
-			"attachmentAriaLabelUploading": "Pièce jointe {{type}}, téléversement en cours"
+			"attachmentAriaLabelUploading": "Pièce jointe {{type}}, téléversement en cours",
+			"contextInjection": {
+				"attachContext": "Joindre du contexte",
+				"contextSearchPlaceholder": "Rechercher des tâches, documents, conversations, automatisations…",
+				"removeContextItem": "Retirer {{title}}",
+				"addCurrent": "Joindre {{title}}",
+				"contextTypeTask": "Tâche",
+				"contextTypeDoc": "Document",
+				"contextTypeConversation": "Conversation",
+				"contextTypeAutomation": "Automatisation",
+				"noContextResults": "Aucun résultat trouvé",
+				"contextSearchMinChars": "Saisissez au moins 2 caractères pour rechercher"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "画像添付ファイルのプレビュー",
 			"attachmentAriaLabel": "{{type}}の添付ファイル",
 			"attachmentAriaLabelError": "{{type}}の添付ファイル、アップロード失敗",
-			"attachmentAriaLabelUploading": "{{type}}の添付ファイル、アップロード中"
+			"attachmentAriaLabelUploading": "{{type}}の添付ファイル、アップロード中",
+			"contextInjection": {
+				"attachContext": "コンテキストを添付",
+				"contextSearchPlaceholder": "タスク、ドキュメント、会話、自動化を検索…",
+				"removeContextItem": "{{title}}を削除",
+				"addCurrent": "{{title}}を添付",
+				"contextTypeTask": "タスク",
+				"contextTypeDoc": "ドキュメント",
+				"contextTypeConversation": "会話",
+				"contextTypeAutomation": "自動化",
+				"noContextResults": "結果が見つかりません",
+				"contextSearchMinChars": "検索するには2文字以上入力してください"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "이미지 첨부 파일 미리보기",
 			"attachmentAriaLabel": "{{type}} 첨부 파일",
 			"attachmentAriaLabelError": "{{type}} 첨부 파일, 업로드 실패",
-			"attachmentAriaLabelUploading": "{{type}} 첨부 파일, 업로드 중"
+			"attachmentAriaLabelUploading": "{{type}} 첨부 파일, 업로드 중",
+			"contextInjection": {
+				"attachContext": "컨텍스트 첨부",
+				"contextSearchPlaceholder": "작업, 문서, 대화, 자동화 검색…",
+				"removeContextItem": "{{title}} 제거",
+				"addCurrent": "{{title}} 첨부",
+				"contextTypeTask": "작업",
+				"contextTypeDoc": "문서",
+				"contextTypeConversation": "대화",
+				"contextTypeAutomation": "자동화",
+				"noContextResults": "결과를 찾을 수 없습니다",
+				"contextSearchMinChars": "검색하려면 2자 이상 입력하세요"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "Visualização do anexo de imagem",
 			"attachmentAriaLabel": "Anexo {{type}}",
 			"attachmentAriaLabelError": "Anexo {{type}}, falha no upload",
-			"attachmentAriaLabelUploading": "Anexo {{type}}, enviando"
+			"attachmentAriaLabelUploading": "Anexo {{type}}, enviando",
+			"contextInjection": {
+				"attachContext": "Anexar contexto",
+				"contextSearchPlaceholder": "Buscar tarefas, documentos, conversas, automações…",
+				"removeContextItem": "Remover {{title}}",
+				"addCurrent": "Anexar {{title}}",
+				"contextTypeTask": "Tarefa",
+				"contextTypeDoc": "Documento",
+				"contextTypeConversation": "Conversa",
+				"contextTypeAutomation": "Automação",
+				"noContextResults": "Nenhum resultado encontrado",
+				"contextSearchMinChars": "Digite pelo menos 2 caracteres para buscar"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -347,7 +347,19 @@
 			"imageAttachmentPreviewTitle": "Предпросмотр вложенного изображения",
 			"attachmentAriaLabel": "Вложение: {{type}}",
 			"attachmentAriaLabelError": "Вложение: {{type}}, ошибка загрузки",
-			"attachmentAriaLabelUploading": "Вложение: {{type}}, загружается"
+			"attachmentAriaLabelUploading": "Вложение: {{type}}, загружается",
+			"contextInjection": {
+				"attachContext": "Прикрепить контекст",
+				"contextSearchPlaceholder": "Поиск задач, документов, бесед, автоматизаций…",
+				"removeContextItem": "Удалить {{title}}",
+				"addCurrent": "Прикрепить {{title}}",
+				"contextTypeTask": "Задача",
+				"contextTypeDoc": "Документ",
+				"contextTypeConversation": "Беседа",
+				"contextTypeAutomation": "Автоматизация",
+				"noContextResults": "Результаты не найдены",
+				"contextSearchMinChars": "Введите минимум 2 символа для поиска"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "Xem trước hình ảnh đính kèm",
 			"attachmentAriaLabel": "Tệp đính kèm {{type}}",
 			"attachmentAriaLabelError": "Tệp đính kèm {{type}}, tải lên thất bại",
-			"attachmentAriaLabelUploading": "Tệp đính kèm {{type}}, đang tải lên"
+			"attachmentAriaLabelUploading": "Tệp đính kèm {{type}}, đang tải lên",
+			"contextInjection": {
+				"attachContext": "Đính kèm ngữ cảnh",
+				"contextSearchPlaceholder": "Tìm kiếm công việc, tài liệu, cuộc trò chuyện, tự động hóa…",
+				"removeContextItem": "Xóa {{title}}",
+				"addCurrent": "Đính kèm {{title}}",
+				"contextTypeTask": "Công việc",
+				"contextTypeDoc": "Tài liệu",
+				"contextTypeConversation": "Cuộc trò chuyện",
+				"contextTypeAutomation": "Tự động hóa",
+				"noContextResults": "Không tìm thấy kết quả",
+				"contextSearchMinChars": "Nhập ít nhất 2 ký tự để tìm kiếm"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -337,7 +337,19 @@
 			"imageAttachmentPreviewTitle": "图片附件预览",
 			"attachmentAriaLabel": "{{type}}附件",
 			"attachmentAriaLabelError": "{{type}}附件，上传失败",
-			"attachmentAriaLabelUploading": "{{type}}附件，正在上传"
+			"attachmentAriaLabelUploading": "{{type}}附件，正在上传",
+			"contextInjection": {
+				"attachContext": "附加上下文",
+				"contextSearchPlaceholder": "搜索任务、文档、对话、自动化…",
+				"removeContextItem": "移除{{title}}",
+				"addCurrent": "附加{{title}}",
+				"contextTypeTask": "任务",
+				"contextTypeDoc": "文档",
+				"contextTypeConversation": "对话",
+				"contextTypeAutomation": "自动化",
+				"noContextResults": "未找到结果",
+				"contextSearchMinChars": "请输入至少2个字符进行搜索"
+			}
 		}
 	},
 	"environments": {

--- a/apps/web/src/lib/agent-api.test.ts
+++ b/apps/web/src/lib/agent-api.test.ts
@@ -43,8 +43,11 @@ import {
 	listGlobalMCPServers,
 	listGlobalSkills,
 	pauseGlobalConversation,
+	sendChatMessage,
+	sendConversationMessage,
 	sendGlobalChatMessage,
 	sendGlobalConversationMessage,
+	startChatSession,
 	startGlobalChatSession,
 	stopGlobalConversation,
 	updateGlobalAgent,
@@ -262,6 +265,161 @@ describe("agent-api", () => {
 			);
 			expect(result).toBe(conversation);
 		});
+
+		it("startGlobalChatSession includes context_items (snake_case, project_id omitted when absent) when contextItems is staged", async () => {
+			mockPost.mockResolvedValue(
+				ok({ session: { id: SESSION_ID }, conversation: { id: "conv-1" } }),
+			);
+			await startGlobalChatSession(AGENT_ID, {
+				message: "hi",
+				contextItems: [
+					{ type: "task", id: "task-1", title: "Fix login bug" },
+					{ type: "doc", id: "doc-1", projectId: "proj-1", title: "Runbook" },
+				],
+			});
+			expect(mockPost).toHaveBeenCalledWith(
+				`/agents/${AGENT_ID}/chat-sessions`,
+				{
+					message: "hi",
+					context_items: [
+						{ type: "task", id: "task-1", title: "Fix login bug" },
+						{
+							type: "doc",
+							id: "doc-1",
+							project_id: "proj-1",
+							title: "Runbook",
+						},
+					],
+				},
+			);
+		});
+
+		it("startGlobalChatSession omits context_items entirely when nothing is staged", async () => {
+			mockPost.mockResolvedValue(
+				ok({ session: { id: SESSION_ID }, conversation: { id: "conv-1" } }),
+			);
+			await startGlobalChatSession(AGENT_ID, { message: "hi" });
+			expect(mockPost).toHaveBeenCalledWith(
+				`/agents/${AGENT_ID}/chat-sessions`,
+				{
+					message: "hi",
+				},
+			);
+		});
+
+		it("sendGlobalChatMessage includes context_items when contextItems is staged", async () => {
+			mockPost.mockResolvedValue(ok({ conversation: { id: "conv-1" } }));
+			await sendGlobalChatMessage(SESSION_ID, {
+				message: "hi",
+				contextItems: [
+					{ type: "automation", id: "auto-1", title: "Nightly sync" },
+				],
+			});
+			expect(mockPost).toHaveBeenCalledWith(
+				`/agents/chat-sessions/${SESSION_ID}/messages`,
+				{
+					message: "hi",
+					context_items: [
+						{ type: "automation", id: "auto-1", title: "Nightly sync" },
+					],
+				},
+			);
+		});
+	});
+
+	// ── Project-scoped chat sessions / conversation messages ────────────────────
+	//
+	// context_items coverage for the project-scoped siblings of the global
+	// functions tested above — the send-time context-injection mapping
+	// (ContextItem[] -> snake_case context_items, project_id omitted when
+	// absent) is shared code (withContextItems/toWireContextItems), but each
+	// call site's own payload construction is still worth pinning.
+
+	describe("project-scoped chat sessions and conversation messages", () => {
+		const AGENT_ID = "agent-1";
+		const SESSION_ID = "sess-1";
+		const CONV_ID = "conv-1";
+
+		it("startChatSession includes context_items alongside other payload fields when staged", async () => {
+			mockPost.mockResolvedValue(
+				ok({ session: { id: SESSION_ID }, conversation: { id: CONV_ID } }),
+			);
+			await startChatSession(PROJECT_ID, AGENT_ID, {
+				message: "hi",
+				environment_id: "env-1",
+				contextItems: [{ type: "task", id: "task-1", title: "Fix login bug" }],
+			});
+			expect(mockPost).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/agents/${AGENT_ID}/chat-sessions`,
+				{
+					message: "hi",
+					environment_id: "env-1",
+					context_items: [
+						{ type: "task", id: "task-1", title: "Fix login bug" },
+					],
+				},
+			);
+		});
+
+		it("startChatSession omits context_items when nothing is staged", async () => {
+			mockPost.mockResolvedValue(
+				ok({ session: { id: SESSION_ID }, conversation: { id: CONV_ID } }),
+			);
+			await startChatSession(PROJECT_ID, AGENT_ID, { message: "hi" });
+			expect(mockPost).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/agents/${AGENT_ID}/chat-sessions`,
+				{ message: "hi" },
+			);
+		});
+
+		it("sendChatMessage includes context_items when staged", async () => {
+			mockPost.mockResolvedValue(ok({ conversation: { id: CONV_ID } }));
+			await sendChatMessage(PROJECT_ID, AGENT_ID, SESSION_ID, {
+				message: "hi",
+				contextItems: [
+					{ type: "doc", id: "doc-1", projectId: PROJECT_ID, title: "Runbook" },
+				],
+			});
+			expect(mockPost).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/agents/${AGENT_ID}/chat-sessions/${SESSION_ID}/messages`,
+				{
+					message: "hi",
+					context_items: [
+						{
+							type: "doc",
+							id: "doc-1",
+							project_id: PROJECT_ID,
+							title: "Runbook",
+						},
+					],
+				},
+			);
+		});
+
+		it("sendConversationMessage includes context_items only when staged", async () => {
+			mockPost.mockResolvedValue({});
+			await sendConversationMessage(PROJECT_ID, CONV_ID, "hello", [
+				{ type: "automation", id: "auto-1", title: "Nightly sync" },
+			]);
+			expect(mockPost).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/conversations/${CONV_ID}/messages`,
+				{
+					message: "hello",
+					context_items: [
+						{ type: "automation", id: "auto-1", title: "Nightly sync" },
+					],
+				},
+			);
+		});
+
+		it("sendConversationMessage posts only {message} when contextItems is omitted", async () => {
+			mockPost.mockResolvedValue({});
+			await sendConversationMessage(PROJECT_ID, CONV_ID, "hello");
+			expect(mockPost).toHaveBeenCalledWith(
+				`/projects/${PROJECT_ID}/conversations/${CONV_ID}/messages`,
+				{ message: "hello" },
+			);
+		});
 	});
 
 	// ── Global conversations (/agents/conversations) ────────────────────────────
@@ -322,6 +480,22 @@ describe("agent-api", () => {
 			expect(mockPost).toHaveBeenCalledWith(
 				`/agents/conversations/${CONV_ID}/messages`,
 				{ message: "hello" },
+			);
+		});
+
+		it("sendGlobalConversationMessage adds context_items only when contextItems is staged", async () => {
+			mockPost.mockResolvedValue({});
+			await sendGlobalConversationMessage(CONV_ID, "hello", [
+				{ type: "conversation", id: "conv-2", title: "Earlier thread" },
+			]);
+			expect(mockPost).toHaveBeenCalledWith(
+				`/agents/conversations/${CONV_ID}/messages`,
+				{
+					message: "hello",
+					context_items: [
+						{ type: "conversation", id: "conv-2", title: "Earlier thread" },
+					],
+				},
 			);
 		});
 

--- a/apps/web/src/lib/agent-api.ts
+++ b/apps/web/src/lib/agent-api.ts
@@ -3,8 +3,27 @@ import {
 	type QueryClient,
 	queryOptions,
 } from "@tanstack/react-query";
+import {
+	type ContextItem,
+	toWireContextItems,
+	type WireContextItem,
+} from "@/lib/context-items";
 import { apiClient } from "./api-client";
 import type { SuccessEnvelope } from "./api-error";
+
+// Appends `context_items` (wire shape, snake_case) onto a request body when
+// contextItems is non-empty — shared by every send/start function below so
+// the "map ContextItem[] to the wire shape, omit the key when there's
+// nothing staged" logic lives in exactly one place. See lib/context-items.ts
+// for the ContextItem <-> WireContextItem mapping itself.
+function withContextItems<T extends Record<string, unknown>>(
+	body: T,
+	contextItems: ContextItem[] | undefined,
+): T & { context_items?: WireContextItem[] } {
+	return contextItems && contextItems.length > 0
+		? { ...body, context_items: toWireContextItems(contextItems) }
+		: body;
+}
 
 // ── Shapes ────────────────────────────────────────────────────────────────────
 
@@ -440,21 +459,26 @@ export async function listGlobalChatSessions(
 
 export async function startGlobalChatSession(
 	agentId: string,
-	payload: { message: string; title?: string },
+	payload: { message: string; title?: string; contextItems?: ContextItem[] },
 ): Promise<StartChatSessionResponse> {
+	const { contextItems, ...rest } = payload;
 	const { data } = await apiClient.instance.post<
 		SuccessEnvelope<StartChatSessionResponse>
-	>(`/agents/${agentId}/chat-sessions`, payload);
+	>(`/agents/${agentId}/chat-sessions`, withContextItems(rest, contextItems));
 	return data.data;
 }
 
 export async function sendGlobalChatMessage(
 	sessionId: string,
-	payload: { message: string },
+	payload: { message: string; contextItems?: ContextItem[] },
 ): Promise<AgentConversation> {
+	const { contextItems, ...rest } = payload;
 	const { data } = await apiClient.instance.post<
 		SuccessEnvelope<{ conversation: AgentConversation }>
-	>(`/agents/chat-sessions/${sessionId}/messages`, payload);
+	>(
+		`/agents/chat-sessions/${sessionId}/messages`,
+		withContextItems(rest, contextItems),
+	);
 	return data.data.conversation;
 }
 
@@ -580,10 +604,11 @@ export async function heartbeatGlobalConversation(
 export async function sendGlobalConversationMessage(
 	conversationId: string,
 	message: string,
+	contextItems?: ContextItem[],
 ): Promise<void> {
 	await apiClient.instance.post(
 		`/agents/conversations/${conversationId}/messages`,
-		{ message },
+		withContextItems({ message }, contextItems),
 	);
 }
 
@@ -1150,10 +1175,11 @@ export async function sendConversationMessage(
 	projectId: string,
 	conversationId: string,
 	message: string,
+	contextItems?: ContextItem[],
 ): Promise<void> {
 	await apiClient.instance.post(
 		`/projects/${projectId}/conversations/${conversationId}/messages`,
-		{ message },
+		withContextItems({ message }, contextItems),
 	);
 }
 
@@ -1214,11 +1240,16 @@ export async function startChatSession(
 		// default_environment_id if set, else spins up an ephemeral sandbox.
 		environment_id?: string;
 		folder_id?: string;
+		contextItems?: ContextItem[];
 	},
 ): Promise<StartChatSessionResponse> {
+	const { contextItems, ...rest } = payload;
 	const { data } = await apiClient.instance.post<
 		SuccessEnvelope<StartChatSessionResponse>
-	>(`/projects/${projectId}/agents/${agentId}/chat-sessions`, payload);
+	>(
+		`/projects/${projectId}/agents/${agentId}/chat-sessions`,
+		withContextItems(rest, contextItems),
+	);
 	return data.data;
 }
 
@@ -1226,13 +1257,14 @@ export async function sendChatMessage(
 	projectId: string,
 	agentId: string,
 	sessionId: string,
-	payload: { message: string },
+	payload: { message: string; contextItems?: ContextItem[] },
 ): Promise<AgentConversation> {
+	const { contextItems, ...rest } = payload;
 	const { data } = await apiClient.instance.post<
 		SuccessEnvelope<{ conversation: AgentConversation }>
 	>(
 		`/projects/${projectId}/agents/${agentId}/chat-sessions/${sessionId}/messages`,
-		payload,
+		withContextItems(rest, contextItems),
 	);
 	return data.data.conversation;
 }

--- a/apps/web/src/lib/automation-api.ts
+++ b/apps/web/src/lib/automation-api.ts
@@ -81,6 +81,11 @@ export interface Automation {
 	updated_at: string;
 }
 
+export interface AutomationListResult {
+	items: Automation[];
+	next_cursor?: string | null;
+}
+
 export interface AutomationNode {
 	id: string;
 	automation_id: string;
@@ -374,11 +379,38 @@ export interface ActionConfig {
 export async function listAutomations(
 	projectId: string,
 	status?: AutomationStatus,
+	/** Case-insensitive name match, server-side (mirrors task/doc search) —
+	 *  used by hooks/use-context-item-search.ts's Automation tab. */
+	search?: string,
 ): Promise<Automation[]> {
+	const params: Record<string, string> = {};
+	if (status) params.status = status;
+	if (search?.trim()) params.search = search.trim();
 	const { data } = await apiClient.instance.get<
 		SuccessEnvelope<{ items: Automation[] }>
-	>(`/projects/${projectId}/automations`, { params: status ? { status } : {} });
+	>(`/projects/${projectId}/automations`, { params });
 	return data.data.items;
+}
+
+/** Paginated sibling of listAutomations for the context-injection search
+ *  picker (hooks/use-context-item-search.ts): same endpoint, but requests a
+ *  bounded, cursor-paginated page instead of every matching automation at
+ *  once. Returns the page envelope (not just the array) so the caller can
+ *  keep paging via next_cursor. */
+export async function listAutomationsPage(
+	projectId: string,
+	opts: { search?: string; cursor?: string; pageSize?: number } = {},
+): Promise<AutomationListResult> {
+	const params: Record<string, string | number> = {};
+	if (opts.search?.trim()) params.search = opts.search.trim();
+	if (opts.cursor) params.cursor = opts.cursor;
+	if (opts.pageSize) params.page_size = opts.pageSize;
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<AutomationListResult>
+	>(`/projects/${projectId}/automations`, {
+		params: Object.keys(params).length > 0 ? params : undefined,
+	});
+	return data.data;
 }
 
 export async function createAutomation(

--- a/apps/web/src/lib/context-injection-store.ts
+++ b/apps/web/src/lib/context-injection-store.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+import type { ContextItem, ContextItemType } from "@/lib/context-items";
+
+/**
+ * Items staged for the *next* outgoing chat message — populated by the "+"
+ * search popover / quick-add affordance in
+ * components/assistant-ui/context-injection.tsx, read and cleared by
+ * whichever composer call site actually sends the message (ai-chat-float.tsx,
+ * ai-chat-float-global.tsx, new-conversation-thread.tsx, conversation-view.tsx).
+ *
+ * A single global (non-scoped) store is safe here: exactly one `Composer`
+ * (components/assistant-ui/thread.tsx) is ever mounted anywhere in the app at
+ * a time — the project-scoped and global floating chats hide themselves on
+ * the routes where the Conversations page's own composer mounts instead (see
+ * routes/_authenticated/projects/$projectId.tsx's onConversationsPage check
+ * and routes/_authenticated.tsx's CONVERSATIONS_ROUTE_RE check).
+ */
+interface ContextInjectionState {
+	items: ContextItem[];
+	add: (item: ContextItem) => void;
+	remove: (type: ContextItemType, id: string) => void;
+	clear: () => void;
+}
+
+export const useContextInjectionStore = create<ContextInjectionState>(
+	(set, get) => ({
+		items: [],
+		add: (item) => {
+			if (get().items.some((i) => i.type === item.type && i.id === item.id)) {
+				return;
+			}
+			set((s) => ({ items: [...s.items, item] }));
+		},
+		remove: (type, id) =>
+			set((s) => ({
+				items: s.items.filter((i) => !(i.type === type && i.id === id)),
+			})),
+		clear: () => set({ items: [] }),
+	}),
+);

--- a/apps/web/src/lib/context-items.ts
+++ b/apps/web/src/lib/context-items.ts
@@ -1,0 +1,98 @@
+// Shared "context item" concept for the chat context-injection feature: a
+// reference to a Task, Doc, Conversation, or Automation the user attaches to
+// an outgoing chat message so the agent can pull in its full content (via
+// get_task/read_doc/get_automation/read_conversation on the agent-runner
+// side — see services/agent-runner's context_item.go). Kept field-identical
+// across three languages on purpose:
+//   - this file (camelCase, app-internal state/UI shape)
+//   - the wire shape below (snake_case, matches services/api's
+//     ContextItemRef JSON tags exactly)
+//   - services/api's Go ContextItemRef / services/agent-runner's copy of it
+
+export type ContextItemType = "task" | "doc" | "conversation" | "automation";
+
+export interface ContextItem {
+	type: ContextItemType;
+	id: string;
+	projectId?: string;
+	title: string;
+}
+
+const CONTEXT_ITEM_TYPES: readonly ContextItemType[] = [
+	"task",
+	"doc",
+	"conversation",
+	"automation",
+];
+
+function isContextItemType(value: unknown): value is ContextItemType {
+	return (
+		typeof value === "string" &&
+		(CONTEXT_ITEM_TYPES as readonly string[]).includes(value)
+	);
+}
+
+/** The exact JSON shape services/api expects/returns — snake_case
+ *  `project_id`, omitted entirely (never `null`) when the item has none.
+ *  Mirrors `ContextItemRef` in services/api/internal/domain/agent/entity.go. */
+export interface WireContextItem {
+	type: ContextItemType;
+	id: string;
+	project_id?: string;
+	title: string;
+}
+
+/** Maps staged ContextItems to the wire shape for an outgoing request body —
+ *  used by lib/agent-api.ts's send/start functions. */
+export function toWireContextItems(
+	items: readonly ContextItem[],
+): WireContextItem[] {
+	return items.map((item) => ({
+		type: item.type,
+		id: item.id,
+		title: item.title,
+		...(item.projectId !== undefined ? { project_id: item.projectId } : {}),
+	}));
+}
+
+/**
+ * Parses an arbitrary JSON value into ContextItem[], dropping any malformed
+ * entries defensively rather than throwing. Accepts either the wire shape's
+ * `project_id` or the already-camelCase `projectId` (whichever a caller
+ * happens to be reading from — a freshly-parsed API response payload in the
+ * first case, or a `ThreadMessageLike.metadata.custom` value we set
+ * ourselves in the second), so this one helper covers both:
+ *   - conversation-to-thread-messages.ts reading a persisted event's
+ *     `payload.context_items` (snake_case, straight from the JSON API)
+ *   - thread.tsx reading a message's `metadata.custom.contextItems` (already
+ *     camelCase, since that's what we stored there ourselves)
+ */
+export function parseContextItems(raw: unknown): ContextItem[] {
+	if (!Array.isArray(raw)) return [];
+	const items: ContextItem[] = [];
+	for (const entry of raw) {
+		if (!entry || typeof entry !== "object") continue;
+		const rec = entry as Record<string, unknown>;
+		const { type, id, title } = rec;
+		if (
+			!isContextItemType(type) ||
+			typeof id !== "string" ||
+			typeof title !== "string"
+		) {
+			continue;
+		}
+		const projectId =
+			typeof rec.project_id === "string"
+				? rec.project_id
+				: typeof rec.projectId === "string"
+					? rec.projectId
+					: undefined;
+		items.push({
+			type,
+			id,
+			title,
+			...(projectId !== undefined ? { projectId } : {}),
+		});
+	}
+	return items;
+}

--- a/apps/web/src/lib/doc-api.ts
+++ b/apps/web/src/lib/doc-api.ts
@@ -35,6 +35,7 @@ export interface Document {
 
 export interface DocumentListResult {
 	items: Document[];
+	next_cursor?: string | null;
 }
 
 export interface DocSnapshot {
@@ -231,13 +232,41 @@ export async function deleteFolder(
 export async function listDocuments(
 	projectId: string,
 	folderId?: string,
+	/** Case-insensitive title match, server-side (mirrors task search) — used
+	 *  by hooks/use-context-item-search.ts's Doc tab. Omitted/blank means
+	 *  "don't filter", same as omitting folderId. */
+	search?: string,
 ): Promise<Document[]> {
+	const params: Record<string, string> = {};
+	if (folderId) params.folder_id = folderId;
+	if (search?.trim()) params.search = search.trim();
 	const { data } = await apiClient.instance.get<
 		SuccessEnvelope<DocumentListResult>
 	>(`/projects/${projectId}/docs`, {
-		params: folderId ? { folder_id: folderId } : undefined,
+		params: Object.keys(params).length > 0 ? params : undefined,
 	});
 	return data.data.items;
+}
+
+/** Paginated sibling of listDocuments for the context-injection search
+ *  picker (hooks/use-context-item-search.ts): same endpoint, but requests a
+ *  bounded, cursor-paginated page instead of every matching document at
+ *  once. Returns the page envelope (not just the array) so the caller can
+ *  keep paging via next_cursor. */
+export async function listDocumentsPage(
+	projectId: string,
+	opts: { search?: string; cursor?: string; pageSize?: number } = {},
+): Promise<DocumentListResult> {
+	const params: Record<string, string | number> = {};
+	if (opts.search?.trim()) params.search = opts.search.trim();
+	if (opts.cursor) params.cursor = opts.cursor;
+	if (opts.pageSize) params.page_size = opts.pageSize;
+	const { data } = await apiClient.instance.get<
+		SuccessEnvelope<DocumentListResult>
+	>(`/projects/${projectId}/docs`, {
+		params: Object.keys(params).length > 0 ? params : undefined,
+	});
+	return data.data;
 }
 
 export async function getDocument(

--- a/apps/web/src/lib/shortcuts/current-context-store.ts
+++ b/apps/web/src/lib/shortcuts/current-context-store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import type { ContextItem, ContextItemType } from "@/lib/context-items";
+
+/**
+ * The Task/Doc/Automation currently on screen (a task detail modal/page, a
+ * doc editor page, or an automation builder page) — registered by that
+ * page/modal on mount/data-load and cleared on unmount, mirroring
+ * hovered-task-store.ts's "latest registration wins" pattern exactly: only
+ * one such page can be showing at a time, so the store just holds the latest
+ * registration, with `clearActive` guarded so a slow-unmounting page can't
+ * clobber a newly-focused one's registration.
+ *
+ * Powers the chat composer's one-click "quick add" affordance (see
+ * components/assistant-ui/context-injection.tsx) — read `active` there and
+ * call the context-injection-store's `add` directly, no search needed.
+ */
+interface CurrentContextState {
+	active: ContextItem | null;
+	setActive: (item: ContextItem) => void;
+	clearActive: (type: ContextItemType, id: string) => void;
+}
+
+export const useCurrentContextStore = create<CurrentContextState>(
+	(set, get) => ({
+		active: null,
+		setActive: (item) => set({ active: item }),
+		clearActive: (type, id) => {
+			const active = get().active;
+			if (active?.type === type && active.id === id) set({ active: null });
+		},
+	}),
+);

--- a/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/automation/$automationId.tsx
@@ -9,7 +9,7 @@ import {
 	Workflow,
 	X,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AutomationCanvas } from "@/components/projects/automation/automation-canvas";
 import { AutomationNodeConfigPanel } from "@/components/projects/automation/automation-node-config-panel";
@@ -50,6 +50,7 @@ import {
 	taskStatusesQueryOptions,
 	taskTypesQueryOptions,
 } from "@/lib/project-api";
+import { useCurrentContextStore } from "@/lib/shortcuts/current-context-store";
 import { cn } from "@/lib/utils";
 
 function extractErrorMessage(err: unknown, fallback: string): string {
@@ -87,6 +88,22 @@ function AutomationBuilderPage() {
 	const { data: graph } = useQuery(
 		automationQueryOptions(projectId, automationId),
 	);
+
+	// Register this automation as "currently on screen" for the chat
+	// composer's quick-add affordance — see
+	// lib/shortcuts/current-context-store.ts.
+	useEffect(() => {
+		if (!graph) return;
+		useCurrentContextStore.getState().setActive({
+			type: "automation",
+			id: automationId,
+			projectId,
+			title: graph.automation.name,
+		});
+		return () => {
+			useCurrentContextStore.getState().clearActive("automation", automationId);
+		};
+	}, [graph, automationId, projectId]);
 	const { data: statuses = [] } = useQuery(taskStatusesQueryOptions(projectId));
 	const { data: members = [] } = useQuery(
 		projectMembersQueryOptions(projectId),

--- a/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/docs/$docId.tsx
@@ -18,6 +18,7 @@ import {
 	docQueryOptions,
 	updateDocument,
 } from "@/lib/doc-api";
+import { useCurrentContextStore } from "@/lib/shortcuts/current-context-store";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute(
@@ -37,6 +38,21 @@ function DocEditorPage() {
 
 	const { data: doc, isError } = useQuery(docQueryOptions(projectId, docId));
 	const { data: allFolders = [] } = useQuery(docFoldersQueryOptions(projectId));
+
+	// Register this doc as "currently on screen" for the chat composer's
+	// quick-add affordance — see lib/shortcuts/current-context-store.ts.
+	useEffect(() => {
+		if (!doc) return;
+		useCurrentContextStore.getState().setActive({
+			type: "doc",
+			id: docId,
+			projectId,
+			title: doc.title,
+		});
+		return () => {
+			useCurrentContextStore.getState().clearActive("doc", docId);
+		};
+	}, [doc, docId, projectId]);
 
 	const [rightPanel, setRightPanel] = useState<RightPanel>(null);
 	const [dirty, setDirty] = useState(false);

--- a/services/agent-runner/internal/acpbridge/message.go
+++ b/services/agent-runner/internal/acpbridge/message.go
@@ -104,5 +104,7 @@ func BuildACPMessage(trigger agent.Trigger, acpProvider string) string {
 		fmt.Fprintf(&b, "Chat Session ID: %s\n", trigger.ChatSessionID)
 	}
 
+	b.WriteString(agent.FormatAttachedContext(trigger.ContextItems))
+
 	return b.String()
 }

--- a/services/agent-runner/internal/agent/config.go
+++ b/services/agent-runner/internal/agent/config.go
@@ -2,6 +2,11 @@ package agent
 
 import "github.com/google/uuid"
 
+// AgentScopeGlobal is the Config.AgentScope value for a global agent (mirrors
+// services/api's agentdom.AgentScopeGlobal — see Config.AgentScope's doc
+// comment).
+const AgentScopeGlobal = "global"
+
 // Config is the subset of agentdom.Agent this service needs to run an
 // llm-type conversation — agent-runner never handles acp-type agents (those
 // stay on apps/acp-bridge), so ACPProvider/ACPCommand and friends are
@@ -10,6 +15,13 @@ type Config struct {
 	ID     uuid.UUID
 	Name   string
 	Handle string
+	// AgentScope is "project" or "global" (agents.agent_scope). Only a
+	// global agent may legitimately be attributed to a human actor — see
+	// buildMCPServers's use of this field and services/api's
+	// verifyAgentIdentity, which enforces the same rule server-side
+	// ("a project-scoped agent's actions are attributed via its
+	// project_members.id, never a raw actor_user_id").
+	AgentScope string
 
 	LLMProvider string
 	LLMModel    string

--- a/services/agent-runner/internal/agent/context_item.go
+++ b/services/agent-runner/internal/agent/context_item.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ContextItemType discriminates which kind of resource a ContextItemRef
+// points at. Byte-identical to services/api's
+// internal/domain/agent/entity.go ContextItemType — see this package's own
+// doc comment (in trigger.go) for why agent-runner keeps its own copy
+// instead of importing services/api's internal package.
+type ContextItemType string
+
+// ContextItemType values — mirrors the constants in services/api.
+const (
+	ContextItemTask         ContextItemType = "task"
+	ContextItemDoc          ContextItemType = "doc"
+	ContextItemConversation ContextItemType = "conversation"
+	ContextItemAutomation   ContextItemType = "automation"
+)
+
+// ContextItemRef is a reference to a Task, Doc, Conversation, or Automation
+// the user attached to a chat message from the frontend composer's
+// context-item picker. Byte-identical (field names/JSON tags) to
+// services/api's agentdom.ContextItemRef — decoded here from the trigger
+// stream's flat "context_items" JSON-string field (see
+// messaging/decode.go's decodeTrigger) rather than shared via import, per
+// this package's cross-service-duplication convention (see trigger.go).
+type ContextItemRef struct {
+	Type      ContextItemType `json:"type"`
+	ID        string          `json:"id"`
+	ProjectID *string         `json:"project_id,omitempty"`
+	Title     string          `json:"title"`
+}
+
+// FormatAttachedContext renders the "## Attached Context" prompt section for
+// items the user attached to a chat message (see ContextItemRef) — a hint
+// block telling the agent which MCP tool to call to load full details on
+// each one, since only a type+id+title stub rides the trigger stream, not
+// the referenced content itself. Returns "" for an empty slice so callers
+// can unconditionally insert/append the result without a separate len
+// check of their own.
+//
+// Shared by both prompt-building call sites — executor/prompt.go's
+// buildInitialMessage (LLM/sandbox path) and acpbridge/message.go's
+// BuildACPMessage (ACP-bridge path) — specifically so the
+// type-to-tool-name mapping can never drift between the two as separate
+// hand-copies.
+func FormatAttachedContext(items []ContextItemRef) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n## Attached Context\n")
+	b.WriteString("The user attached the following as context. Load full details before answering:\n")
+	for _, item := range items {
+		switch item.Type {
+		case ContextItemTask:
+			fmt.Fprintf(&b, "- Task (ID: %s) %q — call `get_task`.\n", item.ID, item.Title)
+		case ContextItemDoc:
+			fmt.Fprintf(&b, "- Documentation page (ID: %s) %q — call `read_doc` with `docId: %q`.\n", item.ID, item.Title, item.ID)
+		case ContextItemAutomation:
+			fmt.Fprintf(&b, "- Automation (ID: %s) %q — call `get_automation`.\n", item.ID, item.Title)
+		case ContextItemConversation:
+			fmt.Fprintf(&b, "- Conversation (ID: %s) %q — call `read_conversation`.\n", item.ID, item.Title)
+		default:
+			fmt.Fprintf(&b, "- %s (ID: %s) %q\n", item.Type, item.ID, item.Title)
+		}
+	}
+	return b.String()
+}

--- a/services/agent-runner/internal/agent/trigger.go
+++ b/services/agent-runner/internal/agent/trigger.go
@@ -74,4 +74,11 @@ type Trigger struct {
 	// meaningful alongside EnvironmentID; nil whenever EnvironmentID is
 	// nil.
 	Workdir *string
+	// ContextItems are Task/Doc/Conversation/Automation references the user
+	// attached to this chat message via the frontend composer's
+	// context-item picker (see ContextItemRef) — decoded from the flat
+	// context_items JSON-string stream field by messaging.decodeTrigger.
+	// Rendered into the prompt as a "## Attached Context" hint block by
+	// FormatAttachedContext. nil/empty when no items were attached.
+	ContextItems []ContextItemRef
 }

--- a/services/agent-runner/internal/executor/executor.go
+++ b/services/agent-runner/internal/executor/executor.go
@@ -960,6 +960,14 @@ func (e *Executor) buildMCPServers(trigger agent.Trigger, cfg agent.Config) []ac
 		"PACA_API_URL":     e.opts.PacaAPIURL,
 		"PACA_GATEWAY_URL": e.opts.PacaGatewayURL,
 		"PACA_AGENT_ID":    cfg.ID.String(),
+		// The conversation this MCP server instance is running as part of —
+		// always set (trigger.ConversationID is required, never uuid.Nil).
+		// Forwarded as X-Conversation-ID on the read_conversation tool's API
+		// calls so services/api's GetConversationForAgent can authorize a
+		// cross-conversation read against *this* conversation's own
+		// project/actor/owning member, instead of bare agent identity alone
+		// — see that method's doc comment.
+		"PACA_CONVERSATION_ID": trigger.ConversationID.String(),
 	}
 	if trigger.ProjectID != uuid.Nil {
 		env["PACA_PROJECT_ID"] = trigger.ProjectID.String()

--- a/services/agent-runner/internal/executor/executor.go
+++ b/services/agent-runner/internal/executor/executor.go
@@ -964,7 +964,17 @@ func (e *Executor) buildMCPServers(trigger agent.Trigger, cfg agent.Config) []ac
 	if trigger.ProjectID != uuid.Nil {
 		env["PACA_PROJECT_ID"] = trigger.ProjectID.String()
 	}
-	if trigger.ActorUserID != nil {
+	// services/api's verifyAgentIdentity rejects an X-Actor-User-ID claim
+	// outright for any non-global agent ("a project-scoped agent's actions
+	// are attributed via its project_members.id, never a raw actor_user_id")
+	// — so forwarding it here for a project-scoped agent doesn't just fail
+	// to help, it 401s *every* MCP call this agent makes, including ones
+	// that never touch actor identity at all (e.g. read_conversation),
+	// because the check runs in required auth middleware before any
+	// handler-specific logic. cfg.AgentScope is the same source of truth
+	// that check uses, so gate on it here too rather than trusting
+	// trigger.ActorUserID's presence alone.
+	if trigger.ActorUserID != nil && cfg.AgentScope == agent.AgentScopeGlobal {
 		env["PACA_ACTOR_USER_ID"] = trigger.ActorUserID.String()
 	}
 	if len(trigger.RepoPluginIDs) > 0 {

--- a/services/agent-runner/internal/executor/executor_test.go
+++ b/services/agent-runner/internal/executor/executor_test.go
@@ -65,3 +65,62 @@ func TestBuildMCPServers_OmitsRepoPluginIDsWhenAbsent(t *testing.T) {
 		t.Errorf("PACA_REPO_PLUGIN_IDS should be omitted when trigger.RepoPluginIDs is empty, env: %+v", paca.Env)
 	}
 }
+
+// TestBuildMCPServers_OmitsActorUserIDForProjectScopedAgent reproduces the
+// real failure: a project-scoped conversation resumed on a persistent
+// environment/sandbox somehow carries a non-nil trigger.ActorUserID (its
+// origin predates this fix and isn't itself reproduced here), and that
+// value gets baked into the sandbox's env at creation and persists across
+// every resume. Forwarding it to a project-scoped agent's MCP calls made
+// every one of them fail auth with "unable to verify claimed agent
+// identity" (401) — including read_conversation, list_tasks, anything —
+// because services/api's verifyAgentIdentity rejects an actor claim
+// outright for a non-global agent, in required (not optional) auth
+// middleware that runs before any handler-specific logic. AgentScope is
+// the guard: it must never be forwarded for a project-scoped agent
+// regardless of what trigger.ActorUserID holds.
+func TestBuildMCPServers_OmitsActorUserIDForProjectScopedAgent(t *testing.T) {
+	e := &Executor{opts: Options{PacaAPIKey: "key", PacaAPIURL: "http://api", PacaGatewayURL: "http://gw"}}
+	actorUserID := uuid.New()
+	trigger := agent.Trigger{
+		ConversationID: uuid.New(),
+		AgentID:        uuid.New(),
+		ProjectID:      uuid.New(),
+		ActorUserID:    &actorUserID,
+	}
+	cfg := agent.Config{ID: uuid.New(), AgentScope: "project"}
+
+	servers := e.buildMCPServers(trigger, cfg)
+	paca := findPacaServer(t, servers)
+
+	if val, ok := envValue(paca.Env, "PACA_ACTOR_USER_ID"); ok {
+		t.Errorf("PACA_ACTOR_USER_ID must never be set for a project-scoped agent, got %q", val)
+	}
+}
+
+// TestBuildMCPServers_SetsActorUserIDForGlobalAgent confirms the fix isn't
+// overly broad — a genuinely global agent acting on behalf of a human (e.g.
+// "create a project for me" from the home-page chat) must still get
+// PACA_ACTOR_USER_ID, since that combination is exactly what
+// verifyAgentIdentity allows server-side.
+func TestBuildMCPServers_SetsActorUserIDForGlobalAgent(t *testing.T) {
+	e := &Executor{opts: Options{PacaAPIKey: "key", PacaAPIURL: "http://api", PacaGatewayURL: "http://gw"}}
+	actorUserID := uuid.New()
+	trigger := agent.Trigger{
+		ConversationID: uuid.New(),
+		AgentID:        uuid.New(),
+		ActorUserID:    &actorUserID,
+	}
+	cfg := agent.Config{ID: uuid.New(), AgentScope: agent.AgentScopeGlobal}
+
+	servers := e.buildMCPServers(trigger, cfg)
+	paca := findPacaServer(t, servers)
+
+	val, ok := envValue(paca.Env, "PACA_ACTOR_USER_ID")
+	if !ok {
+		t.Fatalf("PACA_ACTOR_USER_ID not set in paca MCP server env for a global agent: %+v", paca.Env)
+	}
+	if val != actorUserID.String() {
+		t.Errorf("PACA_ACTOR_USER_ID = %q, want %q", val, actorUserID.String())
+	}
+}

--- a/services/agent-runner/internal/executor/executor_test.go
+++ b/services/agent-runner/internal/executor/executor_test.go
@@ -32,6 +32,30 @@ func envValue(env *[]acp.EnvVariable, name string) (string, bool) {
 	return "", false
 }
 
+// TestBuildMCPServers_AlwaysSetsConversationID pins that PACA_CONVERSATION_ID
+// is forwarded unconditionally (trigger.ConversationID is always set,
+// unlike ProjectID/ActorUserID) — services/api's GetConversationForAgent
+// relies on it being present to authorize a read_conversation call against
+// the calling conversation's own project/actor/owning member; see that
+// method's doc comment.
+func TestBuildMCPServers_AlwaysSetsConversationID(t *testing.T) {
+	e := &Executor{opts: Options{PacaAPIKey: "key", PacaAPIURL: "http://api", PacaGatewayURL: "http://gw"}}
+	conversationID := uuid.New()
+	trigger := agent.Trigger{ConversationID: conversationID, AgentID: uuid.New()}
+	cfg := agent.Config{ID: uuid.New()}
+
+	servers := e.buildMCPServers(trigger, cfg)
+	paca := findPacaServer(t, servers)
+
+	val, ok := envValue(paca.Env, "PACA_CONVERSATION_ID")
+	if !ok {
+		t.Fatalf("PACA_CONVERSATION_ID not set in paca MCP server env: %+v", paca.Env)
+	}
+	if val != conversationID.String() {
+		t.Errorf("PACA_CONVERSATION_ID = %q, want %q", val, conversationID.String())
+	}
+}
+
 func TestBuildMCPServers_SetsRepoPluginIDsWhenPresent(t *testing.T) {
 	e := &Executor{opts: Options{PacaAPIKey: "key", PacaAPIURL: "http://api", PacaGatewayURL: "http://gw"}}
 	trigger := agent.Trigger{

--- a/services/agent-runner/internal/executor/prompt.go
+++ b/services/agent-runner/internal/executor/prompt.go
@@ -117,6 +117,8 @@ func buildInitialMessage(trigger agent.Trigger) string {
 		fmt.Fprintf(&b, "Chat Session ID: %s\n", trigger.ChatSessionID)
 	}
 
+	b.WriteString(agent.FormatAttachedContext(trigger.ContextItems))
+
 	b.WriteString("\n\n## User Message\n")
 	message := strings.TrimSpace(trigger.Message)
 	if message == "" && trigger.TriggerType == agent.TriggerTaskAssigned {

--- a/services/agent-runner/internal/handler/handler.go
+++ b/services/agent-runner/internal/handler/handler.go
@@ -305,9 +305,11 @@ func (h *Handler) Handle(ctx context.Context, trigger agent.Trigger) error {
 	// NOT recorded here, since no human actually said anything in that
 	// case.
 	if msg := strings.TrimSpace(trigger.Message); msg != "" {
-		userPayload, _ := json.Marshal(map[string]any{
-			"content": map[string]any{"type": "text", "text": msg},
-		})
+		fields := map[string]any{"content": map[string]any{"type": "text", "text": msg}}
+		if len(trigger.ContextItems) > 0 {
+			fields["context_items"] = trigger.ContextItems
+		}
+		userPayload, _ := json.Marshal(fields)
 		persistAndPublish("user_message", "user", userPayload)
 	}
 

--- a/services/agent-runner/internal/messaging/decode.go
+++ b/services/agent-runner/internal/messaging/decode.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -61,6 +62,19 @@ func decodeTrigger(values map[string]interface{}) (agent.Trigger, error) {
 	t.EnvironmentID = optionalUUIDPtr(values, "environment_id")
 	if workdir, ok := values["workdir"].(string); ok && workdir != "" {
 		t.Workdir = &workdir
+	}
+
+	// context_items is a JSON-encoded string (AppendFlat needs plain scalar
+	// field values — see Service.publishChatTrigger in services/api), not a
+	// native array, so it needs an extra decode step the other optional
+	// fields above don't. Malformed JSON is swallowed the same permissive
+	// way every other optional field here is: left at its zero value
+	// (nil) rather than failing the whole trigger decode.
+	if raw, ok := values["context_items"].(string); ok && raw != "" {
+		var items []agent.ContextItemRef
+		if err := json.Unmarshal([]byte(raw), &items); err == nil {
+			t.ContextItems = items
+		}
 	}
 
 	return t, nil

--- a/services/agent-runner/internal/repository/postgres/agent_repository.go
+++ b/services/agent-runner/internal/repository/postgres/agent_repository.go
@@ -24,6 +24,7 @@ type agentRecord struct {
 	ID                uuid.UUID `db:"id"`
 	Name              string    `db:"name"`
 	Handle            string    `db:"handle"`
+	AgentScope        string    `db:"agent_scope"`
 	AgentType         string    `db:"agent_type"`
 	LLMProvider       string    `db:"llm_provider"`
 	LLMModel          string    `db:"llm_model"`
@@ -79,7 +80,7 @@ func NewAgentRepository(db *sqlx.DB) *AgentRepository {
 func (r *AgentRepository) FindByID(ctx context.Context, id uuid.UUID) (*agent.Config, error) {
 	var rec agentRecord
 	err := r.db.GetContext(ctx, &rec, `
-		SELECT id, name, handle, agent_type, llm_provider, llm_model,
+		SELECT id, name, handle, agent_scope, agent_type, llm_provider, llm_model,
 		       llm_api_key_secret, llm_base_url, system_prompt,
 		       max_iterations, timeout_minutes,
 		       git_committer_name, git_committer_email, docker_enabled
@@ -110,6 +111,7 @@ func (r *AgentRepository) FindByID(ctx context.Context, id uuid.UUID) (*agent.Co
 		ID:                rec.ID,
 		Name:              rec.Name,
 		Handle:            rec.Handle,
+		AgentScope:        rec.AgentScope,
 		LLMProvider:       rec.LLMProvider,
 		LLMModel:          rec.LLMModel,
 		LLMAPIKeySecret:   rec.LLMAPIKeySecret,

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -2,6 +2,7 @@
 package agentdom
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -273,6 +274,43 @@ type ContextItemRef struct {
 	ID        string          `json:"id"`
 	ProjectID *string         `json:"project_id,omitempty"`
 	Title     string          `json:"title"`
+}
+
+// MaxContextItems bounds how many ContextItemRefs a single send-message
+// request may carry — see ValidateContextItems. The UI's composer never
+// stages more than a handful; this just keeps a malformed or abusive client
+// payload from ballooning the persisted event row and every prompt built
+// from it.
+const MaxContextItems = 20
+
+// MaxContextItemTitleLength bounds ContextItemRef.Title — see
+// ValidateContextItems.
+const MaxContextItemTitleLength = 500
+
+// ValidateContextItems rejects a client-supplied context_items payload that
+// is too large or malformed: too many items, an unrecognized Type, a blank
+// ID, or an oversized Title. Called at the HTTP boundary (see the
+// send-message/chat-session handlers) before the items are persisted
+// verbatim and rendered into every subsequent prompt — see ContextItemRef's
+// own doc comment for that data flow.
+func ValidateContextItems(items []ContextItemRef) error {
+	if len(items) > MaxContextItems {
+		return fmt.Errorf("context_items: at most %d items allowed, got %d", MaxContextItems, len(items))
+	}
+	for i, item := range items {
+		switch item.Type {
+		case ContextItemTask, ContextItemDoc, ContextItemConversation, ContextItemAutomation:
+		default:
+			return fmt.Errorf("context_items[%d]: unknown type %q", i, item.Type)
+		}
+		if item.ID == "" {
+			return fmt.Errorf("context_items[%d]: id is required", i)
+		}
+		if len(item.Title) > MaxContextItemTitleLength {
+			return fmt.Errorf("context_items[%d]: title exceeds %d characters", i, MaxContextItemTitleLength)
+		}
+	}
+	return nil
 }
 
 // AgentConversation tracks each OpenHands conversation session.

--- a/services/api/internal/domain/agent/entity.go
+++ b/services/api/internal/domain/agent/entity.go
@@ -242,6 +242,39 @@ const (
 	AudienceProjectShared ConversationAudience = "project_shared"
 )
 
+// ContextItemType discriminates which kind of resource a ContextItemRef
+// points at.
+type ContextItemType string
+
+// ContextItemType values.
+const (
+	ContextItemTask         ContextItemType = "task"
+	ContextItemDoc          ContextItemType = "doc"
+	ContextItemConversation ContextItemType = "conversation"
+	ContextItemAutomation   ContextItemType = "automation"
+)
+
+// ContextItemRef is a reference to a Task, Doc, Conversation, or Automation
+// the user attached to a chat message from the frontend composer's
+// context-item picker (shown as removable badges above the composer). It
+// rides the send-message DTOs → the Redis/Valkey trigger stream (JSON-
+// encoded into a single flat string field, since AppendFlat needs scalar
+// values — see agentsvc.Service.publishTrigger) → agent-runner, which
+// renders it into a "## Attached Context" prompt hint telling the agent
+// which MCP tool to call for full details. It is also persisted verbatim
+// (as a nested JSON array, not re-stringified) on the conversation's
+// user_message event payload so the frontend can redisplay the badges when
+// a conversation is reloaded. services/agent-runner keeps its own
+// byte-identical copy of this type (internal/agent/context_item.go) since
+// it is a separate Go module and cannot import this package — see that
+// copy's doc comment.
+type ContextItemRef struct {
+	Type      ContextItemType `json:"type"`
+	ID        string          `json:"id"`
+	ProjectID *string         `json:"project_id,omitempty"`
+	Title     string          `json:"title"`
+}
+
 // AgentConversation tracks each OpenHands conversation session.
 type AgentConversation struct {
 	ID            uuid.UUID

--- a/services/api/internal/domain/agent/entity_test.go
+++ b/services/api/internal/domain/agent/entity_test.go
@@ -1,0 +1,77 @@
+package agentdom
+
+import "testing"
+
+func TestValidateContextItems_Valid(t *testing.T) {
+	items := []ContextItemRef{
+		{Type: ContextItemTask, ID: "t1", Title: "Fix login bug"},
+		{Type: ContextItemDoc, ID: "d1", Title: "Runbook"},
+		{Type: ContextItemConversation, ID: "c1", Title: "Earlier thread"},
+		{Type: ContextItemAutomation, ID: "a1", Title: "Nightly sync"},
+	}
+	if err := ValidateContextItems(items); err != nil {
+		t.Errorf("expected valid items to pass, got: %v", err)
+	}
+}
+
+func TestValidateContextItems_Empty(t *testing.T) {
+	if err := ValidateContextItems(nil); err != nil {
+		t.Errorf("expected nil/empty items to pass, got: %v", err)
+	}
+}
+
+func TestValidateContextItems_TooMany(t *testing.T) {
+	items := make([]ContextItemRef, MaxContextItems+1)
+	for i := range items {
+		items[i] = ContextItemRef{Type: ContextItemTask, ID: "t", Title: "x"}
+	}
+	if err := ValidateContextItems(items); err == nil {
+		t.Error("expected an error for more than MaxContextItems items")
+	}
+}
+
+func TestValidateContextItems_AtLimit(t *testing.T) {
+	items := make([]ContextItemRef, MaxContextItems)
+	for i := range items {
+		items[i] = ContextItemRef{Type: ContextItemTask, ID: "t", Title: "x"}
+	}
+	if err := ValidateContextItems(items); err != nil {
+		t.Errorf("expected exactly MaxContextItems items to pass, got: %v", err)
+	}
+}
+
+func TestValidateContextItems_UnknownType(t *testing.T) {
+	items := []ContextItemRef{{Type: "not-a-real-type", ID: "x1", Title: "x"}}
+	if err := ValidateContextItems(items); err == nil {
+		t.Error("expected an error for an unrecognized Type")
+	}
+}
+
+func TestValidateContextItems_EmptyID(t *testing.T) {
+	items := []ContextItemRef{{Type: ContextItemTask, ID: "", Title: "x"}}
+	if err := ValidateContextItems(items); err == nil {
+		t.Error("expected an error for a blank ID")
+	}
+}
+
+func TestValidateContextItems_TitleTooLong(t *testing.T) {
+	title := make([]byte, MaxContextItemTitleLength+1)
+	for i := range title {
+		title[i] = 'a'
+	}
+	items := []ContextItemRef{{Type: ContextItemTask, ID: "t1", Title: string(title)}}
+	if err := ValidateContextItems(items); err == nil {
+		t.Error("expected an error for a title exceeding MaxContextItemTitleLength")
+	}
+}
+
+func TestValidateContextItems_TitleAtLimit(t *testing.T) {
+	title := make([]byte, MaxContextItemTitleLength)
+	for i := range title {
+		title[i] = 'a'
+	}
+	items := []ContextItemRef{{Type: ContextItemTask, ID: "t1", Title: string(title)}}
+	if err := ValidateContextItems(items); err != nil {
+		t.Errorf("expected a title at exactly MaxContextItemTitleLength to pass, got: %v", err)
+	}
+}

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -114,6 +114,22 @@ type ConversationService interface {
 	// conversations are readable by any project member; owner-private ones
 	// only by their chat-session owner).
 	GetConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*AgentConversation, error)
+	// GetConversationForAgent returns a conversation for an agent-
+	// authenticated caller (X-Agent-ID, no human member/actor identity to
+	// check against) — used by the read_conversation MCP tool when a user
+	// attaches a Conversation as chat context. GetConversation and
+	// GetGlobalConversation both require a human member/actor identity a
+	// bare agent doesn't have (agents aren't project members, and a
+	// project-scoped agent's trigger never carries an actor_user_id), so
+	// this is a separate, narrower authorization rule: the requesting agent
+	// may read a conversation only if it is that conversation's own agent
+	// — it already saw everything in a conversation it participated in, so
+	// this exposes nothing new, regardless of project or audience (an
+	// owner_private chat with a human included). Any other conversation —
+	// a different agent's, or the same agent's shared-with-the-project
+	// conversation triggered for a different reason — is not reachable via
+	// this path (ErrConversationNotFound).
+	GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*AgentConversation, error)
 	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window ConversationEventWindow) ([]*AgentConversationEvent, int64, error)
 	// StopConversation interrupts (if running) and permanently tears down the
 	// conversation's sandbox. memberID gates ownership (see GetConversation).
@@ -124,7 +140,7 @@ type ConversationService interface {
 	// Heartbeat refreshes a chat conversation's idle timer; called
 	// periodically by the frontend while a conversation is loaded in a tab.
 	Heartbeat(ctx context.Context, projectID, conversationID, memberID uuid.UUID) error
-	SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID) error
+	SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID, contextItems []ContextItemRef) error
 
 	// -- Global chat conversations (ProjectID == uuid.Nil). Thin siblings of
 	// the methods above with the ownership check inverted (ProjectID must be
@@ -147,7 +163,7 @@ type ConversationService interface {
 	StopGlobalConversation(ctx context.Context, conversationID, actorUserID uuid.UUID) error
 	PauseGlobalConversation(ctx context.Context, conversationID, actorUserID uuid.UUID) error
 	GlobalHeartbeat(ctx context.Context, conversationID, actorUserID uuid.UUID) error
-	SendGlobalConversationMessage(ctx context.Context, conversationID uuid.UUID, message string, actorUserID uuid.UUID) error
+	SendGlobalConversationMessage(ctx context.Context, conversationID uuid.UUID, message string, actorUserID uuid.UUID, contextItems []ContextItemRef) error
 }
 
 // ChatSessionService defines chat session use cases.
@@ -158,8 +174,8 @@ type ChatSessionService interface {
 	// environmentID falls back to the agent's own DefaultEnvironmentID;
 	// folderID auto-selects if the resolved environment has exactly one
 	// folder). See environmentdom.EnvironmentService.ResolveConversationWorkdir.
-	StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string, environmentID, folderID *uuid.UUID) (*AgentChatSession, *AgentConversation, error)
-	SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string) (*AgentConversation, error)
+	StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string, environmentID, folderID *uuid.UUID, contextItems []ContextItemRef) (*AgentChatSession, *AgentConversation, error)
+	SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string, contextItems []ContextItemRef) (*AgentConversation, error)
 	ListChatMessages(ctx context.Context, sessionID, memberID uuid.UUID, offset, limit int) ([]*AgentConversationEvent, int64, error)
 
 	// -- Global chat sessions (chatting with a global agent from the home
@@ -167,8 +183,8 @@ type ChatSessionService interface {
 	// comment.
 
 	ListGlobalChatSessions(ctx context.Context, agentID, actorUserID uuid.UUID) ([]*AgentChatSession, error)
-	StartGlobalChatSession(ctx context.Context, agentID, actorUserID uuid.UUID, message string) (*AgentChatSession, *AgentConversation, error)
-	SendGlobalChatMessage(ctx context.Context, sessionID, actorUserID uuid.UUID, message string) (*AgentConversation, error)
+	StartGlobalChatSession(ctx context.Context, agentID, actorUserID uuid.UUID, message string, contextItems []ContextItemRef) (*AgentChatSession, *AgentConversation, error)
+	SendGlobalChatMessage(ctx context.Context, sessionID, actorUserID uuid.UUID, message string, contextItems []ContextItemRef) (*AgentConversation, error)
 }
 
 // ActivityFeedService defines the agent activity feed use case.

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -124,11 +124,29 @@ type ConversationService interface {
 	// this is a separate, narrower authorization rule: the requesting agent
 	// may read a conversation only if it is that conversation's own agent
 	// — it already saw everything in a conversation it participated in, so
-	// this exposes nothing new, regardless of project or audience (an
-	// owner_private chat with a human included). Any other conversation —
-	// a different agent's, or the same agent's shared-with-the-project
-	// conversation triggered for a different reason — is not reachable via
-	// this path (ErrConversationNotFound).
+	// this exposes nothing new *for that agent's own conversations*,
+	// regardless of project or audience (an owner_private chat with a
+	// human included). Any other conversation — a different agent's, or
+	// the same agent's shared-with-the-project conversation triggered for
+	// a different reason — is not reachable via this path
+	// (ErrConversationNotFound).
+	//
+	// Deliberate trust-boundary note: callerAgentID here is whatever
+	// X-Agent-ID the auth middleware accepted (middleware.AgentIDFromContext,
+	// see verifyAgentIdentity), which under a shared static agent API key
+	// (apikeysvc.WithAgentKey — the dev default, see AGENT_API_KEY) is
+	// verified only as "a real, non-deleted agent UUID," not "this specific
+	// process is actually that agent." Any agent process holding that
+	// shared key can therefore claim a different agent's ID and read that
+	// agent's full transcripts — including its owner_private human chats —
+	// through this endpoint. That capability didn't exist before this
+	// endpoint (transcripts were previously unreachable for any bare agent
+	// identity at all). A deployment issuing per-agent MCP keys instead
+	// (key.AgentID, see agentClaimsForKey) is not exposed this way, since
+	// the key itself — not a self-reported header — is the identity
+	// evidence there. If a deployment relies on the shared key, treat this
+	// as an accepted, deliberate extension of that key's existing trust
+	// model rather than a new one scoped down for this endpoint.
 	GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*AgentConversation, error)
 	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window ConversationEventWindow) ([]*AgentConversationEvent, int64, error)
 	// StopConversation interrupts (if running) and permanently tears down the

--- a/services/api/internal/domain/agent/service.go
+++ b/services/api/internal/domain/agent/service.go
@@ -115,39 +115,49 @@ type ConversationService interface {
 	// only by their chat-session owner).
 	GetConversation(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*AgentConversation, error)
 	// GetConversationForAgent returns a conversation for an agent-
-	// authenticated caller (X-Agent-ID, no human member/actor identity to
-	// check against) — used by the read_conversation MCP tool when a user
-	// attaches a Conversation as chat context. GetConversation and
-	// GetGlobalConversation both require a human member/actor identity a
-	// bare agent doesn't have (agents aren't project members, and a
-	// project-scoped agent's trigger never carries an actor_user_id), so
-	// this is a separate, narrower authorization rule: the requesting agent
-	// may read a conversation only if it is that conversation's own agent
-	// — it already saw everything in a conversation it participated in, so
-	// this exposes nothing new *for that agent's own conversations*,
-	// regardless of project or audience (an owner_private chat with a
-	// human included). Any other conversation — a different agent's, or
-	// the same agent's shared-with-the-project conversation triggered for
-	// a different reason — is not reachable via this path
-	// (ErrConversationNotFound).
+	// authenticated caller (X-Agent-ID, no human member/actor identity of
+	// its own to check against) — used by the read_conversation MCP tool
+	// when a user attaches a Conversation as chat context.
+	// GetConversation/GetGlobalConversation both require a human
+	// member/actor identity a bare agent doesn't have (agents aren't
+	// project members, and a project-scoped agent's trigger never carries
+	// an actor_user_id), so this can't just delegate to either of those.
 	//
-	// Deliberate trust-boundary note: callerAgentID here is whatever
-	// X-Agent-ID the auth middleware accepted (middleware.AgentIDFromContext,
-	// see verifyAgentIdentity), which under a shared static agent API key
-	// (apikeysvc.WithAgentKey — the dev default, see AGENT_API_KEY) is
-	// verified only as "a real, non-deleted agent UUID," not "this specific
-	// process is actually that agent." Any agent process holding that
-	// shared key can therefore claim a different agent's ID and read that
-	// agent's full transcripts — including its owner_private human chats —
-	// through this endpoint. That capability didn't exist before this
-	// endpoint (transcripts were previously unreachable for any bare agent
-	// identity at all). A deployment issuing per-agent MCP keys instead
-	// (key.AgentID, see agentClaimsForKey) is not exposed this way, since
-	// the key itself — not a self-reported header — is the identity
-	// evidence there. If a deployment relies on the shared key, treat this
-	// as an accepted, deliberate extension of that key's existing trust
-	// model rather than a new one scoped down for this endpoint.
-	GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*AgentConversation, error)
+	// It is NOT enough to check "is this the requested conversation's own
+	// agent" and stop there: the same agent can be talking to many
+	// different humans (a global agent chats with any authenticated user;
+	// a project-scoped agent can hold a separate owner-private conversation
+	// with each project member, and can be invited into more than one
+	// project). Authorizing on agent identity alone would let any one of
+	// those humans point the agent at another human's conversation ID —
+	// one it has no relationship to at all — and have the agent read it
+	// back, bypassing owner_private/project/actor isolation entirely via
+	// the agent as a confused deputy. (An earlier version of this method
+	// did exactly that; see the currentConversationID parameter below for
+	// the fix.)
+	//
+	// currentConversationID is the conversation the calling agent process
+	// is actually running as part of right now (agent-runner's own
+	// trigger.ConversationID, forwarded as X-Conversation-ID — see
+	// ConversationHandler.GetConversationForAgent). The rule:
+	//   - conversationID == currentConversationID is always allowed (an
+	//     agent may always read the conversation it's currently in).
+	//   - Otherwise, currentConversationID must itself resolve to a
+	//     conversation belonging to callerAgentID (an unverifiable or
+	//     mismatched currentConversationID means there is no trusted
+	//     context to check against, so nothing else is reachable), and the
+	//     requested conversation must be visible to *whichever human is
+	//     driving that current conversation* — the same rule
+	//     authorizeConversationAccess/GetGlobalConversation already apply
+	//     when that human asks directly: same actor for two global
+	//     conversations, or same project plus (project_shared, or
+	//     owner-private to that same chat-session member) for two
+	//     project-scoped ones. See the implementation's doc comment for
+	//     the exact rule.
+	// Any conversation outside that boundary is not reachable via this
+	// path (ErrConversationNotFound), including a different agent's, or
+	// the same agent's conversation with an unrelated human.
+	GetConversationForAgent(ctx context.Context, conversationID, callerAgentID, currentConversationID uuid.UUID) (*AgentConversation, error)
 	ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window ConversationEventWindow) ([]*AgentConversationEvent, int64, error)
 	// StopConversation interrupts (if running) and permanently tears down the
 	// conversation's sandbox. memberID gates ownership (see GetConversation).

--- a/services/api/internal/domain/automation/cursor.go
+++ b/services/api/internal/domain/automation/cursor.go
@@ -1,0 +1,39 @@
+package automationdom
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"time"
+)
+
+// AutomationCursor holds the stable ordering fields for keyset-based
+// pagination over a searchable/paginated automation listing (see
+// Repository.ListAutomations), ordered by created_at DESC, id DESC.
+type AutomationCursor struct {
+	CreatedAt time.Time `json:"ca"`
+	ID        string    `json:"id"`
+}
+
+// EncodeAutomationCursor builds an opaque base64 cursor from the last
+// automation on a page.
+func EncodeAutomationCursor(a *Automation) string {
+	cur := AutomationCursor{CreatedAt: a.CreatedAt.UTC(), ID: a.ID.String()}
+	b, _ := json.Marshal(cur)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// DecodeAutomationCursor parses a cursor token produced by
+// EncodeAutomationCursor. A malformed token returns ok=false rather than an
+// error — see docdom.DecodeDocumentCursor's doc comment for why this is
+// permissive rather than a hard failure.
+func DecodeAutomationCursor(s string) (cur AutomationCursor, ok bool) {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return AutomationCursor{}, false
+	}
+	if err := json.Unmarshal(b, &cur); err != nil {
+		return AutomationCursor{}, false
+	}
+	cur.CreatedAt = cur.CreatedAt.UTC()
+	return cur, true
+}

--- a/services/api/internal/domain/automation/repository.go
+++ b/services/api/internal/domain/automation/repository.go
@@ -11,7 +11,18 @@ import (
 type Repository interface {
 	CreateAutomation(ctx context.Context, a *Automation) error
 	FindAutomationByID(ctx context.Context, id uuid.UUID) (*Automation, error)
-	ListAutomations(ctx context.Context, projectID uuid.UUID, status *Status) ([]*Automation, error)
+	// ListAutomations returns projectID's automations, optionally filtered
+	// by status and/or a case-insensitive name search, always ordered
+	// created_at DESC, id DESC.
+	//
+	// limit nil means "no pagination" — every matching automation is
+	// returned and hasMore is always false (cursor ignored), matching the
+	// existing behavior every current caller relies on. limit non-nil
+	// switches to keyset pagination: fetches one extra row to compute
+	// hasMore, returns at most *limit. cursor, if non-nil, resumes after the
+	// automation EncodeAutomationCursor produced for the last row of the
+	// previous page.
+	ListAutomations(ctx context.Context, projectID uuid.UUID, status *Status, search *string, cursor *string, limit *int) (automations []*Automation, hasMore bool, err error)
 	// UpdateAutomation persists changes to name, description, and/or status.
 	UpdateAutomation(ctx context.Context, a *Automation) error
 	// DeleteAutomation soft-deletes an automation (cascades nodes/edges via FK).

--- a/services/api/internal/domain/automation/service.go
+++ b/services/api/internal/domain/automation/service.go
@@ -11,7 +11,9 @@ import (
 // projectID verify the automation (or its node/edge ancestor) actually
 // belongs to that project before mutating anything.
 type Service interface {
-	ListAutomations(ctx context.Context, projectID uuid.UUID, status *Status) ([]*Automation, error)
+	// ListAutomations — see Repository.ListAutomations's doc comment for the
+	// limit/cursor/hasMore pagination contract.
+	ListAutomations(ctx context.Context, projectID uuid.UUID, status *Status, search *string, cursor *string, limit *int) (automations []*Automation, hasMore bool, err error)
 	GetAutomation(ctx context.Context, projectID, automationID uuid.UUID) (*Graph, error)
 	CreateAutomation(ctx context.Context, in CreateAutomationInput) (*Automation, error)
 	UpdateAutomation(ctx context.Context, projectID, automationID uuid.UUID, in UpdateAutomationInput) (*Automation, error)

--- a/services/api/internal/domain/doc/cursor.go
+++ b/services/api/internal/domain/doc/cursor.go
@@ -1,0 +1,40 @@
+package docdom
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+// DocumentCursor holds the stable ordering fields for keyset-based
+// pagination over a searchable/paginated document listing (see
+// Repository.ListDocuments), ordered by title ASC, id ASC.
+type DocumentCursor struct {
+	Title string `json:"t"`
+	ID    string `json:"id"`
+}
+
+// EncodeDocumentCursor builds an opaque base64 cursor from the last document
+// on a page.
+func EncodeDocumentCursor(d *Document) string {
+	cur := DocumentCursor{Title: d.Title, ID: d.ID.String()}
+	b, _ := json.Marshal(cur)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// DecodeDocumentCursor parses a cursor token produced by
+// EncodeDocumentCursor. A malformed token (never produced by this codebase's
+// own frontend, which only ever round-trips an opaque cursor it was handed)
+// returns ok=false rather than an error — the repository treats that as "no
+// cursor" and restarts from the first page instead of hard-failing the
+// request, the same permissive-decode convention used elsewhere for opaque
+// pagination tokens.
+func DecodeDocumentCursor(s string) (cur DocumentCursor, ok bool) {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return DocumentCursor{}, false
+	}
+	if err := json.Unmarshal(b, &cur); err != nil {
+		return DocumentCursor{}, false
+	}
+	return cur, true
+}

--- a/services/api/internal/domain/doc/repository.go
+++ b/services/api/internal/domain/doc/repository.go
@@ -32,10 +32,22 @@ type DocFolderRepository interface {
 
 // DocumentRepository defines persistence for documents.
 type DocumentRepository interface {
-	// ListDocuments returns all non-deleted documents for a project.
-	// When folderID is non-nil only documents in that folder are returned;
-	// when nil all documents in the project are returned.
-	ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID) ([]*Document, error)
+	// ListDocuments returns non-deleted documents for a project. folderID
+	// non-nil filters to that folder. search non-nil/non-empty filters to a
+	// case-insensitive title match (see postgres.escapeLikePattern).
+	//
+	// limit nil means "no pagination" — every matching document is returned
+	// (ordered position ASC, title ASC), hasMore is always false, and cursor
+	// is ignored. This is the existing behavior every current caller (the
+	// doc-tree sidebar, the mention picker) relies on.
+	//
+	// limit non-nil switches to keyset pagination ordered title ASC, id ASC
+	// instead — sensible for a search result list, independent of the doc
+	// tree's manual position ordering — fetching one extra row to compute
+	// hasMore and returning at most *limit. cursor, if non-nil, resumes after
+	// the document EncodeDocumentCursor produced for the last row of the
+	// previous page.
+	ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID, search *string, cursor *string, limit *int) (docs []*Document, hasMore bool, err error)
 	// FindDocumentByID returns a single non-deleted document.
 	FindDocumentByID(ctx context.Context, id uuid.UUID) (*Document, error)
 	// CreateDocument persists a new document.

--- a/services/api/internal/domain/doc/service.go
+++ b/services/api/internal/domain/doc/service.go
@@ -52,9 +52,9 @@ type UpdateFolderInput struct {
 
 // DocumentService defines document use-cases.
 type DocumentService interface {
-	// ListDocuments returns all non-deleted documents in the project.
-	// folderID non-nil filters to that folder; nil returns all.
-	ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID) ([]*Document, error)
+	// ListDocuments — see Repository.ListDocuments's doc comment for the
+	// limit/cursor/hasMore pagination contract.
+	ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID, search *string, cursor *string, limit *int) (docs []*Document, hasMore bool, err error)
 	// GetDocument returns a single document by ID.
 	GetDocument(ctx context.Context, id uuid.UUID) (*Document, error)
 	// CreateDocument creates a new document in the project.

--- a/services/api/internal/repository/postgres/automation_repository.go
+++ b/services/api/internal/repository/postgres/automation_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -417,31 +418,57 @@ func (r *AutomationRepository) FindAutomationByID(ctx context.Context, id uuid.U
 	return rec.toDomain()
 }
 
-// ListAutomations implements automationdom.Repository.ListAutomations.
-func (r *AutomationRepository) ListAutomations(ctx context.Context, projectID uuid.UUID, status *automationdom.Status) ([]*automationdom.Automation, error) {
+// ListAutomations implements automationdom.Repository.ListAutomations. See
+// its doc comment for the limit/cursor/hasMore pagination contract.
+func (r *AutomationRepository) ListAutomations(ctx context.Context, projectID uuid.UUID, status *automationdom.Status, search *string, cursor *string, limit *int) ([]*automationdom.Automation, bool, error) {
 	q := `
 		SELECT id, project_id, name, description, status, created_by, created_at, updated_at, deleted_at
 		FROM automations WHERE project_id = $1 AND deleted_at IS NULL`
 	args := []interface{}{projectID.String()}
 	if status != nil {
-		q += ` AND status = $2`
 		args = append(args, string(*status))
+		q += fmt.Sprintf(` AND status = $%d`, len(args))
 	}
-	q += ` ORDER BY created_at DESC`
+	if search != nil {
+		if s := strings.TrimSpace(*search); s != "" {
+			args = append(args, "%"+escapeLikePattern(s)+"%")
+			q += fmt.Sprintf(` AND name ILIKE $%d`, len(args))
+		}
+	}
+
+	paginating := limit != nil
+	if paginating && cursor != nil {
+		if cur, ok := automationdom.DecodeAutomationCursor(*cursor); ok {
+			args = append(args, cur.CreatedAt, cur.ID)
+			q += fmt.Sprintf(` AND (created_at, id) < ($%d, $%d)`, len(args)-1, len(args))
+		}
+	}
+	q += ` ORDER BY created_at DESC, id DESC`
+	if paginating {
+		args = append(args, *limit+1)
+		q += fmt.Sprintf(` LIMIT $%d`, len(args))
+	}
 
 	var recs []automationRecord
 	if err := r.db.SelectContext(ctx, &recs, q, args...); err != nil {
-		return nil, err
+		return nil, false, err
 	}
+
+	hasMore := false
+	if paginating && len(recs) > *limit {
+		hasMore = true
+		recs = recs[:*limit]
+	}
+
 	out := make([]*automationdom.Automation, 0, len(recs))
 	for i := range recs {
 		a, err := recs[i].toDomain()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		out = append(out, a)
 	}
-	return out, nil
+	return out, hasMore, nil
 }
 
 // UpdateAutomation implements automationdom.Repository.UpdateAutomation.

--- a/services/api/internal/repository/postgres/document_repository.go
+++ b/services/api/internal/repository/postgres/document_repository.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -299,23 +301,55 @@ func (r *DocumentRepository) DeleteFolder(ctx context.Context, id uuid.UUID) err
 
 const documentCols = `id, project_id, folder_id, title, content, position, created_by, updated_by, created_at, updated_at, deleted_at`
 
-// ListDocuments returns non-deleted documents for a project.
-func (r *DocumentRepository) ListDocuments(_ context.Context, projectID uuid.UUID, folderID *uuid.UUID) ([]*docdom.Document, error) {
-	var records []documentRecord
-	var err error
+// ListDocuments returns non-deleted documents for a project, optionally
+// filtered to a folder and/or a case-insensitive title search, and
+// optionally keyset-paginated — see docdom.Repository.ListDocuments's doc
+// comment for the limit/cursor/hasMore contract and why pagination mode
+// sorts title ASC, id ASC instead of the tree's position ASC, title ASC.
+func (r *DocumentRepository) ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID, search *string, cursor *string, limit *int) ([]*docdom.Document, bool, error) {
+	query := `SELECT ` + documentCols + ` FROM documents WHERE project_id = $1 AND deleted_at IS NULL`
+	args := []any{projectID.String()}
 	if folderID != nil {
-		err = r.db.Select(&records, `SELECT `+documentCols+` FROM documents WHERE project_id = $1 AND folder_id = $2 AND deleted_at IS NULL ORDER BY position ASC, title ASC`, projectID.String(), folderID.String())
-	} else {
-		err = r.db.Select(&records, `SELECT `+documentCols+` FROM documents WHERE project_id = $1 AND deleted_at IS NULL ORDER BY position ASC, title ASC`, projectID.String())
+		args = append(args, folderID.String())
+		query += fmt.Sprintf(" AND folder_id = $%d", len(args))
 	}
-	if err != nil {
-		return nil, err
+	if search != nil {
+		if q := strings.TrimSpace(*search); q != "" {
+			args = append(args, "%"+escapeLikePattern(q)+"%")
+			query += fmt.Sprintf(" AND title ILIKE $%d", len(args))
+		}
+	}
+
+	paginating := limit != nil
+	if paginating {
+		if cursor != nil {
+			if cur, ok := docdom.DecodeDocumentCursor(*cursor); ok {
+				args = append(args, cur.Title, cur.ID)
+				query += fmt.Sprintf(" AND (title, id) > ($%d, $%d)", len(args)-1, len(args))
+			}
+		}
+		query += " ORDER BY title ASC, id ASC"
+		args = append(args, *limit+1)
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	} else {
+		query += " ORDER BY position ASC, title ASC"
+	}
+
+	var records []documentRecord
+	if err := r.db.SelectContext(ctx, &records, query, args...); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := false
+	if paginating && len(records) > *limit {
+		hasMore = true
+		records = records[:*limit]
 	}
 	out := make([]*docdom.Document, 0, len(records))
 	for _, rec := range records {
 		out = append(out, documentFromRecord(rec))
 	}
-	return out, nil
+	return out, hasMore, nil
 }
 
 // FindDocumentByID returns a single non-deleted document.

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -1258,16 +1258,78 @@ func (s *Service) GetConversation(ctx context.Context, projectID, conversationID
 }
 
 // GetConversationForAgent implements agentdom.Service.GetConversationForAgent
-// — see its doc comment for the authorization rule.
-func (s *Service) GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
-	c, err := s.repo.FindConversationByID(ctx, conversationID)
+// — see its doc comment for the full authorization rule and why bare agent-
+// identity matching isn't sufficient on its own.
+func (s *Service) GetConversationForAgent(ctx context.Context, conversationID, callerAgentID, currentConversationID uuid.UUID) (*agentdom.AgentConversation, error) {
+	target, err := s.repo.FindConversationByID(ctx, conversationID)
 	if err != nil {
 		return nil, err
 	}
-	if c.AgentID != callerAgentID {
+	if target.AgentID != callerAgentID {
 		return nil, agentdom.ErrConversationNotFound
 	}
-	return c, nil
+	// Always allowed: an agent may read the conversation it's currently
+	// running as part of. Also short-circuits the common case (no other
+	// conversation was attached) without a second lookup.
+	if target.ID == currentConversationID {
+		return target, nil
+	}
+
+	// Anything else must be authorized against whichever human is driving
+	// currentConversationID, not against callerAgentID alone — see
+	// authorizeAgentConversationRead.
+	current, err := s.repo.FindConversationByID(ctx, currentConversationID)
+	if err != nil || current.AgentID != callerAgentID {
+		// currentConversationID is missing, unverifiable, or (if ever
+		// spoofed) doesn't even belong to this agent — there is no trusted
+		// context to check the target against, so fail closed rather than
+		// falling back to bare agent-identity matching.
+		return nil, agentdom.ErrConversationNotFound
+	}
+	if err := s.authorizeAgentConversationRead(ctx, current, target); err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+// authorizeAgentConversationRead lets an agent read `target` on behalf of
+// `current` — the conversation actually driving this MCP call — only when
+// the human associated with `current` could already reach `target` by
+// asking for it directly, mirroring authorizeConversationAccess (project-
+// scoped) and GetGlobalConversation (global) exactly rather than
+// re-deriving a separate, easier-to-get-wrong rule:
+//   - global (current.ProjectID is nil): target must also be global and
+//     share the same actor_user_id — GetGlobalConversation's own rule.
+//   - project-scoped: target must be in the same project, and either
+//     project_shared (visible to any project member already) or
+//     owner-private to the same chat-session member current belongs to —
+//     authorizeConversationAccess's rule, reused via current's own chat
+//     session so a human never needs to be threaded through explicitly.
+func (s *Service) authorizeAgentConversationRead(ctx context.Context, current, target *agentdom.AgentConversation) error {
+	if current.ProjectID == uuid.Nil {
+		if target.ProjectID != uuid.Nil ||
+			current.ActorUserID == nil || target.ActorUserID == nil ||
+			*target.ActorUserID != *current.ActorUserID {
+			return agentdom.ErrConversationNotFound
+		}
+		return nil
+	}
+
+	if target.ProjectID != current.ProjectID {
+		return agentdom.ErrConversationNotFound
+	}
+	if current.ChatSessionID == nil {
+		// current isn't chat-session-backed (e.g. a task-assigned or
+		// automation-triggered run) — there is no "human currently
+		// chatting" to authorize target's owner-private audience against,
+		// so only its already-project-wide-visible audience is reachable.
+		return s.authorizeConversationAccess(ctx, target, uuid.Nil)
+	}
+	session, err := s.repo.FindChatSessionByID(ctx, *current.ChatSessionID)
+	if err != nil {
+		return agentdom.ErrConversationNotFound
+	}
+	return s.authorizeConversationAccess(ctx, target, session.MemberID)
 }
 
 // authorizeConversationAccess fails closed (ErrConversationNotFound) when a

--- a/services/api/internal/service/agent/agent_service.go
+++ b/services/api/internal/service/agent/agent_service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -1256,6 +1257,19 @@ func (s *Service) GetConversation(ctx context.Context, projectID, conversationID
 	return c, nil
 }
 
+// GetConversationForAgent implements agentdom.Service.GetConversationForAgent
+// — see its doc comment for the authorization rule.
+func (s *Service) GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+	c, err := s.repo.FindConversationByID(ctx, conversationID)
+	if err != nil {
+		return nil, err
+	}
+	if c.AgentID != callerAgentID {
+		return nil, agentdom.ErrConversationNotFound
+	}
+	return c, nil
+}
+
 // authorizeConversationAccess fails closed (ErrConversationNotFound) when a
 // project-scoped owner-private conversation is not owned by memberID.
 // project-shared conversations are readable by any project member, whose
@@ -1372,7 +1386,7 @@ func (s *Service) Heartbeat(ctx context.Context, projectID, conversationID, memb
 // resumed here too, from any status, not just chat_message ones —
 // mirroring SendChatMessage's own terminal-status resume carve-out for
 // chat sessions.
-func (s *Service) SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID) error {
+func (s *Service) SendConversationMessage(ctx context.Context, projectID, conversationID uuid.UUID, message string, memberID uuid.UUID, contextItems []agentdom.ContextItemRef) error {
 	c, err := s.GetConversation(ctx, projectID, conversationID, memberID)
 	if err != nil {
 		return err
@@ -1383,18 +1397,23 @@ func (s *Service) SendConversationMessage(ctx context.Context, projectID, conver
 		return err
 	}
 	if agent.AgentType == agentdom.AgentTypeACP || c.EnvironmentID != nil {
-		return s.resumeConversationMessage(ctx, projectID, c, message, memberID)
+		return s.resumeConversationMessage(ctx, projectID, c, message, memberID, contextItems)
 	}
 
 	if agentdom.ConversationStatus(c.Status) != agentdom.ConversationStatusRunning {
 		return agentdom.ErrConversationNotRunning
 	}
-	return s.publishTrigger(ctx, events.TopicAgentChatMessage, map[string]any{
+	payload := map[string]any{
 		"conversation_id": conversationID.String(),
 		"project_id":      projectID.String(),
 		"message":         message,
 		"member_id":       memberID.String(),
-	})
+	}
+	if len(contextItems) > 0 {
+		b, _ := json.Marshal(contextItems)
+		payload["context_items"] = string(b)
+	}
+	return s.publishTrigger(ctx, events.TopicAgentChatMessage, payload)
 }
 
 // resumeConversationMessage resumes a conversation of any trigger type from
@@ -1402,7 +1421,7 @@ func (s *Service) SendConversationMessage(ctx context.Context, projectID, conver
 // the chat box instead of being stuck once its first turn ends — used for
 // ACP-type agents (see SendConversationMessage's own doc comment) and for
 // any conversation attached to a static environment.
-func (s *Service) resumeConversationMessage(ctx context.Context, projectID uuid.UUID, c *agentdom.AgentConversation, message string, memberID uuid.UUID) error {
+func (s *Service) resumeConversationMessage(ctx context.Context, projectID uuid.UUID, c *agentdom.AgentConversation, message string, memberID uuid.UUID, contextItems []agentdom.ContextItemRef) error {
 	status := agentdom.ConversationStatus(c.Status)
 	if status == agentdom.ConversationStatusRunning || status == agentdom.ConversationStatusQueued {
 		// Still mid-turn (or not yet picked up by the worker) — reject
@@ -1461,6 +1480,10 @@ func (s *Service) resumeConversationMessage(ctx context.Context, projectID uuid.
 	if envID != nil {
 		payload["environment_id"] = envID.String()
 		payload["workdir"] = workdir
+	}
+	if len(contextItems) > 0 {
+		b, _ := json.Marshal(contextItems)
+		payload["context_items"] = string(b)
 	}
 	return s.publishTrigger(ctx, events.TopicAgentChatMessage, payload)
 }
@@ -1547,7 +1570,7 @@ func (s *Service) GlobalHeartbeat(ctx context.Context, conversationID, actorUser
 }
 
 // SendGlobalConversationMessage publishes a chat message to an active global conversation.
-func (s *Service) SendGlobalConversationMessage(ctx context.Context, conversationID uuid.UUID, message string, actorUserID uuid.UUID) error {
+func (s *Service) SendGlobalConversationMessage(ctx context.Context, conversationID uuid.UUID, message string, actorUserID uuid.UUID, contextItems []agentdom.ContextItemRef) error {
 	c, err := s.GetGlobalConversation(ctx, conversationID, actorUserID)
 	if err != nil {
 		return err
@@ -1558,18 +1581,23 @@ func (s *Service) SendGlobalConversationMessage(ctx context.Context, conversatio
 		return err
 	}
 	if agent.AgentType == agentdom.AgentTypeACP {
-		return s.sendACPGlobalConversationMessage(ctx, c, message, actorUserID)
+		return s.sendACPGlobalConversationMessage(ctx, c, message, actorUserID, contextItems)
 	}
 
 	if agentdom.ConversationStatus(c.Status) != agentdom.ConversationStatusRunning {
 		return agentdom.ErrConversationNotRunning
 	}
-	return s.publishTrigger(ctx, events.TopicAgentChatMessage, map[string]any{
+	payload := map[string]any{
 		"conversation_id": conversationID.String(),
 		"agent_id":        c.AgentID.String(),
 		"message":         message,
 		"actor_user_id":   actorUserID.String(),
-	})
+	}
+	if len(contextItems) > 0 {
+		b, _ := json.Marshal(contextItems)
+		payload["context_items"] = string(b)
+	}
+	return s.publishTrigger(ctx, events.TopicAgentChatMessage, payload)
 }
 
 // sendACPGlobalConversationMessage is resumeConversationMessage's
@@ -1579,7 +1607,7 @@ func (s *Service) SendGlobalConversationMessage(ctx context.Context, conversatio
 // resumeConversationMessage: a global-scope agent can never have a default
 // environment (see agentdom.Agent.DefaultEnvironmentID's doc comment), so
 // a global conversation's EnvironmentID is always nil.
-func (s *Service) sendACPGlobalConversationMessage(ctx context.Context, c *agentdom.AgentConversation, message string, actorUserID uuid.UUID) error {
+func (s *Service) sendACPGlobalConversationMessage(ctx context.Context, c *agentdom.AgentConversation, message string, actorUserID uuid.UUID, contextItems []agentdom.ContextItemRef) error {
 	status := agentdom.ConversationStatus(c.Status)
 	if status == agentdom.ConversationStatusRunning || status == agentdom.ConversationStatusQueued {
 		return agentdom.ErrConversationBusy
@@ -1591,13 +1619,18 @@ func (s *Service) sendACPGlobalConversationMessage(ctx context.Context, c *agent
 	if !claimed {
 		return agentdom.ErrConversationBusy
 	}
-	return s.publishTrigger(ctx, events.TopicAgentChatMessage, map[string]any{
+	payload := map[string]any{
 		"conversation_id": c.ID.String(),
 		"agent_id":        c.AgentID.String(),
 		"trigger_type":    c.TriggerType,
 		"actor_user_id":   actorUserID.String(),
 		"message":         message,
-	})
+	}
+	if len(contextItems) > 0 {
+		b, _ := json.Marshal(contextItems)
+		payload["context_items"] = string(b)
+	}
+	return s.publishTrigger(ctx, events.TopicAgentChatMessage, payload)
 }
 
 // -------------------------------------------------------------------------
@@ -1615,7 +1648,7 @@ func (s *Service) ListChatSessions(ctx context.Context, _, agentID, memberID uui
 // resolveChatEnvironment); folderID nil auto-selects the environment's sole
 // folder, or fails with ErrFolderNotFound if that's ambiguous — the caller
 // must ask the user to pick.
-func (s *Service) StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string, environmentID, folderID *uuid.UUID) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
+func (s *Service) StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string, environmentID, folderID *uuid.UUID, contextItems []agentdom.ContextItemRef) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
 	now := time.Now()
 
 	session := &agentdom.AgentChatSession{
@@ -1646,7 +1679,7 @@ func (s *Service) StartChatSession(ctx context.Context, projectID, agentID, memb
 		return nil, nil, err
 	}
 
-	if err := s.publishChatTrigger(ctx, agentID, conv.ID, session.ID, projectID, memberID, message, s.gatherRepoPluginIDs(ctx), envID, workdir); err != nil {
+	if err := s.publishChatTrigger(ctx, agentID, conv.ID, session.ID, projectID, memberID, message, s.gatherRepoPluginIDs(ctx), envID, workdir, contextItems); err != nil {
 		return nil, nil, err
 	}
 
@@ -1750,7 +1783,7 @@ func (s *Service) resolveWorkdirForConversation(ctx context.Context, projectID u
 // is nothing left to attach to." Only an ordinary (non-environment) LLM
 // conversation going terminal still falls through to a brand-new
 // conversation_id below — its ephemeral sandbox really is gone for good.
-func (s *Service) SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string) (*agentdom.AgentConversation, error) {
+func (s *Service) SendChatMessage(ctx context.Context, projectID, sessionID, memberID uuid.UUID, message string, contextItems []agentdom.ContextItemRef) (*agentdom.AgentConversation, error) {
 	session, err := s.repo.FindChatSessionByID(ctx, sessionID)
 	if err != nil {
 		return nil, err
@@ -1863,7 +1896,7 @@ func (s *Service) SendChatMessage(ctx context.Context, projectID, sessionID, mem
 	if err != nil {
 		return nil, err
 	}
-	if err := s.publishChatTrigger(ctx, session.AgentID, conv.ID, sessionID, projectID, memberID, message, s.gatherRepoPluginIDs(ctx), envID, workdir); err != nil {
+	if err := s.publishChatTrigger(ctx, session.AgentID, conv.ID, sessionID, projectID, memberID, message, s.gatherRepoPluginIDs(ctx), envID, workdir, contextItems); err != nil {
 		return nil, err
 	}
 
@@ -1888,7 +1921,7 @@ func (s *Service) ListGlobalChatSessions(ctx context.Context, agentID, actorUser
 
 // StartGlobalChatSession creates a new global chat session and publishes
 // the initial message trigger.
-func (s *Service) StartGlobalChatSession(ctx context.Context, agentID, actorUserID uuid.UUID, message string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
+func (s *Service) StartGlobalChatSession(ctx context.Context, agentID, actorUserID uuid.UUID, message string, contextItems []agentdom.ContextItemRef) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
 	now := time.Now()
 
 	session := &agentdom.AgentChatSession{
@@ -1911,7 +1944,7 @@ func (s *Service) StartGlobalChatSession(ctx context.Context, agentID, actorUser
 		return nil, nil, err
 	}
 
-	if err := s.publishGlobalChatTrigger(ctx, agentID, conv.ID, session.ID, actorUserID, message); err != nil {
+	if err := s.publishGlobalChatTrigger(ctx, agentID, conv.ID, session.ID, actorUserID, message, contextItems); err != nil {
 		return nil, nil, err
 	}
 
@@ -1921,7 +1954,7 @@ func (s *Service) StartGlobalChatSession(ctx context.Context, agentID, actorUser
 // SendGlobalChatMessage sends a message to an existing global chat session
 // and publishes the trigger. Mirrors SendChatMessage's resume/terminal
 // handling — see its doc comment for the pause/resume rationale.
-func (s *Service) SendGlobalChatMessage(ctx context.Context, sessionID, actorUserID uuid.UUID, message string) (*agentdom.AgentConversation, error) {
+func (s *Service) SendGlobalChatMessage(ctx context.Context, sessionID, actorUserID uuid.UUID, message string, contextItems []agentdom.ContextItemRef) (*agentdom.AgentConversation, error) {
 	session, err := s.repo.FindChatSessionByID(ctx, sessionID)
 	if err != nil {
 		return nil, err
@@ -1981,7 +2014,7 @@ func (s *Service) SendGlobalChatMessage(ctx context.Context, sessionID, actorUse
 	// else: resume — reuse the same conversation_id so ai-agent reattaches
 	// to the sandbox it kept alive rather than cold-starting a new one.
 
-	if err := s.publishGlobalChatTrigger(ctx, session.AgentID, conv.ID, sessionID, actorUserID, message); err != nil {
+	if err := s.publishGlobalChatTrigger(ctx, session.AgentID, conv.ID, sessionID, actorUserID, message, contextItems); err != nil {
 		return nil, err
 	}
 
@@ -2327,7 +2360,7 @@ func (s *Service) publishTrigger(ctx context.Context, topic string, payload map[
 // docs/ai-agent/environment-management.md's "Conversation attach path"
 // section for how agent-runner's decode.go/coldStartEnvironment consume
 // them.
-func (s *Service) publishChatTrigger(ctx context.Context, agentID, convID, sessionID, projectID, memberID uuid.UUID, message string, repoPluginIDs []string, environmentID *uuid.UUID, workdir string) error {
+func (s *Service) publishChatTrigger(ctx context.Context, agentID, convID, sessionID, projectID, memberID uuid.UUID, message string, repoPluginIDs []string, environmentID *uuid.UUID, workdir string, contextItems []agentdom.ContextItemRef) error {
 	payload := map[string]any{
 		"conversation_id": convID.String(),
 		"project_id":      projectID.String(),
@@ -2342,6 +2375,10 @@ func (s *Service) publishChatTrigger(ctx context.Context, agentID, convID, sessi
 		payload["environment_id"] = environmentID.String()
 		payload["workdir"] = workdir
 	}
+	if len(contextItems) > 0 {
+		b, _ := json.Marshal(contextItems)
+		payload["context_items"] = string(b)
+	}
 	return s.publishTrigger(ctx, events.TopicAgentChatMessage, payload)
 }
 
@@ -2349,7 +2386,7 @@ func (s *Service) publishChatTrigger(ctx context.Context, agentID, convID, sessi
 // project_id, actor identified by actor_user_id, and repo_plugin_ids
 // omitted entirely (repo/PR tools are excluded from global-chat
 // conversations; see the Global Conversations section's doc comment).
-func (s *Service) publishGlobalChatTrigger(ctx context.Context, agentID, convID, sessionID, actorUserID uuid.UUID, message string) error {
+func (s *Service) publishGlobalChatTrigger(ctx context.Context, agentID, convID, sessionID, actorUserID uuid.UUID, message string, contextItems []agentdom.ContextItemRef) error {
 	payload := map[string]any{
 		"conversation_id": convID.String(),
 		"agent_id":        agentID.String(),
@@ -2357,6 +2394,10 @@ func (s *Service) publishGlobalChatTrigger(ctx context.Context, agentID, convID,
 		"actor_user_id":   actorUserID.String(),
 		"trigger_type":    "chat_message",
 		"message":         message,
+	}
+	if len(contextItems) > 0 {
+		b, _ := json.Marshal(contextItems)
+		payload["context_items"] = string(b)
 	}
 	return s.publishTrigger(ctx, events.TopicAgentChatMessage, payload)
 }

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -1371,13 +1371,11 @@ func TestGetConversation_OwnerPrivate_WrongMember(t *testing.T) {
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
 }
 
-// TestGetConversationForAgent_OwnConversation_Allowed reproduces the
-// read_conversation MCP tool's real use case: an agent (no project_members
-// row, no actor_user_id) reading its own owner-private conversation with a
-// human — the case GetConversation/GetGlobalConversation cannot serve at
-// all, since both require a human member/actor identity a bare agent
-// doesn't have.
-func TestGetConversationForAgent_OwnConversation_Allowed(t *testing.T) {
+// TestGetConversationForAgent_SameConversation_Allowed reproduces the
+// read_conversation MCP tool's simplest case: an agent reading the very
+// conversation it's currently running as part of. Always allowed regardless
+// of audience, and doesn't require a second FindConversationByID lookup.
+func TestGetConversationForAgent_SameConversation_Allowed(t *testing.T) {
 	agentID := uuid.New()
 	conversationID := uuid.New()
 	conversation := &agentdom.AgentConversation{
@@ -1386,17 +1384,20 @@ func TestGetConversationForAgent_OwnConversation_Allowed(t *testing.T) {
 		Audience: agentdom.AudienceOwnerPrivate,
 		Status:   "stopped",
 	}
+	lookups := 0
 	repo := &mockAgentRepo{
 		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			lookups++
 			return conversation, nil
 		},
 	}
 	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
-	result, err := svc.GetConversationForAgent(context.Background(), conversationID, agentID)
+	result, err := svc.GetConversationForAgent(context.Background(), conversationID, agentID, conversationID)
 
 	assert.NoError(t, err)
 	assert.Equal(t, conversationID, result.ID)
+	assert.Equal(t, 1, lookups, "reading the current conversation itself should not need a second lookup")
 }
 
 // TestGetConversationForAgent_DifferentAgent_Rejected asserts the
@@ -1420,7 +1421,241 @@ func TestGetConversationForAgent_DifferentAgent_Rejected(t *testing.T) {
 	}
 	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
-	_, err := svc.GetConversationForAgent(context.Background(), conversationID, callerAgentID)
+	_, err := svc.GetConversationForAgent(context.Background(), conversationID, callerAgentID, uuid.Nil)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
+// TestGetConversationForAgent_NoCurrentConversation_Rejected pins the
+// fail-closed default: without a verifiable currentConversationID (e.g. an
+// older agent-runner build that never sends X-Conversation-ID), a *different*
+// conversation of the agent's own is not reachable — there is no trusted
+// context to check its audience against. This is deliberately not the old
+// "any conversation this agent ever had" behavior; see
+// GetConversationForAgent's doc comment.
+func TestGetConversationForAgent_NoCurrentConversation_Rejected(t *testing.T) {
+	agentID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:       conversationID,
+		AgentID:  agentID,
+		Audience: agentdom.AudienceProjectShared,
+		Status:   "stopped",
+	}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == conversationID {
+				return conversation, nil
+			}
+			return nil, agentdom.ErrConversationNotFound
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversationForAgent(context.Background(), conversationID, agentID, uuid.Nil)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
+// TestGetConversationForAgent_SpoofedCurrentConversation_Rejected pins that
+// a currentConversationID belonging to a *different* agent (whether spoofed
+// or just stale) is never trusted as context — it's treated the same as no
+// current conversation at all.
+func TestGetConversationForAgent_SpoofedCurrentConversation_Rejected(t *testing.T) {
+	agentID := uuid.New()
+	otherAgentID := uuid.New()
+	conversationID := uuid.New()
+	currentConversationID := uuid.New()
+	target := &agentdom.AgentConversation{ID: conversationID, AgentID: agentID, Audience: agentdom.AudienceProjectShared, ProjectID: uuid.New()}
+	current := &agentdom.AgentConversation{ID: currentConversationID, AgentID: otherAgentID, ProjectID: target.ProjectID}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == conversationID {
+				return target, nil
+			}
+			return current, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversationForAgent(context.Background(), conversationID, agentID, currentConversationID)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
+// TestGetConversationForAgent_Global_SameActor_Allowed and
+// TestGetConversationForAgent_Global_DifferentActor_Rejected are the
+// regression cases for the vulnerability this method used to have: a global
+// agent talks to many different humans, and reading a *different* human's
+// conversation with the same agent must stay denied even though the agent
+// identity matches on both — the whole point of GetGlobalConversation's own
+// actor check ("without it, any authenticated user could read... another
+// user's conversation simply by knowing its ID").
+func TestGetConversationForAgent_Global_SameActor_Allowed(t *testing.T) {
+	agentID := uuid.New()
+	actorUserID := uuid.New()
+	targetID, currentID := uuid.New(), uuid.New()
+	target := &agentdom.AgentConversation{ID: targetID, AgentID: agentID, ActorUserID: &actorUserID}
+	current := &agentdom.AgentConversation{ID: currentID, AgentID: agentID, ActorUserID: &actorUserID}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == targetID {
+				return target, nil
+			}
+			return current, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	result, err := svc.GetConversationForAgent(context.Background(), targetID, agentID, currentID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, targetID, result.ID)
+}
+
+func TestGetConversationForAgent_Global_DifferentActor_Rejected(t *testing.T) {
+	agentID := uuid.New()
+	victimActorUserID := uuid.New()
+	attackerActorUserID := uuid.New()
+	targetID, currentID := uuid.New(), uuid.New()
+	// target: the victim's own private global conversation with the shared agent.
+	target := &agentdom.AgentConversation{ID: targetID, AgentID: agentID, ActorUserID: &victimActorUserID}
+	// current: the attacker's own, unrelated conversation with that same agent.
+	current := &agentdom.AgentConversation{ID: currentID, AgentID: agentID, ActorUserID: &attackerActorUserID}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == targetID {
+				return target, nil
+			}
+			return current, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversationForAgent(context.Background(), targetID, agentID, currentID)
+
+	assert.Error(t, err, "the attacker must not be able to read the victim's private conversation with the same shared agent")
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
+// TestGetConversationForAgent_Project_SharedAudience_Allowed: a
+// project_shared target in the same project is readable regardless of which
+// member current belongs to — it's already visible to any project member.
+func TestGetConversationForAgent_Project_SharedAudience_Allowed(t *testing.T) {
+	agentID := uuid.New()
+	projectID := uuid.New()
+	targetID, currentID := uuid.New(), uuid.New()
+	target := &agentdom.AgentConversation{ID: targetID, AgentID: agentID, ProjectID: projectID, Audience: agentdom.AudienceProjectShared}
+	current := &agentdom.AgentConversation{ID: currentID, AgentID: agentID, ProjectID: projectID, ChatSessionID: nil}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == targetID {
+				return target, nil
+			}
+			return current, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	result, err := svc.GetConversationForAgent(context.Background(), targetID, agentID, currentID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, targetID, result.ID)
+}
+
+// TestGetConversationForAgent_Project_OwnerPrivate_SameMember_Allowed and
+// TestGetConversationForAgent_Project_OwnerPrivate_DifferentMember_Rejected
+// are the project-scoped regression cases: a project-scoped agent can hold
+// a separate owner-private conversation with each project member, and
+// reading a *different* member's private conversation must stay denied —
+// mirroring authorizeConversationAccess's own rule for a human caller.
+func TestGetConversationForAgent_Project_OwnerPrivate_SameMember_Allowed(t *testing.T) {
+	agentID := uuid.New()
+	projectID := uuid.New()
+	memberID := uuid.New()
+	targetID, currentID := uuid.New(), uuid.New()
+	targetSessionID, currentSessionID := uuid.New(), uuid.New()
+	target := &agentdom.AgentConversation{ID: targetID, AgentID: agentID, ProjectID: projectID, Audience: agentdom.AudienceOwnerPrivate, ChatSessionID: &targetSessionID}
+	current := &agentdom.AgentConversation{ID: currentID, AgentID: agentID, ProjectID: projectID, ChatSessionID: &currentSessionID}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == targetID {
+				return target, nil
+			}
+			return current, nil
+		},
+		findChatSessionByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentChatSession, error) {
+			// Both sessions belong to the same human — e.g. the member
+			// attached an earlier private conversation of their own as
+			// context in a new private chat with the same agent.
+			return &agentdom.AgentChatSession{ID: id, MemberID: memberID}, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	result, err := svc.GetConversationForAgent(context.Background(), targetID, agentID, currentID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, targetID, result.ID)
+}
+
+func TestGetConversationForAgent_Project_OwnerPrivate_DifferentMember_Rejected(t *testing.T) {
+	agentID := uuid.New()
+	projectID := uuid.New()
+	victimMemberID := uuid.New()
+	attackerMemberID := uuid.New()
+	targetID, currentID := uuid.New(), uuid.New()
+	targetSessionID, currentSessionID := uuid.New(), uuid.New()
+	// target: the victim's owner-private conversation with the shared project agent.
+	target := &agentdom.AgentConversation{ID: targetID, AgentID: agentID, ProjectID: projectID, Audience: agentdom.AudienceOwnerPrivate, ChatSessionID: &targetSessionID}
+	// current: the attacker's own, unrelated conversation with that same agent, same project.
+	current := &agentdom.AgentConversation{ID: currentID, AgentID: agentID, ProjectID: projectID, ChatSessionID: &currentSessionID}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == targetID {
+				return target, nil
+			}
+			return current, nil
+		},
+		findChatSessionByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentChatSession, error) {
+			if id == targetSessionID {
+				return &agentdom.AgentChatSession{ID: id, MemberID: victimMemberID}, nil
+			}
+			return &agentdom.AgentChatSession{ID: id, MemberID: attackerMemberID}, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversationForAgent(context.Background(), targetID, agentID, currentID)
+
+	assert.Error(t, err, "a fellow project member must not be able to read another member's owner-private conversation with the same agent")
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
+// TestGetConversationForAgent_Project_DifferentProject_Rejected covers an
+// agent invited into more than one project: a project_shared conversation
+// from a *different* project than current's must still be denied, even
+// though every project member there could already see it in their own
+// project — current's own project is the only one this call may reach into.
+func TestGetConversationForAgent_Project_DifferentProject_Rejected(t *testing.T) {
+	agentID := uuid.New()
+	targetID, currentID := uuid.New(), uuid.New()
+	target := &agentdom.AgentConversation{ID: targetID, AgentID: agentID, ProjectID: uuid.New(), Audience: agentdom.AudienceProjectShared}
+	current := &agentdom.AgentConversation{ID: currentID, AgentID: agentID, ProjectID: uuid.New()}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, id uuid.UUID) (*agentdom.AgentConversation, error) {
+			if id == targetID {
+				return target, nil
+			}
+			return current, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversationForAgent(context.Background(), targetID, agentID, currentID)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)

--- a/services/api/internal/service/agent/agent_service_test.go
+++ b/services/api/internal/service/agent/agent_service_test.go
@@ -1095,7 +1095,7 @@ func TestStartGlobalChatSession_Success(t *testing.T) {
 	}
 	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
-	session, conv, err := svc.StartGlobalChatSession(context.Background(), agentID, actorUserID, "hello")
+	session, conv, err := svc.StartGlobalChatSession(context.Background(), agentID, actorUserID, "hello", nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, session)
@@ -1371,6 +1371,61 @@ func TestGetConversation_OwnerPrivate_WrongMember(t *testing.T) {
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
 }
 
+// TestGetConversationForAgent_OwnConversation_Allowed reproduces the
+// read_conversation MCP tool's real use case: an agent (no project_members
+// row, no actor_user_id) reading its own owner-private conversation with a
+// human — the case GetConversation/GetGlobalConversation cannot serve at
+// all, since both require a human member/actor identity a bare agent
+// doesn't have.
+func TestGetConversationForAgent_OwnConversation_Allowed(t *testing.T) {
+	agentID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:       conversationID,
+		AgentID:  agentID,
+		Audience: agentdom.AudienceOwnerPrivate,
+		Status:   "stopped",
+	}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	result, err := svc.GetConversationForAgent(context.Background(), conversationID, agentID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, conversationID, result.ID)
+}
+
+// TestGetConversationForAgent_DifferentAgent_Rejected asserts the
+// authorization boundary: an agent may not read a conversation it wasn't
+// itself the agent of, even when it's project_shared — reading another
+// agent's conversation isn't the case this path exists for.
+func TestGetConversationForAgent_DifferentAgent_Rejected(t *testing.T) {
+	callerAgentID := uuid.New()
+	ownerAgentID := uuid.New()
+	conversationID := uuid.New()
+	conversation := &agentdom.AgentConversation{
+		ID:       conversationID,
+		AgentID:  ownerAgentID,
+		Audience: agentdom.AudienceProjectShared,
+		Status:   "stopped",
+	}
+	repo := &mockAgentRepo{
+		findConversationByID: func(_ context.Context, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return conversation, nil
+		},
+	}
+	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
+
+	_, err := svc.GetConversationForAgent(context.Background(), conversationID, callerAgentID)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
+}
+
 func TestSendChatMessage_WrongMember(t *testing.T) {
 	projectID := uuid.New()
 	agentID := uuid.New()
@@ -1391,7 +1446,7 @@ func TestSendChatMessage_WrongMember(t *testing.T) {
 	}
 	svc := New(repo, &mockProjectRepo{}, nil, &mockPluginRepo{})
 
-	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, otherMemberID, "Hello")
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, otherMemberID, "Hello", nil)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrChatSessionNotFound)
@@ -1513,7 +1568,7 @@ func TestGlobalConversationMutators_RejectWrongActor(t *testing.T) {
 		assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
 	})
 	t.Run("send message", func(t *testing.T) {
-		err := svc.SendGlobalConversationMessage(context.Background(), conversationID, "hi", attacker)
+		err := svc.SendGlobalConversationMessage(context.Background(), conversationID, "hi", attacker, nil)
 		assert.ErrorIs(t, err, agentdom.ErrConversationNotFound)
 	})
 }
@@ -1625,7 +1680,7 @@ func TestSendConversationMessage_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "test message", uuid.New())
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "test message", uuid.New(), nil)
 
 	assert.NoError(t, err)
 }
@@ -1649,7 +1704,7 @@ func TestSendConversationMessage_NotRunning(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "test message", uuid.New())
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "test message", uuid.New(), nil)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrConversationNotRunning)
@@ -1690,7 +1745,7 @@ func TestSendConversationMessage_ACPResumesAnyTriggerType(t *testing.T) {
 			pluginRepo := &mockPluginRepo{}
 			svc := New(repo, projRepo, nil, pluginRepo)
 
-			err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "keep going", uuid.New())
+			err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "keep going", uuid.New(), nil)
 
 			assert.NoError(t, err)
 			assert.Equal(t, status, claimedFrom)
@@ -1724,7 +1779,7 @@ func TestSendConversationMessage_ACPBusyWhenRunning(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "are you there?", uuid.New())
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "are you there?", uuid.New(), nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 	assert.False(t, claimCalled, "must not attempt to claim/dispatch on top of an in-flight turn")
@@ -1750,7 +1805,7 @@ func TestSendConversationMessage_ACPBusyWhenQueued(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "are you there?", uuid.New())
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "are you there?", uuid.New(), nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
@@ -1779,7 +1834,7 @@ func TestSendConversationMessage_ACPResumeRaceLoses(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "keep going", uuid.New())
+	err := svc.SendConversationMessage(context.Background(), projectID, conversationID, "keep going", uuid.New(), nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
@@ -2008,7 +2063,7 @@ func TestStartChatSession_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	resultSession, resultConv, err := svc.StartChatSession(context.Background(), projectID, agentID, memberID, "Hello", nil, nil)
+	resultSession, resultConv, err := svc.StartChatSession(context.Background(), projectID, agentID, memberID, "Hello", nil, nil, nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, resultSession)
@@ -2047,7 +2102,7 @@ func TestSendChatMessage_Success(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello")
+	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello", nil)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, resultConv)
@@ -2102,7 +2157,7 @@ func TestSendChatMessage_ResumesPausedConversation(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…", nil)
 
 	assert.NoError(t, err)
 	assert.False(t, createCalled, "resuming a paused conversation must not create a new one")
@@ -2166,7 +2221,7 @@ func TestSendChatMessage_ACPResumesTerminalConversation(t *testing.T) {
 			pluginRepo := &mockPluginRepo{}
 			svc := New(repo, projRepo, nil, pluginRepo)
 
-			resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+			resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…", nil)
 
 			assert.NoError(t, err)
 			assert.False(t, createCalled, "resuming a terminal ACP conversation must not create a new one")
@@ -2217,7 +2272,7 @@ func TestSendChatMessage_ACPResumeRaceLoses(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…", nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
@@ -2274,7 +2329,7 @@ func TestSendChatMessage_LLMTerminalCreatesNewConversation(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello again")
+	resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello again", nil)
 
 	assert.NoError(t, err)
 	assert.True(t, createCalled, "a terminal LLM conversation must create a new conversation")
@@ -2343,7 +2398,7 @@ func TestSendChatMessage_EnvironmentBackedLLMResumesTerminalConversation(t *test
 			pluginRepo := &mockPluginRepo{}
 			svc := New(repo, projRepo, nil, pluginRepo)
 
-			resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+			resultConv, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…", nil)
 
 			assert.NoError(t, err)
 			assert.False(t, createCalled, "resuming a terminal environment-backed conversation must not create a new one")
@@ -2390,7 +2445,7 @@ func TestSendChatMessage_ResumeRaceLoses(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…")
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Continuing…", nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
@@ -2427,7 +2482,7 @@ func TestSendChatMessage_BusyWhenQueued(t *testing.T) {
 
 	// A conversation that hasn't been dequeued yet must not let a second
 	// message create a duplicate conversation/sandbox for the same session.
-	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Are you there?")
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Are you there?", nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
@@ -2462,7 +2517,7 @@ func TestSendChatMessage_BusyWhenRunning(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Are you there?")
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Are you there?", nil)
 
 	assert.ErrorIs(t, err, agentdom.ErrConversationBusy)
 }
@@ -2488,7 +2543,7 @@ func TestSendChatMessage_WrongProject(t *testing.T) {
 	pluginRepo := &mockPluginRepo{}
 	svc := New(repo, projRepo, nil, pluginRepo)
 
-	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello")
+	_, err := svc.SendChatMessage(context.Background(), projectID, sessionID, memberID, "Hello", nil)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, agentdom.ErrChatSessionNotFound)

--- a/services/api/internal/service/automation/automation_service.go
+++ b/services/api/internal/service/automation/automation_service.go
@@ -77,9 +77,10 @@ func (s *Service) publish(ctx context.Context, topic string, payload map[string]
 
 // --- Automation lifecycle ------------------------------------------------------
 
-// ListAutomations returns a project's automations, optionally filtered by status.
-func (s *Service) ListAutomations(ctx context.Context, projectID uuid.UUID, status *automationdom.Status) ([]*automationdom.Automation, error) {
-	return s.repo.ListAutomations(ctx, projectID, status)
+// ListAutomations returns a project's automations, optionally filtered by
+// status and/or a case-insensitive name search.
+func (s *Service) ListAutomations(ctx context.Context, projectID uuid.UUID, status *automationdom.Status, search *string, cursor *string, limit *int) ([]*automationdom.Automation, bool, error) {
+	return s.repo.ListAutomations(ctx, projectID, status, search, cursor, limit)
 }
 
 // GetAutomation returns one automation together with its full node/edge graph.
@@ -487,7 +488,7 @@ func (s *Service) ListRunSteps(ctx context.Context, projectID, automationID, run
 // configs in projectID, for the read-only, auto-generated dependency view.
 func (s *Service) DependencyMap(ctx context.Context, projectID uuid.UUID) ([]automationdom.DependencyMapEntry, error) {
 	active := automationdom.StatusActive
-	automations, err := s.repo.ListAutomations(ctx, projectID, &active)
+	automations, _, err := s.repo.ListAutomations(ctx, projectID, &active, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/services/api/internal/service/automation/cached_repository.go
+++ b/services/api/internal/service/automation/cached_repository.go
@@ -168,8 +168,8 @@ func (c *CachedRepository) FindAutomationByID(ctx context.Context, id uuid.UUID)
 }
 
 // ListAutomations delegates to the underlying repository.
-func (c *CachedRepository) ListAutomations(ctx context.Context, projectID uuid.UUID, status *automationdom.Status) ([]*automationdom.Automation, error) {
-	return c.repo.ListAutomations(ctx, projectID, status)
+func (c *CachedRepository) ListAutomations(ctx context.Context, projectID uuid.UUID, status *automationdom.Status, search *string, cursor *string, limit *int) ([]*automationdom.Automation, bool, error) {
+	return c.repo.ListAutomations(ctx, projectID, status, search, cursor, limit)
 }
 
 // UpdateAutomation delegates to the underlying repository.

--- a/services/api/internal/service/doc/document_service.go
+++ b/services/api/internal/service/doc/document_service.go
@@ -124,8 +124,8 @@ func (s *Service) DeleteFolder(ctx context.Context, id uuid.UUID, projectID uuid
 // --- Document Service -------------------------------------------------------
 
 // ListDocuments returns non-deleted documents for a project.
-func (s *Service) ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID) ([]*docdom.Document, error) {
-	return s.repo.ListDocuments(ctx, projectID, folderID)
+func (s *Service) ListDocuments(ctx context.Context, projectID uuid.UUID, folderID *uuid.UUID, search *string, cursor *string, limit *int) ([]*docdom.Document, bool, error) {
+	return s.repo.ListDocuments(ctx, projectID, folderID, search, cursor, limit)
 }
 
 // GetDocument returns a single document.

--- a/services/api/internal/service/doc/document_service_test.go
+++ b/services/api/internal/service/doc/document_service_test.go
@@ -5,6 +5,8 @@ package docsvc_test
 import (
 	"context"
 	"encoding/json"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -90,7 +92,7 @@ func (r *fakeDocRepo) DeleteFolder(_ context.Context, id uuid.UUID) error {
 
 // -- DocumentRepository --
 
-func (r *fakeDocRepo) ListDocuments(_ context.Context, projectID uuid.UUID, folderID *uuid.UUID) ([]*docdom.Document, error) {
+func (r *fakeDocRepo) ListDocuments(_ context.Context, projectID uuid.UUID, folderID *uuid.UUID, search *string, cursor *string, limit *int) ([]*docdom.Document, bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var out []*docdom.Document
@@ -103,10 +105,40 @@ func (r *fakeDocRepo) ListDocuments(_ context.Context, projectID uuid.UUID, fold
 				continue
 			}
 		}
+		if search != nil && *search != "" {
+			if !strings.Contains(strings.ToLower(d.Title), strings.ToLower(*search)) {
+				continue
+			}
+		}
 		cp := *d
 		out = append(out, &cp)
 	}
-	return out, nil
+	// Mirrors the real repository's pagination-mode ordering (title ASC, id
+	// ASC) — the map above has no inherent order, so this is required for
+	// the cursor test below to be meaningful, not just cosmetic.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Title != out[j].Title {
+			return out[i].Title < out[j].Title
+		}
+		return out[i].ID.String() < out[j].ID.String()
+	})
+	if limit == nil {
+		return out, false, nil
+	}
+	if cursor != nil {
+		if cur, ok := docdom.DecodeDocumentCursor(*cursor); ok {
+			i := 0
+			for i < len(out) && !(out[i].Title > cur.Title || (out[i].Title == cur.Title && out[i].ID.String() > cur.ID)) {
+				i++
+			}
+			out = out[i:]
+		}
+	}
+	hasMore := len(out) > *limit
+	if hasMore {
+		out = out[:*limit]
+	}
+	return out, hasMore, nil
 }
 
 func (r *fakeDocRepo) FindDocumentByID(_ context.Context, id uuid.UUID) (*docdom.Document, error) {
@@ -750,6 +782,88 @@ func TestDeleteDocument_NotFound(t *testing.T) {
 	err := svc.DeleteDocument(ctx, uuid.New())
 	if err != docdom.ErrDocNotFound {
 		t.Errorf("expected ErrDocNotFound, got %v", err)
+	}
+}
+
+func TestListDocuments_Search(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeDocRepo()
+	svc := docsvc.New(repo, nil)
+	projectID := uuid.New()
+	content := json.RawMessage(`{"type":"doc","content":[]}`)
+
+	if _, err := svc.CreateDocument(ctx, docdom.CreateDocumentInput{ProjectID: projectID, Title: "Onboarding Flow", Content: content}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := svc.CreateDocument(ctx, docdom.CreateDocumentInput{ProjectID: projectID, Title: "Architecture Overview", Content: content}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	search := "onboard"
+	docs, _, err := svc.ListDocuments(ctx, projectID, nil, &search, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 matching document, got %d", len(docs))
+	}
+	if docs[0].Title != "Onboarding Flow" {
+		t.Errorf("expected Title=Onboarding Flow, got %q", docs[0].Title)
+	}
+
+	all, _, err := svc.ListDocuments(ctx, projectID, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("expected 2 documents with no search filter, got %d", len(all))
+	}
+}
+
+func TestListDocuments_CursorPagination(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeDocRepo()
+	svc := docsvc.New(repo, nil)
+	projectID := uuid.New()
+	content := json.RawMessage(`{"type":"doc","content":[]}`)
+
+	titles := []string{"Alpha", "Bravo", "Charlie", "Delta", "Echo"}
+	for _, title := range titles {
+		if _, err := svc.CreateDocument(ctx, docdom.CreateDocumentInput{ProjectID: projectID, Title: title, Content: content}); err != nil {
+			t.Fatalf("unexpected error creating %q: %v", title, err)
+		}
+	}
+
+	pageSize := 2
+	var seen []string
+	var cursor *string
+	for {
+		page, hasMore, err := svc.ListDocuments(ctx, projectID, nil, nil, cursor, &pageSize)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page) > pageSize {
+			t.Fatalf("page returned %d documents, want at most %d", len(page), pageSize)
+		}
+		for _, d := range page {
+			seen = append(seen, d.Title)
+		}
+		if !hasMore {
+			break
+		}
+		s := docdom.EncodeDocumentCursor(page[len(page)-1])
+		cursor = &s
+	}
+
+	if len(seen) != len(titles) {
+		t.Fatalf("expected to page through all %d documents exactly once, got %d: %v", len(titles), len(seen), seen)
+	}
+	want := append([]string(nil), titles...)
+	sort.Strings(want)
+	for i, title := range want {
+		if seen[i] != title {
+			t.Errorf("page %d: expected %q, got %q (full sequence: %v)", i, title, seen[i], seen)
+		}
 	}
 }
 

--- a/services/api/internal/service/doc/document_service_test.go
+++ b/services/api/internal/service/doc/document_service_test.go
@@ -128,7 +128,7 @@ func (r *fakeDocRepo) ListDocuments(_ context.Context, projectID uuid.UUID, fold
 	if cursor != nil {
 		if cur, ok := docdom.DecodeDocumentCursor(*cursor); ok {
 			i := 0
-			for i < len(out) && !(out[i].Title > cur.Title || (out[i].Title == cur.Title && out[i].ID.String() > cur.ID)) {
+			for i < len(out) && (out[i].Title < cur.Title || (out[i].Title == cur.Title && out[i].ID.String() <= cur.ID)) {
 				i++
 			}
 			out = out[i:]

--- a/services/api/internal/transport/http/dto/agent_dto.go
+++ b/services/api/internal/transport/http/dto/agent_dto.go
@@ -465,6 +465,10 @@ type AgentConversationEventResponse struct {
 // SendMessageRequest is the body for POST /conversations/:id/messages.
 type SendMessageRequest struct {
 	Message string `json:"message" binding:"required"`
+	// ContextItems are Task/Doc/Conversation/Automation references the user
+	// attached to this message via the frontend composer's context-item
+	// picker — see agentdom.ContextItemRef.
+	ContextItems []agentdom.ContextItemRef `json:"context_items,omitempty"`
 }
 
 // ConversationFromEntity maps an AgentConversation entity to its DTO.
@@ -576,11 +580,19 @@ type StartChatSessionRequest struct {
 	Message       string     `json:"message" binding:"required"`
 	EnvironmentID *uuid.UUID `json:"environment_id"`
 	FolderID      *uuid.UUID `json:"folder_id"`
+	// ContextItems are Task/Doc/Conversation/Automation references the user
+	// attached to this message via the frontend composer's context-item
+	// picker — see agentdom.ContextItemRef.
+	ContextItems []agentdom.ContextItemRef `json:"context_items,omitempty"`
 }
 
 // SendChatMessageRequest is the body for POST /chat-sessions/:sessionId/messages.
 type SendChatMessageRequest struct {
 	Message string `json:"message" binding:"required"`
+	// ContextItems are Task/Doc/Conversation/Automation references the user
+	// attached to this message via the frontend composer's context-item
+	// picker — see agentdom.ContextItemRef.
+	ContextItems []agentdom.ContextItemRef `json:"context_items,omitempty"`
 }
 
 // ChatSessionFromEntity maps an AgentChatSession entity to its DTO.

--- a/services/api/internal/transport/http/handler/agent_handler.go
+++ b/services/api/internal/transport/http/handler/agent_handler.go
@@ -1263,7 +1263,7 @@ func (h *AgentHandler) StartChatSession(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	session, conv, err := h.svc.StartChatSession(r.Context(), projectID, agentID, memberID, req.Message, req.EnvironmentID, req.FolderID)
+	session, conv, err := h.svc.StartChatSession(r.Context(), projectID, agentID, memberID, req.Message, req.EnvironmentID, req.FolderID, req.ContextItems)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -1301,7 +1301,7 @@ func (h *AgentHandler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conv, err := h.svc.SendChatMessage(r.Context(), projectID, sessionID, memberID, req.Message)
+	conv, err := h.svc.SendChatMessage(r.Context(), projectID, sessionID, memberID, req.Message, req.ContextItems)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -1361,7 +1361,7 @@ func (h *AgentHandler) StartGlobalChatSession(w http.ResponseWriter, r *http.Req
 		presenter.Error(w, r, err)
 		return
 	}
-	session, conv, err := h.svc.StartGlobalChatSession(r.Context(), agentID, userID, req.Message)
+	session, conv, err := h.svc.StartGlobalChatSession(r.Context(), agentID, userID, req.Message, req.ContextItems)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -1393,7 +1393,7 @@ func (h *AgentHandler) SendGlobalChatMessage(w http.ResponseWriter, r *http.Requ
 		presenter.Error(w, r, err)
 		return
 	}
-	conv, err := h.svc.SendGlobalChatMessage(r.Context(), sessionID, userID, req.Message)
+	conv, err := h.svc.SendGlobalChatMessage(r.Context(), sessionID, userID, req.Message, req.ContextItems)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return

--- a/services/api/internal/transport/http/handler/agent_handler.go
+++ b/services/api/internal/transport/http/handler/agent_handler.go
@@ -1257,6 +1257,10 @@ func (h *AgentHandler) StartChatSession(w http.ResponseWriter, r *http.Request) 
 		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "message is required"))
 		return
 	}
+	if err := agentdom.ValidateContextItems(req.ContextItems); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
+		return
+	}
 	memberID, err := h.resolveMemberID(r, projectID)
 	if err != nil {
 		presenter.Error(w, r, err)
@@ -1293,6 +1297,10 @@ func (h *AgentHandler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Message == "" {
 		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "message is required"))
+		return
+	}
+	if err := agentdom.ValidateContextItems(req.ContextItems); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
 		return
 	}
 	memberID, err := h.resolveMemberID(r, projectID)
@@ -1356,6 +1364,10 @@ func (h *AgentHandler) StartGlobalChatSession(w http.ResponseWriter, r *http.Req
 		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "message is required"))
 		return
 	}
+	if err := agentdom.ValidateContextItems(req.ContextItems); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
+		return
+	}
 	userID, err := callerUserID(r)
 	if err != nil {
 		presenter.Error(w, r, err)
@@ -1386,6 +1398,10 @@ func (h *AgentHandler) SendGlobalChatMessage(w http.ResponseWriter, r *http.Requ
 	}
 	if req.Message == "" {
 		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "message is required"))
+		return
+	}
+	if err := agentdom.ValidateContextItems(req.ContextItems); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
 		return
 	}
 	userID, err := callerUserID(r)

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -33,6 +33,7 @@ type mockAgentSvc struct {
 	listConversations             func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
 	listConversationEvents        func(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error)
 	getConversation               func(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*agentdom.AgentConversation, error)
+	getConversationForAgent       func(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error)
 	listAgentActivities           func(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error)
 	getGlobalConversation         func(ctx context.Context, conversationID, actorUserID uuid.UUID) (*agentdom.AgentConversation, error)
 	listGlobalConversations       func(ctx context.Context, actorUserID uuid.UUID, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
@@ -125,6 +126,12 @@ func (m *mockAgentSvc) GetConversation(ctx context.Context, projectID, conversat
 	// gate passes by default; tests asserting rejection configure getConversation.
 	return &agentdom.AgentConversation{ID: conversationID, ProjectID: projectID}, nil
 }
+func (m *mockAgentSvc) GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+	if m.getConversationForAgent != nil {
+		return m.getConversationForAgent(ctx, conversationID, callerAgentID)
+	}
+	return &agentdom.AgentConversation{ID: conversationID, AgentID: callerAgentID}, nil
+}
 func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
 	if m.listConversationEvents != nil {
 		return m.listConversationEvents(ctx, conversationID, window)
@@ -134,19 +141,19 @@ func (m *mockAgentSvc) ListConversationEvents(ctx context.Context, conversationI
 func (m *mockAgentSvc) StopConversation(_ context.Context, _, _, _ uuid.UUID) error  { return nil }
 func (m *mockAgentSvc) PauseConversation(_ context.Context, _, _, _ uuid.UUID) error { return nil }
 func (m *mockAgentSvc) Heartbeat(_ context.Context, _, _, _ uuid.UUID) error         { return nil }
-func (m *mockAgentSvc) SendConversationMessage(_ context.Context, _, _ uuid.UUID, _ string, _ uuid.UUID) error {
+func (m *mockAgentSvc) SendConversationMessage(_ context.Context, _, _ uuid.UUID, _ string, _ uuid.UUID, _ []agentdom.ContextItemRef) error {
 	return nil
 }
 func (m *mockAgentSvc) ListChatSessions(_ context.Context, _, _, _ uuid.UUID) ([]*agentdom.AgentChatSession, error) {
 	return nil, nil
 }
-func (m *mockAgentSvc) StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string, _, _ *uuid.UUID) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
+func (m *mockAgentSvc) StartChatSession(ctx context.Context, projectID, agentID, memberID uuid.UUID, message string, _, _ *uuid.UUID, _ []agentdom.ContextItemRef) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
 	if m.startChatSession != nil {
 		return m.startChatSession(ctx, projectID, agentID, memberID, message)
 	}
 	return &agentdom.AgentChatSession{ID: uuid.New()}, &agentdom.AgentConversation{ID: uuid.New()}, nil
 }
-func (m *mockAgentSvc) SendChatMessage(_ context.Context, _, _, _ uuid.UUID, _ string) (*agentdom.AgentConversation, error) {
+func (m *mockAgentSvc) SendChatMessage(_ context.Context, _, _, _ uuid.UUID, _ string, _ []agentdom.ContextItemRef) (*agentdom.AgentConversation, error) {
 	return &agentdom.AgentConversation{ID: uuid.New()}, nil
 }
 func (m *mockAgentSvc) ListChatMessages(_ context.Context, _, _ uuid.UUID, _, _ int) ([]*agentdom.AgentConversationEvent, int64, error) {
@@ -216,7 +223,7 @@ func (m *mockAgentSvc) GlobalHeartbeat(ctx context.Context, conversationID, acto
 	}
 	return nil
 }
-func (m *mockAgentSvc) SendGlobalConversationMessage(ctx context.Context, conversationID uuid.UUID, message string, actorUserID uuid.UUID) error {
+func (m *mockAgentSvc) SendGlobalConversationMessage(ctx context.Context, conversationID uuid.UUID, message string, actorUserID uuid.UUID, _ []agentdom.ContextItemRef) error {
 	if m.sendGlobalConversationMessage != nil {
 		return m.sendGlobalConversationMessage(ctx, conversationID, message, actorUserID)
 	}
@@ -225,10 +232,10 @@ func (m *mockAgentSvc) SendGlobalConversationMessage(ctx context.Context, conver
 func (m *mockAgentSvc) ListGlobalChatSessions(_ context.Context, _, _ uuid.UUID) ([]*agentdom.AgentChatSession, error) {
 	return nil, nil
 }
-func (m *mockAgentSvc) StartGlobalChatSession(_ context.Context, _, _ uuid.UUID, _ string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
+func (m *mockAgentSvc) StartGlobalChatSession(_ context.Context, _, _ uuid.UUID, _ string, _ []agentdom.ContextItemRef) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
 	return &agentdom.AgentChatSession{ID: uuid.New()}, &agentdom.AgentConversation{ID: uuid.New()}, nil
 }
-func (m *mockAgentSvc) SendGlobalChatMessage(_ context.Context, _, _ uuid.UUID, _ string) (*agentdom.AgentConversation, error) {
+func (m *mockAgentSvc) SendGlobalChatMessage(_ context.Context, _, _ uuid.UUID, _ string, _ []agentdom.ContextItemRef) (*agentdom.AgentConversation, error) {
 	return &agentdom.AgentConversation{ID: uuid.New()}, nil
 }
 func (m *mockAgentSvc) InitiateAvatarUpload(_ context.Context, _, _ uuid.UUID, _, _ string, _ int64, _ uuid.UUID) (*attachmentdom.UploadSession, error) {

--- a/services/api/internal/transport/http/handler/agent_handler_test.go
+++ b/services/api/internal/transport/http/handler/agent_handler_test.go
@@ -33,7 +33,7 @@ type mockAgentSvc struct {
 	listConversations             func(ctx context.Context, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
 	listConversationEvents        func(ctx context.Context, conversationID uuid.UUID, window agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error)
 	getConversation               func(ctx context.Context, projectID, conversationID, memberID uuid.UUID) (*agentdom.AgentConversation, error)
-	getConversationForAgent       func(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error)
+	getConversationForAgent       func(ctx context.Context, conversationID, callerAgentID, currentConversationID uuid.UUID) (*agentdom.AgentConversation, error)
 	listAgentActivities           func(ctx context.Context, filter agentdom.ListAgentActivitiesFilter, limit int) ([]*agentdom.ActivityFeedItem, bool, error)
 	getGlobalConversation         func(ctx context.Context, conversationID, actorUserID uuid.UUID) (*agentdom.AgentConversation, error)
 	listGlobalConversations       func(ctx context.Context, actorUserID uuid.UUID, filter agentdom.ListConversationsFilter, limit int) ([]*agentdom.AgentConversation, bool, error)
@@ -126,9 +126,9 @@ func (m *mockAgentSvc) GetConversation(ctx context.Context, projectID, conversat
 	// gate passes by default; tests asserting rejection configure getConversation.
 	return &agentdom.AgentConversation{ID: conversationID, ProjectID: projectID}, nil
 }
-func (m *mockAgentSvc) GetConversationForAgent(ctx context.Context, conversationID, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+func (m *mockAgentSvc) GetConversationForAgent(ctx context.Context, conversationID, callerAgentID, currentConversationID uuid.UUID) (*agentdom.AgentConversation, error) {
 	if m.getConversationForAgent != nil {
-		return m.getConversationForAgent(ctx, conversationID, callerAgentID)
+		return m.getConversationForAgent(ctx, conversationID, callerAgentID, currentConversationID)
 	}
 	return &agentdom.AgentConversation{ID: conversationID, AgentID: callerAgentID}, nil
 }
@@ -646,6 +646,36 @@ func TestSendChatMessage_EmptyMessage_Returns400(t *testing.T) {
 		map[string]any{"message": ""})
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for empty message, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestStartChatSession_TooManyContextItems_Returns400 pins that
+// context_items is validated (see agentdom.ValidateContextItems) before
+// StartChatSession is ever called — a malformed/abusive payload never
+// reaches the service, let alone gets persisted or forwarded into a prompt.
+func TestStartChatSession_TooManyContextItems_Returns400(t *testing.T) {
+	svcCalled := false
+	r := newAgentRouter(&mockAgentSvc{
+		startChatSession: func(_ context.Context, _, _, _ uuid.UUID, _ string) (*agentdom.AgentChatSession, *agentdom.AgentConversation, error) {
+			svcCalled = true
+			return &agentdom.AgentChatSession{}, &agentdom.AgentConversation{}, nil
+		},
+	})
+	projectID := uuid.New()
+	agentID := uuid.New()
+
+	items := make([]map[string]any, agentdom.MaxContextItems+1)
+	for i := range items {
+		items[i] = map[string]any{"type": "task", "id": "t", "title": "x"}
+	}
+	w := doAgentRequest(t, r, http.MethodPost,
+		"/projects/"+projectID.String()+"/agents/"+agentID.String()+"/chat-sessions",
+		map[string]any{"message": "hi", "context_items": items})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for too many context_items, got %d: %s", w.Code, w.Body.String())
+	}
+	if svcCalled {
+		t.Error("the service must not be called when context_items fails validation")
 	}
 }
 

--- a/services/api/internal/transport/http/handler/automation_handler.go
+++ b/services/api/internal/transport/http/handler/automation_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -56,6 +57,11 @@ func (h *AutomationHandler) ListPluginNodeTypes(w http.ResponseWriter, r *http.R
 // --- Automations ----------------------------------------------------------
 
 // ListAutomations handles GET /projects/:projectId/automations.
+// Optional query params: status — filter by lifecycle status; search — case-
+// insensitive name match; page_size (1-200), cursor — opt into keyset
+// pagination (see automationdom.Repository.ListAutomations's doc comment).
+// Omitting page_size returns every matching automation in one response, as
+// before.
 func (h *AutomationHandler) ListAutomations(w http.ResponseWriter, r *http.Request) {
 	projectID, err := parseProjectID(r)
 	if err != nil {
@@ -73,7 +79,26 @@ func (h *AutomationHandler) ListAutomations(w http.ResponseWriter, r *http.Reque
 		status = &s
 	}
 
-	automations, err := h.svc.ListAutomations(r.Context(), projectID, status)
+	var search *string
+	if raw := strings.TrimSpace(r.URL.Query().Get("search")); raw != "" {
+		search = &raw
+	}
+
+	var limit *int
+	if raw := r.URL.Query().Get("page_size"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "page_size must be an integer between 1 and 200"))
+			return
+		}
+		limit = &n
+	}
+	var cursor *string
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor = &raw
+	}
+
+	automations, hasMore, err := h.svc.ListAutomations(r.Context(), projectID, status, search, cursor, limit)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -82,7 +107,12 @@ func (h *AutomationHandler) ListAutomations(w http.ResponseWriter, r *http.Reque
 	for _, a := range automations {
 		resp = append(resp, dto.NewAutomationResponse(a))
 	}
-	presenter.OK(w, r, map[string]any{"items": resp})
+	var nextCursor *string
+	if hasMore && len(automations) > 0 {
+		s := automationdom.EncodeAutomationCursor(automations[len(automations)-1])
+		nextCursor = &s
+	}
+	presenter.OK(w, r, map[string]any{"items": resp, "next_cursor": nextCursor})
 }
 
 // CreateAutomation handles POST /projects/:projectId/automations.

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -271,6 +271,65 @@ func (h *ConversationHandler) GetConversation(w http.ResponseWriter, r *http.Req
 	presenter.OK(w, r, dto.ConversationFromEntity(conv))
 }
 
+// GetConversationForAgent handles GET /agents/me/conversations/:conversationId
+// — an agent (X-Agent-ID authenticated, no human member/actor identity)
+// reading a conversation by ID, e.g. the read_conversation MCP tool. See
+// agentdom.Service.GetConversationForAgent's doc comment for the
+// authorization rule; it's deliberately not projectId-scoped in the URL
+// (unlike GetConversation) since the calling agent doesn't need to already
+// know which project a referenced conversation lives in.
+func (h *ConversationHandler) GetConversationForAgent(w http.ResponseWriter, r *http.Request) {
+	agentID, ok := middleware.AgentIDFromRequest(r)
+	if !ok {
+		presenter.Error(w, r, apierr.New(apierr.CodeUnauthenticated, "agent identity required"))
+		return
+	}
+	convID, err := parseParamUUID(r, "conversationId")
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	conv, err := h.svc.GetConversationForAgent(r.Context(), convID, agentID)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	presenter.OK(w, r, dto.ConversationFromEntity(conv))
+}
+
+// GetConversationEventsForAgent handles GET
+// /agents/me/conversations/:conversationId/events — the agent-authenticated
+// sibling of ListConversationEvents/GetGlobalConversationEvents. See
+// GetConversationForAgent's doc comment for why this needs its own path.
+func (h *ConversationHandler) GetConversationEventsForAgent(w http.ResponseWriter, r *http.Request) {
+	agentID, ok := middleware.AgentIDFromRequest(r)
+	if !ok {
+		presenter.Error(w, r, apierr.New(apierr.CodeUnauthenticated, "agent identity required"))
+		return
+	}
+	convID, err := parseParamUUID(r, "conversationId")
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	if _, err := h.svc.GetConversationForAgent(r.Context(), convID, agentID); err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	window, err := parseConversationEventWindowQuery(r)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	events, total, err := h.svc.ListConversationEvents(r.Context(), convID, window)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+	writeConversationEventWindowResponse(w, r, events, total)
+}
+
 // parseConversationEventWindowQuery parses the query params shared by
 // ListConversationEvents and GetGlobalConversationEvents:
 //   - after=<opaque cursor>   events after this point, ascending — pages
@@ -479,7 +538,7 @@ func (h *ConversationHandler) SendConversationMessage(w http.ResponseWriter, r *
 		return
 	}
 
-	if err := h.svc.SendConversationMessage(r.Context(), projectID, convID, req.Message, memberID); err != nil {
+	if err := h.svc.SendConversationMessage(r.Context(), projectID, convID, req.Message, memberID, req.ContextItems); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
@@ -622,7 +681,7 @@ func (h *ConversationHandler) SendGlobalConversationMessage(w http.ResponseWrite
 		return
 	}
 
-	if err := h.svc.SendGlobalConversationMessage(r.Context(), convID, req.Message, userID); err != nil {
+	if err := h.svc.SendGlobalConversationMessage(r.Context(), convID, req.Message, userID, req.ContextItems); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}

--- a/services/api/internal/transport/http/handler/conversation_handler.go
+++ b/services/api/internal/transport/http/handler/conversation_handler.go
@@ -271,13 +271,24 @@ func (h *ConversationHandler) GetConversation(w http.ResponseWriter, r *http.Req
 	presenter.OK(w, r, dto.ConversationFromEntity(conv))
 }
 
+// currentConversationIDFromHeader parses X-Conversation-ID — set by
+// agent-runner's MCP server (see executor.go's buildMCPServers and
+// apps/mcp's conversation-client.ts) to the conversation the calling agent
+// process is actually running as part of right now. Missing or malformed
+// yields uuid.Nil, which GetConversationForAgent treats as "no trusted
+// current context to check against" and fails closed, not as a wildcard.
+func currentConversationIDFromHeader(r *http.Request) uuid.UUID {
+	id, _ := uuid.Parse(r.Header.Get("X-Conversation-ID"))
+	return id
+}
+
 // GetConversationForAgent handles GET /agents/me/conversations/:conversationId
-// — an agent (X-Agent-ID authenticated, no human member/actor identity)
-// reading a conversation by ID, e.g. the read_conversation MCP tool. See
-// agentdom.Service.GetConversationForAgent's doc comment for the
-// authorization rule; it's deliberately not projectId-scoped in the URL
-// (unlike GetConversation) since the calling agent doesn't need to already
-// know which project a referenced conversation lives in.
+// — an agent (X-Agent-ID authenticated, no human member/actor identity of
+// its own) reading a conversation by ID, e.g. the read_conversation MCP
+// tool. See agentdom.Service.GetConversationForAgent's doc comment for the
+// full authorization rule; it's deliberately not projectId-scoped in the
+// URL (unlike GetConversation) since the calling agent doesn't need to
+// already know which project a referenced conversation lives in.
 func (h *ConversationHandler) GetConversationForAgent(w http.ResponseWriter, r *http.Request) {
 	agentID, ok := middleware.AgentIDFromRequest(r)
 	if !ok {
@@ -289,7 +300,7 @@ func (h *ConversationHandler) GetConversationForAgent(w http.ResponseWriter, r *
 		presenter.Error(w, r, err)
 		return
 	}
-	conv, err := h.svc.GetConversationForAgent(r.Context(), convID, agentID)
+	conv, err := h.svc.GetConversationForAgent(r.Context(), convID, agentID, currentConversationIDFromHeader(r))
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -312,7 +323,7 @@ func (h *ConversationHandler) GetConversationEventsForAgent(w http.ResponseWrite
 		presenter.Error(w, r, err)
 		return
 	}
-	if _, err := h.svc.GetConversationForAgent(r.Context(), convID, agentID); err != nil {
+	if _, err := h.svc.GetConversationForAgent(r.Context(), convID, agentID, currentConversationIDFromHeader(r)); err != nil {
 		presenter.Error(w, r, err)
 		return
 	}
@@ -529,6 +540,10 @@ func (h *ConversationHandler) SendConversationMessage(w http.ResponseWriter, r *
 		presenter.Error(w, r, err)
 		return
 	}
+	if err := agentdom.ValidateContextItems(req.ContextItems); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
+		return
+	}
 	// Resolve the caller to a project_members.id — agent_conversations store a
 	// member id, not the raw user id (see resolveMemberID). Using claims.Subject
 	// here directly would compare/send the wrong identity on every owner check.
@@ -673,6 +688,10 @@ func (h *ConversationHandler) SendGlobalConversationMessage(w http.ResponseWrite
 	var req dto.SendMessageRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		presenter.Error(w, r, err)
+		return
+	}
+	if err := agentdom.ValidateContextItems(req.ContextItems); err != nil {
+		presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, err.Error()))
 		return
 	}
 	userID, err := callerUserID(r)

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -17,6 +17,7 @@ import (
 	agentdom "github.com/Paca-AI/api/internal/domain/agent"
 	projectdom "github.com/Paca-AI/api/internal/domain/project"
 	"github.com/Paca-AI/api/internal/transport/http/handler"
+	httpmw "github.com/Paca-AI/api/internal/transport/http/middleware"
 )
 
 // fixedTime returns a stable timestamp for building test conversations —
@@ -963,5 +964,177 @@ func TestSendGlobalConversationMessage_ForwardsCallerIDNotBodySuppliedActor(t *t
 	}
 	if gotActorUserID != callerID {
 		t.Fatalf("actorUserID must always be the authenticated caller (%s), never a client-suppliable body field (%s)", callerID, gotActorUserID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Agent self-service conversation reads — GET /agents/me/conversations/:id
+// (and its /events sibling). Distinct from both GetConversation (human
+// member identity, project-scoped) and GetGlobalConversation (human actor
+// identity, global-chat-only): these two authorize purely on the caller's
+// verified X-Agent-ID matching the conversation's own agent_id — see
+// agentdom.Service.GetConversationForAgent's doc comment — with no project
+// or actor concept involved at all.
+// ---------------------------------------------------------------------------
+
+// newAgentSelfServiceConversationRouter wires GetConversationForAgent/
+// GetConversationEventsForAgent behind a middleware that injects agentID
+// via httpmw.WithAgentID — mirroring how the real Authn middleware attaches
+// a verified X-Agent-ID to the request context (see setAPIKeyAuthContext) —
+// or injects no agent identity at all when agentID is nil, to exercise the
+// "agent identity required" 401 path a request with no X-Agent-ID takes.
+func newAgentSelfServiceConversationRouter(svc agentdom.Service, agentID *uuid.UUID) chi.Router {
+	h := handler.NewConversationHandler(svc)
+	r := chi.NewRouter()
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if agentID != nil {
+				r = r.WithContext(httpmw.WithAgentID(r.Context(), *agentID))
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
+	r.Route("/agents/me/conversations/{conversationId}", func(r chi.Router) {
+		r.Get("/", h.GetConversationForAgent)
+		r.Get("/events", h.GetConversationEventsForAgent)
+	})
+	return r
+}
+
+func TestGetConversationForAgent_NoAgentIdentity401s(t *testing.T) {
+	svc := &mockAgentSvc{}
+	r := newAgentSelfServiceConversationRouter(svc, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with no agent identity, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetConversationForAgent_ReturnsOwnConversation(t *testing.T) {
+	agentID := uuid.New()
+	convID := uuid.New()
+	var gotAgentID uuid.UUID
+	svc := &mockAgentSvc{
+		getConversationForAgent: func(_ context.Context, id, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+			gotAgentID = callerAgentID
+			if id != convID {
+				t.Fatalf("unexpected conversation id %s", id)
+			}
+			return &agentdom.AgentConversation{ID: convID, AgentID: callerAgentID}, nil
+		},
+	}
+	r := newAgentSelfServiceConversationRouter(svc, &agentID)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+convID.String(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if gotAgentID != agentID {
+		t.Fatalf("handler must forward the authenticated agent's own id, got %s want %s", gotAgentID, agentID)
+	}
+	var resp struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Data.ID != convID.String() {
+		t.Errorf("expected conversation id %s in response, got %s", convID, resp.Data.ID)
+	}
+}
+
+func TestGetConversationForAgent_DifferentAgentNotFound(t *testing.T) {
+	agentID := uuid.New()
+	svc := &mockAgentSvc{
+		getConversationForAgent: func(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return nil, agentdom.ErrConversationNotFound
+		},
+	}
+	r := newAgentSelfServiceConversationRouter(svc, &agentID)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+uuid.New().String(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for a conversation the agent doesn't own, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetConversationEventsForAgent_NoAgentIdentity401s(t *testing.T) {
+	svc := &mockAgentSvc{}
+	r := newAgentSelfServiceConversationRouter(svc, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+uuid.New().String()+"/events", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with no agent identity, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetConversationEventsForAgent_ReturnsEvents(t *testing.T) {
+	agentID := uuid.New()
+	convID := uuid.New()
+	svc := &mockAgentSvc{
+		getConversationForAgent: func(_ context.Context, id, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+			return &agentdom.AgentConversation{ID: id, AgentID: callerAgentID}, nil
+		},
+		listConversationEvents: func(_ context.Context, id uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			if id != convID {
+				t.Fatalf("unexpected conversation id %s", id)
+			}
+			return []*agentdom.AgentConversationEvent{{ID: uuid.New(), ConversationID: convID}}, 1, nil
+		},
+	}
+	r := newAgentSelfServiceConversationRouter(svc, &agentID)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+convID.String()+"/events", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data.Items) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(resp.Data.Items))
+	}
+}
+
+func TestGetConversationEventsForAgent_UnknownConversationNotFound(t *testing.T) {
+	agentID := uuid.New()
+	eventsCalled := false
+	svc := &mockAgentSvc{
+		getConversationForAgent: func(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+			return nil, agentdom.ErrConversationNotFound
+		},
+		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
+			eventsCalled = true
+			return nil, 0, nil
+		},
+	}
+	r := newAgentSelfServiceConversationRouter(svc, &agentID)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+uuid.New().String()+"/events", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if eventsCalled {
+		t.Error("ListConversationEvents must not be called when the agent doesn't own the conversation")
 	}
 }

--- a/services/api/internal/transport/http/handler/conversation_handler_test.go
+++ b/services/api/internal/transport/http/handler/conversation_handler_test.go
@@ -967,14 +967,45 @@ func TestSendGlobalConversationMessage_ForwardsCallerIDNotBodySuppliedActor(t *t
 	}
 }
 
+// TestSendGlobalConversationMessage_RejectsInvalidContextItems pins that a
+// malformed context_items payload (here: an unrecognized type) is rejected
+// with 400 before the service is ever called — see
+// agentdom.ValidateContextItems.
+func TestSendGlobalConversationMessage_RejectsInvalidContextItems(t *testing.T) {
+	convID := uuid.New()
+	callerID := uuid.New()
+	svcCalled := false
+	svc := &mockAgentSvc{
+		sendGlobalConversationMessage: func(_ context.Context, _ uuid.UUID, _ string, _ uuid.UUID) error {
+			svcCalled = true
+			return nil
+		},
+	}
+	r := newGlobalConversationRouter(svc, callerID.String())
+	body := `{"message":"hi","context_items":[{"type":"not-a-real-type","id":"x1","title":"x"}]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/agents/conversations/"+convID.String()+"/messages", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an invalid context_items type, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if svcCalled {
+		t.Error("the service must not be called when context_items fails validation")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Agent self-service conversation reads — GET /agents/me/conversations/:id
 // (and its /events sibling). Distinct from both GetConversation (human
 // member identity, project-scoped) and GetGlobalConversation (human actor
-// identity, global-chat-only): these two authorize purely on the caller's
-// verified X-Agent-ID matching the conversation's own agent_id — see
-// agentdom.Service.GetConversationForAgent's doc comment — with no project
-// or actor concept involved at all.
+// identity, global-chat-only): these two authorize on the caller's verified
+// X-Agent-ID plus the X-Conversation-ID header naming the conversation
+// currently driving the call — see agentdom.Service.GetConversationForAgent's
+// doc comment for the full rule. These handler-level tests only pin the
+// plumbing (header parsing, 401/404 mapping); the rule itself is covered by
+// agent_service_test.go's TestGetConversationForAgent_* cases.
 // ---------------------------------------------------------------------------
 
 // newAgentSelfServiceConversationRouter wires GetConversationForAgent/
@@ -1016,10 +1047,12 @@ func TestGetConversationForAgent_NoAgentIdentity401s(t *testing.T) {
 func TestGetConversationForAgent_ReturnsOwnConversation(t *testing.T) {
 	agentID := uuid.New()
 	convID := uuid.New()
-	var gotAgentID uuid.UUID
+	currentConvID := uuid.New()
+	var gotAgentID, gotCurrentConvID uuid.UUID
 	svc := &mockAgentSvc{
-		getConversationForAgent: func(_ context.Context, id, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+		getConversationForAgent: func(_ context.Context, id, callerAgentID, currentConversationID uuid.UUID) (*agentdom.AgentConversation, error) {
 			gotAgentID = callerAgentID
+			gotCurrentConvID = currentConversationID
 			if id != convID {
 				t.Fatalf("unexpected conversation id %s", id)
 			}
@@ -1028,6 +1061,7 @@ func TestGetConversationForAgent_ReturnsOwnConversation(t *testing.T) {
 	}
 	r := newAgentSelfServiceConversationRouter(svc, &agentID)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+convID.String(), nil)
+	req.Header.Set("X-Conversation-ID", currentConvID.String())
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
@@ -1036,6 +1070,9 @@ func TestGetConversationForAgent_ReturnsOwnConversation(t *testing.T) {
 	}
 	if gotAgentID != agentID {
 		t.Fatalf("handler must forward the authenticated agent's own id, got %s want %s", gotAgentID, agentID)
+	}
+	if gotCurrentConvID != currentConvID {
+		t.Fatalf("handler must forward X-Conversation-ID, got %s want %s", gotCurrentConvID, currentConvID)
 	}
 	var resp struct {
 		Data struct {
@@ -1050,10 +1087,44 @@ func TestGetConversationForAgent_ReturnsOwnConversation(t *testing.T) {
 	}
 }
 
+// TestGetConversationForAgent_MissingConversationIDHeaderStillForwards
+// pins that an absent X-Conversation-ID (e.g. an older agent-runner build)
+// is forwarded to the service as uuid.Nil rather than dropped/omitted —
+// GetConversationForAgent's own fail-closed handling of uuid.Nil is what
+// actually denies cross-conversation reads in that case; see
+// agent_service_test.go.
+func TestGetConversationForAgent_MissingConversationIDHeaderStillForwards(t *testing.T) {
+	agentID := uuid.New()
+	convID := uuid.New()
+	var gotCurrentConvIDSet bool
+	var gotCurrentConvID uuid.UUID
+	svc := &mockAgentSvc{
+		getConversationForAgent: func(_ context.Context, _, _, currentConversationID uuid.UUID) (*agentdom.AgentConversation, error) {
+			gotCurrentConvIDSet = true
+			gotCurrentConvID = currentConversationID
+			return &agentdom.AgentConversation{ID: convID, AgentID: agentID}, nil
+		},
+	}
+	r := newAgentSelfServiceConversationRouter(svc, &agentID)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/agents/me/conversations/"+convID.String(), nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !gotCurrentConvIDSet {
+		t.Fatal("expected getConversationForAgent to be called")
+	}
+	if gotCurrentConvID != uuid.Nil {
+		t.Errorf("expected uuid.Nil for a missing X-Conversation-ID header, got %s", gotCurrentConvID)
+	}
+}
+
 func TestGetConversationForAgent_DifferentAgentNotFound(t *testing.T) {
 	agentID := uuid.New()
 	svc := &mockAgentSvc{
-		getConversationForAgent: func(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+		getConversationForAgent: func(_ context.Context, _, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return nil, agentdom.ErrConversationNotFound
 		},
 	}
@@ -1083,7 +1154,7 @@ func TestGetConversationEventsForAgent_ReturnsEvents(t *testing.T) {
 	agentID := uuid.New()
 	convID := uuid.New()
 	svc := &mockAgentSvc{
-		getConversationForAgent: func(_ context.Context, id, callerAgentID uuid.UUID) (*agentdom.AgentConversation, error) {
+		getConversationForAgent: func(_ context.Context, id, callerAgentID, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return &agentdom.AgentConversation{ID: id, AgentID: callerAgentID}, nil
 		},
 		listConversationEvents: func(_ context.Context, id uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {
@@ -1118,7 +1189,7 @@ func TestGetConversationEventsForAgent_UnknownConversationNotFound(t *testing.T)
 	agentID := uuid.New()
 	eventsCalled := false
 	svc := &mockAgentSvc{
-		getConversationForAgent: func(_ context.Context, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
+		getConversationForAgent: func(_ context.Context, _, _, _ uuid.UUID) (*agentdom.AgentConversation, error) {
 			return nil, agentdom.ErrConversationNotFound
 		},
 		listConversationEvents: func(_ context.Context, _ uuid.UUID, _ agentdom.ConversationEventWindow) ([]*agentdom.AgentConversationEvent, int64, error) {

--- a/services/api/internal/transport/http/handler/document_handler.go
+++ b/services/api/internal/transport/http/handler/document_handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -172,7 +174,10 @@ func (h *DocumentHandler) DeleteFolder(w http.ResponseWriter, r *http.Request) {
 // =============================================================================
 
 // ListDocuments handles GET /projects/:projectId/docs.
-// Optional query param: folder_id — filter by folder.
+// Optional query params: folder_id — filter by folder; search — case-
+// insensitive title match; page_size (1-200), cursor — opt into keyset
+// pagination (see docdom.Repository.ListDocuments's doc comment). Omitting
+// page_size returns every matching document in one response, as before.
 func (h *DocumentHandler) ListDocuments(w http.ResponseWriter, r *http.Request) {
 	projectID, err := parseProjectID(r)
 	if err != nil {
@@ -190,7 +195,26 @@ func (h *DocumentHandler) ListDocuments(w http.ResponseWriter, r *http.Request) 
 		folderID = &id
 	}
 
-	docs, err := h.svc.ListDocuments(r.Context(), projectID, folderID)
+	var search *string
+	if raw := strings.TrimSpace(r.URL.Query().Get("search")); raw != "" {
+		search = &raw
+	}
+
+	var limit *int
+	if raw := r.URL.Query().Get("page_size"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "page_size must be an integer between 1 and 200"))
+			return
+		}
+		limit = &n
+	}
+	var cursor *string
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor = &raw
+	}
+
+	docs, hasMore, err := h.svc.ListDocuments(r.Context(), projectID, folderID, search, cursor, limit)
 	if err != nil {
 		presenter.Error(w, r, err)
 		return
@@ -199,7 +223,12 @@ func (h *DocumentHandler) ListDocuments(w http.ResponseWriter, r *http.Request) 
 	for _, d := range docs {
 		resp = append(resp, dto.DocumentListItemFromEntity(d))
 	}
-	presenter.OK(w, r, map[string]any{"items": resp})
+	var nextCursor *string
+	if hasMore && len(docs) > 0 {
+		s := docdom.EncodeDocumentCursor(docs[len(docs)-1])
+		nextCursor = &s
+	}
+	presenter.OK(w, r, map[string]any{"items": resp, "next_cursor": nextCursor})
 }
 
 // GetDocument handles GET /projects/:projectId/docs/:docId.

--- a/services/api/internal/transport/http/handler/document_handler_test.go
+++ b/services/api/internal/transport/http/handler/document_handler_test.go
@@ -33,8 +33,8 @@ func (f *fakeDocSvc) UpdateFolder(_ context.Context, _ uuid.UUID, _ docdom.Updat
 }
 func (f *fakeDocSvc) DeleteFolder(_ context.Context, _ uuid.UUID, _ uuid.UUID) error { return nil }
 
-func (f *fakeDocSvc) ListDocuments(_ context.Context, _ uuid.UUID, _ *uuid.UUID) ([]*docdom.Document, error) {
-	return nil, nil
+func (f *fakeDocSvc) ListDocuments(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ *string, _ *string, _ *int) ([]*docdom.Document, bool, error) {
+	return nil, false, nil
 }
 func (f *fakeDocSvc) GetDocument(_ context.Context, _ uuid.UUID) (*docdom.Document, error) {
 	return nil, docdom.ErrDocNotFound

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -299,6 +299,20 @@ func New(deps Deps) http.Handler {
 					r.Get("/me/global-permissions", deps.Agent.GetMyGlobalPermissions)
 					r.Get("/me/projects", deps.Agent.GetMyInvitedProjects)
 
+					// Agent self-service reads of a conversation by ID (any
+					// project, or global) — the read_conversation MCP tool's
+					// path when a user attaches a Conversation as chat context.
+					// Deliberately separate from the human-facing
+					// /projects/{projectId}/conversations and
+					// /agents/conversations routes below: both of those
+					// authorize against a human member/actor identity a bare
+					// agent doesn't have (see
+					// agentdom.Service.GetConversationForAgent's doc comment).
+					if deps.Conversation != nil {
+						r.Get("/me/conversations/{conversationId}", deps.Conversation.GetConversationForAgent)
+						r.Get("/me/conversations/{conversationId}/events", deps.Conversation.GetConversationEventsForAgent)
+					}
+
 					// Global chat — chatting with a global agent from the home
 					// page / admin pages, no project context. Any authenticated
 					// human may chat with any global agent, same as any project

--- a/services/api/test/integration/document_test.go
+++ b/services/api/test/integration/document_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -99,7 +100,11 @@ func (r *fakeDocRepoIT) DeleteFolder(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (r *fakeDocRepoIT) ListDocuments(_ context.Context, projectID uuid.UUID, folderID *uuid.UUID) ([]*docdom.Document, error) {
+// ListDocuments ignores cursor/limit — no test in this file exercises
+// pagination, so it always returns the full matching set (equivalent to
+// always passing limit=nil), matching the real repository's own
+// no-pagination-requested behavior.
+func (r *fakeDocRepoIT) ListDocuments(_ context.Context, projectID uuid.UUID, folderID *uuid.UUID, search *string, _ *string, _ *int) ([]*docdom.Document, bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var out []*docdom.Document
@@ -112,10 +117,15 @@ func (r *fakeDocRepoIT) ListDocuments(_ context.Context, projectID uuid.UUID, fo
 				continue
 			}
 		}
+		if search != nil && *search != "" {
+			if !strings.Contains(strings.ToLower(d.Title), strings.ToLower(*search)) {
+				continue
+			}
+		}
 		cp := *d
 		out = append(out, &cp)
 	}
-	return out, nil
+	return out, false, nil
 }
 
 func (r *fakeDocRepoIT) FindDocumentByID(_ context.Context, id uuid.UUID) (*docdom.Document, error) {


### PR DESCRIPTION
## Summary

Adds context injection to the chat composer: users can attach a Task, Documentation page, Conversation, or Automation to a message — shown as removable badges above the composer, added via a "+" search popover or a one-click quick-add for whatever's currently open. The agent gets a lightweight reference and pulls in full content on demand via MCP tools, including a new `read_conversation` tool. Also fixes several bugs this surfaced, including two real auth failures caught by exercising the feature end-to-end against a live agent.

## What's included

### Chat composer (apps/web)
- New badge row + "+" search popover (`context-injection.tsx`), reusing the existing `ChipField` component. Search is debounced, cursor-paginated, and browses the full list when the box is empty — for all four types.
- One-click quick-add for the Task/Doc/Automation currently open (including the task detail dialog).
- Injected context persists on the message and redisplays (read-only) when a conversation is reloaded.
- Fixed the floating chat widget's stacking so it renders above dialogs, and fixed every dropdown/popover/select/tooltip primitive so they render above the chat widget in turn.
- Fixed a "Maximum update depth exceeded" infinite render loop in the message list caused by a selector that built a new array on every render.
- All new UI strings translated across all 9 locales.

### services/api
- `context_items` flow through the send-message DTOs → Redis trigger stream → agent-runner → the agent's prompt, and are persisted on the conversation event so badges redisplay correctly.
- Docs and Automations list endpoints gained case-insensitive search + keyset cursor pagination (Tasks/Conversations already had this) — fully opt-in, so existing callers (doc tree, mention picker) are unaffected.
- New `GET /agents/me/conversations/:id(/events)`: lets an agent read a conversation it participated in without a human member/actor identity, which a bare agent never has. Fixes a real 404/401 the `read_conversation` tool hit going through the human-facing conversation endpoints.

### services/agent-runner
- Renders a new "## Attached Context" prompt section naming which MCP tool to call for each attached item.
- Fixed a bug where a project-scoped agent's MCP calls could carry a human actor-user claim only global agents are allowed to make — this was silently tripping the backend's own auth check and failing *every* MCP call the agent made, not just conversation reads.

### apps/mcp
- New `read_conversation` tool — reads another conversation's transcript (paginated, condensed to a skimmable summary rather than a full replay).
- `read_doc` now also accepts a direct `docId`, since an injected doc reference has no virtual folder path to resolve.

## Testing

- `go test ./...` passes for `services/api` and `services/agent-runner`, including new tests for search/pagination, the new agent-conversation authorization path, and the actor-user-id fix.
- `npm test` passes for `apps/mcp` (new tests for `read_conversation` and the `docId` path) and `apps/web` (extended for context-item redisplay and payload construction).
- `tsc -b`, `biome check`, and `vite build` all pass clean.
- Manually verified against a local dev stack, including tracing two live 401/404s back to their root cause in agent-runner/services/api and confirming the fix.

## Checklist

- [x] The change is focused and scoped (search/pagination and the agent-conversation auth path exist to support context injection, not as unrelated cleanup).
- [x] New UI strings are translated in every supported locale.
- [x] Covered by tests at the Go, MCP, and frontend layers.
