### PR TITLE
fix(activity-pane): adjust fieldset styling for improved layout

### DIFF
--- a/apps/web/src/components/shared/activity-pane.tsx
+++ b/apps/web/src/components/shared/activity-pane.tsx
@@ -326,7 +326,7 @@ export function ActivityPane<T extends ActivityEntry>({
 					)}
 					<fieldset
 						className={cn(
-							"rounded-xl border border-border/30 bg-card/80 transition-all duration-200 overflow-hidden",
+							"min-w-0 rounded-xl border border-border/30 bg-card/80 transition-all duration-200 overflow-hidden",
 							editorFocused && "border-primary/25 shadow-sm shadow-primary/5",
 							"[&_.bn-editor]:min-h-6 [&_.bn-editor]:max-h-48 [&_.bn-editor]:overflow-y-auto [&_.bn-editor]:py-1.5 [&_.bn-editor]:px-3 [&_.bn-editor]:text-sm [&_.bn-editor]:leading-relaxed",
 						)}


### PR DESCRIPTION
## Summary

Fixes #479 — long, unbroken lines in a comment (e.g. a URL or token with no spaces) blew out the comment input's layout with no way to scroll to the rest of the text.

## Root cause

`<fieldset>` elements get a `min-width: min-content` from the browser's default stylesheet, so they refuse to shrink below the width of their widest unbreakable content. When a comment contained a long line with no spaces, the fieldset wrapping the comment editor grew to fit that string (verified: 295px → 953px) and pushed the whole box past the sidebar's fixed width, off the right edge of the page. Since `body` has `overflow-x: hidden`, the overflow was silently clipped with no scrollbar to reach it.

The text itself already had `overflow-wrap: break-word` from BlockNote's default styles, but it never got a chance to engage — the fieldset never shrank down to a width that would force the text to wrap.

## Fix

Add `min-w-0` to the fieldset so it respects its parent's width instead of the browser's default `min-content` floor. This lets the existing wrap behavior kick in as intended: long lines now wrap within the box instead of stretching it.

## Test plan

- [x] Typed a 14-line comment — box grows up to ~8 lines then scrolls internally (unchanged, already worked)
- [x] Typed a long unbroken line (URL-style string, no spaces) — previously stretched the comment box off-screen with no scrollbar; now wraps correctly within the sidebar's width
- [x] Verified the posted (read-only) comment display renders the same long line correctly with no changes needed there
- [x] `tsc -b` and `biome check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
