### PR TITLE
feat(auth): add annotation refresh endpoint and related cookie handling

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -17,10 +17,10 @@ in one click.
   attaches your Paca login session to a page on that same host automatically
   — this extension never reads, stores, or handles any login token itself.
 - A lightweight, non-sensitive cookie (`paca_port`) that `services/api` sets
-  alongside `access_token`/`refresh_token` at login and on every session
-  refresh (see `auth_handler.go`'s `portCookieName`) — but, unlike those
-  two, deliberately *not* `HttpOnly`, since the extension reads it directly
-  via `document.cookie`. Its value is the port the Paca app is actually
+  alongside its auth cookies at login and on every session refresh (see
+  `auth_handler.go`'s `portCookieName`) — but, unlike the auth cookies,
+  deliberately *not* `HttpOnly`, since the extension reads it directly via
+  `document.cookie`. Its value is the port the Paca app is actually
   reachable on (it can be anything, not just 443/80 — a local dev server on
   `:3000`, say), which the same-hostname trick above makes visible on a
   forwarded preview page too. The content script always takes the port
@@ -30,6 +30,27 @@ in one click.
   enable step: the extension holds broad host permissions from install
   (see Install) and simply stays dormant, everywhere, until this cookie
   shows up.
+- A sibling cookie, `paca_scheme`, records whether the Paca app answers on
+  `http` or `https` — needed because a forwarded preview's own scheme (a
+  project's dev server might run its own local HTTPS, or might not) has no
+  necessary relationship to the Paca app's. The content script uses this
+  instead of assuming its own page's scheme, exactly the same "always read
+  fresh from the cookie" reasoning as `paca_port` above.
+- Two pairs of auth cookies exist, and which one the browser actually
+  attaches depends on that scheme comparison. `access_token`/`refresh_token`
+  (the same pair the main web app uses) ride along when the forwarded
+  preview happens to share the Paca app's scheme — modern browsers only
+  treat that as a "same-site" request, eligible for their
+  `SameSite=Lax`/`Strict` cookies, when the schemes actually match, not just
+  the hostname. When they don't match, a second, narrower pair
+  (`annotation_access_token`/`annotation_refresh_token`, `SameSite=None`)
+  takes over instead — usable *only* against the small set of endpoints this
+  extension actually calls (session rotation, port-forward resolution, and
+  page-annotation CRUD; see `middleware.AnnotationExtensionPathPattern`),
+  never as a substitute for a real login session anywhere else. Either way,
+  the extension itself still never reads, stores, or chooses between them —
+  the browser decides which cookies a given request qualifies for, and
+  `credentials: "include"` just sends whatever applies.
 - Everything else — listing comments, creating one, resolving, turning one
   into a task — is a normal authenticated call the content script makes
   directly to your Paca instance's API.

--- a/apps/extension/src/content/api.ts
+++ b/apps/extension/src/content/api.ts
@@ -7,10 +7,21 @@ import type {
 // Every call here runs from the content script itself, directly against
 // the Paca API — credentials: "include" works because this content script
 // only ever runs on the same hostname the Paca app itself is served from
-// (different port, same site — see services/api's corsMiddleware and the
-// extension's README), so access_token/refresh_token are attached by the
-// browser exactly as they are for the web app's own requests. No token of
-// any kind is read or stored by this extension.
+// (different port, possibly different scheme too — see services/api's
+// corsMiddleware and the extension's README), so the browser attaches
+// whichever of the two token pairs actually applies: access_token/
+// refresh_token when the forwarded preview happens to share the Paca app's
+// scheme (SameSite=Lax/Strict — a "same-site" request under modern
+// browsers' Schemeful Same-Site rules only when the schemes match), or the
+// ScopeAnnotation pair (SameSite=None, see auth_handler.go's
+// setAnnotationTokenCookies) when it doesn't. Either way, no token of any
+// kind is read or stored by this extension — refreshAccessToken below never
+// sees a token value, only whether the rotation call itself succeeded.
+//
+// The ScopeAnnotation refresh flow has its own endpoint
+// (/auth/annotation-refresh, not /auth/refresh) because it's the one that
+// actually works across a scheme mismatch — see domainauth.ScopeAnnotation's
+// doc comment for why a main refresh_token can't be relied on from here.
 
 export class ApiError extends Error {
 	constructor(
@@ -43,14 +54,23 @@ function rawFetch(
 // Coalesces concurrent refresh attempts into one in-flight request — a
 // page with several pins can easily fire a handful of calls at once right
 // as the 15-minute access token expires, and they'd otherwise all race
-// each other into /auth/refresh. Mirrors apps/web's own axios interceptor,
-// just without a request queue: refreshAccessToken's callers each retry
-// their own single request once it resolves.
+// each other into /auth/annotation-refresh. Mirrors apps/web's own axios
+// interceptor, just without a request queue: refreshAccessToken's callers
+// each retry their own single request once it resolves.
+//
+// Deliberately calls /auth/annotation-refresh, not the main /auth/refresh —
+// this content script's requests are only ever guaranteed to carry the
+// ScopeAnnotation cookie pair (see this file's top-of-file doc comment for
+// why the main pair can't be relied on cross-scheme), and the two rotation
+// endpoints each only accept their own token kind, not each other's (see
+// domainauth.Service.RefreshAnnotation's doc comment).
 let refreshInFlight: Promise<boolean> | null = null;
 
 function refreshAccessToken(baseUrl: string): Promise<boolean> {
 	if (!refreshInFlight) {
-		refreshInFlight = rawFetch(baseUrl, "/auth/refresh", { method: "POST" })
+		refreshInFlight = rawFetch(baseUrl, "/auth/annotation-refresh", {
+			method: "POST",
+		})
 			.then((res) => res.ok)
 			.catch(() => false)
 			.finally(() => {

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -3,7 +3,7 @@ import {
 	getFailedRequests,
 	setActiveState,
 } from "../shared/messages";
-import { PORT_COOKIE, readPacaPort } from "../shared/paca-port";
+import { PORT_COOKIE, readPacaPort, readPacaScheme } from "../shared/paca-port";
 import type { ConsoleEntry, PageAnnotation } from "../shared/types";
 import * as api from "./api";
 import { copyToClipboard } from "./clipboard";
@@ -146,13 +146,16 @@ async function main(): Promise<void> {
 		);
 		return;
 	}
-	// This page's own hostname/protocol are the Paca app's too — the whole
-	// design rests on a forwarded preview and the Paca app sharing a
-	// hostname, differing only by port (see the cookie's own doc comment
-	// above) — so no separately-configured instance URL is needed at all;
-	// only the port varies, and that comes fresh from the cookie every
-	// time, never trusted from an earlier point in time.
-	const baseUrl = `${location.protocol}//${location.hostname}:${pacaPort}`;
+	// This page's own hostname is the Paca app's too — the whole design
+	// rests on a forwarded preview and the Paca app sharing a hostname,
+	// differing by port and possibly scheme (see paca-port.ts's own doc
+	// comments) — so no separately-configured instance URL is needed at
+	// all; both come fresh from cookies every time, never trusted from an
+	// earlier point in time or assumed to match this page's own
+	// location.protocol (a project's dev server and the Paca app can each
+	// independently be HTTP or HTTPS — nothing ties the two together).
+	const pacaScheme = readPacaScheme() ?? location.protocol.replace(":", "");
+	const baseUrl = `${pacaScheme}://${location.hostname}:${pacaPort}`;
 
 	let match: Awaited<ReturnType<typeof api.resolvePortForward>>;
 	try {

--- a/apps/extension/src/shared/paca-port.ts
+++ b/apps/extension/src/shared/paca-port.ts
@@ -5,29 +5,56 @@
 // two copies of this cookie-parsing logic drifting apart, not to share
 // state.
 //
-// Set by services/api's login/refresh handler alongside access_token/
-// refresh_token (see auth_handler.go's portCookieName), but deliberately
-// NOT HttpOnly — a plain cookie recording which port the Paca app is
-// actually reachable on. Cookies are scoped by hostname only, never by
-// port, so the SAME cookie set while browsing the app itself is visible
-// here too, on a completely different forwarded port — which is exactly
-// what lets a content script find the real API even when Paca isn't
-// running on 443/80 (e.g. a local dev server on :3000), with no separate
-// setup step: this cookie alone is both the "is this a Paca host" signal
-// and the address to call, read fresh on every page load rather than
-// trusted from some earlier point in time.
+// Set by services/api's login/refresh handler alongside the auth cookies
+// (see auth_handler.go's portCookieName/schemeCookieName), but deliberately
+// NOT HttpOnly — plain cookies recording where the Paca app is actually
+// reachable. Cookies are scoped by hostname only, never by port, so the
+// SAME cookies set while browsing the app itself are visible here too, on a
+// completely different forwarded port — which is exactly what lets a
+// content script find the real API even when Paca isn't running on 443/80
+// (e.g. a local dev server on :3000), with no separate setup step: these
+// cookies alone are both the "is this a Paca host" signal and the address
+// to call, read fresh on every page load rather than trusted from some
+// earlier point in time.
 export const PORT_COOKIE = "paca_port";
+
+// paca_scheme's own doc comment (below) explains why this exists alongside
+// PORT_COOKIE rather than the content script just assuming
+// location.protocol — the forwarded preview page and the Paca app share a
+// hostname, not necessarily a scheme.
+export const SCHEME_COOKIE = "paca_scheme";
+
+function readCookie(name: string): string | null {
+	return (
+		document.cookie
+			.split("; ")
+			.find((c) => c.startsWith(`${name}=`))
+			?.slice(name.length + 1) ?? null
+	);
+}
 
 /** Reads and validates the paca_port cookie on the current document, or
  * null if it's absent or malformed. Cheap and synchronous — meant to gate
  * any more expensive work (a network call, hooking page globals) on "is
  * this even plausibly a Paca host" before doing it. */
 export function readPacaPort(): number | null {
-	const raw = document.cookie
-		.split("; ")
-		.find((c) => c.startsWith(`${PORT_COOKIE}=`))
-		?.slice(PORT_COOKIE.length + 1);
+	const raw = readCookie(PORT_COOKIE);
 	if (!raw) return null;
 	const port = Number(raw);
 	return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+}
+
+/** Reads the paca_scheme cookie — "http" or "https", whichever the Paca app
+ * actually answers on at the port readPacaPort() returns. Needed because
+ * the forwarded preview page's own scheme (the dev server's — whatever the
+ * project happens to run) has no necessary relationship to the Paca app's:
+ * a self-hosted instance might sit behind a plain-HTTP proxy while a
+ * project's dev server serves its own local HTTPS, or vice versa. Returns
+ * null if the cookie is absent (an older services/api that predates it) or
+ * holds anything other than exactly "http"/"https" — callers should fall
+ * back to location.protocol in that case, same as before this cookie
+ * existed. */
+export function readPacaScheme(): "http" | "https" | null {
+	const raw = readCookie(SCHEME_COOKIE);
+	return raw === "http" || raw === "https" ? raw : null;
 }

--- a/services/api/internal/domain/auth/claims.go
+++ b/services/api/internal/domain/auth/claims.go
@@ -3,6 +3,23 @@ package auth
 
 import "github.com/golang-jwt/jwt/v5"
 
+// ScopeAnnotation marks a token minted specifically for the browser
+// extension's page-annotation flow (see AuthHandler.AnnotationRefresh in
+// services/api's handler package, and apps/extension/README.md). Such a
+// token is a real, validly-signed credential for a real user — Login mints
+// it from the exact same identity as the main session — but
+// middleware.applyAuthn only ever honors it against
+// middleware.AnnotationExtensionPathPattern, never as a substitute for a
+// full-scope access token elsewhere. This exists because the extension's
+// content script runs on a forwarded environment preview that shares the
+// Paca app's hostname but not necessarily its scheme, and a cross-scheme
+// request is "cross-site" under modern browsers' Schemeful Same-Site
+// rules — so the main access_token/refresh_token (SameSite=Lax/Strict)
+// can't reliably reach the API from there. This narrower pair uses
+// SameSite=None instead, which only a token this restricted in scope
+// should ever be issued with.
+const ScopeAnnotation = "annotation"
+
 // Claims is the payload embedded in every JWT issued by the service.
 type Claims struct {
 	jwt.RegisteredClaims
@@ -24,4 +41,9 @@ type Claims struct {
 	// AgentID is optionally set when authenticating via agent API key with
 	// X-Agent-ID header to identify which agent is performing the action.
 	AgentID *string `json:"agent_id,omitempty"`
+	// Scope narrows what an access/refresh token may be used for. Empty
+	// (the zero value) means full scope — every token Login/Refresh have
+	// ever issued, usable on any endpoint the subject's role/permissions
+	// allow. ScopeAnnotation is the one narrower value that exists today.
+	Scope string `json:"scope,omitempty"`
 }

--- a/services/api/internal/domain/auth/service.go
+++ b/services/api/internal/domain/auth/service.go
@@ -8,10 +8,26 @@ import (
 // TokenPair holds an access token and a companion refresh token.
 // RefreshTTL is the effective lifetime of the refresh token so callers (e.g.
 // the HTTP handler) can align the cookie MaxAge with the JWT expiry.
+//
+// AnnotationAccessToken/AnnotationRefreshToken are a second, ScopeAnnotation-
+// restricted pair (see that constant's doc comment). Both Login and Refresh
+// populate them, from the same identity/family as the main pair, so the
+// annotation pair's lifetime piggybacks on ordinary session activity
+// instead of requiring the extension to independently keep itself alive —
+// see Service.Refresh's own doc comment for why. RefreshAnnotation is the
+// complementary, independent path: it validates and rotates whichever
+// annotation refresh token the extension itself is holding, for when
+// *only* the extension's own activity is keeping the annotation session
+// alive (e.g. the main web app tab isn't open at all). Empty on
+// RefreshAnnotation's own return — that one never touches the main pair's
+// fields.
 type TokenPair struct {
 	AccessToken  string
 	RefreshToken string
 	RefreshTTL   time.Duration
+
+	AnnotationAccessToken  string
+	AnnotationRefreshToken string
 }
 
 // Service defines the authentication contract.
@@ -20,9 +36,23 @@ type Service interface {
 	// rememberMe=false issues a short-lived session (see JWT_REFRESH_SESSION_TTL);
 	// rememberMe=true issues a long-lived persistent session (JWT_REFRESH_TTL).
 	Login(ctx context.Context, username, password string, rememberMe bool) (*TokenPair, error)
-	// Refresh validates a refresh token and issues a rotated token pair.
-	// Token reuse outside the grace period revokes the entire session family.
+	// Refresh validates a full-scope refresh token and issues a rotated
+	// full-scope token pair, plus a freshly reissued (not rotated —
+	// see the implementation's own doc comment) ScopeAnnotation pair
+	// alongside it. Rejects a ScopeAnnotation refresh token just as
+	// RefreshAnnotation rejects a full-scope one — see RefreshAnnotation's
+	// doc comment for why the two never accept each other's tokens. Token
+	// reuse outside the grace period revokes the entire session family
+	// (shared by both scopes, so this also invalidates the annotation pair).
 	Refresh(ctx context.Context, refreshToken string) (*TokenPair, error)
+	// RefreshAnnotation validates a ScopeAnnotation refresh token and issues
+	// a rotated ScopeAnnotation pair (TokenPair's Annotation* fields only —
+	// AccessToken/RefreshToken are left empty). Deliberately a separate
+	// method rather than a parameter on Refresh: accepting a main refresh
+	// token here would let a credential meant only for the browser
+	// extension mint a full session, which defeats the point of scoping it
+	// down in the first place.
+	RefreshAnnotation(ctx context.Context, annotationRefreshToken string) (*TokenPair, error)
 	// Logout revokes the entire token family identified by familyID.
 	Logout(ctx context.Context, familyID string) error
 }

--- a/services/api/internal/platform/token/jwt_manager.go
+++ b/services/api/internal/platform/token/jwt_manager.go
@@ -29,23 +29,37 @@ func New(secret string, accessTTL, refreshTTL time.Duration) *Manager {
 
 // IssueAccess creates a signed access token for the given claims subject.
 func (m *Manager) IssueAccess(sub, username, role, familyID string, mustChangePassword bool) (string, error) {
-	return m.sign(sub, username, role, familyID, m.accessTTL, "access", false, mustChangePassword)
+	return m.sign(sub, username, role, familyID, m.accessTTL, "access", false, mustChangePassword, "")
 }
 
 // IssueRefresh creates a signed refresh token with the Manager's default TTL.
 // The session is treated as persistent (rememberMe=true).
 func (m *Manager) IssueRefresh(sub, username, role, familyID string) (string, error) {
-	return m.sign(sub, username, role, familyID, m.refreshTTL, "refresh", true, false)
+	return m.sign(sub, username, role, familyID, m.refreshTTL, "refresh", true, false, "")
 }
 
 // IssueRefreshWithTTL creates a signed refresh token with an explicit TTL and
 // rememberMe flag. Use this instead of IssueRefresh when the caller needs to
 // honour the user's "remember me" preference.
 func (m *Manager) IssueRefreshWithTTL(sub, username, role, familyID string, rememberMe bool, ttl time.Duration) (string, error) {
-	return m.sign(sub, username, role, familyID, ttl, "refresh", rememberMe, false)
+	return m.sign(sub, username, role, familyID, ttl, "refresh", rememberMe, false, "")
 }
 
-func (m *Manager) sign(sub, username, role, familyID string, ttl time.Duration, kind string, rememberMe bool, mustChangePassword bool) (string, error) {
+// IssueAnnotationAccess creates a signed, domainauth.ScopeAnnotation access
+// token — same subject/username/role/family/MustChangePassword as
+// IssueAccess (permission checks and the fresh-password gate still need
+// them), same TTL, only Scope differs.
+func (m *Manager) IssueAnnotationAccess(sub, username, role, familyID string, mustChangePassword bool) (string, error) {
+	return m.sign(sub, username, role, familyID, m.accessTTL, "access", false, mustChangePassword, domainauth.ScopeAnnotation)
+}
+
+// IssueAnnotationRefreshWithTTL is IssueRefreshWithTTL's
+// domainauth.ScopeAnnotation counterpart.
+func (m *Manager) IssueAnnotationRefreshWithTTL(sub, username, role, familyID string, rememberMe bool, ttl time.Duration) (string, error) {
+	return m.sign(sub, username, role, familyID, ttl, "refresh", rememberMe, false, domainauth.ScopeAnnotation)
+}
+
+func (m *Manager) sign(sub, username, role, familyID string, ttl time.Duration, kind string, rememberMe bool, mustChangePassword bool, scope string) (string, error) {
 	now := time.Now()
 	claims := domainauth.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -61,6 +75,7 @@ func (m *Manager) sign(sub, username, role, familyID string, ttl time.Duration, 
 		FamilyID:           familyID,
 		RememberMe:         rememberMe,
 		MustChangePassword: mustChangePassword,
+		Scope:              scope,
 	}
 
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/services/api/internal/service/auth/auth_service.go
+++ b/services/api/internal/service/auth/auth_service.go
@@ -85,35 +85,63 @@ func (s *Service) Login(ctx context.Context, username, password string, remember
 		return nil, err
 	}
 
-	return &domainauth.TokenPair{AccessToken: access, RefreshToken: refresh, RefreshTTL: refreshTTL}, nil
-}
-
-// Refresh validates a refresh token and issues a rotated token pair.
-// If the same token is presented twice outside the grace period, the entire
-// session family is revoked to mitigate token-theft scenarios.
-func (s *Service) Refresh(ctx context.Context, refreshToken string) (*domainauth.TokenPair, error) {
-	claims, err := s.tokens.Verify(refreshToken)
+	// Minted from the same identity/family as the pair above, purely so the
+	// browser extension has a working credential from the moment of login —
+	// see domainauth.ScopeAnnotation's doc comment for why it's a separate
+	// pair rather than reusing the one above.
+	annotationAccess, err := s.tokens.IssueAnnotationAccess(sub, u.Username, u.Role, familyID, u.MustChangePassword)
 	if err != nil {
-		return nil, domainauth.ErrTokenInvalid
+		return nil, err
+	}
+	annotationRefresh, err := s.tokens.IssueAnnotationRefreshWithTTL(sub, u.Username, u.Role, familyID, rememberMe, refreshTTL)
+	if err != nil {
+		return nil, err
 	}
 
-	if claims.Kind != "refresh" {
-		return nil, domainauth.ErrTokenInvalid
+	return &domainauth.TokenPair{
+		AccessToken:  access,
+		RefreshToken: refresh,
+		RefreshTTL:   refreshTTL,
+
+		AnnotationAccessToken:  annotationAccess,
+		AnnotationRefreshToken: annotationRefresh,
+	}, nil
+}
+
+// rotateRefreshToken validates refreshToken's rotation state — signature,
+// Kind, wantScope, family revocation, and reuse detection — common to both
+// Refresh and RefreshAnnotation, and looks up the current user so a caller
+// can pick up e.g. a password reset that happened mid-session. Each caller
+// still does its own issuance: it's the one thing that legitimately differs
+// between the two (full-scope tokens vs. domainauth.ScopeAnnotation ones).
+func (s *Service) rotateRefreshToken(ctx context.Context, refreshToken, wantScope string) (*domainauth.Claims, *userdom.User, error) {
+	claims, err := s.tokens.Verify(refreshToken)
+	if err != nil {
+		return nil, nil, domainauth.ErrTokenInvalid
+	}
+
+	// The Scope check is what keeps the two rotation paths from accepting
+	// each other's tokens — see Service.RefreshAnnotation's doc comment for
+	// why a main refresh token minting an annotation pair (or vice versa)
+	// would be a problem even though "vice versa" looks harmless at first
+	// glance.
+	if claims.Kind != "refresh" || claims.Scope != wantScope {
+		return nil, nil, domainauth.ErrTokenInvalid
 	}
 
 	// Fast path: reject immediately if the family was already invalidated.
 	revoked, err := s.refreshStore.IsFamilyRevoked(ctx, claims.FamilyID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if revoked {
-		return nil, domainauth.ErrSessionInvalidated
+		return nil, nil, domainauth.ErrSessionInvalidated
 	}
 
 	// Record use — detect reuse.
 	firstUsedAt, err := s.refreshStore.RecordFirstUse(ctx, claims.ID, s.refreshTTL)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if firstUsedAt != nil {
@@ -121,13 +149,13 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*domainauth
 		if time.Since(*firstUsedAt) <= gracePeriod {
 			// Within the grace period: likely a network retry — reject without
 			// breaking the session so the original response can be retried.
-			return nil, domainauth.ErrTokenInvalid
+			return nil, nil, domainauth.ErrTokenInvalid
 		}
 		// Outside the grace period: potential token theft — revoke the family.
 		if err := s.refreshStore.RevokeFamily(ctx, claims.FamilyID, s.refreshTTL); err != nil {
-			return nil, fmt.Errorf("auth: revoke session family: %w", err)
+			return nil, nil, fmt.Errorf("auth: revoke session family: %w", err)
 		}
-		return nil, domainauth.ErrSessionInvalidated
+		return nil, nil, domainauth.ErrSessionInvalidated
 	}
 
 	// Look up the user to get the current MustChangePassword flag; this
@@ -135,11 +163,47 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*domainauth
 	// active session, the very next Refresh call will carry the updated flag.
 	userID, err := uuid.Parse(claims.Subject)
 	if err != nil {
-		return nil, domainauth.ErrSessionInvalidated
+		return nil, nil, domainauth.ErrSessionInvalidated
 	}
 	u, err := s.users.FindByID(ctx, userID)
 	if err != nil {
-		return nil, domainauth.ErrSessionInvalidated
+		return nil, nil, domainauth.ErrSessionInvalidated
+	}
+
+	return claims, u, nil
+}
+
+// Refresh validates a full-scope refresh token and issues a rotated
+// full-scope token pair. If the same token is presented twice outside the
+// grace period, the entire session family is revoked to mitigate
+// token-theft scenarios.
+//
+// Also reissues a fresh domainauth.ScopeAnnotation pair on every call (the
+// returned TokenPair's Annotation* fields) — piggybacking the annotation
+// pair's effective lifetime on ordinary web-app usage, the same "ride the
+// main session's cadence" reasoning paca_port/paca_scheme already follow.
+// Without this, a user who mostly works in the main app and only
+// occasionally opens a forwarded preview could find the extension silently
+// logged out the moment more than one refresh-TTL passes between two
+// extension-triggered RefreshAnnotation calls, even though their main
+// session never stopped being valid.
+//
+// This is a fresh reissue, not a rotation of whatever annotation refresh
+// token the browser is currently holding: annotation_refresh_token's
+// cookie Path only ever reaches /auth/annotation-refresh (see
+// AuthHandler's annotationRefreshCookiePath), so it never arrives on this
+// endpoint's request for Refresh to validate/consume — there is nothing
+// here to run reuse detection against. The previously-issued annotation
+// refresh token is simply superseded (the handler's new Set-Cookie
+// overwrites it in the browser) rather than explicitly revoked; it stays
+// cryptographically valid until its own TTL expires, same family as
+// everything else, so Logout (which revokes by family) still invalidates
+// it same as before. RefreshAnnotation remains the only path with real
+// rotation/reuse-detection for the annotation refresh token specifically.
+func (s *Service) Refresh(ctx context.Context, refreshToken string) (*domainauth.TokenPair, error) {
+	claims, u, err := s.rotateRefreshToken(ctx, refreshToken, "")
+	if err != nil {
+		return nil, err
 	}
 
 	// Issue a rotated token pair preserving the same session family and
@@ -158,8 +222,62 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string) (*domainauth
 	if err != nil {
 		return nil, err
 	}
+	annotationAccess, err := s.tokens.IssueAnnotationAccess(claims.Subject, claims.Username, claims.Role, claims.FamilyID, u.MustChangePassword)
+	if err != nil {
+		return nil, err
+	}
+	annotationRefresh, err := s.tokens.IssueAnnotationRefreshWithTTL(claims.Subject, claims.Username, claims.Role, claims.FamilyID, claims.RememberMe, refreshTTL)
+	if err != nil {
+		return nil, err
+	}
 
-	return &domainauth.TokenPair{AccessToken: access, RefreshToken: refresh, RefreshTTL: refreshTTL}, nil
+	return &domainauth.TokenPair{
+		AccessToken:  access,
+		RefreshToken: refresh,
+		RefreshTTL:   refreshTTL,
+
+		AnnotationAccessToken:  annotationAccess,
+		AnnotationRefreshToken: annotationRefresh,
+	}, nil
+}
+
+// RefreshAnnotation validates a domainauth.ScopeAnnotation refresh token and
+// issues a rotated ScopeAnnotation pair. Deliberately not folded into
+// Refresh: rotateRefreshToken's wantScope check means a main refresh token
+// presented here — or an annotation refresh token presented to Refresh
+// above — is rejected outright as ErrTokenInvalid, rather than one letting
+// the other mint a token pair it has no business minting. That matters more
+// than it might look: the annotation token is deliberately weaker (usable
+// only against middleware.AnnotationExtensionPathPattern), so silently
+// accepting a main refresh token here would just be a no-op narrowing, but
+// the reverse — an annotation refresh token, plausibly exposed to a page
+// running arbitrary code on a forwarded environment port, being accepted by
+// the *main* Refresh — would let it mint a full-scope session.
+func (s *Service) RefreshAnnotation(ctx context.Context, annotationRefreshToken string) (*domainauth.TokenPair, error) {
+	claims, u, err := s.rotateRefreshToken(ctx, annotationRefreshToken, domainauth.ScopeAnnotation)
+	if err != nil {
+		return nil, err
+	}
+
+	refreshTTL := s.refreshTTL
+	if !claims.RememberMe {
+		refreshTTL = s.refreshSessionTTL
+	}
+
+	access, err := s.tokens.IssueAnnotationAccess(claims.Subject, claims.Username, claims.Role, claims.FamilyID, u.MustChangePassword)
+	if err != nil {
+		return nil, err
+	}
+	refresh, err := s.tokens.IssueAnnotationRefreshWithTTL(claims.Subject, claims.Username, claims.Role, claims.FamilyID, claims.RememberMe, refreshTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domainauth.TokenPair{
+		RefreshTTL:             refreshTTL,
+		AnnotationAccessToken:  access,
+		AnnotationRefreshToken: refresh,
+	}, nil
 }
 
 // Logout revokes the entire token family so all in-flight refresh tokens for

--- a/services/api/internal/service/auth/auth_service_test.go
+++ b/services/api/internal/service/auth/auth_service_test.go
@@ -145,6 +145,56 @@ func TestLogin_WrongPassword(t *testing.T) {
 	}
 }
 
+func TestLogin_IssuesAnnotationPair(t *testing.T) {
+	u := &userdom.User{
+		ID:           uuid.New(),
+		Username:     "alice",
+		Role:         userdom.RoleUser,
+		PasswordHash: hashedPassword(t, "secret123"),
+	}
+	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
+	svc := authsvc.New(&stubUserRepo{
+		findByUsername: func(_ context.Context, _ string) (*userdom.User, error) { return u, nil },
+	}, tm, &stubRefreshStore{}, 7*24*time.Hour, 24*time.Hour)
+
+	pair, err := svc.Login(context.Background(), "alice", "secret123", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pair.AnnotationAccessToken == "" || pair.AnnotationRefreshToken == "" {
+		t.Fatal("expected non-empty annotation token pair")
+	}
+
+	accessClaims, err := tm.Verify(pair.AnnotationAccessToken)
+	if err != nil {
+		t.Fatalf("verify annotation access token: %v", err)
+	}
+	if accessClaims.Scope != domainauth.ScopeAnnotation {
+		t.Errorf("annotation access token Scope = %q, want %q", accessClaims.Scope, domainauth.ScopeAnnotation)
+	}
+	if accessClaims.Kind != "access" {
+		t.Errorf("annotation access token Kind = %q, want %q", accessClaims.Kind, "access")
+	}
+
+	refreshClaims, err := tm.Verify(pair.AnnotationRefreshToken)
+	if err != nil {
+		t.Fatalf("verify annotation refresh token: %v", err)
+	}
+	if refreshClaims.Scope != domainauth.ScopeAnnotation {
+		t.Errorf("annotation refresh token Scope = %q, want %q", refreshClaims.Scope, domainauth.ScopeAnnotation)
+	}
+
+	// The main pair must stay full-scope -- adding the annotation pair
+	// must not narrow what Login's original tokens can do.
+	mainAccessClaims, err := tm.Verify(pair.AccessToken)
+	if err != nil {
+		t.Fatalf("verify main access token: %v", err)
+	}
+	if mainAccessClaims.Scope != "" {
+		t.Errorf("main access token Scope = %q, want empty (full scope)", mainAccessClaims.Scope)
+	}
+}
+
 func TestLogin_RepoError(t *testing.T) {
 	repoErr := errors.New("db down")
 	svc := newAuthSvc(&stubUserRepo{
@@ -191,6 +241,54 @@ func TestRefresh_Success(t *testing.T) {
 	}
 }
 
+// TestRefresh_ReissuesAnnotationPair confirms the piggybacking behavior
+// this whole change is for: refreshing the main session also hands back a
+// fresh, valid domainauth.ScopeAnnotation pair, not just the main one.
+func TestRefresh_ReissuesAnnotationPair(t *testing.T) {
+	userID := uuid.New()
+	u := &userdom.User{ID: userID, Username: "alice", Role: userdom.RoleUser}
+	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
+	repo := &stubUserRepo{
+		findByID: func(_ context.Context, _ uuid.UUID) (*userdom.User, error) { return u, nil },
+	}
+	svc := authsvc.New(repo, tm, &stubRefreshStore{
+		isFamilyRevoked: func(_ context.Context, _ string) (bool, error) { return false, nil },
+		recordFirstUse:  func(_ context.Context, _ string, _ time.Duration) (*time.Time, error) { return nil, nil },
+	}, 7*24*time.Hour, 24*time.Hour)
+
+	refresh, err := tm.IssueRefresh(userID.String(), "alice", userdom.RoleUser, "fam1")
+	if err != nil {
+		t.Fatalf("IssueRefresh: %v", err)
+	}
+
+	pair, err := svc.Refresh(context.Background(), refresh)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pair.AnnotationAccessToken == "" || pair.AnnotationRefreshToken == "" {
+		t.Fatal("expected a freshly reissued annotation token pair")
+	}
+
+	accessClaims, err := tm.Verify(pair.AnnotationAccessToken)
+	if err != nil {
+		t.Fatalf("verify annotation access token: %v", err)
+	}
+	if accessClaims.Scope != domainauth.ScopeAnnotation {
+		t.Errorf("annotation access token Scope = %q, want %q", accessClaims.Scope, domainauth.ScopeAnnotation)
+	}
+	if accessClaims.Subject != userID.String() {
+		t.Errorf("annotation access token Subject = %q, want %q", accessClaims.Subject, userID.String())
+	}
+
+	refreshClaims, err := tm.Verify(pair.AnnotationRefreshToken)
+	if err != nil {
+		t.Fatalf("verify annotation refresh token: %v", err)
+	}
+	if refreshClaims.FamilyID != "fam1" {
+		t.Errorf("annotation refresh token FamilyID = %q, want %q (must share the main pair's family so Logout revokes both)", refreshClaims.FamilyID, "fam1")
+	}
+}
+
 func TestRefresh_WrongKind(t *testing.T) {
 	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
 	svc := authsvc.New(&stubUserRepo{}, tm, &stubRefreshStore{}, 7*24*time.Hour, 24*time.Hour)
@@ -200,6 +298,26 @@ func TestRefresh_WrongKind(t *testing.T) {
 	_, err := svc.Refresh(context.Background(), access)
 	if !errors.Is(err, domainauth.ErrTokenInvalid) {
 		t.Fatalf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+// TestRefresh_RejectsAnnotationScopedToken is the core security property of
+// the whole ScopeAnnotation design: a token minted only for the browser
+// extension's narrow annotation flow must never be usable to mint a
+// full-scope session. Without this check, rotateRefreshToken's wantScope
+// argument would be decorative.
+func TestRefresh_RejectsAnnotationScopedToken(t *testing.T) {
+	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
+	svc := authsvc.New(&stubUserRepo{}, tm, &stubRefreshStore{}, 7*24*time.Hour, 24*time.Hour)
+
+	annotationRefresh, err := tm.IssueAnnotationRefreshWithTTL("sub", "alice", userdom.RoleUser, "fam1", true, 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAnnotationRefreshWithTTL: %v", err)
+	}
+
+	_, err = svc.Refresh(context.Background(), annotationRefresh)
+	if !errors.Is(err, domainauth.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid for an annotation-scoped token, got %v", err)
 	}
 }
 
@@ -294,6 +412,88 @@ func TestRefresh_ReuseOutsideGrace_RevokeFamilyFailure(t *testing.T) {
 	}
 	if !errors.Is(err, revokeErr) {
 		t.Fatalf("expected revoke error to be wrapped, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RefreshAnnotation
+// ---------------------------------------------------------------------------
+
+func TestRefreshAnnotation_Success(t *testing.T) {
+	userID := uuid.New()
+	u := &userdom.User{ID: userID, Username: "alice", Role: userdom.RoleUser}
+	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
+	repo := &stubUserRepo{
+		findByID: func(_ context.Context, _ uuid.UUID) (*userdom.User, error) { return u, nil },
+	}
+	svc := authsvc.New(repo, tm, &stubRefreshStore{
+		isFamilyRevoked: func(_ context.Context, _ string) (bool, error) { return false, nil },
+		recordFirstUse:  func(_ context.Context, _ string, _ time.Duration) (*time.Time, error) { return nil, nil },
+	}, 7*24*time.Hour, 24*time.Hour)
+
+	refresh, err := tm.IssueAnnotationRefreshWithTTL(userID.String(), "alice", userdom.RoleUser, "fam1", true, 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAnnotationRefreshWithTTL: %v", err)
+	}
+
+	pair, err := svc.RefreshAnnotation(context.Background(), refresh)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pair.AnnotationAccessToken == "" || pair.AnnotationRefreshToken == "" {
+		t.Fatal("expected non-empty rotated annotation token pair")
+	}
+	// Must not touch the main pair's fields at all.
+	if pair.AccessToken != "" || pair.RefreshToken != "" {
+		t.Errorf("expected empty main token fields, got AccessToken=%q RefreshToken=%q", pair.AccessToken, pair.RefreshToken)
+	}
+
+	claims, err := tm.Verify(pair.AnnotationAccessToken)
+	if err != nil {
+		t.Fatalf("verify rotated annotation access token: %v", err)
+	}
+	if claims.Scope != domainauth.ScopeAnnotation {
+		t.Errorf("rotated access token Scope = %q, want %q", claims.Scope, domainauth.ScopeAnnotation)
+	}
+}
+
+// TestRefreshAnnotation_RejectsMainScopedToken is Refresh's cross-rejection
+// property, mirrored: a full-scope refresh token must not be accepted here
+// either. Not a privilege-escalation risk the way the reverse is (a full
+// token can already do everything an annotation token can), but accepting
+// it would blur the two rotation paths' independence -- e.g. logging out
+// only the annotation session should never be possible by design, and
+// letting either endpoint accept the other's token is a step toward that.
+func TestRefreshAnnotation_RejectsMainScopedToken(t *testing.T) {
+	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
+	svc := authsvc.New(&stubUserRepo{}, tm, &stubRefreshStore{}, 7*24*time.Hour, 24*time.Hour)
+
+	mainRefresh, err := tm.IssueRefreshWithTTL("sub", "alice", userdom.RoleUser, "fam1", true, 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("IssueRefreshWithTTL: %v", err)
+	}
+
+	_, err = svc.RefreshAnnotation(context.Background(), mainRefresh)
+	if !errors.Is(err, domainauth.ErrTokenInvalid) {
+		t.Fatalf("expected ErrTokenInvalid for a main-scoped token, got %v", err)
+	}
+}
+
+func TestRefreshAnnotation_FamilyRevoked(t *testing.T) {
+	// The annotation pair shares its family with the main pair (see
+	// Service.Login) specifically so that Logout -- which revokes by family
+	// -- kills both. This confirms RefreshAnnotation actually honors that
+	// shared revocation rather than checking some separate state.
+	tm := jwttoken.New("test-secret", 15*time.Minute, 7*24*time.Hour)
+	store := &stubRefreshStore{
+		isFamilyRevoked: func(_ context.Context, _ string) (bool, error) { return true, nil },
+	}
+	svc := authsvc.New(&stubUserRepo{}, tm, store, 7*24*time.Hour, 24*time.Hour)
+
+	refresh, _ := tm.IssueAnnotationRefreshWithTTL("sub", "alice", userdom.RoleUser, "fam1", true, 7*24*time.Hour)
+	_, err := svc.RefreshAnnotation(context.Background(), refresh)
+	if !errors.Is(err, domainauth.ErrSessionInvalidated) {
+		t.Fatalf("expected ErrSessionInvalidated, got %v", err)
 	}
 }
 

--- a/services/api/internal/transport/http/handler/auth_handler.go
+++ b/services/api/internal/transport/http/handler/auth_handler.go
@@ -73,9 +73,11 @@ func NewAuthHandler(svc domainauth.Service, cookie CookieConfig) *AuthHandler {
 }
 
 // Login handles POST /auth/login.
-// On success, access and refresh tokens are set as HttpOnly cookies (no
-// token values appear in the response body), alongside the client-readable
-// paca_port cookie (see portCookieName).
+// On success, the main access/refresh tokens and the domainauth.
+// ScopeAnnotation pair are all set as HttpOnly cookies (no token values
+// appear in the response body), alongside the two client-readable
+// paca_port/paca_scheme cookies (see portCookieName/schemeCookieName) —
+// see setTokenCookies for the full set.
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	var req dto.LoginRequest
 	if !middleware.BindJSON(w, r, &req) {

--- a/services/api/internal/transport/http/handler/auth_handler.go
+++ b/services/api/internal/transport/http/handler/auth_handler.go
@@ -31,6 +31,26 @@ const (
 	// login/refresh cadence already happening for other reasons, not
 	// because it's itself auth state.
 	portCookieName = "paca_port"
+	// schemeCookieName is portCookieName's scheme counterpart: the
+	// forwarded preview page shares the Paca app's hostname but not
+	// necessarily its scheme (e.g. a dev server the user runs with its own
+	// local HTTPS cert, while Paca itself sits behind a plain-HTTP
+	// self-hosted proxy, or vice versa) — apps/extension used to just
+	// assume location.protocol matched, which broke silently whenever it
+	// didn't. Same non-HttpOnly, same login/refresh cadence as
+	// portCookieName, for the same reason.
+	schemeCookieName = "paca_scheme"
+	// annotationAccessCookieName/annotationRefreshCookieName carry a second,
+	// domainauth.ScopeAnnotation-restricted token pair for the browser
+	// extension specifically — see that constant's doc comment for why
+	// access_token/refresh_token alone aren't reliably usable from a
+	// forwarded preview page. Must stay in sync with the literal cookie
+	// names middleware.applyAuthn falls back to reading.
+	annotationAccessCookieName  = "annotation_access_token"
+	annotationRefreshCookieName = "annotation_refresh_token"
+	// annotationRefreshCookiePath mirrors refreshCookiePath's reasoning,
+	// scoped to the annotation pair's own rotation endpoint instead.
+	annotationRefreshCookiePath = "/api/v1/auth/annotation-refresh"
 )
 
 // CookieConfig carries compile-time-safe settings for auth cookies.
@@ -101,6 +121,28 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	presenter.OK(w, r, map[string]any{"message": "token refreshed"})
 }
 
+// AnnotationRefresh handles POST /auth/annotation-refresh. Mirrors Refresh,
+// but reads/rotates only the domainauth.ScopeAnnotation pair the browser
+// extension uses — see domainauth.Service.RefreshAnnotation's doc comment
+// for why this is a fully separate endpoint rather than folded into
+// Refresh.
+func (h *AuthHandler) AnnotationRefresh(w http.ResponseWriter, r *http.Request) {
+	refreshCookie, err := r.Cookie(annotationRefreshCookieName)
+	if err != nil || refreshCookie.Value == "" {
+		presenter.Error(w, r, apierr.New(apierr.CodeMissingToken, "missing annotation refresh token"))
+		return
+	}
+
+	pair, err := h.svc.RefreshAnnotation(r.Context(), refreshCookie.Value)
+	if err != nil {
+		presenter.Error(w, r, err)
+		return
+	}
+
+	h.setAnnotationTokenCookies(w, pair.AnnotationAccessToken, pair.AnnotationRefreshToken, pair.RefreshTTL)
+	presenter.OK(w, r, map[string]any{"message": "annotation token refreshed"})
+}
+
 // Logout handles POST /auth/logout.  Requires an authenticated access token.
 // Revokes the session family and clears both auth cookies.
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
@@ -149,8 +191,76 @@ func (h *AuthHandler) setTokenCookies(w http.ResponseWriter, r *http.Request, pa
 		Value:    requestPort(r),
 		Path:     "/",
 		HttpOnly: false,
-		Secure:   h.cookie.Secure,
+		// Never Secure, regardless of h.cookie.Secure — deliberately not
+		// the same knob the two auth cookies above use. This cookie's
+		// whole job is to be readable via document.cookie from a
+		// forwarded environment preview, which is very commonly plain
+		// HTTP (a raw dev-server port, no TLS termination in that path)
+		// even when the main Paca app itself sits behind real HTTPS
+		// (COOKIE_SECURE=true). A Secure cookie is invisible to
+		// document.cookie — and never attached to any request — on a
+		// non-HTTPS page, full stop, regardless of SameSite or hostname
+		// matching; inheriting h.cookie.Secure here would silently break
+		// the extension on exactly that (common) combination. Carries no
+		// token material, so there's no security reason to restrict it.
+		Secure:   false,
 		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(refreshTTL.Seconds()),
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     schemeCookieName,
+		Value:    h.requestScheme(),
+		Path:     "/",
+		HttpOnly: false,
+		// See portCookieName's cookie just above for why this is
+		// unconditionally non-Secure too.
+		Secure:   false,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(refreshTTL.Seconds()),
+	})
+	// Both Login and Refresh populate these now — see TokenPair's own doc
+	// comment for why Refresh reissues rather than leaves them alone. The
+	// guard just means a hypothetical future caller of setTokenCookies that
+	// doesn't populate the annotation fields can't accidentally wipe out an
+	// already-set annotation pair with empty values.
+	if pair.AnnotationAccessToken != "" {
+		h.setAnnotationTokenCookies(w, pair.AnnotationAccessToken, pair.AnnotationRefreshToken, refreshTTL)
+	}
+}
+
+// setAnnotationTokenCookies writes the domainauth.ScopeAnnotation-restricted
+// pair into their own HttpOnly cookies. Unlike every other cookie this
+// handler sets, these use SameSite=None: the browser extension calls this
+// API directly from a forwarded preview page that only shares a hostname
+// with this one (see portCookieName's doc comment), often a different
+// scheme too, which modern browsers treat as cross-site for
+// SameSite=Lax/Strict purposes — see domainauth.ScopeAnnotation's doc
+// comment. SameSite=None requires Secure, so on a COOKIE_SECURE=false
+// deployment these two cookies are silently never stored at all (browsers
+// drop a None cookie that isn't also Secure) — the correct, if unhelpful,
+// degradation: without TLS on at least one side there's no way for a
+// cross-scheme request to carry a cookie safely regardless of SameSite, and
+// a plain-HTTP page fetching a plain-HTTP API on a different scheme-tagged
+// origin was never actually the failure mode this pair fixes (an
+// HTTPS-page-to-HTTP-API request is mixed content and gets blocked before
+// any cookie is considered either way).
+func (h *AuthHandler) setAnnotationTokenCookies(w http.ResponseWriter, accessToken, refreshToken string, refreshTTL time.Duration) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     annotationAccessCookieName,
+		Value:    accessToken,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   h.cookie.Secure,
+		SameSite: http.SameSiteNoneMode,
+		MaxAge:   int(h.cookie.AccessTTL.Seconds()),
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     annotationRefreshCookieName,
+		Value:    refreshToken,
+		Path:     annotationRefreshCookiePath,
+		HttpOnly: true,
+		Secure:   h.cookie.Secure,
+		SameSite: http.SameSiteNoneMode,
 		MaxAge:   int(refreshTTL.Seconds()),
 	})
 }
@@ -175,7 +285,28 @@ func requestPort(r *http.Request) string {
 	return "80"
 }
 
-// clearCookies expires all three cookies immediately.
+// requestScheme returns the scheme the Paca app is externally reachable on.
+// Deliberately reads h.cookie.Secure rather than trying to detect the
+// current request's own scheme (an earlier version checked X-Forwarded-Proto/
+// r.TLS, mirroring requestPort's own reasoning) — that detection depends on
+// every hop of whatever reverse proxy chain fronts this deployment
+// correctly forwarding the header, which isn't this codebase's to control
+// (e.g. Caddy's reverse_proxy recomputes X-Forwarded-Proto from its own
+// connection by default, discarding a value an upstream Ingress already
+// set correctly, unless separately configured not to). h.cookie.Secure has
+// no such dependency: it's the operator's own COOKIE_SECURE setting, and it
+// already has to correctly reflect whether the deployment is HTTPS or the
+// access_token/refresh_token cookies above wouldn't work at all — so
+// deriving paca_scheme from the same value costs nothing new and can't be
+// broken by a proxy hop losing a header.
+func (h *AuthHandler) requestScheme() string {
+	if h.cookie.Secure {
+		return "https"
+	}
+	return "http"
+}
+
+// clearCookies expires every cookie this handler ever sets.
 func (h *AuthHandler) clearCookies(w http.ResponseWriter, _ *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     accessCookieName,
@@ -200,8 +331,35 @@ func (h *AuthHandler) clearCookies(w http.ResponseWriter, _ *http.Request) {
 		Value:    "",
 		Path:     "/",
 		HttpOnly: false,
-		Secure:   h.cookie.Secure,
+		Secure:   false, // matches setTokenCookies — see that Set-Cookie's own comment
 		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     schemeCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: false,
+		Secure:   false, // matches setTokenCookies — see that Set-Cookie's own comment
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     annotationAccessCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   h.cookie.Secure,
+		SameSite: http.SameSiteNoneMode,
+		MaxAge:   -1,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     annotationRefreshCookieName,
+		Value:    "",
+		Path:     annotationRefreshCookiePath,
+		HttpOnly: true,
+		Secure:   h.cookie.Secure,
+		SameSite: http.SameSiteNoneMode,
 		MaxAge:   -1,
 	})
 }

--- a/services/api/internal/transport/http/handler/auth_handler_test.go
+++ b/services/api/internal/transport/http/handler/auth_handler_test.go
@@ -31,9 +31,10 @@ var testCookieConfig = handler.CookieConfig{
 // ---------------------------------------------------------------------------
 
 type mockAuthSvc struct {
-	login   func(ctx context.Context, username, pass string, rememberMe bool) (*domainauth.TokenPair, error)
-	refresh func(ctx context.Context, token string) (*domainauth.TokenPair, error)
-	logout  func(ctx context.Context, familyID string) error
+	login             func(ctx context.Context, username, pass string, rememberMe bool) (*domainauth.TokenPair, error)
+	refresh           func(ctx context.Context, token string) (*domainauth.TokenPair, error)
+	refreshAnnotation func(ctx context.Context, token string) (*domainauth.TokenPair, error)
+	logout            func(ctx context.Context, familyID string) error
 }
 
 func (m *mockAuthSvc) Login(ctx context.Context, username, pass string, rememberMe bool) (*domainauth.TokenPair, error) {
@@ -47,6 +48,12 @@ func (m *mockAuthSvc) Refresh(ctx context.Context, token string) (*domainauth.To
 		return m.refresh(ctx, token)
 	}
 	return nil, errors.New("mock: refresh not configured")
+}
+func (m *mockAuthSvc) RefreshAnnotation(ctx context.Context, token string) (*domainauth.TokenPair, error) {
+	if m.refreshAnnotation != nil {
+		return m.refreshAnnotation(ctx, token)
+	}
+	return nil, errors.New("mock: refreshAnnotation not configured")
 }
 func (m *mockAuthSvc) Logout(ctx context.Context, familyID string) error {
 	if m.logout != nil {
@@ -564,5 +571,255 @@ func TestLogin_PacaPortCookie_DefaultsWhenHostHasNoPort(t *testing.T) {
 	c := findCookie(t, w, "paca_port")
 	if c.Value != "80" {
 		t.Errorf("paca_port = %q, want %q (default for a plain-HTTP request with no explicit port)", c.Value, "80")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// paca_scheme cookie — portCookieName's scheme counterpart. Same reasoning:
+// read from a completely different (forwarded-preview) page, so it must
+// never be HttpOnly.
+// ---------------------------------------------------------------------------
+
+func TestLogin_SetsPacaSchemeCookie_NotHttpOnly(t *testing.T) {
+	svc := &mockAuthSvc{
+		login: func(_ context.Context, _, _ string, _ bool) (*domainauth.TokenPair, error) {
+			return &domainauth.TokenPair{AccessToken: "at", RefreshToken: "rt", RefreshTTL: time.Hour}, nil
+		},
+	}
+	r := chi.NewRouter()
+	r.Post("/auth/login", handler.NewAuthHandler(svc, testCookieConfig).Login)
+
+	w := do(t, r, http.MethodPost, "/auth/login",
+		jsonBody(t, map[string]string{"username": "alice", "password": "secret12"}))
+
+	c := findCookie(t, w, "paca_scheme")
+	if c.HttpOnly {
+		t.Error("paca_scheme must not be HttpOnly — the extension reads it via document.cookie")
+	}
+	if c.Value != "http" {
+		t.Errorf("paca_scheme = %q, want %q (testCookieConfig has Secure: false)", c.Value, "http")
+	}
+}
+
+// TestLogin_PortAndSchemeCookies_NeverSecure_EvenWithCookieSecureTrue is the
+// regression test for a real bug: a deployment with COOKIE_SECURE=true (the
+// main app correctly sitting behind real HTTPS, e.g. via an Ingress) was
+// applying that same Secure flag to paca_port/paca_scheme — but those two
+// exist specifically to be read via document.cookie from a forwarded
+// environment preview, which is very commonly plain HTTP (a raw dev-server
+// port, no TLS termination in that path) even when the main app is HTTPS.
+// A Secure cookie is invisible to document.cookie on a non-HTTPS page,
+// full stop — so with COOKIE_SECURE=true the extension silently couldn't
+// see either cookie at all on exactly that common combination, even though
+// every other test here (which all use testCookieConfig's Secure: false)
+// passed. This is the one test in the file that deliberately uses a
+// Secure:true config to catch it.
+func TestLogin_PortAndSchemeCookies_NeverSecure_EvenWithCookieSecureTrue(t *testing.T) {
+	svc := &mockAuthSvc{
+		login: func(_ context.Context, _, _ string, _ bool) (*domainauth.TokenPair, error) {
+			return &domainauth.TokenPair{AccessToken: "at", RefreshToken: "rt", RefreshTTL: time.Hour}, nil
+		},
+	}
+	securedCfg := testCookieConfig
+	securedCfg.Secure = true
+	r := chi.NewRouter()
+	r.Post("/auth/login", handler.NewAuthHandler(svc, securedCfg).Login)
+
+	w := do(t, r, http.MethodPost, "/auth/login",
+		jsonBody(t, map[string]string{"username": "alice", "password": "secret12"}))
+
+	// Sanity check the premise: the auth cookies really are Secure here.
+	if c := findCookie(t, w, "access_token"); !c.Secure {
+		t.Fatalf("test setup broken: access_token should be Secure when COOKIE_SECURE=true")
+	}
+
+	if c := findCookie(t, w, "paca_port"); c.Secure {
+		t.Error("paca_port must never be Secure, even when COOKIE_SECURE=true — it would become invisible to document.cookie on a plain-HTTP forwarded preview")
+	}
+	if c := findCookie(t, w, "paca_scheme"); c.Secure {
+		t.Error("paca_scheme must never be Secure, even when COOKIE_SECURE=true — same reasoning as paca_port")
+	}
+}
+
+// TestLogin_PacaSchemeCookie_ReflectsCookieSecure_NotHeaders confirms
+// paca_scheme is derived purely from h.cookie.Secure (COOKIE_SECURE) — not
+// from X-Forwarded-Proto or any other per-request signal. An earlier
+// version read X-Forwarded-Proto, which broke silently whenever a reverse
+// proxy in front of this service (e.g. Caddy's reverse_proxy, which
+// recomputes that header from its own connection by default) didn't
+// faithfully forward it — see requestScheme's own doc comment for why
+// h.cookie.Secure has no equivalent failure mode.
+func TestLogin_PacaSchemeCookie_ReflectsCookieSecure_NotHeaders(t *testing.T) {
+	cases := []struct {
+		name       string
+		secure     bool
+		wantScheme string
+	}{
+		{"COOKIE_SECURE=false", false, "http"},
+		{"COOKIE_SECURE=true", true, "https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &mockAuthSvc{
+				login: func(_ context.Context, _, _ string, _ bool) (*domainauth.TokenPair, error) {
+					return &domainauth.TokenPair{AccessToken: "at", RefreshToken: "rt", RefreshTTL: time.Hour}, nil
+				},
+			}
+			cfg := testCookieConfig
+			cfg.Secure = tc.secure
+			r := chi.NewRouter()
+			r.Post("/auth/login", handler.NewAuthHandler(svc, cfg).Login)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/auth/login",
+				jsonBody(t, map[string]string{"username": "alice", "password": "secret12"}))
+			req.Header.Set("Content-Type", "application/json")
+			// A header claiming the opposite scheme must be ignored entirely.
+			opposite := map[string]string{"http": "https", "https": "http"}[tc.wantScheme]
+			req.Header.Set("X-Forwarded-Proto", opposite)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			c := findCookie(t, w, "paca_scheme")
+			if c.Value != tc.wantScheme {
+				t.Errorf("paca_scheme = %q, want %q (from h.cookie.Secure=%v, ignoring X-Forwarded-Proto: %q)", c.Value, tc.wantScheme, tc.secure, opposite)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// annotation_access_token / annotation_refresh_token — the
+// domainauth.ScopeAnnotation pair the browser extension relies on when the
+// forwarded preview page and this API don't share a scheme (see
+// AuthHandler.setAnnotationTokenCookies's doc comment).
+// ---------------------------------------------------------------------------
+
+func TestLogin_SetsAnnotationCookies_SameSiteNone(t *testing.T) {
+	svc := &mockAuthSvc{
+		login: func(_ context.Context, _, _ string, _ bool) (*domainauth.TokenPair, error) {
+			return &domainauth.TokenPair{
+				AccessToken: "at", RefreshToken: "rt", RefreshTTL: time.Hour,
+				AnnotationAccessToken: "aat", AnnotationRefreshToken: "art",
+			}, nil
+		},
+	}
+	r := chi.NewRouter()
+	// SameSite=None requires Secure, or the browser drops the cookie
+	// outright -- exercise this with Secure:true so the cookie is actually
+	// well-formed, matching a real HTTPS deployment.
+	securedCfg := testCookieConfig
+	securedCfg.Secure = true
+	r.Post("/auth/login", handler.NewAuthHandler(svc, securedCfg).Login)
+
+	w := do(t, r, http.MethodPost, "/auth/login",
+		jsonBody(t, map[string]string{"username": "alice", "password": "secret12"}))
+
+	access := findCookie(t, w, "annotation_access_token")
+	if access.Value != "aat" || !access.HttpOnly || !access.Secure || access.SameSite != http.SameSiteNoneMode {
+		t.Errorf("annotation_access_token = %+v, want HttpOnly+Secure+SameSite=None with value %q", access, "aat")
+	}
+	refresh := findCookie(t, w, "annotation_refresh_token")
+	if refresh.Value != "art" || refresh.Path != "/api/v1/auth/annotation-refresh" {
+		t.Errorf("annotation_refresh_token = %+v, want value %q scoped to the annotation-refresh path", refresh, "art")
+	}
+}
+
+func TestRefresh_ReissuesAnnotationCookies(t *testing.T) {
+	// Refresh now reissues the annotation pair on every call (see
+	// domainauth.Service.Refresh's doc comment) so its lifetime piggybacks
+	// on ordinary web-app usage instead of requiring the extension to
+	// independently keep itself alive.
+	svc := &mockAuthSvc{
+		refresh: func(_ context.Context, _ string) (*domainauth.TokenPair, error) {
+			return &domainauth.TokenPair{
+				AccessToken: "at2", RefreshToken: "rt2", RefreshTTL: time.Hour,
+				AnnotationAccessToken: "aat2", AnnotationRefreshToken: "art2",
+			}, nil
+		},
+	}
+	r := chi.NewRouter()
+	securedCfg := testCookieConfig
+	securedCfg.Secure = true // SameSite=None cookies require Secure to actually be stored
+	r.Post("/auth/refresh", handler.NewAuthHandler(svc, securedCfg).Refresh)
+
+	w := doWithCookie(t, r, http.MethodPost, "/auth/refresh", nil, "refresh_token", "rt")
+
+	access := findCookie(t, w, "annotation_access_token")
+	if access.Value != "aat2" || access.SameSite != http.SameSiteNoneMode {
+		t.Errorf("annotation_access_token = %+v, want value %q with SameSite=None", access, "aat2")
+	}
+	refresh := findCookie(t, w, "annotation_refresh_token")
+	if refresh.Value != "art2" {
+		t.Errorf("annotation_refresh_token = %+v, want value %q", refresh, "art2")
+	}
+}
+
+func TestRefresh_EmptyAnnotationFields_SetsNoAnnotationCookies(t *testing.T) {
+	// Guards setTokenCookies's own guard: a TokenPair with no annotation
+	// fields populated (never actually returned by the real service today,
+	// but the contract setTokenCookies relies on) must not emit annotation
+	// cookies at all, rather than emitting them empty.
+	svc := &mockAuthSvc{
+		refresh: func(_ context.Context, _ string) (*domainauth.TokenPair, error) {
+			return &domainauth.TokenPair{AccessToken: "at2", RefreshToken: "rt2", RefreshTTL: time.Hour}, nil
+		},
+	}
+	r := chi.NewRouter()
+	r.Post("/auth/refresh", handler.NewAuthHandler(svc, testCookieConfig).Refresh)
+
+	w := doWithCookie(t, r, http.MethodPost, "/auth/refresh", nil, "refresh_token", "rt")
+
+	for _, name := range []string{"annotation_access_token", "annotation_refresh_token"} {
+		for _, c := range w.Result().Cookies() {
+			if c.Name == name {
+				t.Errorf("expected no %s cookie for an empty-annotation-fields TokenPair, got %+v", name, c)
+			}
+		}
+	}
+}
+
+func TestAnnotationRefresh_Success(t *testing.T) {
+	svc := &mockAuthSvc{
+		refreshAnnotation: func(_ context.Context, token string) (*domainauth.TokenPair, error) {
+			if token != "art" {
+				t.Errorf("expected annotation_refresh_token value %q, got %q", "art", token)
+			}
+			return &domainauth.TokenPair{
+				RefreshTTL:             time.Hour,
+				AnnotationAccessToken:  "aat2",
+				AnnotationRefreshToken: "art2",
+			}, nil
+		},
+	}
+	r := chi.NewRouter()
+	r.Post("/auth/annotation-refresh", handler.NewAuthHandler(svc, testCookieConfig).AnnotationRefresh)
+
+	w := doWithCookie(t, r, http.MethodPost, "/auth/annotation-refresh", nil, "annotation_refresh_token", "art")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	access := findCookie(t, w, "annotation_access_token")
+	if access.Value != "aat2" {
+		t.Errorf("annotation_access_token = %q, want %q", access.Value, "aat2")
+	}
+	// Must not touch the main session's cookies at all.
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "access_token" || c.Name == "refresh_token" {
+			t.Errorf("AnnotationRefresh must not set %s, got %+v", c.Name, c)
+		}
+	}
+}
+
+func TestAnnotationRefresh_MissingCookie(t *testing.T) {
+	r := chi.NewRouter()
+	r.Post("/auth/annotation-refresh", handler.NewAuthHandler(&mockAuthSvc{}, testCookieConfig).AnnotationRefresh)
+
+	w := do(t, r, http.MethodPost, "/auth/annotation-refresh", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without cookie, got %d", w.Code)
+	}
+	if code := errorCode(t, w); code != "AUTH_MISSING_TOKEN" {
+		t.Errorf("expected error_code AUTH_MISSING_TOKEN, got %q", code)
 	}
 }

--- a/services/api/internal/transport/http/middleware/authn.go
+++ b/services/api/internal/transport/http/middleware/authn.go
@@ -186,6 +186,20 @@ func applyAuthn(w http.ResponseWriter, r *http.Request, tm *jwttoken.Manager, ap
 		tokenStr = cookie.Value
 	}
 	if tokenStr == "" {
+		// Falls back to the browser extension's own, narrower-scoped
+		// cookie (see domainauth.ScopeAnnotation) — present whenever
+		// access_token itself isn't, e.g. because the extension's
+		// forwarded-preview page and this API differ in scheme, so
+		// SameSite withholds access_token but not this SameSite=None one.
+		// The Scope check below is what stops a token that arrived this
+		// way from authenticating anything but
+		// AnnotationExtensionPathPattern. Literal name must match
+		// handler.annotationAccessCookieName.
+		if cookie, err := r.Cookie("annotation_access_token"); err == nil && cookie.Value != "" {
+			tokenStr = cookie.Value
+		}
+	}
+	if tokenStr == "" {
 		header := r.Header.Get("Authorization")
 		if header != "" {
 			parts := strings.SplitN(header, " ", 2)
@@ -266,6 +280,17 @@ func applyAuthn(w http.ResponseWriter, r *http.Request, tm *jwttoken.Manager, ap
 	}
 	if claims.Kind != "access" {
 		presenter.Error(w, r, apierr.New(apierr.CodeTokenInvalid, "expected access token"))
+		return r, false
+	}
+	if !enforceTokenScope(claims, r.URL.Path) {
+		// A token whose Scope doesn't permit this path must never
+		// authenticate the request, even though it's a real, validly-
+		// signed token for a real user — see scope.go for the full policy.
+		// Same rejection whether this call came through Authn or
+		// OptionalAuthn: an out-of-scope credential is not "no
+		// credential", it's a credential this endpoint must actively
+		// refuse.
+		presenter.Error(w, r, apierr.New(apierr.CodeTokenInvalid, "token is not valid for this endpoint"))
 		return r, false
 	}
 

--- a/services/api/internal/transport/http/middleware/authn_test.go
+++ b/services/api/internal/transport/http/middleware/authn_test.go
@@ -151,6 +151,83 @@ func TestAuthn_RefreshTokenRejected(t *testing.T) {
 	}
 }
 
+// TestAuthn_AnnotationScopedToken_AllowedOnAnnotationPath and
+// _RejectedOnOtherPath together are the core security property of
+// AnnotationExtensionPathPattern: a domainauth.ScopeAnnotation token is a
+// real, validly-signed credential for a real user, so it must authenticate
+// successfully on the narrow route set the browser extension actually
+// needs, and be refused everywhere else even though the signature and
+// Kind checks alone would happily accept it.
+
+func TestAuthn_AnnotationScopedToken_AllowedOnAnnotationPath(t *testing.T) {
+	tm := newTestTokenManager()
+	at, err := tm.IssueAnnotationAccess("user-id", "alice", "USER", "fam", false)
+	if err != nil {
+		t.Fatalf("issue annotation access token: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.With(Authn(tm)).Get("/api/v1/port-forwards/resolve", okHandler)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/port-forwards/resolve", nil)
+	req.AddCookie(&http.Cookie{Name: "annotation_access_token", Value: at})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestAuthn_AnnotationScopedToken_RejectedOnOtherPath(t *testing.T) {
+	tm := newTestTokenManager()
+	at, err := tm.IssueAnnotationAccess("user-id", "alice", "USER", "fam", false)
+	if err != nil {
+		t.Fatalf("issue annotation access token: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.With(Authn(tm)).Get("/api/v1/projects/{projectId}", okHandler)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/projects/proj1", nil)
+	req.AddCookie(&http.Cookie{Name: "annotation_access_token", Value: at})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for an annotation-scoped token outside its allowed paths, got %d", w.Code)
+	}
+}
+
+func TestAuthn_AnnotationScopedToken_FullAccessTokenTakesPrecedence(t *testing.T) {
+	tm := newTestTokenManager()
+	full, err := tm.IssueAccess("user-id", "alice", "USER", "fam", false)
+	if err != nil {
+		t.Fatalf("issue access token: %v", err)
+	}
+	annotation, err := tm.IssueAnnotationAccess("user-id", "alice", "USER", "fam", false)
+	if err != nil {
+		t.Fatalf("issue annotation access token: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.With(Authn(tm)).Get("/api/v1/projects/{projectId}", okHandler)
+
+	// Both cookies present, as they would be for a same-scheme request
+	// where the browser attaches everything -- the full-scope access_token
+	// must win so an out-of-scope annotation token never even gets
+	// consulted here.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/projects/proj1", nil)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: full})
+	req.AddCookie(&http.Cookie{Name: "annotation_access_token", Value: annotation})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when a full-scope access_token is present alongside an annotation cookie, got %d", w.Code)
+	}
+}
+
 func TestClaimsFrom_Missing(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	if claims := ClaimsFrom(req); claims != nil {

--- a/services/api/internal/transport/http/middleware/content_type.go
+++ b/services/api/internal/transport/http/middleware/content_type.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"mime"
+	"net/http"
+
+	"github.com/Paca-AI/api/internal/apierr"
+	"github.com/Paca-AI/api/internal/transport/http/presenter"
+)
+
+// RequireJSONContentType rejects any request whose Content-Type isn't
+// application/json (parameters like charset are ignored).
+//
+// Apply this to every route that decodes a JSON body via plain
+// encoding/json (BindJSON or a handler's own json.NewDecoder) and is
+// reachable using a SameSite=None credential (see
+// domainauth.ScopeAnnotation) — annotation.go's write endpoints being the
+// case that motivated this. Those decoders happily parse JSON bytes no
+// matter what Content-Type header arrived with them, which matters because
+// three Content-Type values (application/x-www-form-urlencoded,
+// multipart/form-data, text/plain) are CORS-safelisted: a cross-site
+// request using one of them counts as a "simple request" under the Fetch
+// spec and skips the CORS preflight entirely, reaching the handler —
+// cookie attached — regardless of corsMiddleware's same-hostname check,
+// which only ever gates a *preflighted* request. A SameSite=Lax/Strict
+// cookie wouldn't even be attached to that cross-site request in the first
+// place, but a SameSite=None one is attached exactly as designed.
+//
+// Requiring application/json (never CORS-safelisted on its own) forces
+// every cross-origin write through preflight, where corsMiddleware's
+// same-hostname check (or CORS_ORIGINS) is the thing actually doing access
+// control.
+func RequireJSONContentType() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+			if err != nil || mediaType != "application/json" {
+				presenter.Error(w, r, apierr.New(apierr.CodeBadRequest, "Content-Type must be application/json"))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/services/api/internal/transport/http/middleware/content_type_test.go
+++ b/services/api/internal/transport/http/middleware/content_type_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -22,7 +23,7 @@ func TestRequireJSONContentType_Allows(t *testing.T) {
 	handler := newJSONOnlyTestHandler()
 	for _, ct := range cases {
 		t.Run(ct, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{}`))
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", strings.NewReader(`{}`))
 			req.Header.Set("Content-Type", ct)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
@@ -52,7 +53,7 @@ func TestRequireJSONContentType_RejectsSafelistedTypes(t *testing.T) {
 	handler := newJSONOnlyTestHandler()
 	for _, ct := range cases {
 		t.Run(ct, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{}`))
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", strings.NewReader(`{}`))
 			if ct != "" {
 				req.Header.Set("Content-Type", ct)
 			}

--- a/services/api/internal/transport/http/middleware/content_type_test.go
+++ b/services/api/internal/transport/http/middleware/content_type_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newJSONOnlyTestHandler() http.Handler {
+	return RequireJSONContentType()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestRequireJSONContentType_Allows(t *testing.T) {
+	cases := []string{
+		"application/json",
+		"application/json; charset=utf-8",
+		"Application/JSON",
+	}
+	handler := newJSONOnlyTestHandler()
+	for _, ct := range cases {
+		t.Run(ct, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{}`))
+			req.Header.Set("Content-Type", ct)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("Content-Type %q: expected 200, got %d (%s)", ct, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestRequireJSONContentType_RejectsSafelistedTypes is the core property
+// this middleware exists for: none of the three CORS-safelisted Content-Type
+// values (which let a cross-site request skip preflight entirely, per the
+// Fetch spec) may reach the handler. Without this rejection, a cross-site
+// caller could smuggle a JSON body under one of these and still have it
+// parsed by a handler that decodes with plain encoding/json — see this
+// middleware's own doc comment for the full threat model.
+func TestRequireJSONContentType_RejectsSafelistedTypes(t *testing.T) {
+	cases := []string{
+		"text/plain",
+		"text/plain;charset=UTF-8",
+		"application/x-www-form-urlencoded",
+		"multipart/form-data; boundary=----x",
+		"",
+	}
+	handler := newJSONOnlyTestHandler()
+	for _, ct := range cases {
+		t.Run(ct, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{}`))
+			if ct != "" {
+				req.Header.Set("Content-Type", ct)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("Content-Type %q: expected 400, got %d (%s)", ct, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/services/api/internal/transport/http/middleware/scope.go
+++ b/services/api/internal/transport/http/middleware/scope.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"regexp"
+
+	domainauth "github.com/Paca-AI/api/internal/domain/auth"
+)
+
+// This file is entirely about narrow-scope tokens — see
+// domainauth.ScopeAnnotation's doc comment for the one that exists today
+// and why it exists at all. It's kept separate from authn.go on purpose:
+// authn.go already carries JWT verification, API-key auth, and agent-
+// identity checks, and a reviewer auditing "what can a browser-extension
+// token actually do" shouldn't have to read all of that to find out — this
+// file, top to bottom, is the whole answer.
+//
+// enforceTokenScope is called from applyAuthn's shared tail (in authn.go),
+// not mounted as its own r.Use() middleware. That's deliberate: the
+// annotation-extension routes live nested inside the same shared
+// /projects/{projectId} middleware stack as tasks, docs, sprints, and
+// everything else project-scoped, so there's no isolated mount point to
+// attach a standalone middleware to without restructuring that group — and
+// a middleware someone has to remember to mount on the right subtree has
+// the same "forgot to guard it" failure mode this file exists to close,
+// just moved from "forgot to guard a new route" to "forgot to guard a new
+// route group". Calling this from the one function every route's JWT check
+// already funnels through means a future route is safe by construction,
+// not by remembering.
+
+// AnnotationExtensionPathPattern matches the exact set of routes the Paca
+// browser extension's content script needs to call directly from a
+// forwarded environment port: rotating its own domainauth.ScopeAnnotation
+// session, resolving which project/environment/port-forward it's looking
+// at, and the page-annotation CRUD itself. Shared by two gates that must
+// stay in lockstep — router.go's corsMiddleware same-hostname exception
+// (why a cross-origin browser request to these paths is allowed to read
+// its response at all) and enforceTokenScope just below (why a
+// ScopeAnnotation token is honored only on these paths, not any other
+// route) — so it's defined once, here, rather than as two hand-synced
+// copies.
+//
+// The path check matters as much as the Scope check: the forwarded port
+// serves the *user's own dev app*, not code Paca controls, so any script
+// running there — not just the extension's content script — can present
+// whatever cookies the browser attaches. Scoping ScopeAnnotation tokens to
+// this pattern means such a script can, at most, act on page annotations
+// (and read its own port-forward's identity); without it, a token that
+// merely happens to be valid would grant free, ambient access to every
+// other endpoint the underlying user's role/permissions allow.
+var AnnotationExtensionPathPattern = regexp.MustCompile(
+	`^/api/v1/(?:` +
+		`auth/annotation-refresh` +
+		`|port-forwards/resolve` +
+		`|projects/[^/]+/environments/[^/]+/port-forwards/[^/]+/annotations(?:/.*)?` +
+		`)$`,
+)
+
+// enforceTokenScope reports whether claims may authenticate a request to
+// path, given whatever restriction its Scope carries.
+//
+// The default case matters more than the two named ones: an unrecognized
+// Scope value — a future scope this build of the server was never taught
+// to restrict, or a token whose claims were altered after issuance in a
+// way that produced a value nothing here expects — is rejected, not
+// trusted. That's what keeps this function safe to extend later: adding a
+// third scope means adding a case, not remembering to also update every
+// place that currently checks `== domainauth.ScopeAnnotation` explicitly
+// the way an earlier version of this check did.
+func enforceTokenScope(claims *domainauth.Claims, path string) bool {
+	switch claims.Scope {
+	case "":
+		// Full scope — every token Login/Refresh issued before this
+		// concept existed, and every token they issue today unless
+		// explicitly narrowed.
+		return true
+	case domainauth.ScopeAnnotation:
+		return AnnotationExtensionPathPattern.MatchString(path)
+	default:
+		return false
+	}
+}

--- a/services/api/internal/transport/http/middleware/scope_test.go
+++ b/services/api/internal/transport/http/middleware/scope_test.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"testing"
+
+	domainauth "github.com/Paca-AI/api/internal/domain/auth"
+)
+
+func TestEnforceTokenScope_FullScope_AllowsAnyPath(t *testing.T) {
+	claims := &domainauth.Claims{}
+	paths := []string{
+		"/api/v1/projects/proj1",
+		"/api/v1/port-forwards/resolve",
+		"/api/v1/admin/users",
+		"/api/v1/projects/proj1/environments/env1/port-forwards/pf1/annotations",
+	}
+	for _, path := range paths {
+		if !enforceTokenScope(claims, path) {
+			t.Errorf("full-scope (empty Scope) claims should be allowed on %q", path)
+		}
+	}
+}
+
+func TestEnforceTokenScope_Annotation_AllowsOnlyMatchingPaths(t *testing.T) {
+	claims := &domainauth.Claims{Scope: domainauth.ScopeAnnotation}
+
+	allowed := []string{
+		"/api/v1/auth/annotation-refresh",
+		"/api/v1/port-forwards/resolve",
+		"/api/v1/projects/p1/environments/e1/port-forwards/pf1/annotations",
+		"/api/v1/projects/p1/environments/e1/port-forwards/pf1/annotations/ann1/resolve",
+	}
+	for _, path := range allowed {
+		if !enforceTokenScope(claims, path) {
+			t.Errorf("ScopeAnnotation claims should be allowed on %q", path)
+		}
+	}
+
+	denied := []string{
+		"/api/v1/projects/p1",
+		"/api/v1/projects/p1/tasks",
+		"/api/v1/auth/refresh", // the *main* refresh endpoint, not annotation-refresh
+		"/api/v1/admin/users",
+		"/api/v1/projects/p1/annotations", // project-wide search — a different route than the port-forward-scoped one
+	}
+	for _, path := range denied {
+		if enforceTokenScope(claims, path) {
+			t.Errorf("ScopeAnnotation claims should NOT be allowed on %q", path)
+		}
+	}
+}
+
+// TestEnforceTokenScope_UnknownScope_FailsClosed is the property that makes
+// this function safe to extend later: a Scope value nothing here recognizes
+// — a future scope this build predates, or a tampered token — must be
+// rejected everywhere, not just on the one path pattern a narrower case
+// happens to check.
+func TestEnforceTokenScope_UnknownScope_FailsClosed(t *testing.T) {
+	claims := &domainauth.Claims{Scope: "some-future-scope-this-build-does-not-know-about"}
+	paths := []string{
+		"/api/v1/projects/p1",
+		"/api/v1/port-forwards/resolve",
+		"/api/v1/projects/p1/environments/e1/port-forwards/pf1/annotations",
+	}
+	for _, path := range paths {
+		if enforceTokenScope(claims, path) {
+			t.Errorf("an unrecognized Scope must be rejected on every path, was allowed on %q", path)
+		}
+	}
+}

--- a/services/api/internal/transport/http/router/cors_test.go
+++ b/services/api/internal/transport/http/router/cors_test.go
@@ -35,13 +35,14 @@ func TestSameHostnameOrigin(t *testing.T) {
 // hostname as the API, a different port, calling one of the extension's
 // actual routes gets an exact Origin echo plus Allow-Credentials —
 // required for its content script's `credentials: "include"` fetch to
-// actually have access_token/refresh_token attached and readable (see
-// corsMiddleware's own doc comment).
+// actually have a token attached and readable (see corsMiddleware's own
+// doc comment). auth/annotation-refresh, not auth/refresh, is the
+// extension's rotation endpoint — see domainauth.ScopeAnnotation.
 func TestCORSMiddleware_SameHostnameGetsCredentialedAccess(t *testing.T) {
 	mw := corsMiddleware(nil) // default allow-all config, as most deployments run
 
 	paths := []string{
-		"/api/v1/auth/refresh",
+		"/api/v1/auth/annotation-refresh",
 		"/api/v1/port-forwards/resolve",
 		"/api/v1/projects/proj-1/environments/env-1/port-forwards/pf-1/annotations",
 		"/api/v1/projects/proj-1/environments/env-1/port-forwards/pf-1/annotations/",
@@ -73,9 +74,13 @@ func TestCORSMiddleware_SameHostnameGetsCredentialedAccess(t *testing.T) {
 // regression test for the bug this scoping fixes: a same-hostname,
 // different-port origin (i.e. arbitrary code running on *any* forwarded
 // environment port, not just the extension) must NOT get credentialed
-// access to routes outside extensionCredentialedPathPattern — otherwise any
-// forwarded port on the platform would get ambient, full-API access on the
-// signed-in caller's behalf just by matching hostname.
+// access to routes outside httpmw.AnnotationExtensionPathPattern —
+// otherwise any forwarded port on the platform would get ambient, full-API
+// access on the signed-in caller's behalf just by matching hostname.
+// auth/refresh is included deliberately: it moved out of the credentialed
+// set when auth/annotation-refresh replaced it as the extension's rotation
+// endpoint, and it must stay out — the main session's refresh token has no
+// business being reachable cross-origin from a forwarded preview port.
 func TestCORSMiddleware_SameHostnameNonExtensionRouteGetsNoCredentials(t *testing.T) {
 	mw := corsMiddleware(nil)
 
@@ -84,6 +89,7 @@ func TestCORSMiddleware_SameHostnameNonExtensionRouteGetsNoCredentials(t *testin
 		"/api/v1/users/me",
 		"/api/v1/projects/proj-1/tasks",
 		"/api/v1/admin/settings",
+		"/api/v1/auth/refresh",
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -98,6 +97,7 @@ func New(deps Deps) http.Handler {
 			r.Route("/auth", func(r chi.Router) {
 				r.Post("/login", deps.Auth.Login)
 				r.Post("/refresh", deps.Auth.Refresh)
+				r.Post("/annotation-refresh", deps.Auth.AnnotationRefresh)
 				r.With(httpmw.Authn(deps.TokenManager)).Post("/logout", deps.Auth.Logout)
 				// Public — the link a password-set-token email points to;
 				// the token itself (not a session) proves the caller's right
@@ -1065,23 +1065,6 @@ func loggerMiddleware(log *slog.Logger) func(http.Handler) http.Handler {
 	}
 }
 
-// extensionCredentialedPathPattern matches the exact set of routes the Paca
-// browser extension's content script needs to call directly from a
-// forwarded environment port: refreshing its session, resolving which
-// project/environment/port-forward it's looking at, and the page-annotation
-// CRUD itself. See corsMiddleware's doc comment for why this set has to be
-// an explicit allow-list rather than "every route" — deliberately narrow so
-// that a same-hostname origin (i.e. arbitrary code running on *any*
-// forwarded port, not just the extension) can't use this exception to reach
-// unrelated, non-annotation endpoints with the caller's own credentials.
-var extensionCredentialedPathPattern = regexp.MustCompile(
-	`^/api/v1/(?:` +
-		`auth/refresh` +
-		`|port-forwards/resolve` +
-		`|projects/[^/]+/environments/[^/]+/port-forwards/[^/]+/annotations(?:/.*)?` +
-		`)$`,
-)
-
 // corsMiddleware sets CORS headers per the given allow-list. An empty list,
 // or a list containing "*", reflects Access-Control-Allow-Origin: * for
 // every request (the historical default — permissive, tighten in production
@@ -1091,28 +1074,36 @@ var extensionCredentialedPathPattern = regexp.MustCompile(
 //
 // One narrow exception, checked before either of those: a request whose
 // Origin has the same hostname as this server's own Host header (port
-// ignored) *and* whose path matches extensionCredentialedPathPattern gets
-// its exact Origin echoed back with Access-Control-Allow-Credentials: true,
-// regardless of CORS_ORIGINS. This is what lets the Paca browser
+// ignored) *and* whose path matches httpmw.AnnotationExtensionPathPattern
+// gets its exact Origin echoed back with Access-Control-Allow-Credentials:
+// true, regardless of CORS_ORIGINS. This is what lets the Paca browser
 // extension's content script — running directly on a forwarded environment
 // port, e.g. paca.example.com:31842 — call this API with `credentials:
-// "include"` and actually have access_token/refresh_token attached: cookies
-// are scoped by hostname, not by port, and SameSite is evaluated at the
-// same hostname-ignoring-port granularity, so the browser already sends
-// those cookies on such a request; without this branch, the *response*
-// would still be blocked from the extension's own JS by CORS.
+// "include"` and actually have a token attached: cookies are scoped by
+// hostname, not by port, so the browser already holds one there. Which
+// token depends on scheme, though: SameSite ignores port but NOT scheme
+// (modern browsers' "Schemeful Same-Site"), so access_token/refresh_token
+// (SameSite=Lax/Strict) only ride along when the forwarded port happens to
+// share the Paca app's own scheme; the domainauth.ScopeAnnotation pair
+// (SameSite=None — see AuthHandler.setAnnotationTokenCookies) is what
+// covers the far more common case where it doesn't. Either way, without
+// this branch the *response* would still be blocked from the extension's
+// own JS by CORS, cookies notwithstanding.
 //
 // The path check matters as much as the hostname check: the forwarded port
 // serves the *user's own dev app*, not code Paca controls, so any script
 // running there — not just the extension's content script — can make this
 // exact same credentialed request. Scoping the exception to
-// extensionCredentialedPathPattern means that page can, at most, act on
-// page annotations (and read its own port-forward's identity) on the
+// httpmw.AnnotationExtensionPathPattern means that page can, at most, act
+// on page annotations (and read its own port-forward's identity) on the
 // caller's behalf; without this scoping it would get free, ambient,
 // full-API access to every account the caller happens to be signed in as
 // (projects, tasks, docs, admin routes, ...) just because they had that
-// page open. It also can't be widened by CORS_ORIGINS — the pattern is
-// fixed at compile time, not configuration.
+// page open — and for a ScopeAnnotation token specifically,
+// middleware.applyAuthn enforces the exact same path restriction
+// independently of CORS, so it's held even if this Origin check were ever
+// loosened. Also can't be widened by CORS_ORIGINS — the pattern is fixed at
+// compile time, not configuration.
 func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 	allowAll := len(allowedOrigins) == 0
 	allowed := make(map[string]bool, len(allowedOrigins))
@@ -1129,7 +1120,7 @@ func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 			origin := r.Header.Get("Origin")
 			switch {
 			case origin != "" && sameHostnameOrigin(origin, r.Host) &&
-				extensionCredentialedPathPattern.MatchString(r.URL.Path):
+				httpmw.AnnotationExtensionPathPattern.MatchString(r.URL.Path):
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				w.Header().Set("Access-Control-Allow-Credentials", "true")
 				w.Header().Set("Vary", "Origin")

--- a/services/api/internal/transport/http/router/router.go
+++ b/services/api/internal/transport/http/router/router.go
@@ -903,13 +903,30 @@ func New(deps Deps) http.Handler {
 							r.Route("/{environmentId}/port-forwards/{portForwardId}/annotations", func(r chi.Router) {
 								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsRead)).
 									Get("/", deps.Annotation.List)
-								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite)).
+								// The four POST routes below all decode their
+								// body with plain encoding/json, which parses
+								// JSON regardless of the declared Content-Type
+								// — so httpmw.RequireJSONContentType is what
+								// actually makes that header meaningful. These
+								// routes are reachable via the SameSite=None
+								// domainauth.ScopeAnnotation cookie (see
+								// AuthHandler.setAnnotationTokenCookies and
+								// httpmw.AnnotationExtensionPathPattern);
+								// without this, a cross-site request using a
+								// CORS-safelisted Content-Type (e.g.
+								// text/plain) would count as a "simple
+								// request" under the Fetch spec, skip CORS
+								// preflight entirely, and still be parsed —
+								// cookie attached — regardless of
+								// corsMiddleware's same-hostname check, which
+								// only ever gates a *preflighted* request.
+								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite), httpmw.RequireJSONContentType()).
 									Post("/", deps.Annotation.Create)
-								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite)).
+								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite), httpmw.RequireJSONContentType()).
 									Post("/upload-url", deps.Annotation.InitiateScreenshotUpload)
 								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsRead)).
 									Get("/{annotationId}", deps.Annotation.Get)
-								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite)).
+								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite), httpmw.RequireJSONContentType()).
 									Post("/{annotationId}/complete-upload", deps.Annotation.CompleteScreenshotUpload)
 								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsRead)).
 									Get("/{annotationId}/screenshot-url", deps.Annotation.GetScreenshotURL)
@@ -917,9 +934,9 @@ func New(deps Deps) http.Handler {
 									Patch("/{annotationId}/resolve", deps.Annotation.Resolve)
 								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsResolve)).
 									Patch("/{annotationId}/reopen", deps.Annotation.Reopen)
-								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite)).
+								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite), httpmw.RequireJSONContentType()).
 									Post("/{annotationId}/comments", deps.Annotation.AddComment)
-								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite, authz.PermissionTasksWrite)).
+								r.With(httpmw.RequirePermissions(deps.Authorizer, httpmw.ProjectScopeFromParam("projectId"), authz.PermissionAnnotationsWrite, authz.PermissionTasksWrite), httpmw.RequireJSONContentType()).
 									Post("/{annotationId}/create-task", deps.Annotation.CreateTask)
 							})
 						}

--- a/services/api/internal/transport/http/router/router_test.go
+++ b/services/api/internal/transport/http/router/router_test.go
@@ -33,6 +33,9 @@ func (m *mockAuthSvc) Login(context.Context, string, string, bool) (*domainauth.
 func (m *mockAuthSvc) Refresh(context.Context, string) (*domainauth.TokenPair, error) {
 	return &domainauth.TokenPair{AccessToken: "at2", RefreshToken: "rt2", RefreshTTL: 24 * time.Hour}, nil
 }
+func (m *mockAuthSvc) RefreshAnnotation(context.Context, string) (*domainauth.TokenPair, error) {
+	return &domainauth.TokenPair{AnnotationAccessToken: "aat2", AnnotationRefreshToken: "art2", RefreshTTL: 24 * time.Hour}, nil
+}
 func (m *mockAuthSvc) Logout(context.Context, string) error { return nil }
 
 type mockUserSvc struct{}


### PR DESCRIPTION
## Summary

This branch has accumulated 40 commits since diverging from `master`. The headline feature is page annotations end-to-end (a Chrome extension that lets you comment directly on a running environment's forwarded preview, turning comments into tasks), plus several other features that landed on the same branch along the way: `provider_cli` agents, sprint planning UI, task board pagination, custom field colors, conversation permissions/parallelism, and migration-tracking infrastructure.

## Page annotations & the Chrome extension

- New `apps/extension` package: a Chrome extension that detects when you're on a forwarded environment preview and shows a commenting toolbar, backed by a new `AnnotationHandler`/annotation domain+service+repository (list/create/resolve/reopen annotations, add comments, screenshot upload, create-task-from-annotation).
- New `page_annotations`/`page_annotation_comments` tables and REST routes, wired into the router with `annotations.read`/`annotations.write`/`annotations.resolve` permissions.
- Web app additions: a Port Forwards tab and comments UI (`port-forward-detail.tsx`, `port-forward-comments-tab.tsx`, `comment-detail-view.tsx`), a comment-to-task flow, and BlockNote support for pasting/rendering annotation cards.
- Extension polish: icons/manifest, a privacy policy page for the Chrome Web Store listing, idempotent task creation from an annotation, and user-facing error handling/toasts for comment actions instead of silent failures.
- Security fix: reject a foreign `files.id` being used as an annotation screenshot.
- New CI/CD workflows for the extension (`extension-pr-ci.yml`, plus the `cd.yml` release pipeline).

### Auth: making the extension work across scheme mismatches

The extension authenticates purely by relying on browser-attached cookies — it never reads or stores a token itself. That breaks whenever the forwarded preview page and the main Paca app don't share a scheme (e.g. the app sits behind HTTPS while a project's own dev server is plain HTTP, or vice versa): modern browsers only treat a request as "same-site" — eligible for `SameSite=Lax`/`Strict` cookies — when the scheme *also* matches, not just the hostname.

- Added a `paca_scheme` cookie alongside the existing `paca_port` one, so the extension no longer assumes the API shares its current page's `location.protocol`.
- Added a second, narrowly-scoped `ScopeAnnotation` token pair (`annotation_access_token`/`annotation_refresh_token`, `SameSite=None`) issued alongside login, usable only against the small route set the extension actually calls (`middleware.AnnotationExtensionPathPattern`: port-forward resolution, its own refresh endpoint, and page-annotation CRUD) — never a substitute for a full session anywhere else. Enforced centrally in `applyAuthn` via `enforceTokenScope`, which fails closed on any unrecognized scope.
- New `POST /auth/annotation-refresh`, independent from the main `/auth/refresh` — each rejects the other's token kind outright, so a credential scoped to the extension can never mint a full session.
- `/auth/refresh` now also reissues a fresh annotation pair on every call, so the annotation session's lifetime piggybacks on ordinary web-app usage instead of depending solely on the extension's own activity.
- `paca_port`/`paca_scheme` are now unconditionally non-`Secure`, regardless of `COOKIE_SECURE` — they exist specifically to be read via `document.cookie` from a forwarded preview that's very often plain HTTP even when the main app is correctly HTTPS-only, and a `Secure` cookie is invisible to `document.cookie` on a non-HTTPS page.
- `paca_scheme`'s value is derived directly from `COOKIE_SECURE` rather than `X-Forwarded-Proto`/`r.TLS` — the header-based approach broke silently whenever a reverse proxy in front (e.g. Caddy) didn't faithfully forward it through every hop, which isn't something this codebase controls.

## Provider CLI agents

- New `provider_cli` agent type: an agent can run via a local CLI provider (Claude Code, Codex, Cursor Agent, Gemini CLI) instead of calling a model API directly, with new `cli_provider`/`cli_model`/`cli_auth_mode`/`cli_api_key_secret`/`cli_login_verified_at` fields on `agents`.
- New endpoints to verify CLI login status for both agents and environments, surfaced in the agent card/create-agent dialog UI.
- Skill-name validation to prevent directory traversal, plus permission/visibility checks and regression tests for agent-type selection.

## Sprint management UI

- Planned sprints with a collapsible sidebar section and status badges.
- Refactored sprint modals around a single `SprintFormModal`; warns before starting a sprint while another is already active.

## Task board performance

- Infinite scroll for task columns with backoff-retry on failed loads, cancellation on unmount, and retry-scheduling fixes under React StrictMode.

## Custom field colors

- Custom field options can now carry an optional color, with a new `ColorSwatchPicker` component and a migration to backfill existing options into the new format (with `UnmarshalJSON` support for the legacy plain-string shape).

## Conversation permissions & agent parallelism

- New `conversations.read`/`conversations.write` permissions (with dedup logic so role displays don't show redundant grants), and `agents.read` now required for `GetConversationForAgent`.
- Per-agent `parallelism_limit` with an `agent_pending_triggers` queue and a new `AgentQueueConsumer` to advance queued triggers as conversations finish, plus an `onBusy` parameter and folder-capacity checks for conversation dispatching.

## Database migration infrastructure

- New `schema_migrations` tracking table plus an advisory lock, so each migration file runs exactly once and concurrent deploys can't race each other applying migrations.
- Dedicated end-to-end tests that apply every migration file against a real Postgres database; removed the now-superseded ad hoc migration tests.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
