### PR TITLE
feat: add color support for custom field options

### DIFF
--- a/apps/mcp/src/__tests__/tools/view-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/view-tools.test.ts
@@ -604,6 +604,50 @@ describe("handleViewTool – create_custom_field", () => {
 		);
 		expect(result.content[0].text).toContain("created successfully");
 	});
+
+	it("passes through object-shaped options with a color unchanged", async () => {
+		const client = makeClient();
+		await handleViewTool(
+			"create_custom_field",
+			{
+				projectId: "p1",
+				fieldKey: "priority",
+				displayName: "Priority",
+				fieldType: "select",
+				options: [{ value: "low" }, { value: "high", color: "#ef4444" }],
+				isRequired: true,
+			},
+			client,
+		);
+		expect(client.createCustomFieldDefinition).toHaveBeenCalledWith("p1", {
+			field_key: "priority",
+			display_name: "Priority",
+			field_type: "select",
+			options: [{ value: "low" }, { value: "high", color: "#ef4444" }],
+			is_required: true,
+		});
+	});
+
+	it("normalizes a mix of plain strings and color objects", async () => {
+		const client = makeClient();
+		await handleViewTool(
+			"create_custom_field",
+			{
+				projectId: "p1",
+				fieldKey: "priority",
+				displayName: "Priority",
+				fieldType: "select",
+				options: ["low", { value: "high", color: "#ef4444" }],
+			},
+			client,
+		);
+		expect(client.createCustomFieldDefinition).toHaveBeenCalledWith(
+			"p1",
+			expect.objectContaining({
+				options: [{ value: "low" }, { value: "high", color: "#ef4444" }],
+			}),
+		);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/mcp/src/__tests__/tools/view-tools.test.ts
+++ b/apps/mcp/src/__tests__/tools/view-tools.test.ts
@@ -28,7 +28,7 @@ const customField = {
 	field_key: "priority",
 	display_name: "Priority",
 	field_type: "select",
-	options: ["low", "high"],
+	options: [{ value: "low" }, { value: "high" }],
 	is_required: false,
 	created_at: "2024-01-01T00:00:00Z",
 	updated_at: "2024-01-01T00:00:00Z",
@@ -591,7 +591,7 @@ describe("handleViewTool – create_custom_field", () => {
 			field_key: "priority",
 			display_name: "Priority",
 			field_type: "select",
-			options: ["low", "high"],
+			options: [{ value: "low" }, { value: "high" }],
 			is_required: true,
 		});
 	});

--- a/apps/mcp/src/__tests__/utils/formatters.test.ts
+++ b/apps/mcp/src/__tests__/utils/formatters.test.ts
@@ -495,7 +495,7 @@ describe("formatTaskDetail", () => {
 			field_key: "priority",
 			display_name: "Priority",
 			field_type: "select",
-			options: ["low", "high"],
+			options: [{ value: "low" }, { value: "high" }],
 			is_required: false,
 			created_at: "2024-01-01T00:00:00Z",
 			updated_at: "2024-01-01T00:00:00Z",

--- a/apps/mcp/src/tools/view-tools.ts
+++ b/apps/mcp/src/tools/view-tools.ts
@@ -117,12 +117,19 @@ const ListCustomFieldsSchema = z.object({
 	projectId: z.string(),
 });
 
+// A custom field option can be given as a plain string (no color) or as an
+// object carrying an optional color, e.g. { value: "High", color: "#ef4444" }.
+const CustomFieldOptionInputSchema = z.union([
+	z.string(),
+	z.object({ value: z.string(), color: z.string().optional() }),
+]);
+
 const CreateCustomFieldSchema = z.object({
 	projectId: z.string(),
 	fieldKey: z.string(),
 	displayName: z.string(),
 	fieldType: z.string(),
-	options: z.array(z.string()).optional(),
+	options: z.array(CustomFieldOptionInputSchema).optional(),
 	isRequired: z.boolean().optional(),
 });
 
@@ -136,9 +143,19 @@ const UpdateCustomFieldSchema = z.object({
 	fieldId: z.string(),
 	displayName: z.string().optional(),
 	fieldType: z.string().optional(),
-	options: z.array(z.string()).optional(),
+	options: z.array(CustomFieldOptionInputSchema).optional(),
 	isRequired: z.boolean().optional(),
 });
+
+// Normalizes a parsed options array (each element either a plain string or
+// an already-{value,color} object) into CustomFieldOption[] for the API.
+function normalizeCustomFieldOptions(
+	options: z.infer<typeof CustomFieldOptionInputSchema>[] | undefined,
+): { value: string; color?: string }[] | undefined {
+	return options?.map((opt) =>
+		typeof opt === "string" ? { value: opt } : opt,
+	);
+}
 
 const DeleteCustomFieldSchema = z.object({
 	projectId: z.string(),
@@ -460,8 +477,21 @@ export function getCustomFieldTools(): Tool[] {
 					},
 					options: {
 						type: "array",
-						items: { type: "string" },
-						description: "Options for select/multi_select types",
+						items: {
+							oneOf: [
+								{ type: "string" },
+								{
+									type: "object",
+									properties: {
+										value: { type: "string" },
+										color: { type: "string" },
+									},
+									required: ["value"],
+								},
+							],
+						},
+						description:
+							'Options for select/multi_select types. Each item is either a plain string, or an object { value, color? } to give that value a display color (e.g. "#ef4444").',
 					},
 					isRequired: {
 						type: "boolean",
@@ -513,8 +543,21 @@ export function getCustomFieldTools(): Tool[] {
 					},
 					options: {
 						type: "array",
-						items: { type: "string" },
-						description: "New options",
+						items: {
+							oneOf: [
+								{ type: "string" },
+								{
+									type: "object",
+									properties: {
+										value: { type: "string" },
+										color: { type: "string" },
+									},
+									required: ["value"],
+								},
+							],
+						},
+						description:
+							'New options. Each item is either a plain string, or an object { value, color? } to give that value a display color (e.g. "#ef4444").',
 					},
 					isRequired: {
 						type: "boolean",
@@ -816,7 +859,7 @@ export async function handleViewTool(
 				field_key: fieldKey,
 				display_name: displayName,
 				field_type: fieldType as any,
-				options: options?.map((value) => ({ value })),
+				options: normalizeCustomFieldOptions(options),
 				is_required: isRequired,
 			});
 			return {
@@ -857,7 +900,7 @@ export async function handleViewTool(
 				{
 					display_name: displayName,
 					field_type: fieldType as any,
-					options: options?.map((value) => ({ value })),
+					options: normalizeCustomFieldOptions(options),
 					is_required: isRequired,
 				},
 			);

--- a/apps/mcp/src/tools/view-tools.ts
+++ b/apps/mcp/src/tools/view-tools.ts
@@ -587,7 +587,7 @@ function formatCustomField(field: any): string {
 ID: ${field.id}
 Key: ${field.field_key}
 Type: ${field.field_type}
-Options: ${field.options.length > 0 ? field.options.join(", ") : "None"}
+Options: ${field.options.length > 0 ? field.options.map((o: { value: string }) => o.value).join(", ") : "None"}
 Required: ${field.is_required}
 Created: ${field.created_at}`;
 }
@@ -816,7 +816,7 @@ export async function handleViewTool(
 				field_key: fieldKey,
 				display_name: displayName,
 				field_type: fieldType as any,
-				options,
+				options: options?.map((value) => ({ value })),
 				is_required: isRequired,
 			});
 			return {
@@ -857,7 +857,7 @@ export async function handleViewTool(
 				{
 					display_name: displayName,
 					field_type: fieldType as any,
-					options,
+					options: options?.map((value) => ({ value })),
 					is_required: isRequired,
 				},
 			);

--- a/apps/mcp/src/types/index.ts
+++ b/apps/mcp/src/types/index.ts
@@ -560,13 +560,18 @@ export type FieldType =
 	| "boolean"
 	| "url";
 
+export interface CustomFieldOption {
+	value: string;
+	color?: string | null;
+}
+
 export interface CustomFieldDefinition {
 	id: string;
 	project_id: string;
 	field_key: string;
 	display_name: string;
 	field_type: FieldType;
-	options: string[];
+	options: CustomFieldOption[];
 	is_required: boolean;
 	created_at: string;
 	updated_at: string;
@@ -576,14 +581,14 @@ export interface CreateCustomFieldInput {
 	display_name: string;
 	field_key: string;
 	field_type: FieldType;
-	options?: string[];
+	options?: CustomFieldOption[];
 	is_required?: boolean;
 }
 
 export interface UpdateCustomFieldInput {
 	display_name?: string;
 	field_type?: FieldType;
-	options?: string[];
+	options?: CustomFieldOption[];
 	is_required?: boolean;
 }
 

--- a/apps/web/src/components/projects/automation/automation-node-config-panel.tsx
+++ b/apps/web/src/components/projects/automation/automation-node-config-panel.tsx
@@ -1965,8 +1965,8 @@ function ConditionConfigForm({
 									</SelectTrigger>
 									<SelectContent>
 										{selectedCustomField.options.map((opt) => (
-											<SelectItem key={opt} value={opt}>
-												{opt}
+											<SelectItem key={opt.value} value={opt.value}>
+												{opt.value}
 											</SelectItem>
 										))}
 									</SelectContent>

--- a/apps/web/src/components/projects/interactions/interaction-layout.tsx
+++ b/apps/web/src/components/projects/interactions/interaction-layout.tsx
@@ -652,7 +652,10 @@ export function InteractionLayout({
 				if (!f) continue;
 				if (cf.field_type === "select" || cf.field_type === "multi_select") {
 					if (!f.selector) continue;
-					const values = resolveFilterConfig(f.selector, cf.options);
+					const values = resolveFilterConfig(
+						f.selector,
+						cf.options.map((o) => o.value),
+					);
 					if (values.length > 0) resolved[cf.field_key] = { values };
 				} else if (cf.field_type === "boolean") {
 					if (!f.selector) continue;

--- a/apps/web/src/components/projects/interactions/task-card.tsx
+++ b/apps/web/src/components/projects/interactions/task-card.tsx
@@ -23,6 +23,10 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+	customFieldBadgeStyle,
+	getCustomFieldOptionColor,
+} from "@/lib/custom-field-colors";
 import { formatDate } from "@/lib/format-date";
 import type { Task } from "@/lib/interaction-api";
 import {
@@ -710,27 +714,40 @@ export function TaskCard({
 								)}
 							</span>
 						);
-					case "select":
+					case "select": {
+						const color = getCustomFieldOptionColor(cf.options, String(val));
 						return (
 							<span
 								key={fieldKey}
-								className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary/80 shrink-0"
+								className={cn(
+									"inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium shrink-0",
+									!color && "bg-primary/10 text-primary/80",
+								)}
+								style={customFieldBadgeStyle(color)}
 							>
 								{String(val)}
 							</span>
 						);
+					}
 					case "multi_select": {
 						const arr = Array.isArray(val) ? (val as string[]) : [String(val)];
 						return (
 							<span key={fieldKey} className="inline-flex gap-0.5 flex-wrap">
-								{arr.map((v) => (
-									<span
-										key={v}
-										className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary/80"
-									>
-										{v}
-									</span>
-								))}
+								{arr.map((v) => {
+									const color = getCustomFieldOptionColor(cf.options, v);
+									return (
+										<span
+											key={v}
+											className={cn(
+												"inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium",
+												!color && "bg-primary/10 text-primary/80",
+											)}
+											style={customFieldBadgeStyle(color)}
+										>
+											{v}
+										</span>
+									);
+								})}
 							</span>
 						);
 					}

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/custom-field-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/custom-field-editor.tsx
@@ -1,5 +1,6 @@
 import { CalendarDays } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { CustomFieldOption } from "@/lib/project-api";
 import { FieldValue } from "../primitives";
 import { CheckboxEditor } from "./checkbox-editor";
 import { SingleDateEditor } from "./date-editor";
@@ -28,7 +29,7 @@ export function CustomFieldEditor({
 		| "Url";
 	rawValue: unknown;
 	canEdit: boolean;
-	options?: string[];
+	options?: CustomFieldOption[];
 	onChange?: (value: unknown) => void;
 }) {
 	const { t } = useTranslation("projects");
@@ -79,8 +80,9 @@ export function CustomFieldEditor({
 			);
 		case "Select": {
 			const selectOptions: SelectOption[] = options.map((o) => ({
-				value: o,
-				label: o,
+				value: o.value,
+				label: o.value,
+				colorDot: o.color ?? undefined,
 			}));
 			const currentVal = rawValue != null ? String(rawValue) : null;
 			if (!canEdit) {
@@ -96,8 +98,9 @@ export function CustomFieldEditor({
 		}
 		case "MultiSelect": {
 			const selectOptions: SelectOption[] = options.map((o) => ({
-				value: o,
-				label: o,
+				value: o.value,
+				label: o.value,
+				colorDot: o.color ?? undefined,
 			}));
 			const currentVal = Array.isArray(rawValue)
 				? rawValue.filter((v): v is string => typeof v === "string")

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/multi-select-editor.tsx
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/multi-select-editor.tsx
@@ -50,7 +50,20 @@ export function MultiSelectEditor({
 
 	return (
 		<ChipField
-			chips={selected.map((opt) => ({ key: opt.value, label: opt.label }))}
+			chips={selected.map((opt) => ({
+				key: opt.value,
+				label: opt.colorDot ? (
+					<span className="inline-flex items-center gap-1.5">
+						<span
+							className="size-1.75 rounded-full shrink-0"
+							style={{ background: opt.colorDot }}
+						/>
+						{opt.label}
+					</span>
+				) : (
+					opt.label
+				),
+			}))}
 			onRemoveChip={toggle}
 			canEdit={canEdit}
 			addLabel={t("taskDetail.propertyField.multiSelectEditor.addOption")}

--- a/apps/web/src/components/projects/interactions/task-detail/property-field/types.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/property-field/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { CustomFieldOption } from "@/lib/project-api";
 
 export type PropertyFieldMode =
 	| "select"
@@ -83,7 +84,7 @@ export interface PropertyFieldProps {
 		| "Url";
 	customRawValue?: unknown;
 	onCustomChange?: (value: unknown) => void;
-	customOptions?: string[];
+	customOptions?: CustomFieldOption[];
 
 	hidden?: boolean;
 	linkIcon?: ReactNode;

--- a/apps/web/src/components/projects/interactions/task-detail/types.ts
+++ b/apps/web/src/components/projects/interactions/task-detail/types.ts
@@ -1,5 +1,10 @@
 import type { Activity, Task } from "@/lib/interaction-api";
-import type { ProjectMember, TaskStatus, TaskType } from "@/lib/project-api";
+import type {
+	CustomFieldOption,
+	ProjectMember,
+	TaskStatus,
+	TaskType,
+} from "@/lib/project-api";
 
 // ── Extended types (UI-first, wired to API later) ─────────────────────────────
 
@@ -16,7 +21,7 @@ export interface CustomFieldDef {
 		| "MultiSelect"
 		| "Url";
 	required?: boolean;
-	options?: string[];
+	options?: CustomFieldOption[];
 }
 
 export interface Attachment {

--- a/apps/web/src/components/projects/interactions/task-row.tsx
+++ b/apps/web/src/components/projects/interactions/task-row.tsx
@@ -23,6 +23,10 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+	customFieldBadgeStyle,
+	getCustomFieldOptionColor,
+} from "@/lib/custom-field-colors";
 import { formatDate } from "@/lib/format-date";
 import type { Task } from "@/lib/interaction-api";
 import {
@@ -812,26 +816,41 @@ export function TaskRow({
 									)}
 								</span>
 							);
-						case "select":
+						case "select": {
+							const color = getCustomFieldOptionColor(cf.options, String(val));
 							return (
-								<span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary/80 truncate max-w-full">
+								<span
+									className={cn(
+										"inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium truncate max-w-full",
+										!color && "bg-primary/10 text-primary/80",
+									)}
+									style={customFieldBadgeStyle(color)}
+								>
 									{String(val)}
 								</span>
 							);
+						}
 						case "multi_select": {
 							const arr = Array.isArray(val)
 								? (val as string[])
 								: [String(val)];
 							return (
 								<span className="inline-flex gap-1 flex-wrap">
-									{arr.map((v) => (
-										<span
-											key={v}
-											className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary/80"
-										>
-											{v}
-										</span>
-									))}
+									{arr.map((v) => {
+										const color = getCustomFieldOptionColor(cf.options, v);
+										return (
+											<span
+												key={v}
+												className={cn(
+													"inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium",
+													!color && "bg-primary/10 text-primary/80",
+												)}
+												style={customFieldBadgeStyle(color)}
+											>
+												{v}
+											</span>
+										);
+									})}
 								</span>
 							);
 						}

--- a/apps/web/src/components/projects/interactions/view-settings-panel.tsx
+++ b/apps/web/src/components/projects/interactions/view-settings-panel.tsx
@@ -996,7 +996,10 @@ function CustomFieldFilterSection({
 		const selectedIds = filterConfigToIds(value?.selector);
 		return (
 			<CustomFieldSelectorFilter
-				options={cf.options.map((opt) => ({ key: opt, label: opt }))}
+				options={cf.options.map((opt) => ({
+					key: opt.value,
+					label: opt.value,
+				}))}
 				selectedIds={selectedIds}
 				noOptionsLabel={t("layout.viewSettings.customFieldFilter.noOptions")}
 				onChange={(ids) => {

--- a/apps/web/src/components/projects/interactions/view-utils.ts
+++ b/apps/web/src/components/projects/interactions/view-utils.ts
@@ -158,9 +158,10 @@ export function getColumnGroupDefs(
 		if (cf.field_type === "select" || cf.field_type === "multi_select") {
 			return [
 				...cf.options.map((opt) => ({
-					key: opt,
-					label: opt,
-					fieldValue: opt,
+					key: opt.value,
+					label: opt.value,
+					color: opt.color ?? undefined,
+					fieldValue: opt.value,
 				})),
 				{ key: "__none", label: t("viewUtils.groups.none"), fieldValue: null },
 			];

--- a/apps/web/src/components/projects/settings/CustomFieldsSettings.tsx
+++ b/apps/web/src/components/projects/settings/CustomFieldsSettings.tsx
@@ -4,6 +4,7 @@ import { Check, Edit2, Loader2, Plus, Trash2, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
+import { ColorSwatchPicker } from "@/components/ui/color-swatch-picker";
 import {
 	Dialog,
 	DialogClose,
@@ -27,6 +28,7 @@ import {
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
 import {
 	type CustomFieldDefinition,
+	type CustomFieldOption,
 	createCustomFieldDefinition,
 	customFieldsQueryOptions,
 	deleteCustomFieldDefinition,
@@ -113,7 +115,7 @@ function CreateCustomFieldDialog({
 	const [keyManuallyEdited, setKeyManuallyEdited] = useState(false);
 	const [fieldType, setFieldType] = useState<UIFieldType>("Text");
 	const [required, setRequired] = useState(false);
-	const [options, setOptions] = useState<string[]>([]);
+	const [options, setOptions] = useState<CustomFieldOption[]>([]);
 	const [newOption, setNewOption] = useState("");
 	const [error, setError] = useState<string | null>(null);
 
@@ -251,14 +253,27 @@ function CreateCustomFieldDialog({
 							<div className="space-y-1">
 								{options.map((opt, i) => (
 									<div
-										key={opt + i.toString()}
+										key={opt.value + i.toString()}
 										className="flex items-center gap-2"
 									>
+										<ColorSwatchPicker
+											value={opt.color}
+											onChange={(color) => {
+												const updated = [...options];
+												updated[i] = { ...updated[i], color };
+												setOptions(updated);
+											}}
+											triggerLabel={t("settings.customFields.optionColorLabel")}
+											customColorTitle={t(
+												"taskStatuses.formDialog.customColorTitle",
+											)}
+											clearLabel={t("settings.customFields.noColor")}
+										/>
 										<Input
-											value={opt}
+											value={opt.value}
 											onChange={(e) => {
 												const updated = [...options];
-												updated[i] = e.target.value;
+												updated[i] = { ...updated[i], value: e.target.value };
 												setOptions(updated);
 											}}
 											className="text-xs h-8"
@@ -280,7 +295,7 @@ function CreateCustomFieldDialog({
 										onChange={(e) => setNewOption(e.target.value)}
 										onKeyDown={(e) => {
 											if (e.key === "Enter" && newOption.trim()) {
-												setOptions([...options, newOption.trim()]);
+												setOptions([...options, { value: newOption.trim() }]);
 												setNewOption("");
 											}
 										}}
@@ -293,7 +308,7 @@ function CreateCustomFieldDialog({
 										type="button"
 										disabled={!newOption.trim()}
 										onClick={() => {
-											setOptions([...options, newOption.trim()]);
+											setOptions([...options, { value: newOption.trim() }]);
 											setNewOption("");
 										}}
 										className="flex items-center gap-1 rounded-md bg-muted px-2.5 text-xs font-medium text-muted-foreground hover:bg-muted/80 disabled:opacity-40 transition-colors"
@@ -388,7 +403,9 @@ function EditCustomFieldDialog({
 	const { t } = useTranslation("projects");
 	const queryClient = useQueryClient();
 	const [displayName, setDisplayName] = useState(field?.display_name ?? "");
-	const [options, setOptions] = useState<string[]>(field?.options ?? []);
+	const [options, setOptions] = useState<CustomFieldOption[]>(
+		field?.options ?? [],
+	);
 	const [required, setRequired] = useState(field?.is_required ?? false);
 	const [newOption, setNewOption] = useState("");
 	const [error, setError] = useState<string | null>(null);
@@ -500,14 +517,27 @@ function EditCustomFieldDialog({
 							<div className="space-y-1">
 								{options.map((opt, i) => (
 									<div
-										key={opt + i.toString()}
+										key={opt.value + i.toString()}
 										className="flex items-center gap-2"
 									>
+										<ColorSwatchPicker
+											value={opt.color}
+											onChange={(color) => {
+												const updated = [...options];
+												updated[i] = { ...updated[i], color };
+												setOptions(updated);
+											}}
+											triggerLabel={t("settings.customFields.optionColorLabel")}
+											customColorTitle={t(
+												"taskStatuses.formDialog.customColorTitle",
+											)}
+											clearLabel={t("settings.customFields.noColor")}
+										/>
 										<Input
-											value={opt}
+											value={opt.value}
 											onChange={(e) => {
 												const updated = [...options];
-												updated[i] = e.target.value;
+												updated[i] = { ...updated[i], value: e.target.value };
 												setOptions(updated);
 											}}
 											className="text-xs h-8"
@@ -529,7 +559,7 @@ function EditCustomFieldDialog({
 										onChange={(e) => setNewOption(e.target.value)}
 										onKeyDown={(e) => {
 											if (e.key === "Enter" && newOption.trim()) {
-												setOptions([...options, newOption.trim()]);
+												setOptions([...options, { value: newOption.trim() }]);
 												setNewOption("");
 											}
 										}}
@@ -542,7 +572,7 @@ function EditCustomFieldDialog({
 										type="button"
 										disabled={!newOption.trim()}
 										onClick={() => {
-											setOptions([...options, newOption.trim()]);
+											setOptions([...options, { value: newOption.trim() }]);
 											setNewOption("");
 										}}
 										className="flex items-center gap-1 rounded-md bg-muted px-2.5 text-xs font-medium text-muted-foreground hover:bg-muted/80 disabled:opacity-40"

--- a/apps/web/src/components/projects/task-statuses/TaskStatusFormDialog.tsx
+++ b/apps/web/src/components/projects/task-statuses/TaskStatusFormDialog.tsx
@@ -23,6 +23,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import { COLOR_PRESETS } from "@/lib/color-presets";
 import {
 	createTaskStatus,
 	STATUS_CATEGORIES,
@@ -40,21 +41,6 @@ interface TaskStatusFormDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
-
-const COLOR_PRESETS = [
-	"#6366f1",
-	"#8b5cf6",
-	"#ec4899",
-	"#ef4444",
-	"#f97316",
-	"#eab308",
-	"#22c55e",
-	"#14b8a6",
-	"#06b6d4",
-	"#3b82f6",
-	"#64748b",
-	"#78716c",
-];
 
 export function TaskStatusFormDialog({
 	projectId,

--- a/apps/web/src/components/projects/task-types/TaskTypeFormDialog.tsx
+++ b/apps/web/src/components/projects/task-types/TaskTypeFormDialog.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ApiErrorCode, getApiErrorCode } from "@/lib/api-error";
+import { COLOR_PRESETS } from "@/lib/color-presets";
 import {
 	createTaskType,
 	type TaskType,
@@ -30,21 +31,6 @@ interface TaskTypeFormDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
-
-const COLOR_PRESETS = [
-	"#6366f1",
-	"#8b5cf6",
-	"#ec4899",
-	"#ef4444",
-	"#f97316",
-	"#eab308",
-	"#22c55e",
-	"#14b8a6",
-	"#06b6d4",
-	"#3b82f6",
-	"#64748b",
-	"#78716c",
-];
 
 export function TaskTypeFormDialog({
 	projectId,

--- a/apps/web/src/components/ui/color-swatch-picker.tsx
+++ b/apps/web/src/components/ui/color-swatch-picker.tsx
@@ -1,0 +1,95 @@
+import { X } from "lucide-react";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { COLOR_PRESETS } from "@/lib/color-presets";
+
+// Compact color picker: a small circular trigger (shows the current color, or
+// a dashed ring when none is set) that opens a popover with the shared
+// preset swatches, a native custom-color input, and a clear button. Reuses
+// the same preset palette/interaction as TaskStatusFormDialog and
+// TaskTypeFormDialog, just packaged for use inline in a list of rows (e.g.
+// one per custom field option) rather than a single full-width field.
+export function ColorSwatchPicker({
+	value,
+	onChange,
+	triggerLabel,
+	customColorTitle,
+	clearLabel,
+}: {
+	value: string | null | undefined;
+	onChange: (color: string | null) => void;
+	triggerLabel: string;
+	customColorTitle: string;
+	clearLabel: string;
+}) {
+	return (
+		<Popover>
+			<PopoverTrigger
+				type="button"
+				title={triggerLabel}
+				aria-label={triggerLabel}
+				className="relative size-6 shrink-0 rounded-full border-2 border-border/50 transition-transform hover:scale-110"
+				style={
+					value ? { backgroundColor: value, borderColor: value } : undefined
+				}
+			>
+				{!value && (
+					<span className="absolute inset-1 rounded-full border border-dashed border-muted-foreground/40" />
+				)}
+			</PopoverTrigger>
+			<PopoverContent className="w-auto p-2" align="start">
+				<div className="flex max-w-44 flex-wrap items-center gap-1.5">
+					{COLOR_PRESETS.map((preset) => (
+						<button
+							key={preset}
+							type="button"
+							className={`size-5 rounded-full border-2 transition-transform hover:scale-110 ${
+								value === preset
+									? "border-foreground scale-110"
+									: "border-transparent"
+							}`}
+							style={{ backgroundColor: preset }}
+							onClick={() => onChange(preset)}
+							aria-label={preset}
+						/>
+					))}
+					<label
+						title={customColorTitle}
+						className={`relative size-5 shrink-0 cursor-pointer overflow-hidden rounded-full border-2 transition-transform hover:scale-110 ${
+							value && !COLOR_PRESETS.includes(value)
+								? "border-foreground scale-110"
+								: "border-transparent"
+						}`}
+						style={{
+							background:
+								"conic-gradient(#ef4444, #f97316, #eab308, #22c55e, #14b8a6, #06b6d4, #3b82f6, #6366f1, #8b5cf6, #ec4899, #ef4444)",
+							backgroundSize: "120% 120%",
+							backgroundPosition: "center",
+						}}
+					>
+						<input
+							type="color"
+							value={value ?? "#6366f1"}
+							onChange={(e) => onChange(e.target.value)}
+							className="sr-only"
+						/>
+					</label>
+					{value && (
+						<button
+							type="button"
+							title={clearLabel}
+							aria-label={clearLabel}
+							onClick={() => onChange(null)}
+							className="flex size-5 shrink-0 items-center justify-center rounded-full border-2 border-transparent text-muted-foreground transition-colors hover:text-destructive"
+						>
+							<X className="size-3.5" />
+						</button>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/web/src/i18n/locales/en/projects.json
+++ b/apps/web/src/i18n/locales/en/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "Options",
 			"addOptionPlaceholder": "Add option…",
 			"addOption": "Add",
+			"optionColorLabel": "Option color",
+			"noColor": "No color",
 			"requiredLabel": "Required",
 			"requiredHint": "Users must fill this field when creating or editing a task.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/es/projects.json
+++ b/apps/web/src/i18n/locales/es/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "Opciones",
 			"addOptionPlaceholder": "Añadir opción…",
 			"addOption": "Añadir",
+			"optionColorLabel": "Color de la opción",
+			"noColor": "Sin color",
 			"requiredLabel": "Obligatorio",
 			"requiredHint": "Los usuarios deben completar este campo al crear o editar una tarea.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/fr/projects.json
+++ b/apps/web/src/i18n/locales/fr/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "Options",
 			"addOptionPlaceholder": "Ajouter une option…",
 			"addOption": "Ajouter",
+			"optionColorLabel": "Couleur de l'option",
+			"noColor": "Aucune couleur",
 			"requiredLabel": "Requis",
 			"requiredHint": "Les utilisateurs doivent renseigner ce champ lors de la création ou de la modification d'une tâche.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/ja/projects.json
+++ b/apps/web/src/i18n/locales/ja/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "選択肢",
 			"addOptionPlaceholder": "選択肢を追加…",
 			"addOption": "追加",
+			"optionColorLabel": "オプションの色",
+			"noColor": "色なし",
 			"requiredLabel": "必須",
 			"requiredHint": "タスクの作成・編集時にユーザーはこのフィールドを入力する必要があります。",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/ko/projects.json
+++ b/apps/web/src/i18n/locales/ko/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "옵션",
 			"addOptionPlaceholder": "옵션 추가…",
 			"addOption": "추가",
+			"optionColorLabel": "옵션 색상",
+			"noColor": "색상 없음",
 			"requiredLabel": "필수",
 			"requiredHint": "사용자는 작업을 생성하거나 수정할 때 이 필드를 입력해야 합니다.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/pt-BR/projects.json
+++ b/apps/web/src/i18n/locales/pt-BR/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "Opções",
 			"addOptionPlaceholder": "Adicionar opção…",
 			"addOption": "Adicionar",
+			"optionColorLabel": "Cor da opção",
+			"noColor": "Sem cor",
 			"requiredLabel": "Obrigatório",
 			"requiredHint": "Os usuários devem preencher este campo ao criar ou editar uma tarefa.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/ru/projects.json
+++ b/apps/web/src/i18n/locales/ru/projects.json
@@ -896,6 +896,8 @@
 			"optionsLabel": "Опции",
 			"addOptionPlaceholder": "Добавить опцию…",
 			"addOption": "Добавить",
+			"optionColorLabel": "Цвет варианта",
+			"noColor": "Без цвета",
 			"requiredLabel": "Обязательное",
 			"requiredHint": "Пользователи должны заполнять это поле при создании или редактировании задачи.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/vi/projects.json
+++ b/apps/web/src/i18n/locales/vi/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "Tùy chọn",
 			"addOptionPlaceholder": "Thêm tùy chọn…",
 			"addOption": "Thêm",
+			"optionColorLabel": "Màu tùy chọn",
+			"noColor": "Không màu",
 			"requiredLabel": "Bắt buộc",
 			"requiredHint": "Người dùng phải điền trường này khi tạo hoặc chỉnh sửa nhiệm vụ.",
 			"fieldTypes": {

--- a/apps/web/src/i18n/locales/zh-CN/projects.json
+++ b/apps/web/src/i18n/locales/zh-CN/projects.json
@@ -882,6 +882,8 @@
 			"optionsLabel": "选项",
 			"addOptionPlaceholder": "添加选项…",
 			"addOption": "添加",
+			"optionColorLabel": "选项颜色",
+			"noColor": "无颜色",
 			"requiredLabel": "必填",
 			"requiredHint": "用户在创建或编辑任务时必须填写此字段。",
 			"fieldTypes": {

--- a/apps/web/src/lib/color-presets.ts
+++ b/apps/web/src/lib/color-presets.ts
@@ -1,0 +1,17 @@
+// Shared preset palette for hex color pickers (task statuses, task types,
+// custom field option colors, ...). Kept as plain hex strings — see
+// task_types/task_statuses `color` columns, the closest existing precedent.
+export const COLOR_PRESETS = [
+	"#6366f1",
+	"#8b5cf6",
+	"#ec4899",
+	"#ef4444",
+	"#f97316",
+	"#eab308",
+	"#22c55e",
+	"#14b8a6",
+	"#06b6d4",
+	"#3b82f6",
+	"#64748b",
+	"#78716c",
+];

--- a/apps/web/src/lib/custom-field-colors.test.ts
+++ b/apps/web/src/lib/custom-field-colors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	customFieldBadgeStyle,
+	getCustomFieldOptionColor,
+} from "./custom-field-colors";
+
+describe("getCustomFieldOptionColor", () => {
+	it("returns the matching option's color", () => {
+		const options = [
+			{ value: "Low", color: "#22c55e" },
+			{ value: "High", color: "#ef4444" },
+		];
+		expect(getCustomFieldOptionColor(options, "High")).toBe("#ef4444");
+	});
+
+	it("returns undefined when the option has no color", () => {
+		const options = [{ value: "Low" }];
+		expect(getCustomFieldOptionColor(options, "Low")).toBeUndefined();
+	});
+
+	it("returns undefined when no option matches the value", () => {
+		const options = [{ value: "Low", color: "#22c55e" }];
+		expect(getCustomFieldOptionColor(options, "Missing")).toBeUndefined();
+	});
+
+	it("returns undefined when options is undefined", () => {
+		expect(getCustomFieldOptionColor(undefined, "Low")).toBeUndefined();
+	});
+});
+
+describe("customFieldBadgeStyle", () => {
+	it("returns a tinted background plus solid text color for a valid hex color", () => {
+		expect(customFieldBadgeStyle("#ef4444")).toEqual({
+			backgroundColor: "#ef44441a",
+			color: "#ef4444",
+		});
+	});
+
+	it("returns undefined when color is undefined", () => {
+		expect(customFieldBadgeStyle(undefined)).toBeUndefined();
+	});
+
+	// Regression test: nothing validates `color` server-side, so a value
+	// written some other way (bare color name, 3-digit hex, garbage from a
+	// direct API call or MCP tool call) could reach this function. Appending
+	// the alpha suffix to anything other than a 6-digit hex string produces
+	// invalid CSS, silently dropping the tint — reject it up front instead.
+	it.each(["red", "#fff", "not-a-color", "#gggggg", "#ef444"])(
+		"returns undefined for a non-hex color %s",
+		(color) => {
+			expect(customFieldBadgeStyle(color)).toBeUndefined();
+		},
+	);
+});

--- a/apps/web/src/lib/custom-field-colors.test.ts
+++ b/apps/web/src/lib/custom-field-colors.test.ts
@@ -45,10 +45,13 @@ describe("customFieldBadgeStyle", () => {
 	// direct API call or MCP tool call) could reach this function. Appending
 	// the alpha suffix to anything other than a 6-digit hex string produces
 	// invalid CSS, silently dropping the tint — reject it up front instead.
-	it.each(["red", "#fff", "not-a-color", "#gggggg", "#ef444"])(
-		"returns undefined for a non-hex color %s",
-		(color) => {
-			expect(customFieldBadgeStyle(color)).toBeUndefined();
-		},
-	);
+	it.each([
+		"red",
+		"#fff",
+		"not-a-color",
+		"#gggggg",
+		"#ef444",
+	])("returns undefined for a non-hex color %s", (color) => {
+		expect(customFieldBadgeStyle(color)).toBeUndefined();
+	});
 });

--- a/apps/web/src/lib/custom-field-colors.ts
+++ b/apps/web/src/lib/custom-field-colors.ts
@@ -1,0 +1,21 @@
+import type { CSSProperties } from "react";
+import type { CustomFieldOption } from "@/lib/project-api";
+
+// Looks up the color chosen for one select/multi_select option value, if any.
+export function getCustomFieldOptionColor(
+	options: CustomFieldOption[] | undefined,
+	value: string,
+): string | undefined {
+	return options?.find((o) => o.value === value)?.color ?? undefined;
+}
+
+// Badge style for a colored custom field option chip: a tinted background
+// derived from the option's color plus solid-color text. Returns undefined
+// when no color was chosen, so callers fall back to their default
+// (bg-primary/10 text-primary/80) className instead.
+export function customFieldBadgeStyle(
+	color: string | undefined,
+): CSSProperties | undefined {
+	if (!color) return undefined;
+	return { backgroundColor: `${color}1a`, color };
+}

--- a/apps/web/src/lib/custom-field-colors.ts
+++ b/apps/web/src/lib/custom-field-colors.ts
@@ -9,13 +9,23 @@ export function getCustomFieldOptionColor(
 	return options?.find((o) => o.value === value)?.color ?? undefined;
 }
 
+// Matches exactly the "#rrggbb" shape the color picker (presets + native
+// <input type="color">) always produces. Nothing enforces this format
+// server-side, so a value written some other way (a bare color name, 3-digit
+// hex, garbage from a direct API call or MCP tool call) could otherwise reach
+// here — appending an alpha suffix to a non-6-digit-hex string produces
+// invalid CSS, silently dropping the background tint. Reject anything else
+// up front so callers cleanly fall back to their default styling instead.
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
 // Badge style for a colored custom field option chip: a tinted background
 // derived from the option's color plus solid-color text. Returns undefined
-// when no color was chosen, so callers fall back to their default
-// (bg-primary/10 text-primary/80) className instead.
+// when no color was chosen (or it isn't a valid "#rrggbb" hex string), so
+// callers fall back to their default (bg-primary/10 text-primary/80)
+// className instead.
 export function customFieldBadgeStyle(
 	color: string | undefined,
 ): CSSProperties | undefined {
-	if (!color) return undefined;
+	if (!color || !HEX_COLOR_RE.test(color)) return undefined;
 	return { backgroundColor: `${color}1a`, color };
 }

--- a/apps/web/src/lib/project-api.ts
+++ b/apps/web/src/lib/project-api.ts
@@ -439,13 +439,18 @@ export type FieldType =
 	| "boolean"
 	| "url";
 
+export interface CustomFieldOption {
+	value: string;
+	color?: string | null;
+}
+
 export interface CustomFieldDefinition {
 	id: string;
 	project_id: string;
 	field_key: string;
 	display_name: string;
 	field_type: FieldType;
-	options: string[];
+	options: CustomFieldOption[];
 	is_required: boolean;
 	created_at: string;
 	updated_at: string;
@@ -476,7 +481,7 @@ export async function createCustomFieldDefinition(
 		display_name: string;
 		field_key: string;
 		field_type: FieldType;
-		options?: string[];
+		options?: CustomFieldOption[];
 		is_required?: boolean;
 	},
 ): Promise<CustomFieldDefinition> {
@@ -491,7 +496,7 @@ export async function updateCustomFieldDefinition(
 	fieldId: string,
 	payload: {
 		display_name?: string;
-		options?: string[];
+		options?: CustomFieldOption[];
 		is_required?: boolean;
 	},
 ): Promise<CustomFieldDefinition> {

--- a/services/api/internal/domain/task/entity.go
+++ b/services/api/internal/domain/task/entity.go
@@ -83,6 +83,21 @@ var ValidFieldTypes = map[FieldType]bool{
 	FieldTypeURL:         true,
 }
 
+// CustomFieldOption is one selectable value of a select / multi_select
+// custom field. Color is an optional hex string (e.g. "#6366f1") used to
+// render the value as a colored badge; nil means no color was chosen and
+// the UI falls back to its default styling. Value is also the raw string
+// stored in Task.CustomFields under the field's key, so renaming a Value
+// orphans any task data that already references the old string.
+// Value and Color use lowercase json tags because the repository layer
+// marshals CustomFieldOption directly into the options JSONB column (see
+// task_repository.go's marshalOptions/toCustomFieldEntity) — these tags are
+// the on-disk/wire shape, not just an API-layer concern.
+type CustomFieldOption struct {
+	Value string  `json:"value"`
+	Color *string `json:"color,omitempty"`
+}
+
 // CustomFieldDefinition is a project-level schema entry that describes one
 // extra field that can be stored in Task.CustomFields under FieldKey.
 type CustomFieldDefinition struct {
@@ -91,7 +106,7 @@ type CustomFieldDefinition struct {
 	FieldKey    string
 	DisplayName string
 	FieldType   FieldType
-	Options     []string // populated for select / multi_select types
+	Options     []CustomFieldOption // populated for select / multi_select types
 	IsRequired  bool
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/services/api/internal/domain/task/service.go
+++ b/services/api/internal/domain/task/service.go
@@ -204,7 +204,7 @@ type CreateCustomFieldDefinitionInput struct {
 	FieldKey    string
 	DisplayName string
 	FieldType   FieldType
-	Options     []string
+	Options     []CustomFieldOption
 	IsRequired  bool
 }
 
@@ -213,6 +213,6 @@ type CreateCustomFieldDefinitionInput struct {
 type UpdateCustomFieldDefinitionInput struct {
 	DisplayName string
 	FieldType   *FieldType
-	Options     []string
+	Options     []CustomFieldOption
 	IsRequired  *bool
 }

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -1687,14 +1687,9 @@ func toCustomFieldEntity(r *customFieldDefinitionRecord) (*taskdom.CustomFieldDe
 	id, _ := uuid.Parse(r.ID)
 	pid, _ := uuid.Parse(r.ProjectID)
 
-	var opts []taskdom.CustomFieldOption
-	if len(r.Options) > 0 {
-		if err := json.Unmarshal(r.Options, &opts); err != nil {
-			return nil, fmt.Errorf("custom field repo: unmarshal options: %w", err)
-		}
-	}
-	if opts == nil {
-		opts = []taskdom.CustomFieldOption{}
+	opts, err := unmarshalCustomFieldOptions(r.Options)
+	if err != nil {
+		return nil, fmt.Errorf("custom field repo: unmarshal options: %w", err)
 	}
 
 	return &taskdom.CustomFieldDefinition{
@@ -1708,6 +1703,39 @@ func toCustomFieldEntity(r *customFieldDefinitionRecord) (*taskdom.CustomFieldDe
 		CreatedAt:   r.CreatedAt,
 		UpdatedAt:   r.UpdatedAt,
 	}, nil
+}
+
+// unmarshalCustomFieldOptions parses the options JSONB column into
+// CustomFieldOption structs, tolerating rows still holding the pre-000050
+// plain-string element shape (e.g. ["Web","iOS"]) rather than the current
+// {"value":...,"color":...} objects. 000050 backfills every row at boot,
+// but during a rolling deploy an old-code replica can still write the
+// legacy shape after a new-code replica has already migrated the table —
+// unmarshaling straight into []CustomFieldOption would then fail on that
+// row's plain string elements. Each element that isn't already a
+// {value,color} object is coerced to CustomFieldOption{Value: <string>}.
+func unmarshalCustomFieldOptions(raw []byte) ([]taskdom.CustomFieldOption, error) {
+	if len(raw) == 0 {
+		return []taskdom.CustomFieldOption{}, nil
+	}
+	var rawElems []json.RawMessage
+	if err := json.Unmarshal(raw, &rawElems); err != nil {
+		return nil, err
+	}
+	opts := make([]taskdom.CustomFieldOption, len(rawElems))
+	for i, elem := range rawElems {
+		var opt taskdom.CustomFieldOption
+		if err := json.Unmarshal(elem, &opt); err == nil {
+			opts[i] = opt
+			continue
+		}
+		var legacyValue string
+		if err := json.Unmarshal(elem, &legacyValue); err != nil {
+			return nil, err
+		}
+		opts[i] = taskdom.CustomFieldOption{Value: legacyValue}
+	}
+	return opts, nil
 }
 
 func marshalOptions(opts []taskdom.CustomFieldOption) ([]byte, error) {

--- a/services/api/internal/repository/postgres/task_repository.go
+++ b/services/api/internal/repository/postgres/task_repository.go
@@ -1687,14 +1687,14 @@ func toCustomFieldEntity(r *customFieldDefinitionRecord) (*taskdom.CustomFieldDe
 	id, _ := uuid.Parse(r.ID)
 	pid, _ := uuid.Parse(r.ProjectID)
 
-	var opts []string
+	var opts []taskdom.CustomFieldOption
 	if len(r.Options) > 0 {
 		if err := json.Unmarshal(r.Options, &opts); err != nil {
 			return nil, fmt.Errorf("custom field repo: unmarshal options: %w", err)
 		}
 	}
 	if opts == nil {
-		opts = []string{}
+		opts = []taskdom.CustomFieldOption{}
 	}
 
 	return &taskdom.CustomFieldDefinition{
@@ -1710,9 +1710,9 @@ func toCustomFieldEntity(r *customFieldDefinitionRecord) (*taskdom.CustomFieldDe
 	}, nil
 }
 
-func marshalOptions(opts []string) ([]byte, error) {
+func marshalOptions(opts []taskdom.CustomFieldOption) ([]byte, error) {
 	if opts == nil {
-		opts = []string{}
+		opts = []taskdom.CustomFieldOption{}
 	}
 	b, err := json.Marshal(opts)
 	if err != nil {

--- a/services/api/internal/repository/postgres/task_repository_test.go
+++ b/services/api/internal/repository/postgres/task_repository_test.go
@@ -459,3 +459,54 @@ func TestApplyTaskFilter_Tags_ORsAnyMatch(t *testing.T) {
 		t.Fatalf("args = %+v, want %+v", b.args, wantArgs)
 	}
 }
+
+// TestUnmarshalCustomFieldOptions_LegacyStringElements is a regression test
+// for a rolling-deploy window flagged in PR review: an old-code replica can
+// still write the pre-000050 plain-string options shape
+// (`["Low","High"]`) to a row after a new-code replica has already
+// migrated the table to `{value,color}` objects. Reads must tolerate a mix
+// of both shapes rather than erroring.
+func TestUnmarshalCustomFieldOptions_LegacyStringElements(t *testing.T) {
+	opts, err := unmarshalCustomFieldOptions([]byte(`["Low","High"]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []taskdom.CustomFieldOption{{Value: "Low"}, {Value: "High"}}
+	if !reflect.DeepEqual(opts, want) {
+		t.Fatalf("opts = %+v, want %+v", opts, want)
+	}
+}
+
+func TestUnmarshalCustomFieldOptions_NewObjectElements(t *testing.T) {
+	opts, err := unmarshalCustomFieldOptions([]byte(`[{"value":"Low","color":"#22c55e"},{"value":"High","color":null}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	green := "#22c55e"
+	want := []taskdom.CustomFieldOption{{Value: "Low", Color: &green}, {Value: "High"}}
+	if !reflect.DeepEqual(opts, want) {
+		t.Fatalf("opts = %+v, want %+v", opts, want)
+	}
+}
+
+func TestUnmarshalCustomFieldOptions_MixedLegacyAndNewElements(t *testing.T) {
+	opts, err := unmarshalCustomFieldOptions([]byte(`["Low",{"value":"High","color":"#ef4444"}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	red := "#ef4444"
+	want := []taskdom.CustomFieldOption{{Value: "Low"}, {Value: "High", Color: &red}}
+	if !reflect.DeepEqual(opts, want) {
+		t.Fatalf("opts = %+v, want %+v", opts, want)
+	}
+}
+
+func TestUnmarshalCustomFieldOptions_Empty(t *testing.T) {
+	opts, err := unmarshalCustomFieldOptions(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts) != 0 {
+		t.Fatalf("opts = %+v, want empty", opts)
+	}
+}

--- a/services/api/internal/service/task/task_service.go
+++ b/services/api/internal/service/task/task_service.go
@@ -545,7 +545,7 @@ func (s *Service) CreateCustomFieldDefinition(ctx context.Context, in taskdom.Cr
 
 	opts := in.Options
 	if opts == nil {
-		opts = []string{}
+		opts = []taskdom.CustomFieldOption{}
 	}
 
 	now := time.Now()

--- a/services/api/internal/service/task/task_service_test.go
+++ b/services/api/internal/service/task/task_service_test.go
@@ -2033,8 +2033,10 @@ func TestCreateCustomFieldDefinition_OK(t *testing.T) {
 		FieldKey:    "priority",
 		DisplayName: "Priority",
 		FieldType:   taskdom.FieldTypeSelect,
-		Options:     []string{"low", "medium", "high"},
-		IsRequired:  true,
+		Options: []taskdom.CustomFieldOption{
+			{Value: "low"}, {Value: "medium"}, {Value: "high"},
+		},
+		IsRequired: true,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2146,7 +2148,7 @@ func TestUpdateCustomFieldDefinition_OK(t *testing.T) {
 	updated, err := svc.UpdateCustomFieldDefinition(ctx, f.ProjectID, f.ID, taskdom.UpdateCustomFieldDefinitionInput{
 		DisplayName: "Reason",
 		FieldType:   &newType,
-		Options:     []string{"blocked", "waiting"},
+		Options:     []taskdom.CustomFieldOption{{Value: "blocked"}, {Value: "waiting"}},
 		IsRequired:  &required,
 	})
 	if err != nil {

--- a/services/api/internal/transport/http/dto/task_dto.go
+++ b/services/api/internal/transport/http/dto/task_dto.go
@@ -426,44 +426,76 @@ func TaskFromEntity(t *taskdom.Task) TaskResponse {
 
 // --- Custom Field Definition DTOs ------------------------------------------
 
+// CustomFieldOptionDTO is one selectable value of a select / multi_select
+// custom field, with an optional display color. Mirrors
+// taskdom.CustomFieldOption.
+type CustomFieldOptionDTO struct {
+	Value string  `json:"value"`
+	Color *string `json:"color,omitempty"`
+}
+
 // CreateCustomFieldDefinitionRequest is the body for
 // POST /projects/:projectId/custom-fields.
 type CreateCustomFieldDefinitionRequest struct {
-	FieldKey    string            `json:"field_key" binding:"required"`
-	DisplayName string            `json:"display_name" binding:"required"`
-	FieldType   taskdom.FieldType `json:"field_type" binding:"required"`
-	Options     []string          `json:"options"`
-	IsRequired  bool              `json:"is_required"`
+	FieldKey    string                 `json:"field_key" binding:"required"`
+	DisplayName string                 `json:"display_name" binding:"required"`
+	FieldType   taskdom.FieldType      `json:"field_type" binding:"required"`
+	Options     []CustomFieldOptionDTO `json:"options"`
+	IsRequired  bool                   `json:"is_required"`
 }
 
 // UpdateCustomFieldDefinitionRequest is the body for
 // PATCH /projects/:projectId/custom-fields/:fieldId.
 type UpdateCustomFieldDefinitionRequest struct {
-	DisplayName string             `json:"display_name"`
-	FieldType   *taskdom.FieldType `json:"field_type"`
-	Options     []string           `json:"options"`
-	IsRequired  *bool              `json:"is_required"`
+	DisplayName string                 `json:"display_name"`
+	FieldType   *taskdom.FieldType     `json:"field_type"`
+	Options     []CustomFieldOptionDTO `json:"options"`
+	IsRequired  *bool                  `json:"is_required"`
 }
 
 // CustomFieldDefinitionResponse is the public representation of a custom
 // field definition.
 type CustomFieldDefinitionResponse struct {
-	ID          uuid.UUID         `json:"id"`
-	ProjectID   uuid.UUID         `json:"project_id"`
-	FieldKey    string            `json:"field_key"`
-	DisplayName string            `json:"display_name"`
-	FieldType   taskdom.FieldType `json:"field_type"`
-	Options     []string          `json:"options"`
-	IsRequired  bool              `json:"is_required"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	ID          uuid.UUID              `json:"id"`
+	ProjectID   uuid.UUID              `json:"project_id"`
+	FieldKey    string                 `json:"field_key"`
+	DisplayName string                 `json:"display_name"`
+	FieldType   taskdom.FieldType      `json:"field_type"`
+	Options     []CustomFieldOptionDTO `json:"options"`
+	IsRequired  bool                   `json:"is_required"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+}
+
+// customFieldOptionsToDomain maps request DTOs to domain options.
+func customFieldOptionsToDomain(opts []CustomFieldOptionDTO) []taskdom.CustomFieldOption {
+	if opts == nil {
+		return nil
+	}
+	out := make([]taskdom.CustomFieldOption, len(opts))
+	for i, o := range opts {
+		out[i] = taskdom.CustomFieldOption{Value: o.Value, Color: o.Color}
+	}
+	return out
+}
+
+// CustomFieldOptionsToDomain maps the create request body's options to their
+// domain representation.
+func (r CreateCustomFieldDefinitionRequest) CustomFieldOptionsToDomain() []taskdom.CustomFieldOption {
+	return customFieldOptionsToDomain(r.Options)
+}
+
+// CustomFieldOptionsToDomain maps the update request body's options to their
+// domain representation.
+func (r UpdateCustomFieldDefinitionRequest) CustomFieldOptionsToDomain() []taskdom.CustomFieldOption {
+	return customFieldOptionsToDomain(r.Options)
 }
 
 // CustomFieldDefinitionFromEntity maps a domain CustomFieldDefinition to a DTO.
 func CustomFieldDefinitionFromEntity(f *taskdom.CustomFieldDefinition) CustomFieldDefinitionResponse {
-	opts := f.Options
-	if opts == nil {
-		opts = []string{}
+	opts := make([]CustomFieldOptionDTO, len(f.Options))
+	for i, o := range f.Options {
+		opts[i] = CustomFieldOptionDTO{Value: o.Value, Color: o.Color}
 	}
 	return CustomFieldDefinitionResponse{
 		ID:          f.ID,

--- a/services/api/internal/transport/http/dto/task_dto.go
+++ b/services/api/internal/transport/http/dto/task_dto.go
@@ -434,6 +434,29 @@ type CustomFieldOptionDTO struct {
 	Color *string `json:"color,omitempty"`
 }
 
+// UnmarshalJSON accepts either a plain string (the pre-000050 wire shape,
+// e.g. "Open") or an object carrying an optional color (e.g.
+// {"value":"Open","color":"#6366f1"}). Without this, a request body built
+// by a direct API caller still using the old plain-string options array
+// would hard-fail decoding instead of being accepted like it used to.
+// Mirrors the same two-shape tolerance already applied when reading legacy
+// rows in unmarshalCustomFieldOptions and when normalizing MCP tool input.
+func (o *CustomFieldOptionDTO) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err == nil {
+		o.Value = value
+		o.Color = nil
+		return nil
+	}
+	type alias CustomFieldOptionDTO
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*o = CustomFieldOptionDTO(a)
+	return nil
+}
+
 // CreateCustomFieldDefinitionRequest is the body for
 // POST /projects/:projectId/custom-fields.
 type CreateCustomFieldDefinitionRequest struct {

--- a/services/api/internal/transport/http/dto/task_dto_test.go
+++ b/services/api/internal/transport/http/dto/task_dto_test.go
@@ -1,0 +1,92 @@
+package dto_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/Paca-AI/api/internal/transport/http/dto"
+)
+
+// ---------------------------------------------------------------------------
+// CustomFieldOptionDTO.UnmarshalJSON
+// ---------------------------------------------------------------------------
+
+// TestCustomFieldOptionDTO_UnmarshalJSON_PlainString is a regression test for
+// a PR review finding: a direct API caller still sending the pre-000050
+// plain-string options shape (e.g. ["Open","Closed"]) must not get a hard
+// decode failure now that options carry an optional color, matching the
+// same two-shape tolerance already applied by the MCP tool layer and the
+// repository's legacy-row unmarshaling.
+func TestCustomFieldOptionDTO_UnmarshalJSON_PlainString(t *testing.T) {
+	var opt dto.CustomFieldOptionDTO
+	if err := json.Unmarshal([]byte(`"Open"`), &opt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := dto.CustomFieldOptionDTO{Value: "Open"}
+	if !reflect.DeepEqual(opt, want) {
+		t.Fatalf("opt = %+v, want %+v", opt, want)
+	}
+}
+
+func TestCustomFieldOptionDTO_UnmarshalJSON_ObjectWithColor(t *testing.T) {
+	var opt dto.CustomFieldOptionDTO
+	if err := json.Unmarshal([]byte(`{"value":"High","color":"#ef4444"}`), &opt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	red := "#ef4444"
+	want := dto.CustomFieldOptionDTO{Value: "High", Color: &red}
+	if !reflect.DeepEqual(opt, want) {
+		t.Fatalf("opt = %+v, want %+v", opt, want)
+	}
+}
+
+func TestCustomFieldOptionDTO_UnmarshalJSON_ObjectWithoutColor(t *testing.T) {
+	var opt dto.CustomFieldOptionDTO
+	if err := json.Unmarshal([]byte(`{"value":"Low"}`), &opt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := dto.CustomFieldOptionDTO{Value: "Low"}
+	if !reflect.DeepEqual(opt, want) {
+		t.Fatalf("opt = %+v, want %+v", opt, want)
+	}
+}
+
+func TestCustomFieldOptionDTO_UnmarshalJSON_MixedArray(t *testing.T) {
+	var opts []dto.CustomFieldOptionDTO
+	if err := json.Unmarshal([]byte(`["Low",{"value":"High","color":"#ef4444"}]`), &opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	red := "#ef4444"
+	want := []dto.CustomFieldOptionDTO{{Value: "Low"}, {Value: "High", Color: &red}}
+	if !reflect.DeepEqual(opts, want) {
+		t.Fatalf("opts = %+v, want %+v", opts, want)
+	}
+}
+
+func TestCustomFieldOptionDTO_UnmarshalJSON_InvalidType(t *testing.T) {
+	var opt dto.CustomFieldOptionDTO
+	if err := json.Unmarshal([]byte(`42`), &opt); err == nil {
+		t.Fatal("expected an error for a non-string, non-object element")
+	}
+}
+
+// TestCreateCustomFieldDefinitionRequest_LegacyPlainStringOptions verifies
+// the fix end-to-end: a full request body using the old plain-string
+// options array still decodes successfully.
+func TestCreateCustomFieldDefinitionRequest_LegacyPlainStringOptions(t *testing.T) {
+	body := []byte(`{
+		"field_key": "priority",
+		"display_name": "Priority",
+		"field_type": "select",
+		"options": ["Low", "High"]
+	}`)
+	var req dto.CreateCustomFieldDefinitionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := req.CustomFieldOptionsToDomain()
+	if len(got) != 2 || got[0].Value != "Low" || got[1].Value != "High" {
+		t.Fatalf("got = %+v, want [{Low <nil>} {High <nil>}]", got)
+	}
+}

--- a/services/api/internal/transport/http/handler/task_handler.go
+++ b/services/api/internal/transport/http/handler/task_handler.go
@@ -405,10 +405,14 @@ func parseTaskSort(ctx context.Context, svc taskdom.Service, projectID uuid.UUID
 		}
 		for _, cf := range cfs {
 			if cf.FieldKey == sortBy {
+				optValues := make([]string, len(cf.Options))
+				for i, o := range cf.Options {
+					optValues[i] = o.Value
+				}
 				return taskdom.TaskSort{
 					By:     sortBy,
 					CFType: string(cf.FieldType),
-					CFOpts: cf.Options,
+					CFOpts: optValues,
 				}
 			}
 		}
@@ -1419,7 +1423,7 @@ func (h *TaskHandler) CreateCustomFieldDefinition(w http.ResponseWriter, r *http
 		FieldKey:    req.FieldKey,
 		DisplayName: req.DisplayName,
 		FieldType:   req.FieldType,
-		Options:     req.Options,
+		Options:     req.CustomFieldOptionsToDomain(),
 		IsRequired:  req.IsRequired,
 	})
 	if err != nil {
@@ -1450,7 +1454,7 @@ func (h *TaskHandler) UpdateCustomFieldDefinition(w http.ResponseWriter, r *http
 	f, err := h.svc.UpdateCustomFieldDefinition(r.Context(), projectID, fieldID, taskdom.UpdateCustomFieldDefinitionInput{
 		DisplayName: req.DisplayName,
 		FieldType:   req.FieldType,
-		Options:     req.Options,
+		Options:     req.CustomFieldOptionsToDomain(),
 		IsRequired:  req.IsRequired,
 	})
 	if err != nil {

--- a/services/api/internal/transport/http/handler/task_handler_test.go
+++ b/services/api/internal/transport/http/handler/task_handler_test.go
@@ -645,7 +645,7 @@ func TestTaskHandler_ListTasks_TaskTypeIDsDriveFiltering(t *testing.T) {
 func TestTaskHandler_ListTasks_CustomFieldFilters_SelectResolvesFieldType(t *testing.T) {
 	svc := newFakeTaskSvc()
 	svc.customFields = []*taskdom.CustomFieldDefinition{
-		{FieldKey: "priority", FieldType: taskdom.FieldTypeSelect, Options: []string{"Low", "High"}},
+		{FieldKey: "priority", FieldType: taskdom.FieldTypeSelect, Options: []taskdom.CustomFieldOption{{Value: "Low"}, {Value: "High"}}},
 	}
 	r := buildTaskHandlerRouter(svc)
 	projectID := uuid.New()
@@ -694,7 +694,7 @@ func TestTaskHandler_ListTasks_CustomFieldFilters_NumberRange(t *testing.T) {
 func TestTaskHandler_ListTasks_CustomFieldFilters_UnknownFieldKeyIgnored(t *testing.T) {
 	svc := newFakeTaskSvc()
 	svc.customFields = []*taskdom.CustomFieldDefinition{
-		{FieldKey: "priority", FieldType: taskdom.FieldTypeSelect, Options: []string{"Low", "High"}},
+		{FieldKey: "priority", FieldType: taskdom.FieldTypeSelect, Options: []taskdom.CustomFieldOption{{Value: "Low"}, {Value: "High"}}},
 	}
 	r := buildTaskHandlerRouter(svc)
 	projectID := uuid.New()

--- a/services/api/migrations/000050_add_custom_field_option_colors.sql
+++ b/services/api/migrations/000050_add_custom_field_option_colors.sql
@@ -1,0 +1,38 @@
+-- 000050_add_custom_field_option_colors.sql
+-- Issue #458: lets each value of a select/multi_select custom field carry
+-- its own optional color, so board/list badges stop rendering every value
+-- in the same primary color.
+--
+-- custom_field_definitions.options was a plain JSONB array of strings
+-- (e.g. ["Web","iOS"]). It becomes an array of objects
+-- (e.g. [{"value":"Web","color":"#6366f1"},{"value":"iOS","color":null}])
+-- so each value can carry a color alongside it. The column itself is
+-- unchanged (still JSONB, still nullable) — only the shape of its elements
+-- changes, so no ALTER COLUMN is needed, just a data backfill.
+--
+-- Per database.RunMigrationsFS, every *.sql file re-runs unconditionally on
+-- every server startup, so this UPDATE must be idempotent: it only rewrites
+-- rows that still contain plain-string elements (jsonb_typeof = 'string'),
+-- which becomes false once a row has already been migrated to objects.
+
+BEGIN;
+
+UPDATE custom_field_definitions
+SET options = (
+    SELECT jsonb_agg(
+        CASE
+            WHEN jsonb_typeof(elem) = 'string'
+                THEN jsonb_build_object('value', elem, 'color', NULL)
+            ELSE elem
+        END
+    )
+    FROM jsonb_array_elements(options) AS elem
+)
+WHERE options IS NOT NULL
+  AND jsonb_typeof(options) = 'array'
+  AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(options) AS elem
+      WHERE jsonb_typeof(elem) = 'string'
+  );
+
+COMMIT;

--- a/services/api/test/e2e/task_filter_test.go
+++ b/services/api/test/e2e/task_filter_test.go
@@ -93,7 +93,7 @@ func TestE2ETaskFilters_CustomFieldSelect(t *testing.T) {
 		"field_key":    "priority",
 		"display_name": "Priority",
 		"field_type":   "select",
-		"options":      []string{"Open", "Closed", "Blocked"},
+		"options":      customFieldOptions("Open", "Closed", "Blocked"),
 	})
 
 	open1 := createTaskViaAPIWithBody(t, env, client, token, projID, map[string]any{
@@ -168,7 +168,7 @@ func TestE2ETaskFilters_CustomFieldMultiSelect(t *testing.T) {
 		"field_key":    "labels",
 		"display_name": "Labels",
 		"field_type":   "multi_select",
-		"options":      []string{"backend", "frontend", "urgent"},
+		"options":      customFieldOptions("backend", "frontend", "urgent"),
 	})
 
 	backendUrgent := createTaskViaAPIWithBody(t, env, client, token, projID, map[string]any{
@@ -452,7 +452,7 @@ func TestE2ETaskFilters_CustomFieldsCombinedAND(t *testing.T) {
 
 	createCustomFieldViaAPI(t, env, client, token, projID, map[string]any{
 		"field_key": "priority", "display_name": "Priority", "field_type": "select",
-		"options": []string{"High", "Low"},
+		"options": customFieldOptions("High", "Low"),
 	})
 	createCustomFieldViaAPI(t, env, client, token, projID, map[string]any{
 		"field_key": "effort", "display_name": "Effort", "field_type": "number",
@@ -778,7 +778,7 @@ func TestE2ETaskFilters_CombinedAcrossDimensions(t *testing.T) {
 
 	createCustomFieldViaAPI(t, env, client, token, projID, map[string]any{
 		"field_key": "priority", "display_name": "Priority", "field_type": "select",
-		"options": []string{"High", "Low"},
+		"options": customFieldOptions("High", "Low"),
 	})
 
 	match := createTaskViaAPIWithBody(t, env, client, token, projID, map[string]any{
@@ -828,7 +828,7 @@ func TestE2ETaskFilters_TotalCountAndFieldSumRespectFilters(t *testing.T) {
 
 	createCustomFieldViaAPI(t, env, client, token, projID, map[string]any{
 		"field_key": "priority", "display_name": "Priority", "field_type": "select",
-		"options": []string{"High", "Low"},
+		"options": customFieldOptions("High", "Low"),
 	})
 
 	createTaskViaAPIWithBody(t, env, client, token, projID, map[string]any{

--- a/services/api/test/e2e/task_management_test.go
+++ b/services/api/test/e2e/task_management_test.go
@@ -1389,6 +1389,17 @@ func TestE2ETaskManagement_MultipleAssignees(t *testing.T) {
 // Custom field definition helpers
 // ---------------------------------------------------------------------------
 
+// customFieldOptions builds the wire shape for a select/multi_select custom
+// field's options list: an array of {"value": ...} objects (each may also
+// carry an optional "color", not needed by these tests).
+func customFieldOptions(values ...string) []map[string]any {
+	opts := make([]map[string]any, len(values))
+	for i, v := range values {
+		opts[i] = map[string]any{"value": v}
+	}
+	return opts
+}
+
 func createCustomFieldViaAPI(t *testing.T, env *e2eEnv, client *http.Client, token, projectID string, body map[string]any) string {
 	t.Helper()
 	req := mustRequest(env.ctx, t, http.MethodPost,
@@ -1495,7 +1506,7 @@ func TestE2ECustomFieldManagement_CRUD(t *testing.T) {
 			"field_key":    "status_tag",
 			"display_name": "Status Tag",
 			"field_type":   "select",
-			"options":      []string{"open", "in_progress", "done"},
+			"options":      customFieldOptions("open", "in_progress", "done"),
 			"is_required":  true,
 		})
 		req := mustRequest(env.ctx, t, http.MethodGet,

--- a/services/api/test/e2e/task_pagination_test.go
+++ b/services/api/test/e2e/task_pagination_test.go
@@ -1035,7 +1035,7 @@ func TestE2ECustomFieldFilters_FieldKeyReuseAfterDeleteDoesNotCrash(t *testing.T
 		"field_key":    "custom_1",
 		"display_name": "Custom 1",
 		"field_type":   "select",
-		"options":      []string{"Test 3", "Other"},
+		"options":      customFieldOptions("Test 3", "Other"),
 	})
 	createTaskWithCustomFieldViaAPI(t, env, client, token, projID, "Stale select value",
 		map[string]any{"custom_1": "Test 3"})

--- a/services/api/test/integration/task_test.go
+++ b/services/api/test/integration/task_test.go
@@ -2475,8 +2475,12 @@ func TestIntegrationCustomFields_SelectTypeWithOptions(t *testing.T) {
 		"field_key":    "priority",
 		"display_name": "Priority",
 		"field_type":   "select",
-		"options":      []string{"low", "medium", "high"},
-		"is_required":  true,
+		"options": []map[string]any{
+			{"value": "low"},
+			{"value": "medium"},
+			{"value": "high"},
+		},
+		"is_required": true,
 	}))
 	if createW.Code != http.StatusCreated {
 		t.Fatalf("create select field: expected 201, got %d (%s)", createW.Code, createW.Body.String())


### PR DESCRIPTION
## Summary

Lets each value of a select/multi_select custom field carry its own optional color, so board/list badges stop rendering every value in the same primary color (#458: fields like Platform, QA Status, or Source of Issue were all-one-color and hard to tell apart at a glance).

- **Data model**: `custom_field_definitions.options` changes from a plain array of strings (`["A","B"]`) to an array of `{value, color}` objects, with an idempotent migration (`000050_add_custom_field_option_colors.sql`) backfilling existing rows on startup.
- **Backend**: `CustomFieldOption{Value, Color}` threaded through the domain entity, service inputs, repository marshal/unmarshal, and the create/update/get/list DTOs and handlers.
- **Settings UI**: the custom field create/edit dialogs get a compact `ColorSwatchPicker` per option (12 presets + a native custom-color input + clear), reusing the same preset palette (now shared via `lib/color-presets.ts`) already used by Task Status/Task Type colors.
- **Rendering**: colors flow into every place a custom field value is shown —
  - Task detail panel's select/multi-select editors (via the existing `SelectOption.colorDot`, previously wired up for statuses but never for custom fields).
  - Board (`task-card.tsx`) and list (`task-row.tsx`) view badges, via a small shared helper (`lib/custom-field-colors.ts`) that tints the badge background/text from the option's color, falling back to the old `bg-primary/10` styling when no color was chosen.
  - Multi-select chips in the task detail panel now show their color dot immediately after selection, not just in read-only mode (`ChipField`'s chips previously dropped `colorDot` when building the editable chip list — same pattern already used by `MultiUserEditor`'s avatar chips).
  - Board "group by custom field" columns and the view-settings custom-field filter (both already supported `color` for task-type/status columns).
- **MCP server**: mirrored types updated; the AI-facing tool args stay plain strings (mapped to `{value}` internally) so existing MCP callers are unaffected.
- Translated the new UI strings across all 9 supported locales (en, es, fr, ja, ko, pt-BR, ru, vi, zh-CN).

## Notes

- An option's `value` is still the raw string stored in `tasks.custom_fields` (there's no separate option-id column) — the migration only changes the shape of `options`' elements, not what identifies a value.
- No color format validation was added server-side, matching the existing (unvalidated) `color` handling on task types/statuses.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — `services/api` (unit, integration, and e2e packages)
- [x] `npx tsc --noEmit && npx vitest run` — `apps/mcp` (610/610 passing)
- [x] `npx tsc -b && npx vitest run` — `apps/web` (623/623 passing)
- [x] `biome check` / `gofmt` clean across all changed files
- [x] Manually verified end-to-end against the running dev stack (created a select field with colored options via the API, then confirmed in the browser): color picker in the field settings dialog, colored dot in the task detail panel, colored badge in the list view, and colored chips in an editable multi-select field right after choosing values.

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
