### PR TITLE
cicd: add CI and CD workflow for browser extension

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,10 @@ name: cd
 #     paca-acp-bridge_<version>_<os>_<arch>.{tar.gz,zip} — ACP bridge local
 #       daemon (Go binary; end users run this on their own machine, so it
 #       ships as release assets rather than a Docker image)
+#     paca-extension.zip — pre-built Chrome extension (unpacked); not on the
+#       Chrome Web Store (see build-extension job below for why), so this
+#       fixed-name zip is what apps/extension/README.md's install steps
+#       point users at, same as install.sh/docker-compose.yml above
 #
 # "Latest" tag sequencing (promote-release, the last job below): no image is
 # pushed with a :latest Docker tag until every job in this workflow has
@@ -653,6 +657,64 @@ jobs:
             "${{ steps.package.outputs.asset }}" --clobber
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # Browser extension → GitHub Release asset
+  #
+  # apps/extension is loaded as an unpacked directory in Chrome rather than
+  # published to the Chrome Web Store — it needs <all_urls> host permissions
+  # to work against any self-hosted Paca instance (the hostname can't be
+  # known in advance), which doesn't fit through the Store's review model.
+  # So this just zips the build output and attaches it as a fixed-name
+  # release asset, same pattern as install.sh/docker-compose.yml below, so
+  # /releases/latest/download/paca-extension.zip is a stable URL end users
+  # can download and unzip without cloning the repo or installing Node. See
+  # apps/extension/README.md for the full install steps.
+  # ─────────────────────────────────────────────────────────────────────────────
+  build-extension:
+    name: Build browser extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # gh release upload
+
+    defaults:
+      run:
+        working-directory: apps/extension
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: apps/extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Zips a named paca-extension/ directory (copied from dist/) rather
+      # than dist/'s contents directly, so extracting the archive always
+      # yields a paca-extension/ folder to point "Load unpacked" at,
+      # regardless of which unzip tool a user's OS reaches for.
+      - name: Package archive
+        run: |
+          set -euo pipefail
+          cp -r dist paca-extension
+          zip -r paca-extension.zip paca-extension
+
+      - name: Upload archive to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            paca-extension.zip --clobber
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Deployment assets → GitHub Release
   #
   # Uploads four files so that users can run or upgrade Paca without cloning the repo:
@@ -685,6 +747,7 @@ jobs:
         helm-chart,
         publish-mcp,
         build-acp-bridge,
+        build-extension,
       ]
     permissions:
       contents: write
@@ -761,6 +824,7 @@ jobs:
         helm-chart,
         publish-mcp,
         build-acp-bridge,
+        build-extension,
         release-assets,
       ]
     permissions:

--- a/.github/workflows/extension-pr-ci.yml
+++ b/.github/workflows/extension-pr-ci.yml
@@ -1,0 +1,47 @@
+name: extension-pr-ci
+
+on:
+  pull_request:
+    paths:
+      - "apps/extension/**"
+      - ".github/workflows/extension-pr-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: extension-pr-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  extension-quality:
+    name: Lint and build browser extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: apps/extension
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: apps/extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Biome lint
+        run: npm run lint
+
+      - name: Typecheck and build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ But Paca is built from conviction: human-AI collaboration in a real Scrum team s
 | [docs/guides/local-development.md](docs/guides/local-development.md) | Contributor dev environment setup |
 | [docs/guides/mcp-server-setup.md](docs/guides/mcp-server-setup.md) | Connect AI agents via MCP |
 | [docs/guides/install-skills.md](docs/guides/install-skills.md) | `/paca` skill for Claude Code — manage Paca from your editor |
+| [apps/extension/README.md](apps/extension/README.md) | Browser extension — comment on environment preview pages, turn comments into tasks |
 | [docs/plugins/](docs/plugins/) | Plugin system: backend (WASM) and frontend |
 | [deploy/README.md](deploy/README.md) | Full deployment reference |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -28,21 +28,30 @@ in one click.
   working even if Paca later moves to a different port. Its presence is
   also the *entire* activation signal — there is no separate per-site
   enable step: the extension holds broad host permissions from install
-  (see Setup) and simply stays dormant, everywhere, until this cookie
+  (see Install) and simply stays dormant, everywhere, until this cookie
   shows up.
 - Everything else — listing comments, creating one, resolving, turning one
   into a task — is a normal authenticated call the content script makes
   directly to your Paca instance's API.
 
-## Setup
+## Install
 
-1. `npm install && npm run build` (outputs an unpacked extension to `dist/`).
-2. In Chrome, open `chrome://extensions`, enable Developer Mode, and "Load
-   unpacked" pointing at `dist/`. Chrome will show an install-time prompt
-   for reading/changing data on all sites — that's `<all_urls>` in
-   `manifest.json`, needed because a self-hosted Paca instance's hostname
-   isn't known in advance; the content script itself stays inert
-   everywhere except where the `paca_port` cookie above actually shows up.
+Not on the Chrome Web Store — the extension needs `<all_urls>` host
+permissions to work against any self-hosted Paca instance (its hostname
+isn't known in advance), which doesn't fit the Store's review model. Instead
+each [release](https://github.com/Paca-AI/paca/releases) ships a pre-built
+zip; install it as an unpacked extension:
+
+1. Download and unzip
+   [`paca-extension.zip`](https://github.com/Paca-AI/paca/releases/latest/download/paca-extension.zip)
+   — this always points at the newest release. You get a `paca-extension/`
+   folder.
+2. In Chrome, open `chrome://extensions`, enable Developer Mode (top-right
+   toggle), and click "Load unpacked", pointing at that `paca-extension/`
+   folder. Chrome will show an install-time prompt for reading/changing
+   data on all sites — that's the `<all_urls>` permission above; the
+   content script itself stays inert everywhere except where the
+   `paca_port` cookie above actually shows up.
 3. Log into your Paca instance in a normal tab. That's it — no extension
    UI to click through. The next time you open a forwarded environment
    preview on the same hostname, the toolbar appears on its own.
@@ -51,6 +60,22 @@ in one click.
    from (just a different port per environment). If it points somewhere
    else entirely (a different domain/IP), the extension will stay dormant on
    a forwarded preview — it has no way to authenticate there.
+
+To upgrade, download the zip again over the same folder path and click the
+reload icon on the extension's card in `chrome://extensions` (Chrome
+doesn't auto-update unpacked extensions).
+
+### Building from source instead
+
+Skip the download above and build straight from a checkout — useful for
+development, or to run an unreleased change:
+
+```bash
+npm install && npm run build   # outputs an unpacked extension to dist/
+```
+
+Then "Load unpacked" against `dist/` in place of the downloaded
+`paca-extension/` folder; steps 3–4 above are unchanged.
 
 If a forwarded preview doesn't show the toolbar and you expected it to,
 open DevTools' console on that page and filter for `[Paca]` — the content


### PR DESCRIPTION
## Summary

Adds CI and CD for the Chrome extension (`apps/extension`), plus install docs for the new distributable it produces:

- **CI** — [`extension-pr-ci.yml`](.github/workflows/extension-pr-ci.yml): on any PR touching `apps/extension/**`, runs `npm ci`, Biome lint, and `tsc -b` + the four Vite builds. Mirrors the existing `mcp-pr-ci.yml`/`web-pr-ci.yml` shape, adapted to npm since the extension is the only npm-based package in the repo (everything else is Bun). No test step — the extension has no test runner configured.
- **CD** — a `build-extension` job in [`cd.yml`](.github/workflows/cd.yml), modeled on the existing `build-acp-bridge` job (the closest analog: a locally-installed end-user artifact rather than a server image). On every published GitHub Release it builds the extension, zips `dist/` into a `paca-extension/` folder, and uploads `paca-extension.zip` to the release with a **fixed name** (`--clobber`), same convention as `install.sh`/`docker-compose.yml`, so `.../releases/latest/download/paca-extension.zip` is a stable link. Wired into `release-assets`/`promote-release`'s `needs:` so a release isn't promoted to "Latest" until the extension zip has shipped too.
- **Docs** — [`apps/extension/README.md`](apps/extension/README.md)'s "Setup" section is now "Install," leading with the no-build path (download the release zip → unzip → Load unpacked in Chrome); building from source is kept as a secondary/dev path. Added one row to the root [`README.md`](README.md)'s documentation table, since the extension wasn't linked from anywhere before.

### Not in scope here

The extension isn't on the Chrome Web Store — it needs `<all_urls>` host permissions to work against any self-hosted Paca instance, and no store listing or OAuth credentials exist yet (that's a manual, one-time step only the team can do in the Google console). `build-extension` produces exactly the artifact a future store-upload step would consume, so wiring that in later is additive.

## Type of Change

- Scaffolding (CI/CD workflows)
- Documentation

## Checklist

- [x] The change is focused and scoped.
- [x] Related documentation is updated.
- [x] New structure or direction is explained clearly.
- [x] I avoided unnecessary detail or premature abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
