### PR TITLE
feat: update agent card and create agent dialog for provider_cli supp…

### DIFF
--- a/apps/web/src/components/projects/agents/agent-card.tsx
+++ b/apps/web/src/components/projects/agents/agent-card.tsx
@@ -54,6 +54,7 @@ export function AgentCard({
 	const navigate = useNavigate();
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const isAcp = agent.agent_type === "acp";
+	const isProviderCli = agent.agent_type === "provider_cli";
 
 	const deleteMutation = useMutation({
 		mutationFn: () =>
@@ -131,7 +132,11 @@ export function AgentCard({
 
 					<div className="flex items-center gap-1.5 shrink-0">
 						<Badge variant="secondary" className="text-xs font-medium">
-							{isAcp ? (agent.acp_provider ?? "acp") : agent.llm_provider}
+							{isAcp
+								? (agent.acp_provider ?? "acp")
+								: isProviderCli
+									? (agent.cli_provider ?? "provider_cli")
+									: agent.llm_provider}
 						</Badge>
 						{canWrite && (
 							<DropdownMenu>

--- a/apps/web/src/components/projects/agents/create-agent-dialog.tsx
+++ b/apps/web/src/components/projects/agents/create-agent-dialog.tsx
@@ -118,7 +118,7 @@ function cliLoginCommand(provider: CLIProvider): string {
 		case "gemini-cli":
 			return "gemini";
 		default:
-			return "claude auth login";
+			return "claude login";
 	}
 }
 

--- a/services/agent-runner/internal/executor/providercli/claude_code.go
+++ b/services/agent-runner/internal/executor/providercli/claude_code.go
@@ -32,13 +32,11 @@ func (claudeCode) HomeDirName() string { return claudeCodeHomeDir }
 func (claudeCode) APIKeyEnvVar() (string, bool) { return "ANTHROPIC_API_KEY", true }
 
 // AuthStatusCommand: confidence HIGH — confirmed directly inside a real
-// environment container. `claude login` (bare) does not exist as a
-// command at all (the actual subcommand is `claude auth login`); a
-// prior version of this adapter probed for
+// environment container. A prior version of this adapter probed for
 // ~/.claude/.credentials.json, which turned out to never be created by a
-// real, successful login either — that file-existence guess reported
-// "not authenticated" even right after the user completed `claude auth
-// login`. `claude auth status` is Claude Code's own status subcommand:
+// real, successful `claude login` either — that file-existence guess
+// reported "not authenticated" even right after the user completed
+// login. `claude auth status` is Claude Code's own status subcommand:
 // no network call, prints JSON to stdout, exits 1 when logged out.
 func (claudeCode) AuthStatusCommand() []string { return []string{"claude", "auth", "status"} }
 

--- a/services/agent-runner/internal/executor/providercli/providercli.go
+++ b/services/agent-runner/internal/executor/providercli/providercli.go
@@ -38,13 +38,12 @@
 // each adapter. Claude Code's is confirmed directly (see claude_code.go):
 // an earlier version of this design used a guessed
 // ~/.claude/.credentials.json file-existence probe, which turned out not
-// to reflect real login state at all — `claude auth login` (the actual
-// subcommand; a bare `claude login` doesn't exist and fails silently-ish
-// with a generic error) never created that file, so every login looked
-// unverified even after a real, working login. `claude auth status`
-// (confirmed: prints JSON with a top-level "loggedIn" boolean, no network
-// call, safe to run on every click) is the CLI's own authoritative answer
-// instead of a guess about its internals.
+// to reflect real login state at all — `claude login` never created that
+// file, so every login looked unverified even after a real, working
+// login. `claude auth status` (confirmed: prints JSON with a top-level
+// "loggedIn" boolean, no network call, safe to run on every click) is
+// the CLI's own authoritative answer instead of a guess about its
+// internals.
 package providercli
 
 import "github.com/Paca-AI/agent-runner/internal/agent"

--- a/services/agent-runner/internal/executor/providercli/providercli_test.go
+++ b/services/agent-runner/internal/executor/providercli/providercli_test.go
@@ -165,7 +165,7 @@ func TestCodexSyncFilesSkipsNonStdio(t *testing.T) {
 // running each CLI — not hand-typed guesses. This is exactly the class of
 // bug that shipped once already: an earlier, unconfirmed file-existence
 // probe for Claude Code reported "not authenticated" even right after a
-// real, successful `claude auth login`, because the guessed credential
+// real, successful `claude login`, because the guessed credential
 // path was simply wrong.
 func TestParseAuthStatus_RealCapturedOutput(t *testing.T) {
 	cases := []struct {

--- a/services/agent-runner/internal/sandbox/k8s/manager.go
+++ b/services/agent-runner/internal/sandbox/k8s/manager.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	utilexec "k8s.io/utils/exec"
+	utilexec "k8s.io/client-go/util/exec"
 	"k8s.io/utils/ptr"
 
 	"github.com/Paca-AI/agent-runner/internal/sandbox"
@@ -529,10 +529,13 @@ func (m *Manager) Exec(ctx context.Context, containerID string, cmd []string) (o
 // out of Exec as its own pure function so the errors.As unwrapping can be
 // unit tested directly, without needing a real (or faked) exec stream.
 // k8s.io/client-go/tools/remotecommand wraps the remote command's exit
-// code in a k8s.io/utils/exec.CodeExitError (confirmed directly in that
-// package's v4.go, the streaming protocol version this client negotiates)
-// — the same type kubectl's own exec implementation unwraps for the
-// identical reason.
+// code in a k8s.io/client-go/util/exec.CodeExitError (confirmed directly
+// in that package's v4.go, the streaming protocol version this client
+// negotiates) — the same type kubectl's own exec implementation unwraps
+// for the identical reason. Note this is a *different* package from the
+// similarly-named k8s.io/utils/exec, which defines its own same-shaped
+// CodeExitError that errors.As will never match here — easy to reach for
+// by mistake since both are commonly aliased "utilexec".
 func exitCodeFromExecErr(err error) (code int, ok bool) {
 	var exitErr utilexec.CodeExitError
 	if errors.As(err, &exitErr) {

--- a/services/agent-runner/internal/sandbox/k8s/manager_test.go
+++ b/services/agent-runner/internal/sandbox/k8s/manager_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	utilexec "k8s.io/utils/exec"
+	utilexec "k8s.io/client-go/util/exec"
 )
 
 // Unlike ../sandbox_test.go's Docker-backed Manager, Start/Stop/


### PR DESCRIPTION
## Summary

Three fixes surfaced while debugging a provider_cli agent's environment failing on Kubernetes: a real exit-code handling bug in the k8s sandbox backend, an empty badge on the agent list card, and a wrong CLI login command in the Create Agent dialog's guidance text.

### 1. k8s sandbox backend misreported every non-zero exit as a hard error

`sandbox/k8s/manager.go`'s `exitCodeFromExecErr` checked a failed exec's error against `k8s.io/utils/exec.CodeExitError` to distinguish "the command ran and exited non-zero" from "the exec itself failed" (pod gone, connection dropped, etc.) — the same distinction the Docker backend already makes correctly. But `client-go`'s `remotecommand` package (the actual k8s exec transport) wraps a non-zero exit in `k8s.io/client-go/util/exec.CodeExitError` — a different type from a different module with the identical name and shape. `errors.As` matches by concrete type, so this check has silently failed every single time since it was written, for every command run through `Exec`/`ExecEnvironment` on the k8s backend.

This first became user-visible as `syncProviderCLIConfig` failing to bootstrap a provider_cli agent's environment: it reads a CLI's config file (e.g. `~/.claude.json`) via `cat` before merging in Paca's MCP servers, and treats a missing file (normal on a fresh environment) as an expected non-zero exit — except that exit was always escalated into a fatal "sandbox/k8s: exec in environment pod ...: command terminated with exit code 1" error instead, blocking every provider_cli agent's first turn on a new environment. Confirmed live against a real environment pod (v0.36.3 `client-go`'s `remotecommand/v4.go` source), then fixed the import; the existing unit test made the identical wrong-package assumption, so it always passed for the wrong reason — corrected it to use the real type so it now actually exercises the failure this class of bug produces.

### 2. Empty badge on provider_cli agent cards in the agent list

`agent-card.tsx`'s `isAcp` check only matched `agent_type === "acp"`, with no case for `"provider_cli"` — so a provider_cli agent's card fell through to the badge's `llm_provider` branch, a field provider_cli agents never set, rendering an empty badge. Added the missing `isProviderCli` case, mirroring the badge logic already correct on the agent detail page (`agent-detail.tsx`), so the badge now shows the CLI provider name (e.g. "claude-code").

### 3. Create Agent dialog showed the wrong Claude Code login command

The dialog's `cliLoginCommand` guidance (surfaced next to the "Verify login" button so a user can copy-paste it into the environment terminal) showed `claude auth login` for Claude Code. Confirmed directly against a real `claude` CLI (v2.1.263) in a sandbox environment that the correct command is the shorter `claude login` — an undocumented top-level shortcut not listed in `claude --help`'s command list (which only shows the `auth` subcommand namespace), which is presumably why it was missed originally. Corrected the guidance text and the doc comments in `providercli`'s Claude Code adapter that had asserted the opposite.

## Testing

- `services/agent-runner`: `go build ./...`, `go vet ./internal/sandbox/...` clean; `go test ./internal/sandbox/... ./internal/executor/...` passing, including the corrected `TestExitCodeFromExecErr_*` cases.
- `apps/web`: `tsc -b` and `biome check` clean on the touched files.
- Verified live on a k3s cluster: reproduced the original `.claude.json` sync failure on a real environment pod, deployed the patched `agent-runner`/`web` images, and confirmed the sync no longer errors on a legitimately-missing config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
