### PR TITLE
fix(settings-page, team-page): refactor permission checks to use project-specific hooks

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
@@ -17,13 +17,11 @@ import { RolesSettings } from "@/components/projects/settings/RolesSettings";
 import { TaskStatusesSettings } from "@/components/projects/settings/TaskStatusesSettings";
 import { TaskTypesSettings } from "@/components/projects/settings/TaskTypesSettings";
 import { usePermissions } from "@/hooks/use-permissions";
-import { currentUserQueryOptions } from "@/lib/auth-api";
+import { useProjectPermissions } from "@/hooks/use-project-permissions";
 import { RemoteComponent } from "@/lib/plugins/loader";
 import { usePluginRegistry } from "@/lib/plugins/registry";
 import {
 	customFieldsQueryOptions,
-	type ProjectMember,
-	type ProjectRole,
 	projectMembersQueryOptions,
 	projectQueryOptions,
 	projectRolesQueryOptions,
@@ -83,43 +81,18 @@ function SettingsPage() {
 	const { projectId } = Route.useParams();
 	const { data: project } = useQuery(projectQueryOptions(projectId));
 	const { hasPermission } = usePermissions();
-	const { data: currentUser } = useQuery(currentUserQueryOptions);
-	const { data: members = [] } = useQuery(
-		projectMembersQueryOptions(projectId),
-	);
-	const { data: roles = [] } = useQuery(projectRolesQueryOptions(projectId));
+	const { hasProjectPermission } = useProjectPermissions(projectId);
 
-	const myMembership = (members as ProjectMember[]).find(
-		(m) => m.user_id === currentUser?.id,
-	);
-	const myRole = (roles as ProjectRole[]).find(
-		(r) => r.id === myMembership?.project_role_id,
-	);
-	const hasProjectDelete = Boolean(
-		(myRole?.permissions as Record<string, boolean> | undefined)?.[
-			"projects.delete"
-		],
-	);
-	const hasProjectWrite = Boolean(
-		(myRole?.permissions as Record<string, boolean> | undefined)?.[
-			"projects.write"
-		],
-	);
-	const hasProjectRolesWrite = Boolean(
-		(myRole?.permissions as Record<string, boolean> | undefined)?.[
-			"project.roles.write"
-		],
-	);
-	const canDelete = hasPermission("projects.delete") || hasProjectDelete;
-	const canEditProject = hasPermission("projects.write") || hasProjectWrite;
+	const canDelete =
+		hasPermission("projects.delete") ||
+		hasProjectPermission("projects.delete");
+	const canEditProject =
+		hasPermission("projects.write") || hasProjectPermission("projects.write");
 	const canManageRoles =
-		hasPermission("project.roles.write") || hasProjectRolesWrite;
-	const hasTasksWrite = Boolean(
-		(myRole?.permissions as Record<string, boolean> | undefined)?.[
-			"tasks.write"
-		],
-	);
-	const canManageTasks = hasPermission("tasks.write") || hasTasksWrite;
+		hasPermission("project.roles.write") ||
+		hasProjectPermission("project.roles.write");
+	const canManageTasks =
+		hasPermission("tasks.write") || hasProjectPermission("tasks.write");
 
 	const { getRegistrations } = usePluginRegistry();
 	const pluginTabs = getRegistrations("project.settings.tab").filter(

--- a/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/settings/index.tsx
@@ -84,8 +84,7 @@ function SettingsPage() {
 	const { hasProjectPermission } = useProjectPermissions(projectId);
 
 	const canDelete =
-		hasPermission("projects.delete") ||
-		hasProjectPermission("projects.delete");
+		hasPermission("projects.delete") || hasProjectPermission("projects.delete");
 	const canEditProject =
 		hasPermission("projects.write") || hasProjectPermission("projects.write");
 	const canManageRoles =

--- a/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/team/index.tsx
@@ -51,9 +51,9 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePermissions } from "@/hooks/use-permissions";
+import { useProjectPermissions } from "@/hooks/use-project-permissions";
 import { type User, usersInfiniteQueryOptions } from "@/lib/admin-api";
 import { type Agent, chattableAgentsQueryOptions } from "@/lib/agent-api";
-import { currentUserQueryOptions } from "@/lib/auth-api";
 import {
 	addProjectMember,
 	type ProjectMember,
@@ -741,24 +741,16 @@ function TeamPage() {
 	);
 
 	const { hasPermission } = usePermissions();
-	const { data: currentUser } = useQuery(currentUserQueryOptions);
+	const { hasProjectPermission } = useProjectPermissions(projectId);
 	const { data: project } = useQuery(projectQueryOptions(projectId));
 	const { data: members, isLoading } = useQuery(
 		projectMembersQueryOptions(projectId),
 	);
 	const { data: roles = [] } = useQuery(projectRolesQueryOptions(projectId));
 
-	const myMembership = (members ?? []).find(
-		(m) => m.user_id === currentUser?.id,
-	);
-	const myRole = roles.find((r) => r.id === myMembership?.project_role_id);
-	const hasProjectMembersWrite = Boolean(
-		(myRole?.permissions as Record<string, boolean> | undefined)?.[
-			"project.members.write"
-		],
-	);
 	const canManageMembers =
-		hasPermission("project.members.write") || hasProjectMembersWrite;
+		hasPermission("project.members.write") ||
+		hasProjectPermission("project.members.write");
 
 	const existingMemberIds = useMemo(
 		() => new Set((members ?? []).map((m) => m.user_id)),


### PR DESCRIPTION
## Summary

Fixes #468 — drag-and-drop reordering of task statuses could silently appear disabled (no grab cursor, no handle) for users who actually had `tasks.write`, and only a hard page reload fixed it.

**Root cause:** the Settings and Team pages each hand-rolled their own permission check by fetching the *entire* project members list and *entire* roles list, then manually cross-referencing them client-side to find "my role" and read its permission map. That derived state had no reliable invalidation path, so it could go stale in an open tab until a full reload forced everything to refetch.

**Fix:** both pages now use `useProjectPermissions(projectId)` — the dedicated hook (backed by `GET /projects/:id/members/me/permissions`) already used consistently across ~20 other pages (backlog, sprints, docs, task detail, etc.) — instead of reimplementing permission derivation from bulk members/roles data.

## Changes

- `settings/index.tsx`: `canDelete`, `canEditProject`, `canManageRoles`, and `canManageTasks` (which gates the task-status drag handle) now read from `hasProjectPermission(...)` instead of manually resolving `members` → `myMembership` → `myRole` → `permissions`. Removed the now-unused `currentUserQueryOptions`/members/roles derivation.
- `team/index.tsx`: `canManageMembers` follows the same pattern; removed the now-unused `currentUserQueryOptions` fetch.

Both pages still fetch `members`/`roles` where that data is actually rendered (member list, role dropdowns) — only the permission-derivation logic changed.

## Testing

- `tsc -b` passes
- `biome check` passes
- No existing test coverage for these two route files

Note: this fixes the architectural inconsistency and removes staleness on normal remount/refocus/navigation, but doesn't add a live push — if a role's permissions change while an affected user's tab stays open and focused with no navigation, they'd still need some trigger (refocus/nav/reload) to see it, since the backend doesn't yet publish a change event for role/member updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)