### PR TITLE
feat: enhance side menu and suggestion menus to support slash commands and improve block handling

### DIFF
--- a/apps/web/src/components/projects/docs/doc-editor.tsx
+++ b/apps/web/src/components/projects/docs/doc-editor.tsx
@@ -182,6 +182,7 @@ export const DocEditor = forwardRef<DocEditorHandle, DocEditorProps>(
 					theme={resolvedMode}
 					onChange={handleChange}
 					sideMenu={false}
+					slashMenu={false}
 				>
 					<SideMenuController sideMenu={CustomSideMenu} />
 					{editable && (

--- a/apps/web/src/components/shared/blocknote-custom-side-menu.tsx
+++ b/apps/web/src/components/shared/blocknote-custom-side-menu.tsx
@@ -16,12 +16,17 @@ export const CustomSideMenu = () => {
 		return null;
 	}
 
-	const hasContent = Array.isArray(block.content) && block.content.length > 0;
+	// Only "inline" content blocks (paragraph, heading, ...) can be empty in a
+	// meaningful sense — show "+" for those so the user can pick a block type.
+	// Every other content model ("none" or "table": image, video, file, table,
+	// divider, mermaid, ...) has no such empty state and always gets the drag
+	// handle, since block.content is never an array for them.
+	const isEmptyTextBlock =
+		Array.isArray(block.content) && block.content.length === 0;
 
 	return (
 		<SideMenu>
-			{!hasContent && <AddBlockButton />}
-			{hasContent && <DragHandleButton />}
+			{isEmptyTextBlock ? <AddBlockButton /> : <DragHandleButton />}
 		</SideMenu>
 	);
 };

--- a/apps/web/src/components/shared/comment-blocknote.tsx
+++ b/apps/web/src/components/shared/comment-blocknote.tsx
@@ -77,6 +77,7 @@ export const CommentEditor = forwardRef<
 			theme={resolvedMode}
 			className="bn-shadcn"
 			sideMenu={false}
+			slashMenu={false}
 		>
 			<SideMenuController sideMenu={CustomSideMenu} />
 			<MentionSuggestionMenus

--- a/apps/web/src/components/shared/mention-suggestion-menus.tsx
+++ b/apps/web/src/components/shared/mention-suggestion-menus.tsx
@@ -1,9 +1,14 @@
 import type { BlockNoteEditor } from "@blocknote/core";
-import { filterSuggestionItems } from "@blocknote/core/extensions";
+import {
+	filterSuggestionItems,
+	insertOrUpdateBlockForSlashMenu,
+} from "@blocknote/core/extensions";
 import {
 	type DefaultReactSuggestionItem,
+	getDefaultReactSlashMenuItems,
 	SuggestionMenuController,
 } from "@blocknote/react";
+import { Workflow } from "lucide-react";
 import { EntityAvatarContent } from "@/components/shared/entity-avatar";
 import { useDebouncedAsyncCallback } from "@/hooks/use-debounced-callback";
 import { searchMentionableTasks } from "@/lib/mention-api";
@@ -134,8 +139,28 @@ export function MentionSuggestionMenus({
 		}));
 	};
 
+	const getSlashMenuItems = (): DefaultReactSuggestionItem[] => [
+		...getDefaultReactSlashMenuItems(editor),
+		{
+			title: "Mermaid Diagram",
+			subtext: "Insert a Mermaid diagram",
+			aliases: ["mermaid", "diagram", "flowchart", "graph", "sequence"],
+			group: "Advanced",
+			icon: <Workflow size={18} />,
+			onItemClick: () => {
+				insertOrUpdateBlockForSlashMenu(editor, { type: "mermaid" });
+			},
+		},
+	];
+
 	return (
 		<>
+			<SuggestionMenuController
+				triggerCharacter="/"
+				getItems={async (query) =>
+					filterSuggestionItems(getSlashMenuItems(), query)
+				}
+			/>
 			<SuggestionMenuController
 				triggerCharacter="@"
 				getItems={async (query) =>


### PR DESCRIPTION
## Summary
- Add a "Mermaid Diagram" item to BlockNote's `/` slash menu, wired into both the doc editor and comment editor, so a Mermaid block can be inserted directly instead of only via pasting a ```mermaid code fence.
- Fix `CustomSideMenu` so blocks with a "none"/"table" content model (Image, Video, Audio, File, Table, Divider, and now Mermaid) show the drag-handle/block-actions menu on hover instead of incorrectly falling back to the "+" add-block button — the old check assumed `block.content` was always an array, which is only true for inline-content blocks.

## Details
- `mention-suggestion-menus.tsx`: added a `SuggestionMenuController` for `/` returning BlockNote's default slash items plus a custom "Mermaid Diagram" entry (via `insertOrUpdateBlockForSlashMenu`), grouped under "Advanced".
- `doc-editor.tsx` / `comment-blocknote.tsx`: set `slashMenu={false}` on `BlockNoteView` so the custom controller replaces BlockNote's built-in one instead of both being active.
- `blocknote-custom-side-menu.tsx`: replaced the array-length-based `hasContent` check with `isEmptyTextBlock`, which only treats inline-content blocks as capable of being "empty".

## Test plan
- [x] Type `/` in a doc/comment editor, confirm "Mermaid Diagram" appears and inserts an empty, editable Mermaid block.
- [x] Hover Image/Video/Audio/File/Table/Divider/Mermaid blocks, confirm the drag-handle/ellipsis menu shows instead of "+".
- [x] Confirm an empty paragraph/heading still shows "+" as before.