### PR TITLE
chore(user-menu): remove role capitalization in user display

### DIFF
--- a/apps/web/src/components/app-shell/user-menu.tsx
+++ b/apps/web/src/components/app-shell/user-menu.tsx
@@ -105,8 +105,8 @@ export function UserMenu() {
 						</Avatar>
 						<div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
 							<span className="truncate font-semibold">{displayName}</span>
-							<span className="truncate text-xs text-muted-foreground capitalize">
-								{user.role.toLowerCase()}
+							<span className="truncate text-xs text-muted-foreground">
+								{user.role}
 							</span>
 						</div>
 						<ChevronsUpDown className="ml-auto size-4 shrink-0 opacity-50 group-data-[collapsible=icon]:hidden" />


### PR DESCRIPTION
## Summary
- Fixes the sidebar user menu showing the role in the wrong case (e.g. "CTO" rendered as "Cto") while the profile page showed it correctly.
- `user.role.toLowerCase()` combined with Tailwind's `capitalize` class lowercased the raw role first, then title-cased it — but CSS `capitalize` only uppercases the first letter of each word, so acronyms like "CTO" collapsed to "Cto" instead of staying "CTO".
- Roles are free-text strings an admin can name however they like (e.g. via the Global Roles admin UI) and are returned by the API verbatim, so any case transform is lossy. The fix renders `user.role` as-is, matching how the profile page and other role-display call sites (`UsersTable.tsx`, `GlobalRolesTable.tsx`) already do it.

Fixes #472

## Test plan
- [x] `tsc -b` passes
- [x] `biome check` passes on the changed file
