### PR TITLE
feat: implement infinite scroll for task columns and optimize loading…

### DIFF
--- a/apps/web/src/components/projects/interactions/board-view.test.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.test.tsx
@@ -327,4 +327,92 @@ describe("BoardView", () => {
 			expect(onTaskClick).toHaveBeenCalledWith(task);
 		});
 	});
+
+	describe("column auto-fill pagination", () => {
+		// jsdom never lays out real dimensions, so a column's scrollHeight and
+		// clientHeight are both 0 — the same "not scrollable yet" state as a real
+		// under-filled column — which is what lets these tests exercise the
+		// auto-fill effect without needing to mock element sizes.
+
+		it("requests the next page on mount when a column has more but isn't scrollable", async () => {
+			const onLoadMore = vi.fn();
+			renderBoard([], {
+				columnPagination: {
+					"status-todo": { hasMore: true, isLoadingMore: false, onLoadMore },
+				},
+			});
+			await waitFor(() => expect(onLoadMore).toHaveBeenCalled());
+		});
+
+		it("does not request another page while one is already loading", async () => {
+			const onLoadMore = vi.fn();
+			renderBoard([], {
+				columnPagination: {
+					"status-todo": { hasMore: true, isLoadingMore: true, onLoadMore },
+				},
+			});
+			await new Promise((r) => setTimeout(r, 0));
+			expect(onLoadMore).not.toHaveBeenCalled();
+		});
+
+		it("does not request another page once there's nothing left to load", async () => {
+			const onLoadMore = vi.fn();
+			renderBoard([], {
+				columnPagination: {
+					"status-todo": { hasMore: false, isLoadingMore: false, onLoadMore },
+				},
+			});
+			await new Promise((r) => setTimeout(r, 0));
+			expect(onLoadMore).not.toHaveBeenCalled();
+		});
+
+		it("backs off before retrying an auto-fill after a failed load-more, instead of retrying every render", () => {
+			vi.useFakeTimers();
+			try {
+				const onLoadMore = vi.fn();
+				renderBoard([], {
+					columnPagination: {
+						"status-todo": {
+							hasMore: true,
+							isLoadingMore: false,
+							onLoadMore,
+							lastLoadMoreFailed: true,
+						},
+					},
+				});
+				// Mirrors AUTO_FILL_RETRY_BACKOFF_MS in board-view.tsx.
+				const backoffMs = 4000;
+				vi.advanceTimersByTime(backoffMs - 1);
+				expect(onLoadMore).not.toHaveBeenCalled();
+
+				vi.advanceTimersByTime(1);
+				expect(onLoadMore).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("cancels a pending auto-fill retry when the column unmounts before it fires", () => {
+			vi.useFakeTimers();
+			try {
+				const onLoadMore = vi.fn();
+				const { unmount } = renderBoard([], {
+					columnPagination: {
+						"status-todo": {
+							hasMore: true,
+							isLoadingMore: false,
+							onLoadMore,
+							lastLoadMoreFailed: true,
+						},
+					},
+				});
+
+				unmount();
+				vi.advanceTimersByTime(4000);
+				expect(onLoadMore).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
 });

--- a/apps/web/src/components/projects/interactions/board-view.test.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.test.tsx
@@ -4,6 +4,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock @/lib/interaction-api before any imports that pull it in ─────────────
@@ -18,7 +19,7 @@ vi.mock("@/lib/interaction-api", () => ({
 
 import type { Task } from "@/lib/interaction-api";
 import type { TaskStatus, TaskType } from "@/lib/project-api";
-import { BoardView } from "./board-view";
+import { BoardView, ColumnScrollArea } from "./board-view";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -410,6 +411,39 @@ describe("BoardView", () => {
 				unmount();
 				vi.advanceTimersByTime(4000);
 				expect(onLoadMore).not.toHaveBeenCalled();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("still schedules a backoff retry after StrictMode's dev-only mount→cleanup→remount", () => {
+			// Tested directly against ColumnScrollArea (rather than through the
+			// full BoardView + react-query tree) because unrelated re-renders
+			// elsewhere in that tree can mask this bug: as long as some other
+			// state change re-runs the deps-less auto-fill effect again after the
+			// double-invoke, it looks like the retry "worked" even when the ref
+			// guard was left stuck. Testing the component in isolation makes the
+			// double-invoke sequence deterministic.
+			vi.useFakeTimers();
+			try {
+				const onLoadMore = vi.fn();
+				render(
+					<StrictMode>
+						<ColumnScrollArea
+							pagination={{
+								hasMore: true,
+								isLoadingMore: false,
+								onLoadMore,
+								lastLoadMoreFailed: true,
+							}}
+						>
+							<div />
+						</ColumnScrollArea>
+					</StrictMode>,
+				);
+
+				vi.advanceTimersByTime(4000);
+				expect(onLoadMore).toHaveBeenCalledTimes(1);
 			} finally {
 				vi.useRealTimers();
 			}

--- a/apps/web/src/components/projects/interactions/board-view.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.tsx
@@ -103,7 +103,7 @@ const AUTO_FILL_RETRY_BACKOFF_MS = 4000;
  * pages are available), requests the next page directly — repeating until
  * either the content fills the column or there's nothing left to load.
  */
-function ColumnScrollArea({
+export function ColumnScrollArea({
 	pagination,
 	children,
 }: {
@@ -132,7 +132,15 @@ function ColumnScrollArea({
 
 	useEffect(() => {
 		return () => {
+			// Reset retryScheduledRef too, not just the timer — React StrictMode's
+			// dev-only mount→cleanup→remount double-invoke would otherwise clear
+			// the timer here but leave the guard at `true`, so the remount's
+			// effect run immediately bails on `if (retryScheduledRef.current)
+			// return` and never reschedules it, leaving the column permanently
+			// stuck under-filled in dev.
 			if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+			retryScheduledRef.current = false;
+			retryTimeoutRef.current = null;
 		};
 	}, []);
 

--- a/apps/web/src/components/projects/interactions/board-view.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.tsx
@@ -125,6 +125,16 @@ function ColumnScrollArea({
 	// Guards against queuing a new backoff timer on every render while one is
 	// already pending.
 	const retryScheduledRef = useRef(false);
+	// Lets the mount/unmount effect below clear a pending backoff timer if the
+	// column unmounts before it fires — otherwise it would still call
+	// onLoadMore() for a column that's no longer visible.
+	const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+		};
+	}, []);
 
 	useEffect(() => {
 		const el = scrollRef.current;
@@ -142,8 +152,9 @@ function ColumnScrollArea({
 			// would otherwise be stuck at its under-filled size forever.
 			if (retryScheduledRef.current) return;
 			retryScheduledRef.current = true;
-			setTimeout(() => {
+			retryTimeoutRef.current = setTimeout(() => {
 				retryScheduledRef.current = false;
+				retryTimeoutRef.current = null;
 				const current = paginationRef.current;
 				if (current?.hasMore && !current.isLoadingMore) {
 					current.onLoadMore();

--- a/apps/web/src/components/projects/interactions/board-view.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.tsx
@@ -79,11 +79,19 @@ interface BoardViewProps {
 			onLoadMore: () => void;
 			totalCount?: number;
 			fieldSum?: number;
+			/** True when the column's last load-more attempt failed. Stops
+			 * ColumnScrollArea's auto-fill effect from immediately retrying on
+			 * every render; a manual scroll or button click can still retry. */
+			lastLoadMoreFailed?: boolean;
 		}
 	>;
 }
 
 // ── Column scroll area ──────────────────────────────────────────────────────
+
+/** How long ColumnScrollArea waits before retrying its own auto-fill request
+ * after a failure, instead of retrying on the very next render. */
+const AUTO_FILL_RETRY_BACKOFF_MS = 4000;
 
 /**
  * Wraps a column's scrollable card list. `onScroll` alone only covers the
@@ -99,17 +107,52 @@ function ColumnScrollArea({
 	pagination,
 	children,
 }: {
-	pagination: LoadMorePagination | undefined;
+	pagination:
+		| (LoadMorePagination & {
+				/** True when the last load-more attempt failed — see the
+				 * dedicated comment on this effect below. */
+				lastLoadMoreFailed?: boolean;
+		  })
+		| undefined;
 	children: ReactNode;
 }) {
 	const scrollRef = useRef<HTMLDivElement>(null);
+	// Lets the backoff timer below retry with whatever is current by the time
+	// it fires, rather than the (possibly several-renders-stale) pagination
+	// object captured when the timer was scheduled.
+	const paginationRef = useRef(pagination);
+	paginationRef.current = pagination;
+	// Guards against queuing a new backoff timer on every render while one is
+	// already pending.
+	const retryScheduledRef = useRef(false);
 
 	useEffect(() => {
 		const el = scrollRef.current;
 		if (!el || !pagination?.hasMore || pagination.isLoadingMore) return;
-		if (el.scrollHeight <= el.clientHeight) {
-			pagination.onLoadMore();
+		if (el.scrollHeight > el.clientHeight) return;
+
+		if (pagination.lastLoadMoreFailed) {
+			// A failed fetch (network blip, 5xx) leaves the column just as
+			// under-filled as before it tried — since this effect has no
+			// dependency array, it re-runs on every subsequent render, and
+			// retrying immediately would hammer the backend in a tight loop.
+			// Back off instead: wait, then retry once with fresh state. This
+			// column has no visible scrollbar to manually retry from (that's
+			// the whole reason auto-fill exists), so without this the column
+			// would otherwise be stuck at its under-filled size forever.
+			if (retryScheduledRef.current) return;
+			retryScheduledRef.current = true;
+			setTimeout(() => {
+				retryScheduledRef.current = false;
+				const current = paginationRef.current;
+				if (current?.hasMore && !current.isLoadingMore) {
+					current.onLoadMore();
+				}
+			}, AUTO_FILL_RETRY_BACKOFF_MS);
+			return;
 		}
+
+		pagination.onLoadMore();
 	});
 
 	return (

--- a/apps/web/src/components/projects/interactions/board-view.tsx
+++ b/apps/web/src/components/projects/interactions/board-view.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -15,6 +16,10 @@ import type {
 	TaskStatus,
 	TaskType,
 } from "@/lib/project-api";
+import {
+	createLoadMoreScrollHandler,
+	type LoadMorePagination,
+} from "@/lib/scroll-pagination";
 import { cn } from "@/lib/utils";
 
 import { AddTaskRow } from "./add-task-row";
@@ -76,6 +81,46 @@ interface BoardViewProps {
 			fieldSum?: number;
 		}
 	>;
+}
+
+// ── Column scroll area ──────────────────────────────────────────────────────
+
+/**
+ * Wraps a column's scrollable card list. `onScroll` alone only covers the
+ * case where there's already enough content to scroll — if the initial page
+ * (e.g. a small configured page size) doesn't fill the visible column
+ * height, no `scroll` event will ever fire, so infinite scroll would never
+ * kick in even though more pages exist. This effect checks after every
+ * render whether the container is actually scrollable and, if not (and more
+ * pages are available), requests the next page directly — repeating until
+ * either the content fills the column or there's nothing left to load.
+ */
+function ColumnScrollArea({
+	pagination,
+	children,
+}: {
+	pagination: LoadMorePagination | undefined;
+	children: ReactNode;
+}) {
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el || !pagination?.hasMore || pagination.isLoadingMore) return;
+		if (el.scrollHeight <= el.clientHeight) {
+			pagination.onLoadMore();
+		}
+	});
+
+	return (
+		<div
+			ref={scrollRef}
+			className="min-h-0 flex-1 overflow-y-auto pb-2"
+			onScroll={createLoadMoreScrollHandler(pagination)}
+		>
+			{children}
+		</div>
+	);
 }
 
 // ── Board view ────────────────────────────────────────────────────────────────
@@ -483,8 +528,78 @@ export function BoardView({
 
 	const hasSwimlanes = Boolean(swimlaneBy && swimlaneBy !== "none");
 
-	/** Renders the cards inside one [column × swimlane] cell. */
-	const renderCellCards = (colDef: ColumnGroupDef, swimDef: ColumnGroupDef) => {
+	/** Renders the "add task" row for one [column × swimlane] cell, or null if
+	 * task creation isn't available there. Factored out so the no-swimlane
+	 * layout can pin it as a non-scrolling footer (like the header) instead of
+	 * letting it scroll away with the cards. */
+	const renderAddTaskRow = (
+		colDef: ColumnGroupDef,
+		swimDef: ColumnGroupDef,
+	) => {
+		if (
+			!canCreate ||
+			!(isStatusGrouping || columnBy === "sprint") ||
+			colDef.key === "__none"
+		) {
+			return null;
+		}
+		return (
+			<AddTaskRow
+				variant="board"
+				taskTypes={taskTypes}
+				onAdd={(title, typeId) => {
+					const extra: TaskFieldUpdate = {};
+					if (!isStatusGrouping && columnBy === "sprint") {
+						extra.sprint_id =
+							colDef.key === "__backlog" ? null : (colDef.key as string);
+					}
+					if (
+						hasSwimlanes &&
+						swimDef.key !== "__all" &&
+						swimlaneBy &&
+						swimlaneBy !== "none"
+					) {
+						const swimUpdate = buildColumnDropUpdate(
+							swimlaneBy,
+							swimDef.fieldValue,
+							customFields,
+						);
+						Object.assign(extra, swimUpdate);
+					}
+					const statusId = isStatusGrouping
+						? colDef.key
+						: (statuses.find((s) => s.category !== "done")?.id ??
+							statuses[0]?.id ??
+							"");
+					onCreateTask(
+						statusId,
+						title,
+						typeId,
+						Object.keys(extra).length > 0 ? extra : undefined,
+					);
+				}}
+			/>
+		);
+	};
+
+	/** Renders the cards inside one [column × swimlane] cell.
+	 * `minHeightClassName` lets the no-swimlane layout stretch this to fill its
+	 * independently-scrolling column (`min-h-full`) while the swimlane layout
+	 * keeps a fixed floor (`min-h-28`) since its cells aren't height-bound.
+	 * `showAddTaskRow` is false for the no-swimlane layout, which renders its
+	 * own pinned footer instead (see `renderAddTaskRow` above).
+	 * `useScrollPagination` is true for the no-swimlane layout, whose column
+	 * has its own scroll container to drive infinite scroll from (see the
+	 * `onScroll` handler at its call site) — it then shows a loading
+	 * indicator instead of a click-to-load button. The swimlane layout has no
+	 * such per-cell scroll container, so it keeps the explicit button. */
+	const renderCellCards = (
+		colDef: ColumnGroupDef,
+		swimDef: ColumnGroupDef,
+		minHeightClassName: string = "min-h-28",
+		showAddTaskRow = true,
+		useScrollPagination = false,
+	) => {
 		const swimOverKey = `${colDef.key}|${swimDef.key}`;
 		const laneTasks = getSwimlaneColumnTasks(colDef.key, swimDef.key);
 		const isOver =
@@ -503,7 +618,8 @@ export function BoardView({
 			// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop drop zone
 			<div
 				className={cn(
-					"flex flex-col gap-2 rounded-xl p-2 min-h-28 transition-all duration-200",
+					"flex flex-col gap-2 rounded-xl p-2 transition-all duration-200",
+					minHeightClassName,
 					isOver
 						? "bg-primary/8 ring-2 ring-primary/20"
 						: "bg-muted/40 dark:bg-muted",
@@ -608,6 +724,18 @@ export function BoardView({
 				{(() => {
 					const pg = columnPagination?.[colDef.key];
 					if (!pg?.hasMore) return null;
+					if (useScrollPagination) {
+						// The scroll container itself (see the `onScroll` handler at
+						// this cell's call site) triggers the fetch — this is just
+						// the in-flight indicator, not a click target.
+						if (!pg.isLoadingMore) return null;
+						return (
+							<div className="flex items-center justify-center gap-1.5 py-2 text-xs text-muted-foreground/50">
+								<Loader2 className="size-3 animate-spin" />
+								{t("board.view.loading")}
+							</div>
+						);
+					}
 					return (
 						<button
 							type="button"
@@ -621,45 +749,7 @@ export function BoardView({
 						</button>
 					);
 				})()}
-				{canCreate &&
-					(isStatusGrouping || columnBy === "sprint") &&
-					colDef.key !== "__none" && (
-						<AddTaskRow
-							variant="board"
-							taskTypes={taskTypes}
-							onAdd={(title, typeId) => {
-								const extra: TaskFieldUpdate = {};
-								if (!isStatusGrouping && columnBy === "sprint") {
-									extra.sprint_id =
-										colDef.key === "__backlog" ? null : (colDef.key as string);
-								}
-								if (
-									hasSwimlanes &&
-									swimDef.key !== "__all" &&
-									swimlaneBy &&
-									swimlaneBy !== "none"
-								) {
-									const swimUpdate = buildColumnDropUpdate(
-										swimlaneBy,
-										swimDef.fieldValue,
-										customFields,
-									);
-									Object.assign(extra, swimUpdate);
-								}
-								const statusId = isStatusGrouping
-									? colDef.key
-									: (statuses.find((s) => s.category !== "done")?.id ??
-										statuses[0]?.id ??
-										"");
-								onCreateTask(
-									statusId,
-									title,
-									typeId,
-									Object.keys(extra).length > 0 ? extra : undefined,
-								);
-							}}
-						/>
-					)}
+				{showAddTaskRow && renderAddTaskRow(colDef, swimDef)}
 			</div>
 		);
 	};
@@ -826,7 +916,7 @@ export function BoardView({
 	};
 
 	return (
-		<div className="flex flex-1 min-h-0 items-start gap-4 overflow-auto px-6 py-5 pb-8">
+		<div className="flex flex-1 min-h-0 items-stretch gap-4 overflow-x-auto overflow-y-hidden px-6 pt-5 pb-8">
 			{effectiveColumnDefs.map((colDef) => {
 				const isCollapsed = collapsedColumns.has(colDef.key);
 				const displayCount = getDisplayCount(colDef.key);
@@ -873,14 +963,23 @@ export function BoardView({
 					);
 				}
 
+				const addTaskRow = renderAddTaskRow(colDef, noSwimAll);
 				return (
 					<div
 						key={colDef.key}
 						data-column-key={colDef.key}
-						className="flex w-72 shrink-0 flex-col gap-2.5"
+						className="flex w-72 shrink-0 flex-col gap-2"
 					>
-						{renderColHeader(colDef)}
-						{renderCellCards(colDef, noSwimAll)}
+						{/* Header stays outside the scroll area below, so it never
+						 * scrolls away — same effect as `sticky top-0` without the
+						 * z-index/stacking-context edge cases. */}
+						<div className="shrink-0">{renderColHeader(colDef)}</div>
+						<ColumnScrollArea pagination={columnPagination?.[colDef.key]}>
+							{renderCellCards(colDef, noSwimAll, "min-h-full", false, true)}
+						</ColumnScrollArea>
+						{/* Pinned footer, same reasoning as the header above — always
+						 * reachable without scrolling to the bottom of the column. */}
+						{addTaskRow && <div className="shrink-0">{addTaskRow}</div>}
 					</div>
 				);
 			})}

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -951,6 +951,18 @@ export function InteractionLayout({
 	// render's closure, so the first call's synchronous write is visible to
 	// the very next call regardless of whether a re-render has happened yet.
 	const colLoadingMoreRef = useRef<Record<string, boolean>>({});
+	// Tracks whether a column's last load-more attempt failed. board-view.tsx's
+	// ColumnScrollArea auto-requests more pages on its own (no user scroll)
+	// whenever a column's content doesn't yet fill its visible height — without
+	// this flag, a failed fetch (network blip, 5xx) would still leave the
+	// column under-filled, and that effect would immediately retry on every
+	// subsequent render with no backoff, hammering the backend. Set on failure,
+	// cleared on the next successful fetch; deliberately NOT checked by the
+	// scroll-triggered handler, so a manual scroll (or the swimlane layout's
+	// button) can still retry right away.
+	const [colLoadMoreFailed, setColLoadMoreFailed] = useState<
+		Record<string, boolean>
+	>({});
 
 	// Sync next cursors from initial column query results; reset extras once
 	// each column's own base query has re-fetched at its expanded depth.
@@ -1047,6 +1059,16 @@ export function InteractionLayout({
 					...prev,
 					[colKey]: (prev[colKey] ?? initialColPageSize) + result.items.length,
 				}));
+				setColLoadMoreFailed((prev) =>
+					prev[colKey] ? { ...prev, [colKey]: false } : prev,
+				);
+			} catch (error) {
+				// Caught here (rather than left to reject) so every caller —
+				// ColumnScrollArea's auto-fill effect, the scroll handler, and the
+				// swimlane layout's button — can fire-and-forget onLoadMore()
+				// without each needing its own unhandled-rejection handling.
+				console.error(error);
+				setColLoadMoreFailed((prev) => ({ ...prev, [colKey]: true }));
 			} finally {
 				colLoadingMoreRef.current[colKey] = false;
 				setColLoadingMore((prev) => ({ ...prev, [colKey]: false }));
@@ -1220,6 +1242,7 @@ export function InteractionLayout({
 					onLoadMore: () => void;
 					totalCount?: number;
 					fieldSum?: number;
+					lastLoadMoreFailed?: boolean;
 				}
 			>;
 		const result: Record<
@@ -1230,6 +1253,7 @@ export function InteractionLayout({
 				onLoadMore: () => void;
 				totalCount?: number;
 				fieldSum?: number;
+				lastLoadMoreFailed?: boolean;
 			}
 		> = {};
 		for (let i = 0; i < fetchColumnDefs.length; i++) {
@@ -1241,6 +1265,7 @@ export function InteractionLayout({
 				onLoadMore: () => handleLoadMoreColumn(col.key),
 				totalCount: columnQueries[i]?.data?.total_count,
 				fieldSum: apiFieldSum != null ? apiFieldSum : undefined,
+				lastLoadMoreFailed: Boolean(colLoadMoreFailed[col.key]),
 			};
 		}
 		return result;
@@ -1249,6 +1274,7 @@ export function InteractionLayout({
 		fetchColumnDefs,
 		colNextCursors,
 		colLoadingMore,
+		colLoadMoreFailed,
 		handleLoadMoreColumn,
 		columnQueries,
 	]);

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -831,6 +831,29 @@ export function InteractionLayout({
 							enabled: false,
 						};
 					}
+					// pageSize is deliberately excluded from the queryKey: "load
+					// more" (handleLoadMoreColumn) grows colExpandedPageSizes purely
+					// so that a *future* refetch (a websocket-triggered invalidation,
+					// window refocus, etc.) asks for the same depth the user has
+					// already scrolled to — it fetches the next page itself directly
+					// via listAllTasks, bypassing this query entirely. If pageSize
+					// were part of the key, every such bump would register as a
+					// brand-new query and eagerly trigger its OWN full background
+					// refetch of the whole (growing) range in parallel — a second,
+					// redundant fetch on top of the one load-more already made.
+					// Chained across a fast scroll session (each one taking a full
+					// network round trip) that queued up faster than each one could
+					// resolve, which intermittently left `data` briefly undefined for
+					// this column — enough to trip the `tasksLoading` skeleton gate
+					// below and flash the whole board back to the loading state mid-
+					// scroll, plus doubling backend load for no reason. Keeping the
+					// key stable means growing colExpandedPageSizes never triggers an
+					// implicit fetch — the next time this query naturally refetches
+					// for any other reason, it picks up the current expanded
+					// pageSize (colOpts is rebuilt fresh every render), so the
+					// "same depth on refetch" behavior is preserved without the
+					// eager duplicate work.
+					const { pageSize: _keyPageSize, ...colOptsForKey } = colOpts;
 					return {
 						queryKey: [
 							"projects",
@@ -838,20 +861,10 @@ export function InteractionLayout({
 							"tasks",
 							"col",
 							col.key,
-							colOpts,
+							colOptsForKey,
 						] as const,
 						queryFn: () => listAllTasks(projectId, colOpts),
 						staleTime: 15_000,
-						// "Load more" grows this column's pageSize, which changes the
-						// queryKey above — without this, React Query would drop `data`
-						// back to undefined for the new key until it resolves, making
-						// already-visible tasks disappear from the list mid-fetch.
-						// Keeping the previous (smaller) page's data displayed avoids
-						// that gap. Scoped to pageSize-only key changes so a genuine
-						// filter/sort/search change still drops to `undefined` and
-						// shows the loading skeleton, instead of silently rendering
-						// the previous (non-matching) filter's results.
-						placeholderData: keepPreviousDataOnPageSizeChangeOnly(colOpts),
 					};
 				})
 			: [],
@@ -928,6 +941,16 @@ export function InteractionLayout({
 	const [colLoadingMore, setColLoadingMore] = useState<Record<string, boolean>>(
 		{},
 	);
+	// Mirrors colLoadingMore but reads/writes synchronously, unlike state. A
+	// scroll-triggered "load more" (see board-view.tsx's onScroll handler) can
+	// fire many times in the gap between calling setColLoadingMore(true) and
+	// that update actually reaching this column's isLoadingMore prop — every
+	// scroll tick in that window still sees the old colLoadingMore[colKey]
+	// captured in its own render's closure, so state alone doesn't stop the
+	// same page from being double-fetched. A ref is shared across every
+	// render's closure, so the first call's synchronous write is visible to
+	// the very next call regardless of whether a re-render has happened yet.
+	const colLoadingMoreRef = useRef<Record<string, boolean>>({});
 
 	// Sync next cursors from initial column query results; reset extras once
 	// each column's own base query has re-fetched at its expanded depth.
@@ -997,7 +1020,7 @@ export function InteractionLayout({
 
 	const handleLoadMoreColumn = useCallback(
 		async (colKey: string) => {
-			if (colLoadingMore[colKey]) return;
+			if (colLoadingMoreRef.current[colKey]) return;
 			const cursor = colNextCursors[colKey];
 			if (!cursor) return;
 			const colOpts = buildColumnFilter(colKey, columnBy, {
@@ -1006,6 +1029,7 @@ export function InteractionLayout({
 				cursor,
 			});
 			if (!colOpts) return;
+			colLoadingMoreRef.current[colKey] = true;
 			setColLoadingMore((prev) => ({ ...prev, [colKey]: true }));
 			try {
 				const result = await listAllTasks(projectId, colOpts);
@@ -1024,6 +1048,7 @@ export function InteractionLayout({
 					[colKey]: (prev[colKey] ?? initialColPageSize) + result.items.length,
 				}));
 			} finally {
+				colLoadingMoreRef.current[colKey] = false;
 				setColLoadingMore((prev) => ({ ...prev, [colKey]: false }));
 			}
 		},
@@ -1032,7 +1057,6 @@ export function InteractionLayout({
 			columnBy,
 			colBaseOpts,
 			projectId,
-			colLoadingMore,
 			initialColPageSize,
 			configuredPageSize,
 			activeView?.layout,

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -1059,8 +1059,17 @@ export function InteractionLayout({
 					...prev,
 					[colKey]: (prev[colKey] ?? initialColPageSize) + result.items.length,
 				}));
+				// A response with no items yet a non-null next_cursor makes no
+				// progress — without treating that like a failure here, a column
+				// stuck in that state would retry every render with no backoff,
+				// since ColumnScrollArea's auto-fill effect only backs off when
+				// lastLoadMoreFailed is set.
+				const stalled =
+					result.items.length === 0 && Boolean(result.next_cursor);
 				setColLoadMoreFailed((prev) =>
-					prev[colKey] ? { ...prev, [colKey]: false } : prev,
+					Boolean(prev[colKey]) === stalled
+						? prev
+						: { ...prev, [colKey]: stalled },
 				);
 			} catch (error) {
 				// Caught here (rather than left to reject) so every caller —


### PR DESCRIPTION
## Summary

Redesigns board view scrolling/pagination UX to fix the issues reported in #457, and converts task-column pagination to infinite scroll.

- **Sticky column headers**: each column's header now sits outside its scroll area (structurally, not via CSS `sticky`), so it never scrolls out of view no matter how far down the column you scroll.
- **Independent per-column scrolling**: columns now scroll vertically on their own, like Trello/Jira, instead of the whole board sharing one scroll container. The board container itself only scrolls horizontally.
- **Fixed scroll jumping to the top on "load more"**: root cause was the whole board sharing a single scroll region — each column now keeps its own native scroll position, so loading more items in one column can no longer disturb the board's (or another column's) scroll position.
- **Pinned "Add task" row**: like the header, it now sits outside the scrollable area at the bottom of the column, always reachable without scrolling.
- **Infinite scroll pagination**: replaced the "View more" button with scroll-triggered loading (reusing the app's existing `createLoadMoreScrollHandler`, the same pattern used by the epic/team-member pickers). A small spinner row shows while a page is loading.
- **Auto-load when the first page doesn't fill the column**: if a column's initial page (e.g. a small configured page size) doesn't produce enough content to make it scrollable, no `scroll` event would ever fire to trigger more loading. Columns now detect this and keep requesting more pages on their own until either the content fills the viewport or there's nothing left to load.

## Notable fixes along the way

- **Duplicate-fetch race**: scroll events fire far more often than a deliberate click, so a fast scroll gesture could call "load more" several times before React's loading-state update actually took effect, double-fetching the same page. `handleLoadMoreColumn` now guards re-entrancy with a `useRef` (synchronous) instead of relying solely on state.
- **Periodic full-board "reload" flash during active scrolling**: each "load more" was also bumping the column's React Query key (via the tracked expanded page size), which caused an *additional*, redundant background refetch of the whole column in parallel with the actual "next page" fetch — every single time. Chained across a fast scroll session, these overlapping refetches could leave a column's data briefly `undefined`, tripping the loading-skeleton gate and flashing the whole board back to a loading state mid-scroll (on top of roughly doubling backend load). Fixed by excluding page size from the query key — a column's key now only changes on a genuine filter/sort/search change, while an actual refetch (websocket invalidation, window refocus, etc.) still naturally picks up the current expanded depth.

## Notes

- Scope is the default (no-swimlane) board layout, which is what #457 describes. The niche, opt-in swimlanes grouping mode is unchanged — it doesn't have a per-column scroll container to hook into, so it keeps its existing sticky header and click-to-load button.
- Frontend-only change (`apps/web`); no backend/API changes.

## Test plan

- [x] `tsc -b`, `biome check` — `apps/web`
- [x] `vitest run` — `board-view.test.tsx`, `view-utils.test.ts` (26/26 passing)
- [x] Manually verified in an isolated harness (real `BoardView`, real `@tanstack/react-query`) with headless Chromium:
  - Scrolling one column moves only that column; headers and the pinned "Add task" row stay fixed in place.
  - "Load more" appends items in place with scroll position preserved; other columns' scroll and the page itself are untouched.
  - A stress test of continuous rapid scrolling showed 0 skeleton flashes and 0 redundant background fetches (previously 7 flashes / 8 redundant fetches over the same session).
  - A column with a small initial page size (5) in a tall viewport auto-loaded additional pages with zero scroll events, then correctly stopped once it became scrollable.

Closes #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
